### PR TITLE
Application token support, Part 1

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -122,6 +122,10 @@ This product contains a modified part of java-json-tools/json-patch, distributed
   * License: licenses/LICENSE.fge-json-patch.al20.txt (Apache License v2.0)
   * Homepage: https://github.com/java-json-tools/json-patch
 
+This product contains a modified part of Netty, distributed by Netty.io:
+
+  * License: licenses/LICENSE.netty.al20.txt (Apache License v2.0)
+  * Homepage: https://netty.io/
 
 Dependencies
 ============

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Jackson.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Jackson.java
@@ -161,6 +161,10 @@ public final class Jackson {
         return compactMapper.convertValue(fromValue, toValueType);
     }
 
+    public static <T> T convertValue(Object fromValue, TypeReference<?> toValueTypeRef) {
+        return compactMapper.convertValue(fromValue, toValueTypeRef);
+    }
+
     public static JsonGenerator createGenerator(Writer writer) throws IOException {
         return compactFactory.createGenerator(writer);
     }

--- a/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
@@ -17,7 +17,9 @@
 package com.linecorp.centraldogma.internal;
 
 import static com.linecorp.centraldogma.internal.Util.validateDirPath;
+import static com.linecorp.centraldogma.internal.Util.validateEmailAddress;
 import static com.linecorp.centraldogma.internal.Util.validateFilePath;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
@@ -91,6 +93,27 @@ public class UtilTest {
         assertDirPathValidationFailure("/\uAC00\uB098\uB2E4/"); // 가나다
     }
 
