### PR TITLE
Add cli client with Go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@
 # Client vendor dependencies
 **/webapp/vendor
 
+# Go client output
+/client/go/.gogradle
+/client/go/vendor
+
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -145,6 +145,11 @@ This product depends on Awaitility, distributed by the Awaitility authors:
   * License: licenses/LICENSE.awaitility.al20.txt (Apache License v2.0)
   * Homepage: https://github.com/awaitility/awaitility
 
+This product depends on bgentry/go-netrc, distributed by Fazlul Shahriar and Blake Gentry:
+
+  * License: licenses/LICENSE.bgentry-go-netrc.mit.txt (Apache License v2.0)
+  * Homepage: https://github.com/bgentry/go-netrc
+
 This product depends on Caffeine, distributed by Ben Manes:
 
   * License: licenses/LICENSE.caffeine.al20.txt (Apache License v2.0)
@@ -274,3 +279,8 @@ This product depends on Apache Thrift, distributed by Apache Software Foundation
 
   * License: licenses/LICENSE.thrift.al20.txt (Apache License v2.0)
   * Homepage: https://thrift.apache.org/
+
+ This product depends on urfave/cli, distributed by Jeremy Saenz:
+
+   * License: licenses/LICENSE.urfave-cli.mit.txt (MIT License)
+   * Homepage: https://github.com/urfave/cli

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,10 @@ buildscript {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
         classpath 'net.rdrei.android.buildtimetracker:gradle-plugin:0.10.0'
         classpath 'org.yaml:snakeyaml:1.18'
+
+        // For gogradle. It seems gogradle doesn't support buildscript so just leave this here until
+        // gogradle supports it.
+        classpath 'com.google.inject:guice:4.0'
     }
 }
 
@@ -28,7 +32,7 @@ ext {
     repoStatus = getRepoStatus()
 
     // The list of Java projects
-    javaProjects = subprojects.findAll { !(it.name in ['site']) }
+    javaProjects = subprojects.findAll { !(it.name in ['site', 'client/go']) }
 
     // The list of Java projects whose artifacts are published to the Maven repository
     publishedJavaProjects = javaProjects.findAll {

--- a/client/go/build.gradle
+++ b/client/go/build.gradle
@@ -1,0 +1,31 @@
+plugins {
+    id 'com.github.blindpirate.gogradle' version '0.7.0'
+}
+
+golang {
+    packagePath = 'github.com/line/centraldogma/client/go'
+
+    goVersion = '1.9'
+}
+
+ext {
+    goPath = System.env.GOPATH
+    if (goPath == null) {
+        goPath = "${project.projectDir}/.gogradle/project_gopath"
+    }
+    binDir = "${goPath}/bin"
+}
+
+// Gogradle puts several comman code check task into a check task. We need to explicitly specify this line
+// to invoke the tasks. By default, it is out-of-the-box and depends on vet/fmt and cover.
+build.dependsOn check
+
+build {
+    targetPlatform = ['linux-amd64', 'darwin-amd64', 'windows-amd64']
+
+    go "build -o ${project.ext.binDir}" +
+            '/dogma.${GOOS}-${GOARCH}${GOEXE} github.com/line/centraldogma/client/go/cmd/dogma'
+    doLast {
+        ant.chmod(file: "$project.ext.binDir" + '/dogma.windows-amd64.exe', perm: '644')
+    }
+}

--- a/client/go/client/auth.go
+++ b/client/go/client/auth.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/line/centraldogma/client/go/service"
+	"github.com/line/centraldogma/client/go/util/file"
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func loginIfNeed(remoteURI *url.URL, token, username string) (string, error) {
+	remote := (&url.URL{Scheme: remoteURI.Scheme, Host: remoteURI.Host}).String()
+	PathOfSecurityCheck := remote + "/security_enabled"
+	enabled, err := securityEnabled(PathOfSecurityCheck)
+	if err != nil {
+		return "", err
+	}
+	if !enabled {
+		return "anonymous", nil
+	}
+	if len(token) != 0 {
+		return token, nil
+	}
+
+	password := ""
+	if len(username) == 0 {
+		machine := file.NetrcInfo()
+		if machine != nil {
+			username = machine.Login
+			password = machine.Password
+			if len(username) == 0 || len(password) == 0 {
+				return "", fmt.Errorf(
+					"netrc file doesn't have enough information (username:%q)", username)
+			}
+		} else {
+			username, err = getUsername()
+			if err != nil {
+				return "", err
+			}
+			password, err = getPassword()
+			if err != nil {
+				return "", err
+			}
+		}
+	} else {
+		password, err = getPassword()
+		if err != nil {
+			return "", err
+		}
+	}
+	sessionID, err := login(remote, username, password)
+	if err != nil {
+		return "", err
+	}
+
+	return sessionID, nil
+}
+func login(remote string, username string, password string) (string, error) {
+	values := url.Values{}
+	values.Set("username", username)
+	values.Set("password", password)
+	values.Set("remember_me", "true")
+	buf := new(bytes.Buffer)
+	buf.WriteString(values.Encode())
+	u, _ := url.Parse(remote + service.DefaultPathPrefix + "authenticate")
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/x-www-form-urlencoded"}}
+	res, err := New().client.Do(req)
+	if err != nil {
+		return "", nil
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("cannot login to %s (status: %s)", remote, res.Status)
+	}
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	sessionID := string(b)
+	return sessionID, nil
+}
+
+func securityEnabled(remote string) (bool, error) {
+	u, _ := url.Parse(remote)
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := New().client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("authenticaion check is failed (status: %s)", res.Status)
+	}
+	b, _ := ioutil.ReadAll(res.Body)
+	if string(b) == "true" {
+		return true, nil
+	}
+	return false, nil
+}
+
+func getUsername() (string, error) {
+	fmt.Print("Enter username: ")
+	scanner := bufio.NewScanner(os.Stdin)
+	if !scanner.Scan() {
+		return "", errors.New("you must input username")
+	}
+	line := strings.TrimSpace(scanner.Text())
+	if len(line) == 0 {
+		return "", errors.New("you must input username")
+	}
+	return line, nil
+}
+
+func getPassword() (string, error) {
+	fmt.Print("Enter password: ")
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		return "", err
+	}
+	fmt.Println()
+	password := string(bytePassword)
+	if len(password) == 0 {
+		return "", errors.New("you must input password")
+	}
+	return password, nil
+}

--- a/client/go/client/client.go
+++ b/client/go/client/client.go
@@ -1,0 +1,46 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package client
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+type CDClient struct {
+	client *http.Client
+}
+
+func (cdc *CDClient) Do(req *http.Request, c *cli.Context) (*http.Response, error) {
+	tokenOrSessionID, err := loginIfNeed(req.URL, c.Parent().String("token"), c.Parent().String("login"))
+	if err != nil {
+		return nil, err
+	}
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	req.Header.Add("Authorization", "Bearer "+tokenOrSessionID)
+	return cdc.client.Do(req)
+}
+
+func New() *CDClient {
+	return &CDClient{
+		client: &http.Client{
+			Timeout: time.Second * 10,
+		},
+	}
+}

