### PR TITLE
Update the release guide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -998,7 +998,7 @@ task release(group: 'Publishing',
         println "1. Upload the artifacts to the staging repository and prepare the web site:"
         println()
         println "   git checkout $tag"
-        println "   ./gradlew --no-daemon clean publish site"
+        println "   ./gradlew --no-daemon clean publish tarball site"
         println()
         println '2. Close and release the staging repository at:'
         println()
@@ -1008,7 +1008,7 @@ task release(group: 'Publishing',
         println()
         println '   https://github.com/line/centraldogma/milestones'
         println()
-        println '4. Update the release note at:'
+        println '4. Update the release note and upload the tarball at:'
         println()
         println "   https://github.com/line/centraldogma/releases/tag/${tag}"
         println()


### PR DESCRIPTION
- Make sure the tarball is generated in the first step
- Mention that the tarball has to be uploaded with a release note