### PR TITLE
Work around the reserved keyword problem with 'from' parameters in Thrift

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,20 @@ configure(javaProjects) {
                                     sourceFile.absolutePath
                         }
                     }
+
+                    // Replace 'fromRevision' with 'from' (and 'toRevision' with 'to') because Thrift compiler
+                    // does not let us use the parameter name 'from' complaining it's a reserved keyword.
+                    // We can't rename it because renaming a field or a parameter is a backward-incompatible
+                    // change in TText protocol.
+                    project.fileTree(outputDir) {
+                        include '**/*.java'
+                    }.each { sourceFile ->
+                        def encoding = 'UTF-8'
+                        def content = sourceFile.getText(encoding)
+                                                .replaceAll('fromRevision', 'from')
+                                                .replaceAll('toRevision', 'to')
+                        sourceFile.write(content, encoding)
+                    }
                 }
             }
         }

--- a/common/src/main/thrift/CentralDogma.thrift
+++ b/common/src/main/thrift/CentralDogma.thrift
@@ -304,13 +304,15 @@ service CentralDogmaService {
     /**
      * Retrieves the history of the repository.
      */
-    list<Commit> getHistory(1: string projectName, 2: string repositoryName, 3: Revision from, 4: Revision to,
+    list<Commit> getHistory(1: string projectName, 2: string repositoryName,
+                            3: Revision fromRevision, 4: Revision toRevision,
                             5: string pathPattern) throws (1: CentralDogmaException e),
 
     /**
      * Retrieves the diffs matched by the path pattern from {@code from} to {@code to}.
      */
-    list<Change> getDiffs(1: string projectName, 2: string repositoryName, 3: Revision from, 4: Revision to,
+    list<Change> getDiffs(1: string projectName, 2: string repositoryName,
+                          3: Revision fromRevision, 4: Revision toRevision,
                           5: string pathPattern) throws (1: CentralDogmaException e),
 
     /**
@@ -336,7 +338,8 @@ service CentralDogmaService {
     /**
      * Queries a file at two different revisions and return the diff of the two query results.
      */
-    DiffFileResult diffFile(1: string projectName, 2: string repositoryName, 3: Revision from, 4: Revision to,
+    DiffFileResult diffFile(1: string projectName, 2: string repositoryName,
+                            3: Revision fromRevision, 4: Revision toRevision,
                             5: Query query) throws (1: CentralDogmaException e),
 
     /**


### PR DESCRIPTION
Motivation:

Thrift compiler does not let us use the parameter name 'from'
complaining it's a reserved keyword. We can't rename it because
renaming a field or a parameter is a backward-incompatible change in
TText protocol.

Modifications:

- Rename 'from' and 'to' to 'fromRevision' and 'toRevision' in .thrift
  file
- Perform string replacement over the generated code so we continue
  using 'from' and 'to'

Result:

- Thrift compiler doesn't complain anymore.
- Backward compatibility ensured (until we replace Thrift with
  well-defined RESTful API and GraphQL)