### PR TITLE
Fix startup script name in Dockerfile

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -28,4 +28,4 @@ COPY build/dist/licenses/*  "$CENTRALDOGMA_HOME"/licenses/
 # Expose ports.
 EXPOSE 36462
 
-CMD ["sh", "-c", "${CENTRALDOGMA_HOME}/bin/startup.sh"]
+CMD ["sh", "-c", "${CENTRALDOGMA_HOME}/bin/startup"]

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -111,7 +111,11 @@ task docker(group: 'Build',
             dependsOn: tasks.distDir,
             type: DockerBuildImage) {
     inputDir = file('.')
-    tag = "line/centraldogma:${project.version}"
+    def name = 'line/centraldogma:'
+    tags = [name + "${project.version}"]
+    if (!(project.version =~ /-SNAPSHOT$/)) {
+        tags.add(name + "latest")
+    }
 }
 
 // Tasks for running Central Dogma conveniently.

--- a/site/src/sphinx/client-cli.rst
+++ b/site/src/sphinx/client-cli.rst
@@ -9,8 +9,8 @@ so the client is available regardless of your current working directory.
 .. note::
 
     In this tutorial, we assume your Central Dogma server is running at ``localhost:36462``. Unless specified,
-    ``dogma`` will connect to ``localhost:36462`` by default. Use the ``--host`` option to connect to other
-    Central Dogma server. e.g. ``--host dogma.example.com:36462``
+    ``dogma`` will connect to ``localhost:36462`` by default. Use the ``--connect`` option to connect to other
+    Central Dogma server. e.g. ``--connect dogma.example.com:36462``
 
 Path syntax
 -----------

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -30,6 +30,10 @@ With Central Dogma, you can:
     $ bin/startup
     # Open http://127.0.0.1:36462/ in your browser for administrative console.
 
+Using Docker? Give our image a try::
+
+    $ docker run -p 36462:36462 line/centraldogma
+
 Repository service for textual configuration
 --------------------------------------------
 - Primarily designed for storing JSON

--- a/site/src/sphinx/setup-installation.rst
+++ b/site/src/sphinx/setup-installation.rst
@@ -60,3 +60,11 @@ To stop the server, use the ``bin/shutdown`` script:
     You can also tail the log file::
 
         $ ./gradlew tail
+
+Running on Docker
+-----------------
+You can also pull Central Dogma image from `Docker Hub <https://hub.docker.com/r/line/centraldogma>`_
+and then run it on your Docker::
+
+    $ docker run -p 36462:36462 line/centraldogma
+


### PR DESCRIPTION
Modifications:

- Change startup script name
- Add ‘latest’ tag to docker image
- Add how to run docker image