### PR TITLE
Lower the log level of the expected exceptions to DEBUG

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -770,36 +770,7 @@ configure(javaProjects) {
                     printBuffer = true
                 } else {
                     def lines = buf.readLines().findAll { it =~ /(?:Exception|Error|Throwable|LEAK):/ }
-
-                    // Ignore the expected exceptions.
-                    lines.removeIf { it.matches(/.*Anticipated(?:Exception|Error|Throwable):.*/) }
-
-                    // Ignore known false positives.
                     lines.removeIf { it.contains('Only supported on Linux') }
-                    switch (td.className) {
-                        case 'com.linecorp.armeria.client.Http2ClientSettingsTest':
-                            lines.removeIf { it.contains('Frame length: 32769 exceeds maximum: 32768') }
-                            break
-                        case 'com.linecorp.armeria.client.zookeeper.EndpointGroupTest':
-                            lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
-                            break
-                        case 'com.linecorp.armeria.common.stream.StreamMessageDuplicatorTest':
-                            if (td.name.contains('abort')) {
-                                lines.removeIf {
-                                    it.contains('com.linecorp.armeria.common.stream.AbortedStreamException')
-                                }
-                            }
-                            break
-                        case 'com.linecorp.armeria.server.AnnotatedServiceTest':
-                            lines.removeIf { it.contains('For input string: "fourty-two"') }
-                            break
-                        case 'com.linecorp.armeria.server.zookeeper.ZooKeeperRegistrationTest':
-                            lines.removeIf { it.contains('ServerCnxn$EndOfStreamException') }
-                            lines.removeIf { it.contains('KeeperException$ConnectionLossException') }
-                            lines.removeIf { it.contains('ZooKeeperException: Failed to notify ZooKeeper listener') }
-                            break
-                    }
-
                     printBuffer = !lines.isEmpty()
                 }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/RevisionNormalizationTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RevisionNormalizationTest.java
@@ -17,8 +17,8 @@
 package com.linecorp.centraldogma.it;
 
 import static com.linecorp.centraldogma.internal.thrift.ErrorCode.REVISION_NOT_FOUND;