+    @Test
+    public void testValidEmailAddress() {
+        testValidEmail("dogma@github.com");
+        testValidEmail("dogma@127.0.0.1");
+        testValidEmail("dogma@10.1.1.1");
+        testValidEmail("dogma@0:0:0:0:0:0:0:1");
+        testValidEmail("dogma@::1");
+        testValidEmail("dogma@2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+        testValidEmail("dogma@2001:db8:85a3:0:0:8a2e:370:7334");
+        testValidEmail("dogma@2001:db8:85a3::8a2e:370:7334");
+
+        testInvalidEmail("dogma!@github.com");
+        testInvalidEmail("dogma@127.0.0.256");
+        testInvalidEmail("dogma@10.1.1");
+        testInvalidEmail("dogma@0:0:0:0:0:0:0:0:1");
+        testInvalidEmail("dogma@:::1");
+        testInvalidEmail("dogma@2001:0db8:85a3:0000:0000:8a2e:0370:733X");
+        testInvalidEmail("dogma@2001:db8:85a3:00:8a2e:370:7334");
+        testInvalidEmail("dogma@2001:db8:85a38a2e:370:7334");
+    }
+
     private static void assertFilePathValidationSuccess(String path) {
         validateFilePath(path, "path");
     }
@@ -115,5 +138,14 @@ public class UtilTest {
         } catch (IllegalArgumentException ignored) {
             // Expected
         }
+    }
+
+    private static void testValidEmail(String email) {
+        validateEmailAddress(email, "email");
+    }
+
+    private static void testInvalidEmail(String invalidEmail) {
+        assertThatThrownBy(() -> testValidEmail(invalidEmail))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/ApplicationTokenAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/ApplicationTokenAuthorizer.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.authentication;
+
+import static com.linecorp.armeria.common.util.Functions.voidFunction;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.AuthTokenExtractors;
+import com.linecorp.armeria.server.auth.Authorizer;
+import com.linecorp.armeria.server.auth.OAuth2Token;
+
+/**
+ * A decorator which finds an application token from a request and validates it.
+ */
+public class ApplicationTokenAuthorizer implements Authorizer<HttpRequest> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApplicationTokenAuthorizer.class);
+
+    private final Function<String, CompletionStage<Token>> tokenLookupFunc;
+
+    public ApplicationTokenAuthorizer(Function<String, CompletionStage<Token>> tokenLookupFunc) {
+        this.tokenLookupFunc = requireNonNull(tokenLookupFunc, "tokenLookupFunc");
+    }
+
+    @Override
+    public CompletionStage<Boolean> authorize(ServiceRequestContext ctx, HttpRequest data) {
+        final OAuth2Token token = AuthTokenExtractors.OAUTH2.apply(data.headers());
+        if (token == null) {
+            return completedFuture(true);
+        }
+
+        final CompletableFuture<Boolean> res = new CompletableFuture<>();
+        tokenLookupFunc.apply(token.accessToken())
+                       .thenAccept(appToken -> {
+                           final StringBuilder login = new StringBuilder(appToken.appId());
+                           final SocketAddress ra = ctx.remoteAddress();
+                           if (ra instanceof InetSocketAddress) {
+                               login.append('@').append(((InetSocketAddress) ra).getHostString());
+                           }
+
+                           final User user = new User(login.toString(), User.USER_ROLE);
+                           AuthenticationUtil.setCurrentUser(ctx, user);
+                           res.complete(true);
+                       })
+                       // Should be authorized by the next authorizer.
+                       .exceptionally(voidFunction(cause -> {
+                           logger.debug("Application token authorization failed: {}",
+                                        token.accessToken(), cause);
+                           res.complete(false);
+                       }));
+
+        return res;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/AuthenticationUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/AuthenticationUtil.java
@@ -41,7 +41,7 @@ public final class AuthenticationUtil {
         final User user = ctx.attr(CURRENT_USER_KEY).get();
         assert user != null;
         return user == User.DEFAULT ? Author.DEFAULT
-                                    : new Author(user.getName(), user.getEmail());
+                                    : new Author(user.name(), user.email());
     }
 
     public static Author currentAuthor() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionTokenAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionTokenAuthorizer.java
@@ -35,11 +35,11 @@ import com.linecorp.armeria.server.auth.OAuth2Token;
  * A decorator to check whether the request holds a valid token. If it holds a valid token, this
  * decorator would find a session belonging to the token and attach it to the service context attributes.
  */
-public class CentralDogmaTokenAuthorizer implements Authorizer<HttpRequest> {
+public class SessionTokenAuthorizer implements Authorizer<HttpRequest> {
 
     private final SecurityManager securityManager;
 
-    public CentralDogmaTokenAuthorizer(SecurityManager securityManager) {
+    public SessionTokenAuthorizer(SecurityManager securityManager) {
         this.securityManager = requireNonNull(securityManager, "securityManager");
     }
 
@@ -56,8 +56,10 @@ public class CentralDogmaTokenAuthorizer implements Authorizer<HttpRequest> {
                 final Subject currentUser =
                         new Subject.Builder(securityManager).sessionId(token.accessToken())
                                                             .buildSubject();
-                if (currentUser != null) {
-                    final User user = new User(currentUser.getPrincipal().toString(), User.USER_ROLE);
+                final Object principal = currentUser != null ? currentUser.getPrincipal()
+                                                             : null;
+                if (principal != null) {
+                    final User user = new User(principal.toString(), User.USER_ROLE);
                     AuthenticationUtil.setCurrentUser(ctx, user);
                 }
             } finally {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/Token.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.authentication;
+
+import static java.util.Objects.requireNonNull;
+
+import java.text.ParseException;
+import java.text.ParsePosition;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.util.ISO8601Utils;
+import com.google.common.base.MoreObjects;
+
+@JsonInclude(Include.NON_NULL)
+public final class Token {
+
+    public static final Token EMPTY_TOKEN =
+            new Token(null, null, null, null, null);
+
+    private final String appId;
+    private final String secret;
+    private final User creator;
+    private final Date creationTime;
+    private String creationTimeAsText;
+
+    @JsonCreator
+    public Token(@JsonProperty("appId") String appId,
+                 @JsonProperty("secret") String secret,
+                 @JsonProperty("creator") User creator,
+                 @JsonProperty("creationTime") String creationTimeAsText) throws ParseException {
+        this(requireNonNull(appId, "appId"),
+             requireNonNull(secret, "secret"),
+             requireNonNull(creator, "creator"),
+             ISO8601Utils.parse(requireNonNull(creationTimeAsText, "creationTimeAsText"),
+                                new ParsePosition(0)),
+             creationTimeAsText);
+    }
+
+    public Token(String appId, String secret, User creator, Date creationTime) {
+        this(requireNonNull(appId, "appId"),
+             requireNonNull(secret, "secret"),
+             requireNonNull(creator, "creator"),
+             requireNonNull(creationTime, "creationTime"),
+             null);
+    }
+
+    private Token(String appId, String secret, User creator,
+                  Date creationTime, String creationTimeAsText) {
+        this.appId = appId;
+        this.secret = secret;
+        this.creator = creator;
+        this.creationTime = creationTime;
+        this.creationTimeAsText = creationTimeAsText;
+    }
+
+    @JsonProperty
+    public String appId() {
+        return appId;
+    }
+
+    @JsonProperty
+    public String secret() {
+        return secret;
+    }
+
+    @JsonProperty
+    public User creator() {
+        return creator;
+    }
+
+    @JsonProperty
+    public String creationTime() {
+        if (creationTimeAsText == null) {
+            creationTimeAsText = ISO8601Utils.format(creationTime);
+        }
+        return creationTimeAsText;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("appId", appId())
+                          .add("creator", creator())
+                          .add("creationTime", creationTime())
+                          .toString();
+    }
+
+    /**
+     * Returns a new {@link Token} instance without its secret.
+     */
+    public Token withoutSecret() {
+        return new Token(appId, null, creator, creationTime, creationTimeAsText);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/User.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/User.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.Serializable;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -60,36 +62,35 @@ public class User implements Serializable {
         this.roles = roles;
     }
 
-    public String getLogin() {
+    @JsonCreator
+    public User(@JsonProperty("login") String login,
+                @JsonProperty("name") String name,
+                @JsonProperty("email") String email,
+                @JsonProperty("roles") List<String> roles) {
+        this.login = requireNonNull(login, "login");
+        this.name = requireNonNull(name, "name");
+        this.email = requireNonNull(email, "email");
+        this.roles = ImmutableList.copyOf(requireNonNull(roles, "roles"));
+    }
+
+    @JsonProperty
+    public String login() {
         return login;
     }
 
-    public void setLogin(String login) {
-        this.login = login;
-    }
-
-    public List<String> getRoles() {
-        return roles;
-    }
-
-    public void setRoles(List<String> roles) {
-        this.roles = roles;
-    }
-
-    public String getName() {
+    @JsonProperty
+    public String name() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getEmail() {
+    @JsonProperty
+    public String email() {
         return email;
     }
 
-    public void setEmail(String email) {
-        this.email = email;
+    @JsonProperty
+    public List<String> roles() {
+        return roles;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/AbstractService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/AbstractService.java
@@ -38,15 +38,15 @@ class AbstractService {
         this.executor = requireNonNull(executor, "executor");
     }
 
-    protected final ProjectManager projectManager() {
+    final ProjectManager projectManager() {
         return projectManager;
     }
 
-    protected final CommandExecutor executor() {
+    final CommandExecutor executor() {
         return executor;
     }
 
-    protected <T> CompletableFuture<T> execute(Command<T> command) {
+    <T> CompletableFuture<T> execute(Command<T> command) {
         return executor().execute(command);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.service;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.internal.command.Command;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+
+/**
+ * A utility class which provides common functions for a repository.
+ */
+final class RepositoryUtil {
+
+    static CompletableFuture<?> push(AbstractService service,
+                                     String projectName, String repositoryName,
+                                     Revision revision, Author author,
+                                     String commitSummary, String commitDetail, Markup commitMarkup,
+                                     Change<?> change) {
+        return service
+                .projectManager()
+                .get(projectName).repos().get(repositoryName)
+                .normalize(revision)
+                .thenCompose(normalizedRevision ->
+                                     push0(service, projectName, repositoryName, revision, author,
+                                           commitSummary, commitDetail, commitMarkup, change));
+    }
+
+    private static CompletableFuture<?> push0(AbstractService service,
+                                              String projectName, String repositoryName,
+                                              Revision normalizedRev, Author author,
+                                              String commitSummary, String commitDetail, Markup commitMarkup,
+                                              Change<?> change) {
+        final CompletableFuture<Map<String, Change<?>>> f = normalizeChanges(
+                service.projectManager(), projectName, repositoryName, normalizedRev, ImmutableList.of(change));
+
+        return f.thenCompose(
+                changes -> service.execute(
+                        Command.push(projectName, repositoryName, normalizedRev, author,
+                                     commitSummary, commitDetail, commitMarkup, changes.values())));
+    }
+
+    private static CompletableFuture<Map<String, Change<?>>> normalizeChanges(
+            ProjectManager projectManager, String projectName, String repositoryName, Revision baseRevision,
+            Iterable<Change<?>> changes) {
+        return projectManager
+                .get(projectName).repos().get(repositoryName)
+                .previewDiff(baseRevision, changes);
+    }
+
+    private RepositoryUtil() {}
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.service;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.centraldogma.internal.Util.validateFileName;
+import static com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil.requireLogin;
+import static com.linecorp.centraldogma.server.internal.admin.authentication.Token.EMPTY_TOKEN;
+import static com.linecorp.centraldogma.server.internal.admin.service.RepositoryUtil.push;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.TOKEN_REPOSITORY_NAME;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.common.collect.Maps;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.annotation.Delete;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
+import com.linecorp.centraldogma.server.internal.admin.authentication.Token;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+
+/**
+ * Annotated service object for managing application tokens.
+ */
+public class TokenService extends AbstractService {
+
+    private static final String TOKEN_JSON_PATH = "/token.json";
+    private static final String SECRET_PREFIX = "appToken-";
+
+    private static final TypeReference<Map<String, Token>>
+            TOKEN_MAP_TYPE_REFERENCE = new TypeReference<Map<String, Token>>() {};
+
+    public TokenService(ProjectManager projectManager, CommandExecutor executor) {
+        super(projectManager, executor);
+    }
+
+    /**
+     * GET /tokens
+     * Returns the list of the tokens generated before.
+     */
+    @Get("/tokens")
+    public CompletionStage<Collection<Token>> listTokens() {
+        requireLogin();
+        return getTokens(Revision.HEAD)
+                .thenApply(Map::values)
+                .thenApply(tokens -> {
+                    final List<Token> withoutSecrets = new ArrayList<>();
+                    tokens.forEach(token -> withoutSecrets.add(token.withoutSecret()));
+                    return Collections.unmodifiableList(withoutSecrets);
+                });
+    }
+
+    /**
+     * POST /tokens
+     * Returns a newly-generated token belonging to the current login user.
+     */
+    @Post("/tokens")
+    public CompletionStage<Token> createToken(@Param("appId") String appId) {
+        requireLogin();
+        validateFileName(appId, "appId");
+        return projectManager()
+                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
+                .normalize(Revision.HEAD)
+                .thenCompose(revision -> {
+                    final Token token =
+                            new Token(appId, SECRET_PREFIX + UUID.randomUUID(),
+                                      AuthenticationUtil.currentUser(), new Date());
+                    return createToken0(revision, token);
+                });
+    }
+
+    private CompletionStage<Token> createToken0(Revision revision, Token newToken) {
+        return getTokens(revision).thenCompose(entries -> {
+            final boolean exist = entries.values().stream().anyMatch(
+                    token -> token.appId().equals(newToken.appId()));
+            if (exist) {
+                // TODO(hyangtack) Would send 409 conflict when the following PR is merged.
+                // https://github.com/line/armeria/pull/746
+                throw new HttpResponseException(HttpStatus.CONFLICT);
+            }
+
+            entries.put(newToken.secret(), newToken);
+            final User user = AuthenticationUtil.currentUser();
+            final String summary = user.name() + " generates a token: " + newToken.appId();
+            return updateTokens(revision, entries, summary).thenApply(unused -> newToken);
+        });
+    }
+
+    /**
+     * DELETE /tokens/{id}
+     * Deletes a token of the specified ID then returns it.
+     */
+    @Delete("/tokens/{id}")
+    public CompletionStage<Token> deleteToken(@Param("id") String id) {
+        requireLogin();
+        return projectManager()
+                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
+                .normalize(Revision.HEAD)
+                .thenCompose(revision -> deleteToken0(revision, id));
+    }
+
+    private CompletionStage<Token> deleteToken0(Revision revision, String id) {
+        return getTokens(revision).thenCompose(entries -> {
+            final Optional<Token> target = entries.values().stream()
+                                                  .filter(v -> id.equals(v.appId()))
+                                                  .findAny();
+            if (target.isPresent()) {
+                final Token token = target.get();
+                entries.remove(token.secret());
+                final User user = AuthenticationUtil.currentUser();
+                final String summary = user.name() + " deletes a token: " + token.appId();
+                return updateTokens(revision, entries, summary).thenApply(unused -> token);
+            } else {
+                return CompletableFuture.completedFuture(EMPTY_TOKEN);
+            }
+        });
+    }
+
+    /**
+     * Finds a token of the specified secret.
+     */
+    public CompletionStage<Token> findToken(String secret) {
+        checkArgument(secret != null && secret.startsWith(SECRET_PREFIX),
+                      "Secret should start with " + SECRET_PREFIX + "'");
+        return projectManager()
+                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
+                .get(Revision.HEAD, Query.ofJsonPath(TOKEN_JSON_PATH, "$." + secret))
+                .thenApply(result -> {
+                    if (result.isRemoved() ||
+                        result.type() != EntryType.JSON) {
+                        return null;
+                    }
+                    return Jackson.convertValue(result.content(), Token.class);
+                });
+    }
+
+    private CompletionStage<Map<String, Token>> getTokens(Revision revision) {
+        final CompletableFuture<Map<String, Token>> future = new CompletableFuture<>();
+        projectManager()
+                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
+                .get(revision, TOKEN_JSON_PATH)
+                .thenAccept(entry -> future.complete(convert(entry)))
+                .exceptionally(cause -> {
+                    future.complete(Maps.newHashMap());
+                    return null;
+                });
+        return future;
+    }
+
+    private CompletionStage<?> updateTokens(Revision revision, Map<String, Token> tokens,
+                                            String summary) {
+        return push(this, INTERNAL_PROJECT_NAME, TOKEN_REPOSITORY_NAME, revision,
+                    AuthenticationUtil.currentAuthor(), summary, "",
+                    Markup.PLAINTEXT, Change.ofJsonUpsert(TOKEN_JSON_PATH, Jackson.valueToTree(tokens)));
+    }
+
+    private static Map<String, Token> convert(Entry<?> entry) {
+        if (entry.type() == EntryType.JSON) {
+            return Jackson.convertValue(entry.content(), TOKEN_MAP_TYPE_REFERENCE);
+        } else {
+            return Maps.newHashMap();
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.generateSampleFiles;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_MAIN;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 
@@ -39,7 +40,7 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         final CompletableFuture<Void> f = delegate().execute(c);
         return f.thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_META)))
                 .thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_MAIN)))
-                .thenCompose(unused -> SampleGenerator.generate(delegate(), projectName, REPO_MAIN))
+                .thenCompose(unused -> generateSampleFiles(delegate(), projectName, REPO_MAIN))
                 .thenApply(unused -> null);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.project;
 
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -116,8 +117,7 @@ public class SafeProjectManager implements ProjectManager {
     }
 
     protected static boolean isValidProjectName(String name) {
-        // TODO "dogma" will be replaced with SystemRepository.INTERNAL_PROJECT_NAME after merging
-        // https://github.com/line/centraldogma/pull/13.
-        return name != null && !"dogma".equals(name);
+        return name != null &&
+               !INTERNAL_PROJECT_NAME.equals(name);
     }
 }

--- a/server/src/main/resources/webapp/i18n/en.main.json
+++ b/server/src/main/resources/webapp/i18n/en.main.json
@@ -5,13 +5,12 @@
   },
 
   "navbar": {
-    "entities": "Entities",
     "home": "Home",
     "language": "Language",
     "login": "Log in",
     "logout": "Log out",
-    "projects": "Projects",
-    "user": "User"
+    "user": "User",
+    "tokens": "Application Tokens"
   },
 
   "login": {
@@ -72,5 +71,25 @@
     "title_create_repository": "Create a repository",
     "title_delete_file": "Delete {{path}}?",
     "unsupported_file_type": "Unsupported file type: {{type}}"
+  },
+
+  "settings": {
+    "button_cancel": "Cancel",
+    "button_close": "Close",
+    "button_create_token": "Create a token",
+    "button_delete": "Delete",
+    "button_delete_token": "Delete",
+    "button_generate": "Generate",
+    "button_invalidate_token": "Invalidate",
+    "deleted_token": "Application token '{{path}}' has been deleted.",
+    "title_delete_token": "Delete application token {{token}}?",
+    "title_generate_token": "Generate a new application token",
+    "title_token_generated": "Application token generated",
+    "token_application_id": "Application ID",
+    "token_application_id.exist": "Application ID '{{appId}}' exists. Please try a different ID again.",
+    "token_application_id.placeholder": "Your application name",
+    "token_creation_time": "Created At",
+    "token_creator": "Created By",
+    "token_secret": "Secret"
   }
 }

--- a/server/src/main/resources/webapp/index.html
+++ b/server/src/main/resources/webapp/index.html
@@ -63,6 +63,7 @@
 <script src="scripts/components/auth/provider/auth.session.service.js"></script>
 <script src="scripts/components/entities/project.service.js"></script>
 <script src="scripts/components/entities/repository.service.js"></script>
+<script src="scripts/components/entities/settings.service.js"></script>
 <script src="scripts/components/hostname/hostname.service.js"></script>
 <script src="scripts/components/language/language.service.js"></script>
 <script src="scripts/components/language/language.controller.js"></script>
@@ -87,6 +88,12 @@
 <script src="scripts/app/entities/projects/project.new.controller.js"></script>
 <script src="scripts/app/entities/projects/projects.js"></script>
 <script src="scripts/app/entities/projects/projects.controller.js"></script>
+<script src="scripts/app/settings/setting.js"></script>
+<script src="scripts/app/settings/tokens/token.delete.controller.js"></script>
+<script src="scripts/app/settings/tokens/token.generated.controller.js"></script>
+<script src="scripts/app/settings/tokens/token.new.controller.js"></script>
+<script src="scripts/app/settings/tokens/tokens.js"></script>
+<script src="scripts/app/settings/tokens/tokens.controller.js"></script>
 <script src="scripts/app/entities/repositories/repository.new.controller.js"></script>
 <script src="scripts/app/entities/repositories/repository.tree.controller.js"></script>
 <script src="scripts/app/entities/repositories/repository.file.controller.js"></script>

--- a/server/src/main/resources/webapp/scripts/app/settings/setting.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/setting.js
@@ -1,0 +1,9 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').config(function ($stateProvider) {
+  $stateProvider.state('setting', {
+    abstract: true,
+    parent: 'site',
+    url: "/settings"
+  });
+});

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.delete.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.delete.controller.js
@@ -1,0 +1,34 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').controller('TokenDeleteController',
+  function ($scope, $uibModalInstance, token, StringUtil, SettingsService) {
+
+    $scope.token = token;
+    $scope.message = {
+      summary: '',
+      detail: {
+        content: '',
+        markup: 'PLAINTEXT'
+      }
+    };
+
+    $scope.deleteToken = function () {
+      if (StringUtil.isEmpty($scope.message.summary)) {
+        $scope.message.summary = 'Delete ' + $scope.token;
+      }
+
+      SettingsService.deleteToken($scope.token.appId).then(
+        function () {
+          $uibModalInstance.close({
+            translationId: 'settings.deleted_token',
+            interpolateParams: {path: $scope.id}
+          });
+        }, function (error) {
+          $uibModalInstance.dismiss(error.message);
+        });
+    };
+
+    $scope.cancel = function () {
+      $uibModalInstance.dismiss('');
+    };
+  });

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.delete.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.delete.html
@@ -1,0 +1,24 @@
+<form name="deleteTokenForm" ng-submit="deleteToken()" novalidate>
+  <div class="modal-header">
+    <h4 class="modal-title">{{ 'settings.title_delete_token' | translate: "{ token: '" + token.appId + "' }"
+      }}</h4>
+  </div>
+  <div class="modal-body">
+    <div class="form-group"
+         ng-class="{ 'has-error': deleteTokenForm.messageSummary.$invalid && !deleteTokenForm.messageSummary.$pristine }">
+      <label for="messageSummary" translate>entities.commit_summary</label>
+      <input id="messageSummary" name="messageSummary" type="text" class="form-control"
+             ng-model="message.summary" placeholder="Delete {{token.appId}}" />
+    </div>
+    <div class="form-group">
+      <label for="messageDetail" translate>entities.commit_detail</label>
+      <textarea id="messageDetail" class="form-control" data-ng-model="message.detail.content"></textarea>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="submit" class="btn btn-danger" data-ng-disabled="deleteTokenForm.$invalid" translate>
+      settings.button_delete
+    </button>
+    <button type="button" class="btn" ng-click="cancel()" translate>settings.button_cancel</button>
+  </div>
+</form>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.controller.js
@@ -1,0 +1,9 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').controller('TokenGeneratedController',
+  function ($scope, $timeout, $uibModalInstance, newToken) {
+    $scope.newToken = newToken;
+    $scope.close = function () {
+      $uibModalInstance.close();
+    };
+  });

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.html
@@ -1,0 +1,32 @@
+<div id="openModal" class="modal-dialog">
+  <div class="modal-header">
+    <h4 class="modal-title" translate>settings.title_token_generated</h4>
+  </div>
+  <div class="modal-body">
+    <table class="table table-hover table-responsive">
+      <tbody>
+      <tr>
+        <td><span translate>settings.token_application_id</span></td>
+        <td>{{newToken.appId}}</td>
+      </tr>
+      <tr>
+        <td><span translate>settings.token_secret</span></td>
+        <td>{{newToken.secret}}</td>
+      </tr>
+      <tr>
+        <td><span translate>settings.token_creator</span></td>
+        <td>{{newToken.creator.email}}</td>
+      </tr>
+      <tr>
+        <td><span translate>settings.token_created_time</span></td>
+        <td>{{newToken.creationTimeStr}}</td>
+      </tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="modal-footer">
+    <button ng-click="close()" class="btn btn-primary" translate>
+      settings.button_close
+    </button>
+  </div>
+</div>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.controller.js
@@ -1,0 +1,25 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').controller('TokenNewController',
+  function ($scope, $timeout, $uibModal, $uibModalInstance, $filter, SettingsService, NotificationUtil) {
+
+    $scope.generateToken = function () {
+      var data = 'appId=' + encodeURIComponent($scope.appId);
+
+      SettingsService.createToken(data).then(function (token) {
+        $scope.newToken = token;
+        $scope.newToken.creationTimeStr = moment(token.creationTime).fromNow();
+        $uibModalInstance.close($scope.newToken);
+      }, function (error) {
+        if (typeof error.status !== 'undefined' && error.status === 409) {
+          NotificationUtil.error('settings.token_application_id.exist', {appId: $scope.appId});
+        } else {
+          NotificationUtil.error(error);
+        }
+      });
+    };
+
+    $scope.close = function () {
+      $uibModalInstance.close();
+    };
+  });

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.html
@@ -1,0 +1,19 @@
+<form name="genTokenForm" ng-submit="generateToken()">
+  <div class="modal-header">
+    <h4 class="modal-title" translate>settings.title_generate_token</h4>
+  </div>
+  <div class="modal-body">
+    <div class="form-group">
+      <label for="appId" translate>settings.token_application_id</label>
+      <input type="text" class="form-control" id="appId"
+             placeholder="{{ 'settings.token_application_id.placeholder' | translate }}" ng-model="appId"
+             required>
+    </div>
+  </div>
+  <div class="modal-footer">
+    <button type="submit" class="btn btn-primary" ng-disabled="genTokenForm.$invalid" translate>
+      settings.button_generate
+    </button>
+    <button type="button" class="btn" ng-click="close()" translate>settings.button_cancel</button>
+  </div>
+</form>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.controller.js
@@ -1,0 +1,78 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').controller('TokensController',
+  function ($scope, $uibModal, SettingsService) {
+
+    var refresh = function () {
+      SettingsService.listTokens().then(
+        function (tokens) {
+          var i;
+          for (i in tokens) {
+            tokens[i].creationTimeStr = moment(tokens[i].creationTime).fromNow();
+          }
+          $scope.tokens = tokens;
+        }
+      );
+    };
+
+    $scope.selectedToken = null;
+
+    $scope.selectToken = function (token) {
+      if (token === $scope.selectedToken) {
+        $scope.selectedToken = null;
+      } else {
+        $scope.selectedToken = token;
+      }
+    };
+
+    $scope.showGenerateTokenDialog = function () {
+      var modalInstance = $uibModal.open({
+        templateUrl: 'scripts/app/settings/tokens/token.new.html',
+        controller: 'TokenNewController',
+        backdrop: 'static'
+      });
+      modalInstance.result.then(
+        function (newToken) {
+          if (angular.isDefined(newToken)) {
+            $scope.newToken = newToken;
+            $scope.showTokenGeneratedDialog();
+          }
+        });
+    };
+
+    $scope.showTokenGeneratedDialog = function () {
+      var modalInstance = $uibModal.open({
+        templateUrl: 'scripts/app/settings/tokens/token.generated.html',
+        controller: 'TokenGeneratedController',
+        backdrop: 'static',
+        resolve: {
+          newToken: function () {
+            return $scope.newToken;
+          }
+        }
+      });
+      modalInstance.result.then(
+        function () {
+          refresh();
+        }
+      )
+    };
+
+    $scope.showDeleteTokenDialog = function () {
+      var modalInstance = $uibModal.open({
+        templateUrl: 'scripts/app/settings/tokens/token.delete.html',
+        controller: 'TokenDeleteController',
+        resolve: {
+          token: function () {
+            return $scope.selectedToken;
+          }
+        }
+      });
+      modalInstance.result.then(
+        function () {
+          refresh();
+        });
+    };
+
+    refresh();
+  });

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -1,0 +1,34 @@
+<div ng-cloak>
+  <h2>Application Tokens</h2>
+
+  <table class="table table-hover table-responsive">
+    <thead>
+    <tr>
+      <th><span translate>settings.token_application_id</span></th>
+      <th><span translate>settings.token_creator</span></th>
+      <th><span translate>settings.token_creation_time</span></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr ng-repeat="token in tokens" ng-click="selectToken(token)" ng-class="{info: token === selectedToken}">
+      <td>{{token.appId}}</td>
+      <td>{{token.creator.email}}</td>
+      <td>{{token.creationTimeStr}}</td>
+    </tr>
+    </tbody>
+  </table>
+
+  <hr />
+
+  <div class="row">
+    <div class="pull-right" has-role="ROLE_USER">
+      <a ng-click="showGenerateTokenDialog()" type="button" class="btn btn-primary">
+        <span class="glyphicon glyphicon-plus"></span> {{ 'settings.button_create_token' | translate }}
+      </a>
+      <button class="btn btn-danger"
+              data-ng-disabled="selectedToken == null" ng-click="showDeleteTokenDialog()">
+        <span class="glyphicon glyphicon-remove"></span> {{ 'settings.button_delete_token' | translate }}
+      </button>
+    </div>
+  </div>
+</div>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.js
@@ -1,0 +1,15 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin').config(function ($stateProvider) {
+  $stateProvider.state('tokens', {
+    parent: 'setting',
+    url: '/tokens',
+    data: {},
+    views: {
+      'content@': {
+        templateUrl: 'scripts/app/settings/tokens/tokens.html',
+        controller: 'TokensController'
+      }
+    }
+  });
+});

--- a/server/src/main/resources/webapp/scripts/app/user/login/login.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/user/login/login.controller.js
@@ -16,7 +16,7 @@ angular.module('CentralDogmaAdmin')
                         interpolateParams: { username: $scope.username }
                       });
                     }, function (error) {
-                      if (typeof error.status !== 'undefined' && error.status == 401) {
+                      if (typeof error.status !== 'undefined' && error.status === 401) {
                         NotificationUtil.error('login.auth_failed');
                       } else {
                         NotificationUtil.error(error);

--- a/server/src/main/resources/webapp/scripts/components/entities/settings.service.js
+++ b/server/src/main/resources/webapp/scripts/components/entities/settings.service.js
@@ -1,0 +1,23 @@
+'use strict';
+
+angular.module('CentralDogmaAdmin')
+        .factory('SettingsService',
+  function (ApiService) {
+    return {
+      listTokens: function () {
+        return ApiService.get('tokens');
+      },
+
+      createToken: function (data) {
+        return ApiService.post('tokens', data, {
+          headers: {
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        });
+      },
+
+      deleteToken: function (id) {
+        return ApiService.delete('tokens/' + id);
+      }
+    };
+  });

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
@@ -21,20 +21,6 @@
             <span translate>navbar.home</span>
           </a>
         </li>
-        <li ui-sref-active="active" class="dropdown pointer">
-          <a href="" class="dropdown-toggle" data-toggle="dropdown">
-            <span>
-              <span class="glyphicon glyphicon-th-list"></span>
-              <span class="hidden-tablet" translate>navbar.entities</span>
-              <b class="caret"></b>
-            </span>
-          </a>
-          <ul class="dropdown-menu">
-            <li ui-sref-active="active">
-              <a ui-sref="projects"><span translate>navbar.projects</span></a>
-            </li>
-          </ul>
-        </li>
         <li ng-switch-when="false" ng-show="isSecurityEnabled">
           <a href="" ng-click="$root.showLoginDialog()">
             <span class="glyphicon glyphicon-log-in"></span>&#xA0;
@@ -50,6 +36,9 @@
             </span>
           </a>
           <ul class="dropdown-menu">
+            <li ui-sref-active="active" ng-switch-when="true">
+              <a ui-sref="tokens"><span translate>navbar.tokens</span></a>
+            </li>
             <li ui-sref-active="active" ng-switch-when="true">
               <a href="" ng-click="logout()">
                 <span class="glyphicon glyphicon-log-out"></span>&#xA0;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/authentication/CentralDogmaSessionDAOTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/authentication/CentralDogmaSessionDAOTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.admin.authentication;
 
 import static com.linecorp.centraldogma.server.internal.admin.authentication.CentralDogmaSessionDAO.CACHE_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.initializeInternalProject;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
@@ -77,6 +78,7 @@ public class CentralDogmaSessionDAOTest {
                 rootDir.newFolder(), ForkJoinPool.commonPool(), null);
         final CommandExecutor executor = new StandaloneCommandExecutor(pm, ForkJoinPool.commonPool());
         executor.start(null, null);
+        initializeInternalProject(executor);
 
         final CentralDogmaSessionDAO dao = new CentralDogmaSessionDAO(pm, executor);
         try (SafeCloseable ignored = RequestContext.push(ctx, false)) {
@@ -123,6 +125,7 @@ public class CentralDogmaSessionDAOTest {
                 rootDir.newFolder(), ForkJoinPool.commonPool(), null);
         final CommandExecutor executor = new StandaloneCommandExecutor(pm, ForkJoinPool.commonPool());
         executor.start(null, null);
+        initializeInternalProject(executor);
 
         final CentralDogmaSessionDAO dao = spy(new CentralDogmaSessionDAO(pm, executor));
         final MemoryConstrainedCacheManager cacheManager = new MemoryConstrainedCacheManager();


### PR DESCRIPTION
Motivation:

There has been no way to protect API calls from unprivileged clients until now. So we decided to add an application token in order to solve the problem. An application token may help a user to protect their Central Dogma server from unprivileged clients. This PR is the first step which protects RESTful APIs.

Modifications:

- Add application tokens management page to web admin
- Protect restful API by an application token or a session token

TO-DOs:

- Fix Central Dogma client to support an application token
- ~Protect thrift service by an application token~