### PR TITLE
Prevent accessing internal project from unprivileged requests

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
@@ -32,6 +32,7 @@ import com.linecorp.centraldogma.server.internal.admin.dto.ProjectDto;
 import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectManager;
 
 /**
  * Annotated service object for managing projects.
@@ -40,7 +41,7 @@ public class ProjectService extends AbstractService {
 
     public ProjectService(ProjectManager projectManager,
                           CommandExecutor executor) {
-        super(projectManager, executor);
+        super(new SafeProjectManager(projectManager), executor);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -63,6 +63,7 @@ import com.linecorp.centraldogma.server.internal.admin.exception.BadRequestExcep
 import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 
@@ -79,7 +80,7 @@ public class RepositoryService extends AbstractService {
 
     public RepositoryService(ProjectManager projectManager,
                              CommandExecutor executor) {
-        super(projectManager, executor);
+        super(new SafeProjectManager(projectManager), executor);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
@@ -27,6 +27,7 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.internal.admin.authentication.User;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectManager;
 
 /**
  * Annotated service object for managing users.
@@ -35,7 +36,7 @@ public class UserService extends AbstractService {
 
     public UserService(ProjectManager projectManager,
                        CommandExecutor executor) {
-        super(projectManager, executor);
+        super(new SafeProjectManager(projectManager), executor);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.project;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+/**
+ * A wrapper class of {@link ProjectManager} which prevents accessing internal projects
+ * from unprivileged requests.
+ */
+public class SafeProjectManager implements ProjectManager {
+
+    private final ProjectManager delegate;
+
+    public SafeProjectManager(ProjectManager delegate) {
+        this.delegate = requireNonNull(delegate, "delegate");
+    }
+
+    @Override
+    public CacheStats cacheStats() {
+        return delegate().cacheStats();
+    }
+
+    @Override
+    public void close() {
+        delegate().close();
+    }
+
+    @Override
+    public boolean exists(String name) {
+        validateProjectName(name);
+        return delegate().exists(name);
+    }
+
+    @Override
+    public Project get(String name) {
+        validateProjectName(name);
+        return delegate().get(name);
+    }
+
+    @Override
+    public Project getOrCreate(String name) {
+        validateProjectName(name);
+        return delegate().getOrCreate(name);
+    }
+
+    @Override
+    public Project create(String name) {
+        validateProjectName(name);
+        return delegate().create(name);
+    }
+
+    @Override
+    public Map<String, Project> list() {
+        final Map<String, Project> list = delegate().list();
+        final Map<String, Project> ret = new LinkedHashMap<>(list.size());
+        for (Map.Entry<String, Project> entry : list.entrySet()) {
+            if (isValidProjectName(entry.getValue().name())) {
+                ret.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(ret);
+    }
+
+    @Override
+    public Set<String> listRemoved() {
+        return delegate().listRemoved();
+    }
+
+    @Override
+    public void remove(String name) {
+        validateProjectName(name);
+        delegate().remove(name);
+    }
+
+    @Override
+    public Project unremove(String name) {
+        validateProjectName(name);
+        return delegate().unremove(name);
+    }
+
+    @Override
+    public void ensureOpen() {
+        delegate().ensureOpen();
+    }
+
+    protected final ProjectManager delegate() {
+        return delegate;
+    }
+
+    protected static void validateProjectName(String name) {
+        if (!isValidProjectName(name)) {
+            throw new IllegalArgumentException("Illegal access to project '" + name + "'");
+        }
+    }
+
+    protected static boolean isValidProjectName(String name) {
+        // TODO "dogma" will be replaced with SystemRepository.INTERNAL_PROJECT_NAME after merging
+        // https://github.com/line/centraldogma/pull/13.
+        return name != null && !"dogma".equals(name);
+    }
+}


### PR DESCRIPTION
Motivation:

“dogma” project which is used to store application tokens and session information must not be allowed to access via user requests.

Modifications:

- Add SafeProjectManager class to wrap a ProjectManager instance

To-Dos:

- Change a constant string after https://github.com/line/centraldogma/pull/13 is merged