### PR TITLE
Suppress unexpected 401 unauthorized notification when security is disabled

### DIFF
--- a/server/src/main/resources/webapp/scripts/app/app.js
+++ b/server/src/main/resources/webapp/scripts/app/app.js
@@ -37,7 +37,14 @@ angular.module(
              $rootScope.toState = toState;
              $rootScope.toStateParams = toStateParams;
 
-             Principal.refresh();
+             if (angular.isUndefined($rootScope.isSecurityEnabled)) {
+               Auth.isEnabled().then(function (data) {
+                 $rootScope.isSecurityEnabled = data;
+                 Principal.refresh();
+               });
+             } else {
+               Principal.refresh();
+             }
 
              // Update the language
              Language.getCurrent().then(function (language) {

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
@@ -7,14 +7,6 @@ angular.module('CentralDogmaAdmin')
 
                   $scope.isAuthenticated = Principal.isAuthenticated;
 
-                  Auth.isEnabled().then(function (data) {
-                    $scope.isSecurityEnabled = data;
-
-                    if (!$scope.isSecurityEnabled) {
-                      $window.sessionStorage.setItem('sessionId', "anonymous");
-                    }
-                  });
-
                   Hostname.get().then(function (data) {
                     $scope.hostname = data;
                   });

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
@@ -21,13 +21,13 @@
             <span translate>navbar.home</span>
           </a>
         </li>
-        <li ng-switch-when="false" ng-show="isSecurityEnabled">
+        <li ng-switch-when="false" ng-show="$root.isSecurityEnabled">
           <a href="" ng-click="$root.showLoginDialog()">
             <span class="glyphicon glyphicon-log-in"></span>&#xA0;
             <span translate>navbar.login</span>
           </a>
         </li>
-        <li class="dropdown pointer" ng-show="$root.user && isSecurityEnabled">
+        <li class="dropdown pointer" ng-show="$root.user && $root.isSecurityEnabled">
           <a href="" class="dropdown-toggle" data-toggle="dropdown">
             <span>
               <span class="glyphicon glyphicon-user"></span>

--- a/server/src/main/resources/webapp/scripts/components/util/api.service.js
+++ b/server/src/main/resources/webapp/scripts/components/util/api.service.js
@@ -1,8 +1,9 @@
 'use strict';
 
 angular.module('CentralDogmaAdmin')
-    .factory('ApiService', function ($http, $q, $window, StringUtil, NotificationUtil, CentralDogmaConstant) {
+    .factory('ApiService', function ($rootScope, $http, $q, $window, StringUtil, NotificationUtil, CentralDogmaConstant) {
                function makeRequest(verb, uri, config, data) {
+                 var sessionId;
                  var defer = $q.defer();
 
                  if (angular.isUndefined(config)) {
@@ -12,7 +13,11 @@ angular.module('CentralDogmaAdmin')
                  config.method = verb;
                  config.url = rewriteUri(uri);
 
-                 var sessionId = $window.sessionStorage.getItem('sessionId');
+                 if ($rootScope.isSecurityEnabled) {
+                   sessionId = $window.sessionStorage.getItem('sessionId');
+                 } else {
+                   sessionId = "anonymous";
+                 }
                  if (sessionId !== null) {
                    if (angular.isUndefined(config.headers)) {
                      config.headers = {};

--- a/site/src/sphinx/known-issues.rst
+++ b/site/src/sphinx/known-issues.rst
@@ -17,8 +17,3 @@ Known issues
   - Consider enforcing network-level access control over Thrift calls.
   - Note that the Thrift RPC layer is left only for backward compatibility, and will be removed in the future,
     in favor of the REST API.
-
-- 401 unauthorized notification may be shown when web administrative console is first loaded with security
-  disabled. Please ignore the notification; it's purely a cosmetic issue and you can access everything
-  without logging in.
-


### PR DESCRIPTION
Motivation:

401 unauthorized notification may be shown when web administrative console is first loaded with security disabled.

Modifications:

- Set ‘$rootScope.isSecurityEnabled’ before refreshing a user principal
- Do not put ‘sessionId’ into session storage if security is disabled; checking ‘$rootScope.isSecurityEnabled’ instead