--- a/client/go/cmd/cli_cmds.go
+++ b/client/go/cmd/cli_cmds.go
@@ -1,0 +1,309 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+var revisionFlag = []cli.Flag{cli.StringFlag{
+	Name:  "revision, r",
+	Usage: "Specifies the revision to operate",
+}}
+
+var jsonPathFlag = cli.StringFlag{
+	Name:  "jsonpath, j",
+	Usage: "Specifies the JSON path expressions to apply",
+}
+
+var fromRevisionFlag = cli.StringFlag{
+	Name:  "from",
+	Usage: "Specifies the revision to apply from",
+}
+
+var toRevisionFlag = cli.StringFlag{
+	Name:  "to",
+	Usage: "Specifies the revision to apply until",
+}
+
+var printFormatFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:   "pretty",
+		Hidden: true,
+	},
+	cli.BoolFlag{
+		Name:   "simple",
+		Hidden: true,
+	},
+	cli.BoolFlag{
+		Name:   "json",
+		Hidden: true,
+	},
+}
+
+type PrintStyle int
+
+const (
+	_ PrintStyle = iota
+	Pretty
+	Simple
+	JSON
+)
+
+func getPrintStyle(c *cli.Context) (PrintStyle, error) {
+	var ps PrintStyle
+	if c.Bool("pretty") {
+		ps = Pretty
+	}
+	if c.Bool("simple") {
+		if ps != 0 {
+			return 0, fmt.Errorf("duplicate print style (pretty: %t, simple: %t, json: %t)\n",
+				c.Bool("pretty"), c.Bool("simple"), c.Bool("json"))
+		}
+		ps = Simple
+	}
+	if c.Bool("json") {
+		if ps != 0 {
+			return 0, fmt.Errorf("duplicate print style (pretty: %t, simple: %t, json: %t)\n",
+				c.Bool("pretty"), c.Bool("simple"), c.Bool("json"))
+		}
+		ps = JSON
+	}
+	if ps == 0 {
+		ps = Pretty
+	}
+	return ps, nil
+}
+
+func printWithStyle(data interface{}, format PrintStyle) {
+	// TODO implement this method
+	buf, _ := json.MarshalIndent(data)
+	fmt.Printf("%s\n", buf)
+}
+
+func newCommandLineError(c *cli.Context) *cli.ExitError {
+	com := c.Command
+	return cli.NewExitError("usage: "+com.Name+" "+com.ArgsUsage, 1)
+}
+
+func CLICommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:      "ls",
+			Usage:     "Lists the projects, repositories or files",
+			ArgsUsage: "[<project_name>[/<repository_name>[/<path>]]]",
+			Flags:     append(printFormatFlags, revisionFlag[0]),
+			Action: func(c *cli.Context) error {
+				style, err := getPrintStyle(c)
+				if err != nil {
+					return err
+				}
+				command, err := newLSCommand(c, c.String("revision"), style)
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "new",
+			Usage:     "Creates a project or repository",
+			ArgsUsage: "<project_name>[/<repository_name>]",
+			Action: func(c *cli.Context) error {
+				command, err := newNewCommand(c)
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "put",
+			Usage:     "Puts a file to the repository",
+			ArgsUsage: "<project_name>/<repository_name>[/<path>] file_path",
+			Flags:     revisionFlag,
+			Action: func(c *cli.Context) error {
+				command, err := newPutCommand(c, c.String("revision"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "edit",
+			Usage:     "Edits a file in the path",
+			ArgsUsage: "<project_name>/<repository_name>/<path>",
+			Flags:     revisionFlag,
+			Action: func(c *cli.Context) error {
+				command, err := newEditCommand(c, c.String("revision"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "get",
+			Usage:     "Downloads a file in the path",
+			ArgsUsage: "<project_name>/<repository_name>/<path>",
+			Flags:     append(revisionFlag, jsonPathFlag),
+			Action: func(c *cli.Context) error {
+				command, err := newGetCommand(c, c.String("revision"), c.String("jsonpath"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "cat",
+			Usage:     "Prints a file in the path",
+			ArgsUsage: "<project_name>/<repository_name>/<path>",
+			Flags:     append(revisionFlag, jsonPathFlag),
+			Action: func(c *cli.Context) error {
+				command, err := newCatCommand(c, c.String("revision"), c.String("jsonpath"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "rm",
+			Usage:     "Removes a file in the path",
+			ArgsUsage: "<project_name>/<repository_name>/<path>",
+			Flags:     revisionFlag,
+			Action: func(c *cli.Context) error {
+				command, err := newRMCommand(c, c.String("revision"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "diff",
+			Usage:     "Gets diff of given path",
+			ArgsUsage: "<project_name>/<repository_name>[/<path>]",
+			Flags:     append(printFormatFlags, fromRevisionFlag, toRevisionFlag),
+			Action: func(c *cli.Context) error {
+				style, err := getPrintStyle(c)
+				if err != nil {
+					return err
+				}
+				command, err := newDiffCommand(c, c.String("from"), c.String("to"), style)
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "log",
+			Usage:     "Shows commit logs of the path",
+			ArgsUsage: "<project_name>/<repository_name>[/<path>]",
+			Flags:     append(printFormatFlags, fromRevisionFlag, toRevisionFlag),
+			Action: func(c *cli.Context) error {
+				style, err := getPrintStyle(c)
+				if err != nil {
+					return err
+				}
+				command, err := newLogCommand(c, c.String("from"), c.String("to"), style)
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "normalize",
+			Usage:     "Normalizes a revision into an absolute revision",
+			ArgsUsage: "<project_name>/<repository_name>",
+			Flags:     revisionFlag,
+			Action: func(c *cli.Context) error {
+				command, err := newNormalizeCommand(c, c.String("revision"))
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+		{
+			Name:      "search",
+			Usage:     "Searches files matched by the term",
+			ArgsUsage: "<project_name>/<repository_name> term",
+			Flags:     append(printFormatFlags, revisionFlag[0]),
+			Action: func(c *cli.Context) error {
+				style, err := getPrintStyle(c)
+				if err != nil {
+					return err
+				}
+				command, err := newSearchCommand(c, c.String("revision"), style)
+				if err != nil {
+					return newCommandLineError(c)
+				}
+				err = command.execute(c)
+				if err != nil {
+					return cli.NewExitError(err, 1)
+				}
+				return nil
+			},
+		},
+	}
+}

--- a/client/go/cmd/cli_cmds_test.go
+++ b/client/go/cmd/cli_cmds_test.go
@@ -1,0 +1,78 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/line/centraldogma/client/go/service"
+)
+
+func TestGetServerURI(t *testing.T) {
+	var tests = []struct {
+		host string
+		want *url.URL
+	}{
+		// no input
+		{"", &url.URL{
+			Scheme: "http",
+			Host:   "localhost:36462",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"http://foo.com", &url.URL{
+			Scheme: "http",
+			Host:   "foo.com:36462",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"http://foo.com:8080", &url.URL{
+			Scheme: "http",
+			Host:   "foo.com:8080",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"https://foo.com:8080/", &url.URL{
+			Scheme: "https",
+			Host:   "foo.com:8080",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"foo.com", &url.URL{
+			Scheme: "http",
+			Host:   "foo.com:36462",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"foo.com:8080", &url.URL{
+			Scheme: "http",
+			Host:   "foo.com:8080",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"http://192.168.0.1", &url.URL{
+			Scheme: "http",
+			Host:   "192.168.0.1:36462",
+			Path:   service.DefaultPathPrefix,
+		}},
+		{"http://192.168.0.1:8080", &url.URL{
+			Scheme: "http",
+			Host:   "192.168.0.1:8080",
+			Path:   service.DefaultPathPrefix,
+		}},
+	}
+
+	for _, test := range tests {
+		if got, _ := getRemoteURI(test.host); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("getRemoteURI(%q) = %q, want: %q", test.host, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/cmd.go
+++ b/client/go/cmd/cmd.go
@@ -1,0 +1,228 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package cmd implements commands that execute rest API to download, add, create, modify, or delete the
+// specified resources on the Central Dogma server.
+// Commands are created according to the input from the CLI and executed.
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/line/centraldogma/client/go/service"
+	"github.com/line/centraldogma/client/go/util/file"
+	"github.com/urfave/cli"
+)
+
+// Command is the common interface implemented by all commands.
+type Command interface {
+	// execute execute the command
+	execute(c *cli.Context) error
+}
+
+func getRemoteURI(host string) (*url.URL, error) {
+	if len(host) != 0 {
+		return normalizedURI(host)
+	} else {
+		machine := file.NetrcInfo()
+		if machine != nil && len(machine.Name) != 0 {
+			return normalizedURI(machine.Name)
+		}
+	}
+	return url.Parse(
+		service.DefaultScheme + "://" + service.DefaultHostName + ":" + strconv.Itoa(service.DefaultPort) +
+			service.DefaultPathPrefix)
+}
+
+func normalizedURI(host string) (*url.URL, error) {
+	if !strings.HasPrefix(host, "http") {
+		host = service.DefaultScheme + "://" + host
+	}
+	if strings.HasSuffix(host, "/") {
+		host = host[:len(host)-1]
+	}
+
+	parsedURL, err := url.Parse(host)
+	if err != nil {
+		return nil, err
+	}
+	if len(parsedURL.Scheme) == 0 {
+		host = service.DefaultScheme + "://" + host
+	}
+	port := parsedURL.Port()
+	if len(port) == 0 {
+		host += ":" + strconv.Itoa(service.DefaultPort)
+	}
+	host += service.DefaultPathPrefix
+	return url.Parse(host)
+}
+
+type repositoryRequestInfo struct {
+	remote         *url.URL
+	projectName    string
+	repositoryName string
+	repositoryPath string
+	revision       string
+}
+
+// newRepositoryRequestInfo creates a repositoryRequestInfo. If the revision is not specified,
+// it will be set to "head" which means most recent revision.
+func newRepositoryRequestInfo(c *cli.Context, revision string, needRepositoryPath bool) (
+	repositoryRequestInfo, error) {
+	repo := repositoryRequestInfo{}
+	remoteURI, err := getRemoteURI(c.Parent().String("host"))
+	if err != nil {
+		return repo, err
+	}
+
+	split := SplitPath(c.Args().First())
+
+	repositoryPath := ""
+	if needRepositoryPath {
+		if len(split) < 3 { // need projectName, repositoryName, and repositoryPath
+			return repo, newCommandLineError(c)
+		}
+		repositoryPath = split[2]
+	} else {
+		if len(split) < 2 { // need projectName and repositoryName
+			return repo, newCommandLineError(c)
+		}
+	}
+
+	repo.remote = remoteURI
+	repo.projectName = split[0]
+	repo.repositoryName = split[1]
+	repo.repositoryPath = repositoryPath
+	repo.revision = "head"
+	if len(revision) != 0 {
+		repo.revision = revision
+	}
+	return repo, nil
+}
+
+// SplitPath parses the path into projectName, repositoryName and repositoryPath.
+func SplitPath(wholePath string) []string {
+	endsWithSlash := false
+	if strings.HasSuffix(wholePath, "/") {
+		endsWithSlash = true
+	}
+
+	split := strings.Split(wholePath, "/")
+	var ret []string
+	for _, str := range split {
+		if str != "" {
+			ret = append(ret, str)
+		}
+	}
+	if len(ret) <= 2 {
+		return ret
+	}
+	repositoryPath := "/" + strings.Join(ret[2:], "/")
+	if endsWithSlash {
+		repositoryPath += "/"
+	}
+	return append(ret[:2], repositoryPath)
+}
+
+type repositoryRequestInfoWithFromTo struct {
+	remote         *url.URL
+	projectName    string
+	repositoryName string
+	repositoryPath string
+	from           string
+	to             string
+}
+
+// newRepositoryRequestInfoWithFromTo creates a repositoryRequestInfoWithFromTo. If the from and to revision
+// are not specified, it will be set to "1" and "head" respectively which means the whole range of revisions.
+func newRepositoryRequestInfoWithFromTo(c *cli.Context, from, to string) (
+	repositoryRequestInfoWithFromTo, error) {
+	repo := repositoryRequestInfoWithFromTo{}
+	remoteInfo, err := getRemoteURI(c.Parent().String("host"))
+	if err != nil {
+		return repo, err
+	}
+	repo.remote = remoteInfo
+
+	ca := c.Args()
+	argLen := len(ca)
+	if argLen != 1 {
+		return repo, newCommandLineError(c)
+	}
+
+	split := SplitPath(ca.First())
+
+	if len(split) < 2 { // need at least projectName and repositoryName
+		return repo, newCommandLineError(c)
+	}
+	repo.projectName = split[0]
+	repo.repositoryName = split[1]
+
+	repositoryPath := "/"
+	if len(split) == 3 {
+		repositoryPath = split[2]
+	}
+	repo.repositoryPath = repositoryPath
+
+	// TODO validate from to
+	if len(from) == 0 {
+		from = "1"
+	}
+	repo.from = from
+	if len(to) == 0 {
+		to = "head"
+	}
+	repo.to = to
+	return repo, nil
+}
+
+// getRemoteFileEntry downloads the entry of the specified remote path. If the JSON path expression
+// is specified, only the applied content of the expression will be downloaded.
+func getRemoteFileEntry(c *cli.Context, remoteURI *url.URL, projectName, repositoryName, repositoryPath,
+	revision, expression string) (*json.EntryWithRevision, error) {
+	u, _ := url.Parse(
+		remoteURI.String() + "projects/" + projectName + "/repositories/" + repositoryName +
+			"/files/revisions/" + revision + repositoryPath)
+	if len(expression) != 0 {
+		values := url.Values{}
+		values.Set("queryType", "JSON_PATH")
+		values.Set("expression", expression)
+		u.RawQuery = values.Encode()
+	}
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		message := fmt.Sprintf("cannot get the file: /%s/%s%s revision: %q (status: %s)",
+			projectName, repositoryName, repositoryPath, revision, res.Status)
+		return nil, errors.New(message)
+	}
+
+	entryWithRevision := &json.EntryWithRevision{}
+	if err = json.Fill(entryWithRevision, res.Body); err != nil {
+		return nil, err
+	}
+	return entryWithRevision, nil
+}

--- a/client/go/cmd/cmd_test.go
+++ b/client/go/cmd/cmd_test.go
@@ -1,0 +1,44 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitPath(t *testing.T) {
+	var tests = []struct {
+		path string
+		want []string
+	}{
+		{"", nil},
+		{"/", nil},
+		{"/foo/bar", []string{"foo", "bar"}},
+		{"/foo/bar/", []string{"foo", "bar"}},
+		{"foo/bar/a.txt", []string{"foo", "bar", "/a.txt"}},
+		{"/foo/bar/b.txt", []string{"foo", "bar", "/b.txt"}},
+		{"//foo//bar//c.txt", []string{"foo", "bar", "/c.txt"}},
+		{"/foo/bar/a/", []string{"foo", "bar", "/a/"}},
+		{"/foo/bar/a/d.txt", []string{"foo", "bar", "/a/d.txt"}},
+		{"/foo/bar/a/b/e.txt", []string{"foo", "bar", "/a/b/e.txt"}},
+		{"/foo/bar/a/b//f.txt", []string{"foo", "bar", "/a/b/f.txt"}},
+	}
+	for _, test := range tests {
+		if got := SplitPath(test.path); !reflect.DeepEqual(got, test.want) {
+			t.Errorf("SplitPath(%q) = %q, want:%q", test.path, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/diff_cmd.go
+++ b/client/go/cmd/diff_cmd.go
@@ -1,0 +1,74 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+// A diffCommand returns a diff of the specified path between the from revision and to revision.
+type diffCommand struct {
+	repo  repositoryRequestInfoWithFromTo
+	style PrintStyle
+}
+
+func (dc *diffCommand) execute(c *cli.Context) error {
+	repo := dc.repo
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/diff" + repo.repositoryPath)
+	values := url.Values{}
+	values.Set("from", repo.from)
+	values.Set("to", repo.to)
+	u.RawQuery = values.Encode()
+	req := &http.Request{Method: http.MethodGet, URL: u}
+
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot get the diff of /%s/%s%s from: %q, to: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.repositoryPath,
+			repo.from, repo.to, res.Status)
+	}
+	changes := []json.Change{}
+	if err = json.Fill(&changes, res.Body); err != nil {
+		return err
+	}
+
+	for _, change := range changes {
+		fmt.Println(change.Content)
+	}
+	return nil
+}
+
+// newDiffCommand creates the diffCommand. If the revision is not specified, from revision will be 1 and
+// to revision will be head by default.
+func newDiffCommand(c *cli.Context, from, to string, style PrintStyle) (Command, error) {
+	repo, err := newRepositoryRequestInfoWithFromTo(c, from, to)
+	if err != nil {
+		return nil, err
+	}
+	return &diffCommand{repo: repo, style: style}, nil
+}

--- a/client/go/cmd/dogma/main.go
+++ b/client/go/cmd/dogma/main.go
@@ -1,0 +1,69 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package main
+
+import (
+	"os"
+
+	"github.com/line/centraldogma/client/go/cmd"
+	"github.com/urfave/cli"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "Central Dogma"
+	app.Usage = "Central Dogma client"
+	app.UsageText = "dogma command [arguments]"
+	app.HelpName = "dogma"
+	app.Version = "0.16.0"
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name: "connect, c",
+			Usage: "Specifies host or IP address with port to connect to:" +
+				"[hostname:port] or [http://hostname:port]",
+		},
+		cli.StringFlag{
+			Name:  "username, u",
+			Usage: "Specifies the username to log in as",
+		},
+		cli.StringFlag{
+			Name:  "token, t",
+			Usage: "Specifies the token to authenticate",
+		},
+	}
+
+	app.Commands = cmd.CLICommands()
+	app.HideVersion = true
+	cli.HelpFlag = cli.BoolFlag{
+		Name:  "help, h",
+		Usage: "Shows help",
+	}
+	cli.CommandHelpTemplate = commandHelpTemplate
+	app.Run(os.Args)
+}
+
+var commandHelpTemplate = `DESCRIPTION:
+   {{if .Usage}}{{.Usage}}{{end}}
+
+USAGE:
+   {{if .UsageText}}{{.UsageText}}{{else}}{{.HelpName}}{{if .VisibleFlags}} [command options]{{end}} {{if .ArgsUsage}}{{.ArgsUsage}}{{else}}[arguments...]{{end}}{{end}}{{if .Category}}
+
+CATEGORY:
+   {{.Category}}{{end}}{{if .VisibleFlags}}
+
+OPTIONS:
+   {{range .VisibleFlags}}{{.}}
+   {{end}}{{end}}
+`

--- a/client/go/cmd/edit_cmd.go
+++ b/client/go/cmd/edit_cmd.go
@@ -1,0 +1,124 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/line/centraldogma/client/go/util/commit"
+	"github.com/line/centraldogma/client/go/util/file"
+	"github.com/urfave/cli"
+)
+
+// An editCommand modifies the file of the specified path with the revision.
+type editFileCommand struct {
+	repo repositoryRequestInfo
+}
+
+func (ef *editFileCommand) execute(c *cli.Context) error {
+	repo := ef.repo
+	remoteFileEntry, err := getRemoteFileEntry(
+		c, repo.remote, repo.projectName, repo.repositoryName, repo.repositoryPath, repo.revision, "")
+	if err != nil {
+		return err
+	}
+	entry, err := editRemoteFileContent(remoteFileEntry.File)
+	if err != nil {
+		return err
+	}
+	entry.Type = remoteFileEntry.File.Type
+	entry.Path = remoteFileEntry.File.Path
+
+	commitMessage, err := commit.GetMessage(entry.Path, commit.Edit)
+	if err != nil {
+		return err
+	}
+
+	entryWithCommit := &json.EntryWithCommit{File: entry, CM: commitMessage}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(entryWithCommit)
+
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/files/revisions/" + repo.revision)
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/json"}}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusCreated {
+		return fmt.Errorf("cannot edit the file: /%s/%s%s revision: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.repositoryPath, repo.revision, res.Status)
+	}
+	fmt.Printf("Modified: /%s/%s%s\n", repo.projectName, repo.repositoryName, repo.repositoryPath)
+	return nil
+}
+
+func editRemoteFileContent(remote *json.Entry) (*json.Entry, error) {
+	tempFilePath, err := file.PutIntoTempFile(remote)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tempFilePath)
+
+	cmd := file.CmdToOpenEditor(tempFilePath)
+	if err = cmd.Start(); err != nil {
+		return nil, err
+	}
+	err = cmd.Wait()
+	if err != nil {
+		return nil, fmt.Errorf("failed to edit the file: %s", path.Base(remote.Path))
+	}
+
+	fd, err := os.Open(tempFilePath)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	buf, err := ioutil.ReadAll(fd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to edit the file: %s", path.Base(remote.Path))
+	}
+
+	if strings.EqualFold(remote.Type, "JSON") && !json.Valid(buf) {
+		return nil, fmt.Errorf("failed to edit the file: %s (not a valid JSON format)", path.Base(remote.Path))
+	}
+
+	return &json.Entry{Content: string(buf)}, nil
+}
+
+// newEditCommand creates the editCommand. If the revision is not specified, head will be set by default.
+func newEditCommand(c *cli.Context, revision string) (Command, error) {
+	if len(c.Args()) != 1 {
+		return nil, newCommandLineError(c)
+	}
+	repo, err := newRepositoryRequestInfo(c, revision, true)
+	if err != nil {
+		return nil, err
+	}
+	return &editFileCommand{repo: repo}, nil
+}

--- a/client/go/cmd/edit_cmd_test.go
+++ b/client/go/cmd/edit_cmd_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"flag"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestNewEditCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		revision  string
+		want      interface{}
+	}{
+		{[]string{"foo/bar/a.txt"}, "",
+			editFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/a.txt", revision: "head"}}},
+
+		{[]string{"foo/bar/b/a.txt"}, "10",
+			editFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/b/a.txt", revision: "10"}}},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newEditCommand(c, test.revision)
+		switch comType := got.(type) {
+		case *editFileCommand:
+			got2 := editFileCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newEditCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		default:
+			t.Errorf("newEditCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/get_cmd.go
+++ b/client/go/cmd/get_cmd.go
@@ -1,0 +1,134 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"regexp"
+	"strconv"
+
+	"github.com/urfave/cli"
+)
+
+// A getFileCommand fetches the content of the file in the specified path matched by the
+// <a href="https://github.com/json-path/JsonPath/blob/master/README.md">JSON path expressions</a>
+// with the specified revision.
+type getFileCommand struct {
+	repo          repositoryRequestInfo
+	localFilePath string
+	expression    string
+}
+
+func (ff *getFileCommand) execute(c *cli.Context) error {
+	return execute0(c, ff.repo, ff.localFilePath, ff.expression, saveAction)
+}
+
+// A catFileCommand shows the content of the file in the specified path matched by the
+// <a href="https://github.com/json-path/JsonPath/blob/master/README.md">JSON path expressions</a>
+// with the specified revision.
+type catFileCommand struct {
+	repo       repositoryRequestInfo
+	expression string
+}
+
+func (cf *catFileCommand) execute(c *cli.Context) error {
+	return execute0(c, cf.repo, "", cf.expression, printAction)
+}
+
+var saveAction = func(content, filePath string) error {
+	filePath = creatableFilePath(filePath, 1)
+	fd, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+	_, err = fd.WriteString(content)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Fetched: %s\n", path.Base(filePath))
+	return nil
+}
+
+func creatableFilePath(filePath string, inc int) string {
+	regex, _ := regexp.Compile("\\.[0-9]*$")
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		if inc == 1 {
+			filePath += "."
+		}
+		startIndex := regex.FindStringIndex(filePath)
+		filePath = filePath[0:startIndex[0]+1] + strconv.Itoa(inc)
+		inc++
+		return creatableFilePath(filePath, inc)
+	}
+	return filePath
+}
+
+var printAction = func(content, _ string) error {
+	fmt.Printf("%s\n", content)
+	return nil
+}
+
+func execute0(c *cli.Context, repo repositoryRequestInfo, localFilePath, expression string,
+	action func(content, filePath string) error) error {
+	entryWithRevision, err := getRemoteFileEntry(
+		c, repo.remote, repo.projectName, repo.repositoryName, repo.repositoryPath, repo.revision, expression)
+	if err != nil {
+		return err
+	}
+	if err = action(entryWithRevision.File.Content, localFilePath); err != nil {
+		return err
+	}
+	return nil
+}
+
+// newGetCommand creates the fetchCommand. If the localFilePath is not specified, the file name of the path
+// will be set by default. If the revision is not specified, head will be set by default.
+func newGetCommand(c *cli.Context, revision, expression string) (Command, error) {
+	if len(c.Args()) == 0 || len(c.Args()) > 2 {
+		return nil, newCommandLineError(c)
+	}
+
+	repo, err := newRepositoryRequestInfo(c, revision, true)
+	if err != nil {
+		return nil, err
+	}
+
+	localFilePath := ""
+	if len(c.Args()) == 2 {
+		localFilePath = c.Args().Get(1)
+		if len(localFilePath) == 0 {
+			return nil, newCommandLineError(c)
+		}
+	} else {
+		localFilePath = path.Base(repo.repositoryPath)
+	}
+
+	return &getFileCommand{repo: repo, localFilePath: localFilePath, expression: expression}, nil
+}
+
+// newCatCommand creates the catCommand. If the revision is not specified, head will be set by default.
+func newCatCommand(c *cli.Context, revision, expression string) (Command, error) {
+	if len(c.Args()) != 1 {
+		return nil, newCommandLineError(c)
+	}
+	repo, err := newRepositoryRequestInfo(c, revision, true)
+	if err != nil {
+		return nil, err
+	}
+	return &catFileCommand{repo: repo, expression: expression}, nil
+}

--- a/client/go/cmd/get_cmd_test.go
+++ b/client/go/cmd/get_cmd_test.go
@@ -1,0 +1,75 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"flag"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestNewGetCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		revision  string
+		want      interface{}
+	}{
+		{[]string{"foo/bar/a.txt"}, "",
+			getFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/a.txt", revision: "head"},
+				localFilePath: "a.txt"}},
+
+		{[]string{"foo/bar/b/a.txt"}, "10",
+			getFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/b/a.txt", revision: "10"},
+				localFilePath: "a.txt"}},
+
+		{[]string{"foo/bar/b/a.txt", "c.txt"}, "",
+			getFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/b/a.txt", revision: "head"},
+				localFilePath: "c.txt"}},
+
+		{[]string{"foo/bar/a.txt", "b/c.txt"}, "",
+			getFileCommand{repo: repositoryRequestInfo{
+				remote: defaultRemoteURI, projectName: "foo", repositoryName: "bar",
+				repositoryPath: "/a.txt", revision: "head"},
+				localFilePath: "b/c.txt"}},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newGetCommand(c, test.revision, "")
+		switch comType := got.(type) {
+		case *getFileCommand:
+			got2 := getFileCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newGetCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		default:
+			t.Errorf("newGetCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/log_cmd.go
+++ b/client/go/cmd/log_cmd.go
@@ -1,0 +1,68 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+type logCommand struct {
+	repo  repositoryRequestInfoWithFromTo
+	style PrintStyle
+}
+
+func (hc *logCommand) execute(c *cli.Context) error {
+	repo := hc.repo
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/history" + repo.repositoryPath)
+	values := url.Values{}
+	values.Set("from", repo.from)
+	values.Set("to", repo.to)
+	u.RawQuery = values.Encode()
+	req := &http.Request{Method: http.MethodGet, URL: u}
+
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot get the commit logs of /%s/%s%s from: %q, to: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.repositoryPath, repo.from, repo.to, res.Status)
+	}
+
+	commits := []json.Commit{}
+	if err = json.Fill(&commits, res.Body); err != nil {
+		return err
+	}
+	printWithStyle(commits, hc.style)
+	return nil
+}
+
+// newLogCommand creates the logCommand.
+func newLogCommand(c *cli.Context, from, to string, style PrintStyle) (Command, error) {
+	repo, err := newRepositoryRequestInfoWithFromTo(c, from, to)
+	if err != nil {
+		return nil, err
+	}
+	return &logCommand{repo: repo}, nil
+}

--- a/client/go/cmd/ls_cmds.go
+++ b/client/go/cmd/ls_cmds.go
@@ -1,0 +1,145 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+// An lsProjectCommand list all the projects on the remote Central Dogma server.
+type lsProjectCommand struct {
+	remote *url.URL
+	style  PrintStyle
+}
+
+func (lsp *lsProjectCommand) execute(c *cli.Context) error {
+	u, _ := url.Parse(lsp.remote.String() + "projects")
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return errors.New("cannot get the list of projects")
+	}
+
+	var data []json.Project
+	if err = json.Fill(&data, res.Body); err != nil {
+		return err
+	}
+	printWithStyle(data, lsp.style)
+	return nil
+}
+
+// An lsRepositoryCommand list all the repositories under the specified projectName
+// on the remote Central Dogma server.
+type lsRepositoryCommand struct {
+	remote      *url.URL
+	projectName string
+	style       PrintStyle
+}
+
+func (lsr *lsRepositoryCommand) execute(c *cli.Context) error {
+	u, _ := url.Parse(lsr.remote.String() + "projects/" + lsr.projectName + "/repositories")
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot get the list of repositories in %s", lsr.projectName)
+	}
+
+	var data []json.Repository
+	if err = json.Fill(&data, res.Body); err != nil {
+		return err
+	}
+	printWithStyle(data, lsr.style)
+	return nil
+}
+
+// An lsPathCommand list the specified path which is
+// {repo.projectName}/{repo.repositoryName}/{repo.repositoryPath} on the remote Central Dogma server.
+type lsPathCommand struct {
+	repo  repositoryRequestInfo
+	style PrintStyle
+}
+
+func (lsp *lsPathCommand) execute(c *cli.Context) error {
+	repo := lsp.repo
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/tree/revisions/" + repo.revision + repo.repositoryPath)
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot get the list of files in the /%s/%s%s revision: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.repositoryPath, repo.revision, res.Status)
+	}
+
+	data := []json.Entry{}
+	if err = json.Fill(&data, res.Body); err != nil {
+		return err
+	}
+	printWithStyle(data, lsp.style)
+	return nil
+}
+
+// newLSCommand creates one of the ls project, repository, and path commands according to the
+// command arguments from the CLI. If the revision is not specified, head will be set by default.
+func newLSCommand(c *cli.Context, revision string, style PrintStyle) (Command, error) {
+	remoteURI, err := getRemoteURI(c.Parent().String("host"))
+	if err != nil {
+		return nil, err
+	}
+	ca := c.Args()
+	if len(ca) > 1 {
+		return nil, newCommandLineError(c)
+	}
+
+	split := SplitPath(ca.First())
+	if len(split) == 0 {
+		return &lsProjectCommand{remote: remoteURI, style: style}, nil
+	}
+	if len(split) == 1 {
+		pName := split[0]
+		return &lsRepositoryCommand{remote: remoteURI, projectName: pName, style: style}, nil
+	}
+
+	// lsPathCommand from now on
+	repo := repositoryRequestInfo{
+		remote: remoteURI, projectName: split[0],
+		repositoryName: split[1], repositoryPath: "/", revision: "head"}
+	if len(split) == 3 {
+		repo.repositoryPath = split[2]
+	}
+	if len(revision) != 0 {
+		repo.revision = revision
+	}
+	return &lsPathCommand{repo: repo, style: style}, nil
+}

--- a/client/go/cmd/ls_cmds_test.go
+++ b/client/go/cmd/ls_cmds_test.go
@@ -1,0 +1,121 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"flag"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestNewLSCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		revision  string
+		want      interface{}
+	}{
+		{[]string{""}, "", lsProjectCommand{remote: defaultRemoteURI}},
+		{[]string{"/foo/"}, "", lsRepositoryCommand{remote: defaultRemoteURI, projectName: "foo"}},
+		{[]string{"foo/"}, "", lsRepositoryCommand{remote: defaultRemoteURI, projectName: "foo"}},
+		{[]string{"foo"}, "", lsRepositoryCommand{remote: defaultRemoteURI, projectName: "foo"}},
+		{[]string{"foo/bar"}, "",
+			lsPathCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/",
+					revision:       "head",
+				},
+			},
+		},
+		{[]string{"foo/bar/"}, "",
+			lsPathCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/",
+					revision:       "head",
+				},
+			},
+		},
+		{[]string{"foo/bar/a"}, "",
+			lsPathCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a",
+					revision:       "head",
+				},
+			},
+		},
+		{[]string{"foo/bar/a/"}, "100",
+			lsPathCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a/",
+					revision:       "100",
+				},
+			},
+		},
+		{[]string{"foo/bar/a.txt"}, "",
+			lsPathCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a.txt",
+					revision:       "head",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newLSCommand(c, test.revision, 0)
+		switch comType := got.(type) {
+		case *lsProjectCommand:
+			got2 := lsProjectCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newLSCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		case *lsRepositoryCommand:
+			got2 := lsRepositoryCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newLSCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		case *lsPathCommand:
+			got2 := lsPathCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newAddCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		default:
+			t.Errorf("newLSCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/new_cmds.go
+++ b/client/go/cmd/new_cmds.go
@@ -1,0 +1,192 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/line/centraldogma/client/go/util/commit"
+	"github.com/line/centraldogma/client/go/util/file"
+	"github.com/urfave/cli"
+)
+
+// An newProjectCommand creates a project with the specified projectName on the remote Central Dogma server.
+type newProjectCommand struct {
+	remote      *url.URL
+	projectName string
+}
+
+func (ap *newProjectCommand) execute(c *cli.Context) error {
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(json.Project{Name: ap.projectName})
+
+	u, _ := url.Parse(ap.remote.String() + "projects")
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/json"}}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusCreated {
+		return fmt.Errorf("cannot create %s project (status: %s)", ap.projectName, res.Status)
+	}
+	fmt.Printf("Created: /%s\n", ap.projectName)
+	return nil
+}
+
+// An newRepositoryCommand creates a repository with the specified repository name under the project
+// on the remote Central Dogma server.
+type newRepositoryCommand struct {
+	remote      *url.URL
+	projectName string
+	repository  *json.Repository
+}
+
+func (ar *newRepositoryCommand) execute(c *cli.Context) error {
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(ar.repository)
+
+	u, _ := url.Parse(ar.remote.String() + "projects/" + ar.projectName + "/repositories")
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/json"}}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusCreated {
+		return fmt.Errorf("cannot create %s in %s (status: %s)",
+			ar.repository.Name, ar.projectName, res.Status)
+	}
+	fmt.Printf("Created: /%s/%s\n", ar.projectName, ar.repository.Name)
+	return nil
+}
+
+func newNewCommand(c *cli.Context) (Command, error) {
+	ca := c.Args()
+	argLen := len(ca)
+	if argLen != 1 {
+		return nil, newCommandLineError(c)
+	}
+	remoteURI, err := getRemoteURI(c.Parent().String("host"))
+	if err != nil {
+		return nil, err
+	}
+
+	split := SplitPath(ca.First())
+	if len(split) == 1 {
+		return &newProjectCommand{remote: remoteURI, projectName: split[0]}, nil
+	}
+	if len(split) == 2 {
+		pName := split[0]
+		rName := split[1]
+		return &newRepositoryCommand{
+			remote: remoteURI, projectName: pName, repository: &json.Repository{Name: rName}}, nil
+	}
+
+	return nil, newCommandLineError(c)
+}
+
+// An putFileCommand puts a local file to the specified path which is
+// {repo.projectName}/{repo.repositoryName}/{repo.repositoryPath} on the remote Central Dogma server.
+// If the repositoryPath is not specified, the path will be / followed by the file name of the localFilePath.
+// If the repositoryPath ends with /, the file name of the localFilePath will be added to that /.
+// If the repositoryPath is specified with a file name, the file will be added as the specified name.
+type putFileCommand struct {
+	repo          repositoryRequestInfo
+	localFilePath string
+}
+
+func (af *putFileCommand) execute(c *cli.Context) error {
+	repo := af.repo
+	entry, err := file.NewEntry(af.localFilePath, repo.repositoryPath)
+	if err != nil {
+		return err
+	}
+	commitMessage, err := commit.GetMessage(af.localFilePath, commit.Add)
+	if err != nil {
+		return err
+	}
+
+	entryWithCommit := &json.EntryWithCommit{File: entry, CM: commitMessage}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(entryWithCommit)
+
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/files/revisions/" + repo.revision)
+
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/json"}}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		return fmt.Errorf("cannot put %s to /%s/%s%s revision: %q (status: %s)",
+			af.localFilePath, repo.projectName, repo.repositoryName,
+			repo.repositoryPath, repo.revision, res.Status)
+	}
+	fmt.Printf("Put: /%s/%s%s\n", repo.projectName, repo.repositoryName, repo.repositoryPath)
+	return nil
+}
+
+func newPutCommand(c *cli.Context, revision string) (Command, error) {
+	ca := c.Args()
+	argLen := len(ca)
+	if argLen != 2 {
+		return nil, newCommandLineError(c)
+	}
+	remoteURI, err := getRemoteURI(c.Parent().String("host"))
+	if err != nil {
+		return nil, err
+	}
+
+	split := SplitPath(ca.First())
+	if len(split) < 2 { // need at least projectName and repositoryName
+		return nil, newCommandLineError(c)
+	}
+
+	repo := repositoryRequestInfo{
+		remote: remoteURI, projectName: split[0], repositoryName: split[1], revision: "head"}
+	if len(revision) != 0 {
+		repo.revision = revision
+	}
+
+	fileName := ca.Get(1)
+	if len(fileName) == 0 {
+		return nil, newCommandLineError(c)
+	}
+
+	rPath := ""
+	if len(split) == 3 {
+		rPath = split[2]
+		if strings.HasSuffix(rPath, "/") {
+			rPath += path.Base(fileName)
+		}
+	} else {
+		rPath += "/" + path.Base(fileName)
+	}
+	repo.repositoryPath = rPath
+	return &putFileCommand{repo: repo, localFilePath: fileName}, nil
+}

--- a/client/go/cmd/new_cmds_test.go
+++ b/client/go/cmd/new_cmds_test.go
@@ -1,0 +1,193 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"flag"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+func TestNewNewCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		want      interface{}
+	}{
+		{[]string{"foo"}, newProjectCommand{remote: defaultRemoteURI, projectName: "foo"}},
+		{[]string{"/foo/"}, newProjectCommand{remote: defaultRemoteURI, projectName: "foo"}},
+		{[]string{"foo/bar"}, newRepositoryCommand{
+			remote:      defaultRemoteURI,
+			projectName: "foo",
+			repository:  &json.Repository{Name: "bar"}},
+		},
+		{[]string{"/foo/bar/"}, newRepositoryCommand{
+			remote:      defaultRemoteURI,
+			projectName: "foo",
+			repository:  &json.Repository{Name: "bar"}},
+		},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newNewCommand(c)
+		switch comType := got.(type) {
+		case *newProjectCommand:
+			got2 := newProjectCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newNewCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		case *newRepositoryCommand:
+			got2 := newRepositoryCommand(*comType)
+			want, _ := test.want.(newRepositoryCommand)
+			if !equalNewRepositoryCommand(got2, want) {
+				t.Errorf("newNewCommand(%q) = %q, want: %q", test.arguments, got2, want)
+			}
+		default:
+			t.Errorf("newNewCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}
+
+func equalNewRepositoryCommand(repo1 newRepositoryCommand, repo2 newRepositoryCommand) bool {
+	if repo1.projectName != repo2.projectName ||
+		repo1.repository.Name != repo2.repository.Name {
+		return false
+	}
+	return true
+}
+
+func TestNewAddCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		revision  string
+		want      interface{}
+	}{
+		{[]string{"foo/bar", "a.txt"}, "",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a.txt",
+					revision:       "head"},
+				localFilePath: "a.txt"},
+		},
+
+		{[]string{"foo/bar/b.txt", "a.txt"}, "",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/b.txt",
+					revision:       "head"},
+				localFilePath: "a.txt"},
+		},
+
+		{[]string{"foo/bar", "/Users/my/a.txt"}, "15",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a.txt",
+					revision:       "15"},
+				localFilePath: "/Users/my/a.txt"},
+		},
+
+		{[]string{"foo/bar", "Users/my/a.txt"}, "1",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/a.txt",
+					revision:       "1"},
+				localFilePath: "Users/my/a.txt"},
+		},
+
+		{[]string{"/foo/bar/", "./b.txt"}, "-1",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/b.txt",
+					revision:       "-1"},
+				localFilePath: "./b.txt"},
+		},
+
+		{[]string{"foo/bar/b.txt", "c.txt"}, "-100",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/b.txt",
+					revision:       "-100"},
+				localFilePath: "c.txt"},
+		},
+
+		{[]string{"foo/bar/d", "e.txt"}, "1",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/d",
+					revision:       "1"},
+				localFilePath: "e.txt"},
+		},
+
+		{[]string{"foo/bar/d/", "g.txt"}, "",
+			putFileCommand{
+				repo: repositoryRequestInfo{
+					remote:         defaultRemoteURI,
+					projectName:    "foo",
+					repositoryName: "bar",
+					repositoryPath: "/d/g.txt",
+					revision:       "head"},
+				localFilePath: "g.txt"},
+		},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newPutCommand(c, test.revision)
+		switch comType := got.(type) {
+		case *putFileCommand:
+			got2 := putFileCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newPutCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		default:
+			t.Errorf("newPutCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/normalize_cmd.go
+++ b/client/go/cmd/normalize_cmd.go
@@ -1,0 +1,71 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+type normalizeRevisionCommand struct {
+	repo repositoryRequestInfo
+}
+
+func (nr *normalizeRevisionCommand) execute(c *cli.Context) error {
+	repo := nr.repo
+	revision, err := getNormalizedRevision(c, repo)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("normalized revision: %q\n", revision.RevisionNumber)
+	return nil
+}
+
+func getNormalizedRevision(c *cli.Context, repo repositoryRequestInfo) (*json.Revision, error) {
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/revision/" + repo.revision)
+	req := &http.Request{Method: http.MethodGet, URL: u}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cannot normalize /%s/%s revision: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.revision, res.Status)
+	}
+	revision := &json.Revision{}
+	if err = json.Fill(revision, res.Body); err != nil {
+		return nil, err
+	}
+	return revision, nil
+}
+
+func newNormalizeCommand(c *cli.Context, revision string) (Command, error) {
+	if len(c.Args()) != 1 {
+		return nil, newCommandLineError(c)
+	}
+	repo, err := newRepositoryRequestInfo(c, revision, false)
+	if err != nil {
+		return nil, err
+	}
+	return &normalizeRevisionCommand{repo: repo}, nil
+}

