### PR TITLE
Fix flaky test: GitRepositoryTest.testEmptyCommitWithRedundantRenames

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -401,7 +401,7 @@ public class GitRepositoryTest {
     @Test
     public void testEmptyCommitWithRedundantRenames() throws Exception {
         // Create a file to produce redundant changes.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]);
+        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
 
         // Ensure redundant changes do not count as a valid change.
         assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,


### PR DESCRIPTION
Fixes #29