### PR TITLE
Add the central dogma version to Go client automatically using gogradle

### DIFF
--- a/client/go/build.gradle
+++ b/client/go/build.gradle
@@ -39,8 +39,11 @@ build.dependsOn check
 build {
     targetPlatform = ['linux-amd64', 'darwin-amd64', 'windows-amd64']
 
-    go "build -o ${project.ext.binDir}" +
+    def ldflags = "\"-X main.version=${version} -X main.shortHash=${rootProject.ext.repoStatus.shortCommitHash}\""
+
+    go "build -ldflags=${ldflags} -o ${project.ext.binDir}" +
             '/dogma.${GOOS}-${GOARCH}${GOEXE} github.com/line/centraldogma/client/go/cmd/dogma'
+
     doLast {
         ant.chmod(file: "$project.ext.binDir" + '/dogma.windows-amd64.exe', perm: '644')
     }

--- a/client/go/cmd/dogma/main.go
+++ b/client/go/cmd/dogma/main.go
@@ -21,13 +21,18 @@ import (
 	"github.com/urfave/cli"
 )
 
+var (
+	version   = "unspecified"
+	shortHash = "unspecified"
+)
+
 func main() {
 	app := cli.NewApp()
 	app.Name = "Central Dogma"
 	app.Usage = "Central Dogma client"
 	app.UsageText = "dogma command [arguments]"
 	app.HelpName = "dogma"
-	app.Version = "0.17.0"
+	app.Version = version + " (" + shortHash + ")"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name: "connect, c",
@@ -45,7 +50,6 @@ func main() {
 	}
 
 	app.Commands = cmd.CLICommands()
-	app.HideVersion = true
 	cli.HelpFlag = cli.BoolFlag{
 		Name:  "help, h",
 		Usage: "Shows help",


### PR DESCRIPTION
So, the releaser does not have to change the version again.