--- a/client/go/cmd/normalize_cmd_test.go
+++ b/client/go/cmd/normalize_cmd_test.go
@@ -1,0 +1,67 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"flag"
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestNewNormalizeCommand(t *testing.T) {
+	defaultRemoteURI, _ := url.Parse("http://localhost:36462/api/v0/")
+
+	var tests = []struct {
+		arguments []string
+		revision  string
+		want      interface{}
+	}{
+		{[]string{"foo/bar"}, "",
+			normalizeRevisionCommand{repo: repositoryRequestInfo{
+				remote:         defaultRemoteURI,
+				projectName:    "foo",
+				repositoryName: "bar",
+				revision:       "head"}},
+		},
+
+		{[]string{"foo/bar/"}, "10",
+			normalizeRevisionCommand{repo: repositoryRequestInfo{
+				remote:         defaultRemoteURI,
+				projectName:    "foo",
+				repositoryName: "bar",
+				revision:       "10"}},
+		},
+	}
+
+	for _, test := range tests {
+		flags := flag.FlagSet{}
+		flags.Parse(test.arguments)
+		parent := cli.NewContext(nil, &flag.FlagSet{}, nil)
+		c := cli.NewContext(nil, &flags, parent)
+		got, _ := newNormalizeCommand(c, test.revision)
+		switch comType := got.(type) {
+		case *normalizeRevisionCommand:
+			got2 := normalizeRevisionCommand(*comType)
+			if !reflect.DeepEqual(got2, test.want) {
+				t.Errorf("newNormalizeCommand(%q) = %q, want: %q", test.arguments, got2, test.want)
+			}
+		default:
+			t.Errorf("newNormalizeCommand(%q) = %q, want: %q", test.arguments, got, test.want)
+		}
+	}
+}