+import static com.linecorp.centraldogma.testing.internal.ExpectedExceptionAppender.assertThatThrownByWithExpectedException;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.concurrent.CompletionException;
 
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaException;
+import com.linecorp.centraldogma.server.internal.storage.repository.RevisionNotFoundException;
 
 public class RevisionNormalizationTest {
 
@@ -49,8 +50,8 @@ public class RevisionNormalizationTest {
     @Test
     public void testAbsoluteMajorOutOfRange() throws Exception {
         final Revision outOfRange = new Revision(Integer.MAX_VALUE, 0);
-        assertThatThrownBy(
-                () -> rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
+        assertThatThrownByWithExpectedException(RevisionNotFoundException.class, "2147483647", () ->
+                rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(CentralDogmaException.class)
                 .matches(e -> ((CentralDogmaException) e.getCause()).getErrorCode() == REVISION_NOT_FOUND);
     }
@@ -68,8 +69,8 @@ public class RevisionNormalizationTest {
     @Test
     public void testRelativeMajorOutOfRange() throws Exception {
         final Revision outOfRange = new Revision(Integer.MIN_VALUE, 0);
-        assertThatThrownBy(
-                () -> rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
+        assertThatThrownByWithExpectedException(RevisionNotFoundException.class, "-2147483648", () ->
+                rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(CentralDogmaException.class)
                 .matches(e -> ((CentralDogmaException) e.getCause()).getErrorCode() == REVISION_NOT_FOUND);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -125,7 +125,6 @@ public class ZooKeeperCommandExecutorTest {
         } finally {
             replica1.rm.stop();
             replica2.rm.stop();
-            replica3.rm.stop();
             if (newReplica3 != null) {
                 newReplica3.rm.stop();
             }

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -5,4 +5,5 @@ managedDependencies {
     compile 'junit:junit'
     compile 'org.assertj:assertj-core'
     compile 'net.javacrumbs.json-unit:json-unit-fluent'
+    compile 'ch.qos.logback:logback-classic'
 }

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ExpectedExceptionAppender.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ExpectedExceptionAppender.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.testing.internal;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.slf4j.Marker;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.LoggerContextVO;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.spi.AppenderAttachable;
+import ch.qos.logback.core.spi.AppenderAttachableImpl;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+import io.netty.util.internal.logging.Slf4JLoggerFactory;
+
+/**
+ * A <a href="https://logback.qos.ch/">Logback</a> {@link Appender} that adds {@code "(expected exception)"}
+ * to the log messages of expected exceptions and lower their logging level to {@link Level#DEBUG}
+ * if it's higher than that.
+ */
+public class ExpectedExceptionAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
+        implements AppenderAttachable<ILoggingEvent> {
+
+    private static final String EXPECTED_EXCEPTION = "(expected exception)";
+
+    private static final ConcurrentMap<String, String> exceptionAndMessage = new ConcurrentHashMap<>();
+
+    static {
+        if (InternalLoggerFactory.getDefaultFactory() == null) {
+            // Can happen due to initialization order.
+            InternalLoggerFactory.setDefaultFactory(Slf4JLoggerFactory.INSTANCE);
+        }
+    }
+
+    private final AppenderAttachableImpl<ILoggingEvent> aai = new AppenderAttachableImpl<>();
+
+    /**
+     * Adds {@code "(expected exception)"} to the log message and lower its logging level to
+     * {@link Level#DEBUG} if the exception occurred from the {@code shouldRaiseThrowable} matches
+     * {@code throwable} and contains {@code message}.
+     */
+    public static AbstractThrowableAssert<?, ? extends Throwable> assertThatThrownByWithExpectedException(
+            Class<?> throwable, String message, ThrowingCallable shouldRaiseThrowable) throws Exception {
+        requireNonNull(throwable, "throwable");
+        requireNonNull(message, "message");
+        requireNonNull(shouldRaiseThrowable, "shouldRaiseThrowable");
+        exceptionAndMessage.put(throwable.getName(), message);
+        try {
+            return assertThatThrownBy(shouldRaiseThrowable);
+        } finally {
+            exceptionAndMessage.remove(throwable.getName());
+        }
+    }
+
+    @Override
+    protected void append(ILoggingEvent eventObject) {
+        final IThrowableProxy exception = getException(eventObject);
+        for (String exceptionName : exceptionAndMessage.keySet()) {
+            if (exception != null && exception.getClassName().endsWith(exceptionName) &&
+                containsMessage(exception, exceptionName)) {
+                aai.appendLoopOnAppenders(new ExpectedExceptionEventWrapper(eventObject));
+                return;
+            }
+        }
+        aai.appendLoopOnAppenders(eventObject);
+    }
+
+    private IThrowableProxy getException(ILoggingEvent event) {
+        final IThrowableProxy throwableProxy = event.getThrowableProxy();
+        if (throwableProxy != null) {
+            final IThrowableProxy cause = throwableProxy.getCause();
+            if (cause != null) {
+                return cause;
+            }
+        }
+        return null;
+    }
+
+    private boolean containsMessage(IThrowableProxy exception, String exceptionName) {
+        final String message = exception.getMessage();
+        if (message != null && message.contains(exceptionAndMessage.get(exceptionName))) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void start() {
+        if (!aai.iteratorForAppenders().hasNext()) {
+            addWarn("No appender was attached to " + getClass().getSimpleName() + '.');
+        }
+        super.start();
+    }
+
+    @Override
+    public void stop() {
+        try {
+            aai.detachAndStopAllAppenders();
+        } finally {
+            super.stop();
+        }
+    }
+
+    @Override
+    public void addAppender(Appender<ILoggingEvent> newAppender) {
+        aai.addAppender(newAppender);
+    }
+
+    @Override
+    public Iterator<Appender<ILoggingEvent>> iteratorForAppenders() {
+        return aai.iteratorForAppenders();
+    }
+
+    @Override
+    public Appender<ILoggingEvent> getAppender(String name) {
+        return aai.getAppender(name);
+    }
+
+    @Override
+    public boolean isAttached(Appender<ILoggingEvent> appender) {
+        return aai.isAttached(appender);
+    }
+
+    @Override
+    public void detachAndStopAllAppenders() {
+        aai.detachAndStopAllAppenders();
+    }
+
+    @Override
+    public boolean detachAppender(Appender<ILoggingEvent> appender) {
+        return aai.detachAppender(appender);
+    }
+
+    @Override
+    public boolean detachAppender(String name) {
+        return aai.detachAppender(name);
+    }
+
+    @FunctionalInterface
+    public interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    private static final class ExpectedExceptionEventWrapper implements ILoggingEvent {
+        private final ILoggingEvent event;
+
+        ExpectedExceptionEventWrapper(ILoggingEvent event) {
+            this.event = event;
+        }
+
+        @Override
+        public Object[] getArgumentArray() {
+            return event.getArgumentArray();
+        }
+
+        @Override
+        public Level getLevel() {
+            if (event.getLevel().levelInt <= Level.DEBUG_INT) {
+                return event.getLevel();
+            }
+            return Level.DEBUG;
+        }
+
+        @Override
+        public String getLoggerName() {
+            return event.getLoggerName();
+        }
+
+        @Override
+        public String getThreadName() {
+            return event.getThreadName();
+        }
+
+        @Override
+        public IThrowableProxy getThrowableProxy() {
+            return event.getThrowableProxy();
+        }
+
+        @Override
+        public void prepareForDeferredProcessing() {
+            event.prepareForDeferredProcessing();
+        }
+
+        @Override
+        public LoggerContextVO getLoggerContextVO() {
+            return event.getLoggerContextVO();
+        }
+
+        @Override
+        public String getMessage() {
+            return EXPECTED_EXCEPTION + event.getMessage();
+        }
+
+        @Override
+        public long getTimeStamp() {
+            return event.getTimeStamp();
+        }
+
+        @Override
+        public StackTraceElement[] getCallerData() {
+            return event.getCallerData();
+        }
+
+        @Override
+        public boolean hasCallerData() {
+            return event.hasCallerData();
+        }
+
+        @Override
+        public Marker getMarker() {
+            return event.getMarker();
+        }
+
+        @Override
+        public String getFormattedMessage() {
+            return EXPECTED_EXCEPTION + event.getFormattedMessage();
+        }
+
+        @Override
+        public Map<String, String> getMDCPropertyMap() {
+            return event.getMDCPropertyMap();
+        }
+
+        @Override
+        public Map<String, String> getMdc() {
+            return event.getMdc();
+        }
+
+        @Override
+        public String toString() {
+            return event.toString();
+        }
+    }
+}

--- a/testing-internal/src/main/resources/logback-test.xml
+++ b/testing-internal/src/main/resources/logback-test.xml
@@ -6,12 +6,16 @@
     </encoder>
   </appender>
 
+  <appender name="EEA" class="com.linecorp.centraldogma.testing.internal.ExpectedExceptionAppender">
+    <appender-ref ref="CONSOLE"/>
+  </appender>
+
   <logger name="com.linecorp" level="DEBUG" />
   <logger name="com.linecorp.centraldogma.server.internal.admin.logging.LoggingAspect" level="INFO" />
 
   <logger name="io.netty" level="INFO" />
 
   <root level="WARN">
-    <appender-ref ref="CONSOLE" />
+    <appender-ref ref="EEA" />
   </root>
 </configuration>


### PR DESCRIPTION
Motivation:
Even though the expected exceptions during unit tests are literally expected, they are shown as
`WARN` level so can give some confuse to us.

Modification:
- Add `(expected exception)` and  lower the log level to `DEBUG` using `ExpectedExceptionAppender`

Result:
- Can distinguish the expected exceptions from unexpected ones