### PR TITLE
Fix trivial typo

### DIFF
--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -175,7 +175,7 @@ the process. The client library provides an easy way to watch a file:
     import com.linecorp.centraldogma.client.Latest;
     import com.linecorp.centraldogma.client.Watcher;
 
-    Watcher<JsonNode> watcher = dogma.fileWatcher("myRepo", "myProj", Query.ofJsonPath("$.foo"));
+    Watcher<JsonNode> watcher = dogma.fileWatcher("myProj", "myRepo", Query.ofJsonPath("$.foo"));
 
     // Register a callback for changes.
     watcher.watch((revision, value) -> {


### PR DESCRIPTION
Function signature

```
    default <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
```