### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -13,19 +13,19 @@ com.cronutils:
   cron-utils: { version: '5.0.5' }
 
 com.fasterxml.jackson.core:
-  jackson-annotations: { version: &JACKSON_VERSION '2.8.9' }
+  jackson-annotations: { version: &JACKSON_VERSION '2.9.2' }
   jackson-core: { version: *JACKSON_VERSION }
   jackson-databind: { version: *JACKSON_VERSION }
 
 com.github.ben-manes.caffeine:
-  caffeine: { version: '2.5.5' }
+  caffeine: { version: '2.5.6' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: '23.0'
+    version: '23.2-jre'
     exclusions:
     - com.google.code.findbugs:jsr305
     - com.google.errorprone:error_prone_annotations
@@ -45,15 +45,15 @@ com.jcraft:
   jsch: { version: '0.1.54' }
 
 com.linecorp.armeria:
-  armeria-shaded: { version: &ARMERIA_VERSION '0.53.0' }
+  armeria-shaded: { version: &ARMERIA_VERSION '0.54.1' }
   armeria-logback-shaded: { version: *ARMERIA_VERSION }
   armeria-thrift0.9-shaded: { version: *ARMERIA_VERSION }
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.2' }
+  checkstyle: { version: '8.3' }
 
 com.spotify:
-  completable-futures: { version: '0.3.1' }
+  completable-futures: { version: '0.3.2' }
   futures-extra: { version: '3.0.0' }
 
 commons-daemon:
@@ -91,16 +91,16 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: '4.8.0.201706111038-r' }
+  org.eclipse.jgit: { version: '4.9.0.201710071750-r' }
 
 org.hamcrest:
   hamcrest-library: { version: '1.3' }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.2.Final' }
+  hibernate-validator: { version: '6.0.4.Final' }
 
 org.mockito:
-  mockito-core: { version: '2.8.47' }
+  mockito-core: { version: '2.11.0' }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
@@ -112,7 +112,7 @@ org.slf4j:
   slf4j-api: { version: *SLF4J_VERSION }
 
 org.springframework.boot:
-  spring-boot-starter: { version: &SPRING_BOOT_VERSION '1.5.7.RELEASE' }
+  spring-boot-starter: { version: &SPRING_BOOT_VERSION '1.5.8.RELEASE' }
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }
 
 org.testng:


### PR DESCRIPTION
- Armeria 0.53.0 -> 0.54.1
- Caffeine 2.5.5 -> 2.5.6
- Checkstyle 8.2 -> 8.3
- completable-futures 0.3.1 -> 0.3.2
- Guava 23.0 -> 23.2
- Jackson 2.8.9 -> 2.9.1
- jGit 4.8.0 -> 4.9.0
- Hibernate Validator 6.0.2 -> 6.0.4
- Mockito 2.8.47 -> 2.11.0
- Spring Boot -> 1.5.7 -> 1.5.8