--- a/client/go/cmd/rm_cmd.go
+++ b/client/go/cmd/rm_cmd.go
@@ -1,0 +1,74 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/line/centraldogma/client/go/util/commit"
+	"github.com/urfave/cli"
+)
+
+type rmFileCommand struct {
+	repo repositoryRequestInfo
+}
+
+func (rf *rmFileCommand) execute(c *cli.Context) error {
+	commitMessage, err := commit.GetMessage(rf.repo.repositoryPath, commit.Remove)
+	if err != nil {
+		return err
+	}
+	type data struct {
+		CM *json.CommitMessage `json:"commitMessage"`
+	}
+	buf := new(bytes.Buffer)
+	json.NewEncoder(buf).Encode(data{CM: commitMessage})
+	repo := rf.repo
+
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/delete/revisions/" + repo.revision + repo.repositoryPath)
+	req := &http.Request{Method: http.MethodPost, URL: u, Body: ioutil.NopCloser(buf)}
+	req.Header = http.Header{"Content-Type": {"application/json"}}
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot delete the file: /%s/%s%s revision: %q (status: %s)",
+			repo.projectName, repo.repositoryName, repo.repositoryPath, repo.revision, res.Status)
+	}
+	fmt.Printf("Deleted: /%s/%s%s\n", repo.projectName, repo.repositoryName, repo.repositoryPath)
+	return nil
+}
+
+func newRMCommand(c *cli.Context, revision string) (Command, error) {
+	if len(c.Args()) != 1 {
+		return nil, newCommandLineError(c)
+	}
+	repo, err := newRepositoryRequestInfo(c, revision, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rmFileCommand{repo: repo}, nil
+}

--- a/client/go/cmd/search_cmd.go
+++ b/client/go/cmd/search_cmd.go
@@ -1,0 +1,77 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/line/centraldogma/client/go/client"
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/urfave/cli"
+)
+
+type searchCommand struct {
+	repo  repositoryRequestInfo
+	term  string
+	style PrintStyle
+}
+
+func (sc *searchCommand) execute(c *cli.Context) error {
+	repo := sc.repo
+	u, _ := url.Parse(
+		repo.remote.String() + "projects/" + repo.projectName + "/repositories/" + repo.repositoryName +
+			"/search/revisions/" + repo.revision)
+	values := url.Values{}
+	values.Set("term", sc.term)
+	u.RawQuery = values.Encode()
+	req := &http.Request{Method: http.MethodGet, URL: u}
+
+	res, err := client.New().Do(req, c)
+	if err != nil {
+		return err
+	}
+
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("cannot find files matched by %q in /%s/%s with revision: %q (status: %s)",
+			sc.term, repo.projectName, repo.repositoryName, repo.revision, res.Status)
+	}
+	entries := []json.Entry{}
+	if err = json.Fill(&entries, res.Body); err != nil {
+		return err
+	}
+	printWithStyle(entries, sc.style)
+	return nil
+}
+
+func newSearchCommand(c *cli.Context, revision string, style PrintStyle) (Command, error) {
+	ca := c.Args()
+	if len(ca) == 0 || len(ca) > 2 {
+		return nil, newCommandLineError(c)
+	}
+
+	repo, err := newRepositoryRequestInfo(c, revision, false)
+	if err != nil {
+		return nil, err
+	}
+	term := "/"
+	if len(ca) != 0 {
+		term = ca.Get(1)
+	}
+
+	return &searchCommand{repo: repo, term: term, style: style}, nil
+}

--- a/client/go/json/json.go
+++ b/client/go/json/json.go
@@ -1,0 +1,111 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package json consists of the JSON transferable structs and JSON utilities.
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+)
+
+type Project struct {
+	Name    string   `json:"name"`
+	Schema  string   `json:"schema,omitempty"`
+	Plugins []string `json:"plugins,omitempty"`
+}
+
+type Repository struct {
+	Name string  `json:"name"`
+	Head *Commit `json:"head,omitempty"`
+}
+
+type Commit struct {
+	Rev       *Revision `json:"revision,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	Timestamp string    `json:"timestamp,omitempty"`
+	Summary   string    `json:"summary,omitempty"`
+	Detail    *Comment  `json:"detail,omitempty"`
+	Diffs     []Change  `json:"diffs,omitempty"`
+}
+
+type Revision struct {
+	Major          int    `json:"major"`
+	Minor          int    `json:"minor"`
+	RevisionNumber string `json:"revisionNumber"`
+}
+
+type Comment struct {
+	Content string `json:"content"`
+	Markup  string `json:"markup"`
+}
+
+type Change struct {
+	Path    string `json:"path"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+type EntryWithCommit struct {
+	File *Entry         `json:"file"`
+	CM   *CommitMessage `json:"commitMessage"`
+}
+
+type Entry struct {
+	Path    string `json:"path"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+}
+
+type CommitMessage struct {
+	Summary string   `json:"summary"`
+	Detail  *Comment `json:"detail"`
+}
+
+type EntryWithRevision struct {
+	File *Entry `json:"file"`
+	Rev  string `json:"revision"`
+}
+
+func Fill(data interface{}, resBody io.ReadCloser) error {
+	body, _ := ioutil.ReadAll(resBody)
+	err := json.Unmarshal([]byte(body), data)
+	return err
+}
+
+func MarshalIndent(data interface{}) ([]byte, error) {
+	return json.MarshalIndent(data, "", "    ")
+}
+
+func Marshal(data interface{}) ([]byte, error) {
+	return json.Marshal(data)
+}
+
+func NewEncoder(w io.Writer) *json.Encoder {
+	return json.NewEncoder(w)
+}
+
+func Valid(data []byte) bool {
+	return json.Valid(data)
+}
+
+func Indent(src []byte) (*bytes.Buffer, error) {
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, src, "", "    "); err != nil {
+		return nil, err
+	}
+	return &prettyJSON, nil
+}

--- a/client/go/service/constants.go
+++ b/client/go/service/constants.go
@@ -1,0 +1,22 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package service
+
+var (
+	DefaultScheme     = "http"
+	DefaultHostName   = "localhost"
+	DefaultPort       = 36462
+	DefaultPathPrefix = "/api/v0/"
+)

--- a/client/go/util/commit/commitutil.go
+++ b/client/go/util/commit/commitutil.go
@@ -1,0 +1,142 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package commit implements utilities that parse the input and make commit messages.
+package commit
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"html/template"
+	"os"
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/line/centraldogma/client/go/json"
+	"github.com/line/centraldogma/client/go/util/file"
+)
+
+type CommitType int
+
+const (
+	_ CommitType = iota
+	Add
+	Edit
+	Remove
+)
+
+var tempFileName = "commit-message.txt"
+
+func GetMessage(filePathToBeChanged string, commitType CommitType) (*json.CommitMessage, error) {
+	tempFilePath, fd, err := file.NewTemp(tempFileName)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tempFilePath)
+	tmpl, _ := template.New("").Parse(commitMessageTemplate)
+	tmpl.Execute(fd, typeWithFile{FilePath: filePathToBeChanged, CommitType: commitType})
+	fd.Close()
+	cmd := file.CmdToOpenEditor(tempFilePath)
+	if err = cmd.Start(); err != nil {
+		// Failed to launch the editor.
+		return messageFromCLI()
+	} else {
+		err = cmd.Wait()
+		if err != nil {
+			return nil, errors.New("failed to write the commit message")
+		}
+		return messageFrom(tempFilePath)
+	}
+}
+
+func messageFromCLI() (*json.CommitMessage, error) {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Print("Enter summary: ")
+	summary, _ := reader.ReadString('\n')
+
+	if len(summary) == 0 {
+		return nil, errors.New("you must input summary")
+	}
+	fmt.Print("\nEnter detailed comment: ")
+	content, _ := reader.ReadString('\n')
+	comment := &json.Comment{Content: content, Markup: "PLAINTEXT"}
+	commitMessage := &json.CommitMessage{Summary: summary, Detail: comment}
+	return commitMessage, nil
+}
+
+func messageFrom(filePath string) (*json.CommitMessage, error) {
+	fd, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	scanner := bufio.NewScanner(fd)
+
+	summary, err := getSummary(scanner)
+	if err != nil {
+		return nil, err
+	}
+	comment := &json.Comment{Content: getContent(scanner), Markup: "PLAINTEXT"}
+	commitMessage := &json.CommitMessage{Summary: summary, Detail: comment}
+	return commitMessage, nil
+}
+
+func getSummary(scanner *bufio.Scanner) (string, error) {
+	line := ""
+	for scanner.Scan() {
+		line = strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "#") && len(line) != 0 {
+			return line, nil
+		}
+	}
+	return "", errors.New("must input the summary")
+}
+
+func getContent(scanner *bufio.Scanner) string {
+	var buf bytes.Buffer
+	passedEmptyLinesUnderSummary := false
+	for scanner.Scan() {
+		line := strings.TrimRightFunc(scanner.Text(), unicode.IsSpace)
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		if len(line) == 0 && !passedEmptyLinesUnderSummary {
+			continue
+		} else {
+			passedEmptyLinesUnderSummary = true
+		}
+		buf.WriteString(line)
+		buf.WriteString("\n")
+	}
+	// remove trailing empty lines
+	regex, _ := regexp.Compile("\\n{2,}\\z")
+	return regex.ReplaceAllString(buf.String(), "")
+}
+
+type typeWithFile struct {
+	FilePath   string
+	CommitType CommitType
+}
+
+var commitMessageTemplate = `
+# Please enter the commit message for your changes. Lines starting\n
+# with '#' will be ignored, and an empty message aborts the commit.\n
+#
+# Changes to be committed:
+#   {{if eq .CommitType 1}}new file{{else if eq .CommitType 2}}modified{{else}}deleted{{end}}: {{.FilePath}}
+#
+`

--- a/client/go/util/file/fileutil.go
+++ b/client/go/util/file/fileutil.go
@@ -1,0 +1,129 @@
+// Copyright 2017 LINE Corporation
+//
+// LINE Corporation licenses this file to you under the Apache License,
+// version 2.0 (the "License"); you may not use this file except in compliance
+// with the License. You may obtain a copy of the License at:
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+// Package file implements file-related utilities such as creating a temp file, parsing netrc file, etc.
+package file
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/bgentry/go-netrc/netrc"
+	"github.com/line/centraldogma/client/go/json"
+)
+
+func NetrcInfo() *netrc.Machine {
+	if usr, err := user.Current(); err == nil {
+		netrcFilePath := usr.HomeDir + string(filepath.Separator)
+		if runtime.GOOS == "windows" {
+			netrcFilePath += "_netrc"
+		} else {
+			netrcFilePath += ".netrc"
+		}
+		if netrc, err := netrc.ParseFile(netrcFilePath); err == nil {
+			if machine := netrc.FindMachine("dogma"); machine != nil {
+				return machine
+			}
+		}
+	}
+	return nil
+}
+
+func CmdToOpenEditor(filePath string) *exec.Cmd {
+	editor := editor()
+	cmd := exec.Command(editor, filePath)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}
+
+func editor() string {
+	editor := os.Getenv("EDITOR")
+	if len(editor) != 0 {
+		return editor
+	}
+	out, err := exec.Command("git", "var", "GIT_EDITOR").Output()
+	if err == nil {
+		editor = strings.TrimSpace(string(out))
+		if len(editor) != 0 {
+			return editor
+		}
+	}
+	if strings.EqualFold(runtime.GOOS, "windows") {
+		return "start"
+	} else {
+		return "vim"
+	}
+}
+
+func NewTemp(tempFileName string) (string, *os.File, error) {
+	// TODO(minwoox) change to a file in a fixed place like git
+	tempFilePath := os.TempDir() + string(filepath.Separator) + tempFileName
+	fd, err := os.Create(tempFilePath)
+	if err != nil {
+		return "", nil, errors.New("failed to create a temp file")
+	}
+	return tempFilePath, fd, nil
+}
+
+func PutIntoTempFile(entry *json.Entry) (string, error) {
+	tempFilePath, fd, err := NewTemp(path.Base(entry.Path))
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+	if strings.EqualFold(entry.Type, "JSON") {
+
+		prettyJson, err := json.Indent([]byte(entry.Content))
+		if err == nil {
+			_, err = fd.WriteString(string(prettyJson.Bytes()))
+			return tempFilePath, nil
+		}
+	}
+	_, err = fd.WriteString(entry.Content)
+	return tempFilePath, nil
+}
+
+func NewEntry(fileName, repositoryPath string) (*json.Entry, error) {
+	fileInfo, err := os.Stat(fileName)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("%s does not exist\n", fileName)
+	}
+	if fileInfo.IsDir() {
+		return nil, fmt.Errorf("%s is a directory\n", fileName)
+	}
+
+	entry := &json.Entry{Path: repositoryPath}
+	buf, _ := ioutil.ReadFile(fileName)
+	content := string(buf)
+	if strings.HasSuffix(strings.ToLower(fileName), ".json") {
+		entry.Type = "JSON"
+		if !json.Valid(buf) {
+			return nil, fmt.Errorf("not a valid JSON file: %s", fileName)
+		}
+	} else {
+		entry.Type = "TEXT"
+	}
+	entry.Content = content
+	return entry, nil
+}

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -62,9 +62,17 @@ task copyLib(group: 'Build',
     }
 }
 
+task copyClientBinaries(group: 'Build',
+        description: "Copies client binaries into ${project.ext.relativeDistDir}/lib",
+        dependsOn: project(':client/go').tasks.build,
+        type: Copy) {
+    from project(':client/go').ext.binDir
+    into "${project.ext.distDir}/bin/native"
+}
+
 task distDir(group: 'Build',
              description: "Builds a distribution directory (${project.ext.relativeDistDir})",
-             dependsOn: [tasks.copyLicenses, tasks.copyLib])
+             dependsOn: [tasks.copyLicenses, tasks.copyLib, tasks.copyClientBinaries])
 
 // Create the tasks that copy each directory under src/ into dist/
 ['bin', 'conf'].each { dirName ->

--- a/dist/src/bin/dogma
+++ b/dist/src/bin/dogma
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+OS=`uname -s`
+MACH=`uname -m`
+
+DOGMA_BIN="$(dirname "$0")/native"
+
+if [[ "${OS}" == 'Darwin' ]]; then
+  if [[ "${MACH}" == 'x86_64' ]]; then
+    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin-amd64"
+  else
+    echo "32-bit OS is not supported by default: ${OS}-${MACH}"
+    exit 1
+  fi
+elif [[ "${OS}" == 'Linux' ]]; then
+  if [[ "${MACH}" == 'x86_64' ]]; then
+    DOGMA_BIN="${DOGMA_BIN}/dogma.linux-amd64"
+  else
+    echo "32-bit OS is not supported by default: ${OS}-${MACH}"
+    exit 1
+  fi
+else
+  echo "OS not supported: ${OS}-${MACH}"
+  exit 1
+fi
+
+exec "$DOGMA_BIN" "$@"
+

--- a/licenses/LICENSE.bgentry-go-netrc.mit.txt
+++ b/licenses/LICENSE.bgentry-go-netrc.mit.txt
@@ -1,0 +1,20 @@
+Original version Copyright © 2010 Fazlul Shahriar <fshahriar@gmail.com>. Newer
+portions Copyright © 2014 Blake Gentry <blakesgentry@gmail.com>.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/licenses/LICENSE.urfave-cli.mit.txt
+++ b/licenses/LICENSE.urfave-cli.mit.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 Jeremy Saenz & Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,9 @@ include 'common'
 include 'server'
 include 'testing'
 
+// Published Go project
+include 'client/go'
+
 // Unpublished Java projects
 include 'it'
 include 'shaded-test'


### PR DESCRIPTION
Motivation:
We need a command line client!

Modifications:
- Add a rest client to communicate with the Central Dogma Server

Result:
- We now, have a CLI Client!

Todos:
- Support pretty, simple, JSON print style
- Logging framework
- More unit tests
- Godoc
- Watcher
- Support `HEAD HEAD^ HEAD^^ HEAD^^^ HEAD^3` [revision-selection](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection)