### PR TITLE
Use better Git repository format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,14 @@ buildscript {
     repositories {
         mavenCentral()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
         classpath 'com.github.jengelman.gradle.plugins:shadow:2.0.1'
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.4.0'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.4'
         classpath 'org.yaml:snakeyaml:1.18'
 
         // For gogradle. It seems gogradle doesn't support buildscript so just leave this here until
@@ -102,6 +106,7 @@ configure(javaProjects) {
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'checkstyle'
+    apply plugin: 'me.champeau.gradle.jmh'
 
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
@@ -296,6 +301,35 @@ configure(javaProjects) {
             finalizedBy tasks.jacocoTestReport
         }
     }
+
+    // Configure JMH.
+    jmh {
+        forceGC = true
+        includeTests = false
+        duplicateClassesStrategy = DuplicatesStrategy.EXCLUDE
+        jmhVersion = rootProject.ext.dependencyManagement['org.openjdk.jmh']['jmh-core'].version
+
+        if (rootProject.hasProperty('jmh.fork')) {
+            fork = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.fork')))
+        } else {
+            fork = 1
+        }
+        if (rootProject.hasProperty('jmh.iterations')) {
+            iterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.iterations')))
+        }
+        if (rootProject.hasProperty('jmh.warmupIterations')) {
+            warmupIterations = Integer.parseInt(String.valueOf(rootProject.findProperty('jmh.warmupIterations')))
+        } else {
+            warmupIterations = iterations
+        }
+        if (rootProject.hasProperty('jmh.profilers')) {
+            profilers = String.valueOf(rootProject.findProperty('jmh.profilers')).split(',')
+        }
+        if (rootProject.hasProperty('jmh.verbose')) {
+            verbosity = 'EXTRA'
+        }
+    }
+    configurations.jmh.extendsFrom configurations.testRuntime
 
     // Require Java 8 to build the project.
     tasks.withType(JavaCompile) {

--- a/common/src/main/java/com/linecorp/centraldogma/internal/DeletingFileVisitor.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/DeletingFileVisitor.java
@@ -14,7 +14,7 @@
  * under the License.
  */
 
-package com.linecorp.centraldogma.server.internal.storage.repository.git;
+package com.linecorp.centraldogma.internal;
 
 import java.io.File;
 import java.io.IOException;

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -20,7 +20,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.IOError;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -19,8 +19,11 @@ package com.linecorp.centraldogma.internal;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOError;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -374,6 +377,15 @@ public final class Util {
 
     private static boolean isValidHexChar(char c) {
         return c >= '0' && c <= '9' || c >= 'A' && c <= 'F' || c >= 'a' && c <= 'f';
+    }
+
+    /**
+     * Deletes the specified {@code directory} recursively.
+     */
+    public static void deleteFileTree(File directory) throws IOException {
+        if (directory.exists()) {
+            Files.walkFileTree(directory.toPath(), DeletingFileVisitor.INSTANCE);
+        }
     }
 
     private Util() {}

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -105,6 +105,10 @@ org.mockito:
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.6' }
 
+org.openjdk.jmh:
+  jmh-core: { version: &JMH_VERSION '1.19' }
+  jmh-generator-annprocess: { version: *JMH_VERSION }
+
 org.slf4j:
   jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.25' }
   jul-to-slf4j: { version: *SLF4J_VERSION }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,6 +33,9 @@ managedDependencies {
 
     // Shiro
     compile 'org.apache.shiro:shiro-core'
+
+    // Mockito for mocking a Project
+    jmh 'org.mockito:mockito-core'
 }
 
 clientDependencies {

--- a/server/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
+++ b/server/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Util;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+
+@State(Scope.Benchmark)
+public class GitRepositoryBenchmark {
+
+    private static final Author AUTHOR = new Author("user@example.com");
+
+    @Param({ "0", "2000", "4000", "6000", "8000" })
+    private int previousCommits;
+
+    @Param
+    private GitRepositoryFormat format;
+
+    private File repoDir;
+    private GitRepository repo;
+    private int currentRevision;
+
+    @Setup
+    public void init() throws Exception {
+        repoDir = Files.createTempDirectory("jmh-gitrepository.").toFile();
+        repo = new GitRepository(mock(Project.class), repoDir, format, ForkJoinPool.commonPool(),
+                                 System.currentTimeMillis(), AUTHOR);
+        currentRevision = 1;
+
+        for (int i = 0; i < previousCommits; i++) {
+            addCommit();
+        }
+    }
+
+    @TearDown
+    public void destroy() throws Exception {
+        repo.close();
+        Util.deleteFileTree(repoDir);
+    }
+
+    @Benchmark
+    public void commit(Blackhole bh) throws Exception {
+        bh.consume(addCommit());
+    }
+
+    private Revision addCommit() {
+        final Revision revision =
+                repo.commit(new Revision(currentRevision), currentRevision * 1000, AUTHOR,
+                            "Summary", "Detail", Markup.PLAINTEXT,
+                            Change.ofTextUpsert("/file_" + rnd() + ".txt",
+                                                String.valueOf(currentRevision))).join();
+        currentRevision++;
+        return revision;
+    }
+
+    private static int rnd() {
+        return ThreadLocalRandom.current().nextInt(10);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
@@ -25,7 +25,9 @@ import java.util.stream.Collectors;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
 import com.linecorp.centraldogma.server.internal.admin.dto.ProjectDto;
 import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
@@ -60,8 +62,8 @@ public class ProjectService extends AbstractService {
      */
     @Post("/projects")
     public CompletionStage<ProjectDto> createProject(AggregatedHttpMessage message) throws IOException {
-        final ProjectDto dto =
-                Jackson.readValue(message.content().toStringAscii(), ProjectDto.class);
-        return execute(Command.createProject(dto.getName())).thenApply(unused -> dto);
+        final Author author = AuthenticationUtil.currentAuthor();
+        final ProjectDto dto = Jackson.readValue(message.content().toStringAscii(), ProjectDto.class);
+        return execute(Command.createProject(dto.getName(), author)).thenApply(unused -> dto);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -100,9 +100,12 @@ public class RepositoryService extends AbstractService {
     @Post("/projects/{projectName}/repositories")
     public CompletionStage<RepositoryDto> createRepository(@Param("projectName") String projectName,
                                                            AggregatedHttpMessage message) throws IOException {
+
+        final Author author = AuthenticationUtil.currentAuthor();
         final RepositoryDto dto =
                 Jackson.readValue(message.content().toStringAscii(), RepositoryDto.class);
-        return execute(Command.createRepository(projectName, dto.getName())).thenApply(unused -> dto);
+        return execute(Command.createRepository(projectName, dto.getName(), author))
+                .thenApply(unused -> dto);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
@@ -68,8 +68,13 @@ public interface Command<T> {
     }
 
     static Command<Void> createRepository(String projectName, String repositoryName, Author author) {
+        return createRepository(projectName, repositoryName, null, author);
+    }
+
+    static Command<Void> createRepository(String projectName, String repositoryName,
+                                          @Nullable Long creationTimeMillis, Author author) {
         requireNonNull(author, "author");
-        return new CreateRepositoryCommand(projectName, repositoryName, null, author);
+        return new CreateRepositoryCommand(projectName, repositoryName, creationTimeMillis, author);
     }
 
     static Command<Void> removeRepository(String projectName, String repositoryName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
@@ -49,7 +49,11 @@ import com.linecorp.centraldogma.common.Revision;
 public interface Command<T> {
 
     static Command<Void> createProject(String name) {
-        return new CreateProjectCommand(name);
+        return new CreateProjectCommand(name, null);
+    }
+
+    static Command<Void> createProject(String name, long creationTimeMillis) {
+        return new CreateProjectCommand(name, creationTimeMillis);
     }
 
     static Command<Void> removeProject(String name) {
@@ -61,7 +65,7 @@ public interface Command<T> {
     }
 
     static Command<Void> createRepository(String projectName, String repositoryName) {
-        return new CreateRepositoryCommand(projectName, repositoryName);
+        return new CreateRepositoryCommand(projectName, repositoryName, null);
     }
 
     static Command<Void> removeRepository(String projectName, String repositoryName) {
@@ -77,22 +81,41 @@ public interface Command<T> {
                                   Markup markup, Change<?>... changes) {
 
         requireNonNull(changes, "changes");
-        return new PushCommand(projectName, repositoryName,
-                               baseRevision, author, summary, detail, markup, Arrays.asList(changes));
+        return new PushCommand(projectName, repositoryName, baseRevision, null,
+                               author, summary, detail, markup, Arrays.asList(changes));
     }
 
     static Command<Revision> push(String projectName, String repositoryName,
-                                Revision baseRevision, Author author, String summary, String detail,
-                                Markup markup, Iterable<Change<?>> changes) {
+                                  Revision baseRevision, long commitTimeMillis,
+                                  Author author, String summary, String detail,
+                                  Markup markup, Change<?>... changes) {
 
-        return new PushCommand(projectName, repositoryName,
-                               baseRevision, author, summary, detail, markup, changes);
+        requireNonNull(changes, "changes");
+        return new PushCommand(projectName, repositoryName, baseRevision, commitTimeMillis,
+                               author, summary, detail, markup, Arrays.asList(changes));
+    }
+
+    static Command<Revision> push(String projectName, String repositoryName,
+                                  Revision baseRevision, Author author, String summary, String detail,
+                                  Markup markup, Iterable<Change<?>> changes) {
+
+        return new PushCommand(projectName, repositoryName, baseRevision, null,
+                               author, summary, detail, markup, changes);
+    }
+
+    static Command<Revision> push(String projectName, String repositoryName,
+                                  Revision baseRevision, long commitTimeMillis,
+                                  Author author, String summary, String detail,
+                                  Markup markup, Iterable<Change<?>> changes) {
+
+        return new PushCommand(projectName, repositoryName, baseRevision, commitTimeMillis,
+                               author, summary, detail, markup, changes);
     }
 
     static Command<Void> createRunspace(String projectName, String repositoryName,
-                                        Author author, int baseRevision) {
+                                        int baseRevision, Author author) {
 
-        return new CreateRunspaceCommand(projectName, repositoryName, author, baseRevision);
+        return new CreateRunspaceCommand(projectName, repositoryName, baseRevision, null, author);
     }
 
     static Command<Void> removeRunspace(String projectName, String repositoryName, int baseRevision) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -48,12 +50,13 @@ import com.linecorp.centraldogma.common.Revision;
 })
 public interface Command<T> {
 
-    static Command<Void> createProject(String name) {
-        return new CreateProjectCommand(name, null);
+    static Command<Void> createProject(String name, Author author) {
+        return createProject(name, null, author);
     }
 
-    static Command<Void> createProject(String name, long creationTimeMillis) {
-        return new CreateProjectCommand(name, creationTimeMillis);
+    static Command<Void> createProject(String name, @Nullable Long creationTimeMillis, Author author) {
+        requireNonNull(author, "author");
+        return new CreateProjectCommand(name, creationTimeMillis, author);
     }
 
     static Command<Void> removeProject(String name) {
@@ -64,8 +67,9 @@ public interface Command<T> {
         return new UnremoveProjectCommand(name);
     }
 
-    static Command<Void> createRepository(String projectName, String repositoryName) {
-        return new CreateRepositoryCommand(projectName, repositoryName, null);
+    static Command<Void> createRepository(String projectName, String repositoryName, Author author) {
+        requireNonNull(author, "author");
+        return new CreateRepositoryCommand(projectName, repositoryName, null, author);
     }
 
     static Command<Void> removeRepository(String projectName, String repositoryName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
@@ -18,23 +18,30 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
+import com.linecorp.centraldogma.common.Author;
+
 public final class CreateProjectCommand extends RootCommand<Void> {
 
     private final String projectName;
     private final long creationTimeMillis;
+    private final Author author;
 
     @JsonCreator
     CreateProjectCommand(@JsonProperty("projectName") String projectName,
-                         @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis) {
+                         @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
+                         @JsonProperty("author") @Nullable Author author) {
         super(CommandType.CREATE_PROJECT);
         this.projectName = requireNonNull(projectName, "projectName");
         this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
+        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
@@ -45,6 +52,11 @@ public final class CreateProjectCommand extends RootCommand<Void> {
     @JsonProperty
     public long creationTimeMillis() {
         return creationTimeMillis;
+    }
+
+    @JsonProperty
+    public Author author() {
+        return author;
     }
 
     @Override
@@ -59,13 +71,14 @@ public final class CreateProjectCommand extends RootCommand<Void> {
 
         final CreateProjectCommand that = (CreateProjectCommand) obj;
         return super.equals(obj) &&
+               projectName.equals(that.projectName) &&
                creationTimeMillis == that.creationTimeMillis &&
-               projectName.equals(that.projectName);
+               author.equals(that.author);
     }
 
     @Override
     public int hashCode() {
-        return projectName.hashCode() * 31 + super.hashCode();
+        return Objects.hash(projectName, creationTimeMillis, author) * 31 + super.hashCode();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
@@ -18,6 +18,8 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -25,16 +27,24 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 public final class CreateProjectCommand extends RootCommand<Void> {
 
     private final String projectName;
+    private final long creationTimeMillis;
 
     @JsonCreator
-    CreateProjectCommand(@JsonProperty("projectName") String projectName) {
+    CreateProjectCommand(@JsonProperty("projectName") String projectName,
+                         @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis) {
         super(CommandType.CREATE_PROJECT);
         this.projectName = requireNonNull(projectName, "projectName");
+        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
     }
 
     @JsonProperty
     public String projectName() {
         return projectName;
+    }
+
+    @JsonProperty
+    public long creationTimeMillis() {
+        return creationTimeMillis;
     }
 
     @Override
@@ -49,6 +59,7 @@ public final class CreateProjectCommand extends RootCommand<Void> {
 
         final CreateProjectCommand that = (CreateProjectCommand) obj;
         return super.equals(obj) &&
+               creationTimeMillis == that.creationTimeMillis &&
                projectName.equals(that.projectName);
     }
 
@@ -59,6 +70,8 @@ public final class CreateProjectCommand extends RootCommand<Void> {
 
     @Override
     ToStringHelper toStringHelper() {
-        return super.toStringHelper().add("projectName", projectName);
+        return super.toStringHelper()
+                    .add("projectName", projectName)
+                    .add("creationTimeMillis", creationTimeMillis);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
@@ -18,6 +18,8 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -25,18 +27,26 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
     private final String repositoryName;
+    private final long creationTimeMillis;
 
     @JsonCreator
     CreateRepositoryCommand(@JsonProperty("projectName") String projectName,
-                            @JsonProperty("repositoryName") String repositoryName) {
+                            @JsonProperty("repositoryName") String repositoryName,
+                            @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis) {
 
         super(CommandType.CREATE_REPOSITORY, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
+        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
     }
 
     @JsonProperty
     public String repositoryName() {
         return repositoryName;
+    }
+
+    @JsonProperty
+    public long creationTimeMillis() {
+        return creationTimeMillis;
     }
 
     @Override
@@ -51,6 +61,7 @@ public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
         final CreateRepositoryCommand that = (CreateRepositoryCommand) obj;
         return super.equals(obj) &&
+               creationTimeMillis == that.creationTimeMillis &&
                repositoryName.equals(that.repositoryName);
     }
 
@@ -61,6 +72,8 @@ public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
     @Override
     ToStringHelper toStringHelper() {
-        return super.toStringHelper().add("repositoryName", repositoryName);
+        return super.toStringHelper()
+                    .add("repositoryName", repositoryName)
+                    .add("creationTimeMillis", creationTimeMillis);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
@@ -18,25 +18,32 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
+import com.linecorp.centraldogma.common.Author;
+
 public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
     private final String repositoryName;
     private final long creationTimeMillis;
+    private final Author author;
 
     @JsonCreator
     CreateRepositoryCommand(@JsonProperty("projectName") String projectName,
                             @JsonProperty("repositoryName") String repositoryName,
-                            @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis) {
+                            @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
+                            @JsonProperty("author") @Nullable Author author) {
 
         super(CommandType.CREATE_REPOSITORY, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
         this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
+        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
@@ -47,6 +54,11 @@ public final class CreateRepositoryCommand extends ProjectCommand<Void> {
     @JsonProperty
     public long creationTimeMillis() {
         return creationTimeMillis;
+    }
+
+    @JsonProperty
+    public Author author() {
+        return author;
     }
 
     @Override
@@ -61,13 +73,14 @@ public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
         final CreateRepositoryCommand that = (CreateRepositoryCommand) obj;
         return super.equals(obj) &&
+               repositoryName.equals(that.repositoryName) &&
                creationTimeMillis == that.creationTimeMillis &&
-               repositoryName.equals(that.repositoryName);
+               author.equals(that.author);
     }
 
     @Override
     public int hashCode() {
-        return repositoryName.hashCode() * 31 + super.hashCode();
+        return Objects.hash(repositoryName, creationTimeMillis, author) * 31 + super.hashCode();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -28,28 +30,36 @@ import com.linecorp.centraldogma.common.Author;
 
 public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
 
-    private final Author author;
     private final int baseRevision;
+    private final long creationTimeMillis;
+    private final Author author;
 
     @JsonCreator
     CreateRunspaceCommand(@JsonProperty("projectName") String projectName,
                           @JsonProperty("repositoryName") String repositoryName,
-                          @JsonProperty("author") Author author,
-                          @JsonProperty("baseRevision") int baseRevision) {
+                          @JsonProperty("baseRevision") int baseRevision,
+                          @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
+                          @JsonProperty("author") Author author) {
 
         super(CommandType.CREATE_RUNSPACE, projectName, repositoryName);
-        this.author = requireNonNull(author, "author");
         this.baseRevision = baseRevision;
-    }
-
-    @JsonProperty
-    public Author author() {
-        return author;
+        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
+        this.author = requireNonNull(author, "author");
     }
 
     @JsonProperty
     public int baseRevision() {
         return baseRevision;
+    }
+
+    @JsonProperty
+    public long creationTimeMillis() {
+        return creationTimeMillis;
+    }
+
+    @JsonProperty
+    public Author author() {
+        return author;
     }
 
     @Override
@@ -65,6 +75,7 @@ public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
         final CreateRunspaceCommand that = (CreateRunspaceCommand) obj;
         return super.equals(that) &&
                baseRevision == that.baseRevision &&
+               creationTimeMillis == that.creationTimeMillis &&
                author.equals(that.author);
     }
 
@@ -77,6 +88,7 @@ public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
                     .add("baseRevision", baseRevision)
+                    .add("creationTimeMillis", creationTimeMillis)
                     .add("author", author);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -39,12 +37,12 @@ public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
                           @JsonProperty("repositoryName") String repositoryName,
                           @JsonProperty("baseRevision") int baseRevision,
                           @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
-                          @JsonProperty("author") Author author) {
+                          @JsonProperty("author") @Nullable Author author) {
 
         super(CommandType.CREATE_RUNSPACE, projectName, repositoryName);
         this.baseRevision = baseRevision;
         this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
-        this.author = requireNonNull(author, "author");
+        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
@@ -81,7 +79,7 @@ public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseRevision, author) * 31 + super.hashCode();
+        return Objects.hash(baseRevision, creationTimeMillis, author) * 31 + super.hashCode();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -138,7 +138,7 @@ public final class ProjectInitializer {
      */
     public static void initializeInternalProject(CommandExecutor executor) {
         try {
-            executor.execute(createProject(INTERNAL_PROJECT_NAME))
+            executor.execute(createProject(INTERNAL_PROJECT_NAME, Author.SYSTEM))
                     .get();
         } catch (Exception e) {
             if (!(e.getCause() instanceof ProjectExistsException)) {
@@ -149,7 +149,7 @@ public final class ProjectInitializer {
                                                   SESSION_REPOSITORY_NAME,
                                                   TOKEN_REPOSITORY_NAME)) {
             try {
-                executor.execute(createRepository(INTERNAL_PROJECT_NAME, repo))
+                executor.execute(createRepository(INTERNAL_PROJECT_NAME, repo, Author.SYSTEM))
                         .get();
             } catch (Exception e) {
                 if (!(e.getCause() instanceof RepositoryExistsException)) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -22,6 +22,8 @@ import static com.linecorp.centraldogma.server.internal.storage.project.Project.
 
 import java.util.concurrent.CompletableFuture;
 
+import com.linecorp.centraldogma.common.Author;
+
 public class ProjectInitializingCommandExecutor extends ForwardingCommandExecutor {
 
     public ProjectInitializingCommandExecutor(CommandExecutor delegate) {
@@ -36,10 +38,13 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
 
         final CreateProjectCommand c = (CreateProjectCommand) command;
         final String projectName = c.projectName();
+        final Author author = c.author();
 
         final CompletableFuture<Void> f = delegate().execute(c);
-        return f.thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_META)))
-                .thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_MAIN)))
+        return f.thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_META,
+                                                                                   author)))
+                .thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_MAIN,
+                                                                                   author)))
                 .thenCompose(unused -> generateSampleFiles(delegate(), projectName, REPO_MAIN))
                 .thenApply(unused -> null);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -38,13 +38,14 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
 
         final CreateProjectCommand c = (CreateProjectCommand) command;
         final String projectName = c.projectName();
+        final long creationTimeMillis = c.creationTimeMillis();
         final Author author = c.author();
 
         final CompletableFuture<Void> f = delegate().execute(c);
         return f.thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_META,
-                                                                                   author)))
+                                                                                   creationTimeMillis, author)))
                 .thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_MAIN,
-                                                                                   author)))
+                                                                                   creationTimeMillis, author)))
                 .thenCompose(unused -> generateSampleFiles(delegate(), projectName, REPO_MAIN))
                 .thenApply(unused -> null);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/PushCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/PushCommand.java
@@ -24,6 +24,8 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -36,6 +38,7 @@ import com.linecorp.centraldogma.common.Revision;
 public final class PushCommand extends RepositoryCommand<Revision> {
 
     private final Revision baseRevision;
+    private final long commitTimeMillis;
     private final Author author;
     private final String summary;
     private final String detail;
@@ -46,6 +49,7 @@ public final class PushCommand extends RepositoryCommand<Revision> {
     PushCommand(@JsonProperty("projectName") String projectName,
                 @JsonProperty("repositoryName") String repositoryName,
                 @JsonProperty("baseRevision") Revision baseRevision,
+                @JsonProperty("commitTimeMillis") @Nullable Long commitTimeMillis,
                 @JsonProperty("author") Author author,
                 @JsonProperty("summary") String summary,
                 @JsonProperty("detail") String detail,
@@ -55,6 +59,7 @@ public final class PushCommand extends RepositoryCommand<Revision> {
         super(CommandType.PUSH, projectName, repositoryName);
 
         this.baseRevision = requireNonNull(baseRevision, "baseRevision");
+        this.commitTimeMillis = commitTimeMillis != null ? commitTimeMillis : System.currentTimeMillis();
         this.author = requireNonNull(author, "author");
         this.summary = requireNonNull(summary, "summary");
         this.detail = requireNonNull(detail, "detail");
@@ -68,6 +73,11 @@ public final class PushCommand extends RepositoryCommand<Revision> {
     @JsonProperty
     public Revision baseRevision() {
         return baseRevision;
+    }
+
+    @JsonProperty
+    public long commitTimeMillis() {
+        return commitTimeMillis;
     }
 
     @JsonProperty
@@ -108,6 +118,7 @@ public final class PushCommand extends RepositoryCommand<Revision> {
         final PushCommand that = (PushCommand) obj;
         return super.equals(that) &&
                baseRevision.equals(that.baseRevision) &&
+               commitTimeMillis == that.commitTimeMillis &&
                author.equals(that.author) &&
                summary.equals(that.summary) &&
                detail.equals(that.detail) &&
@@ -117,13 +128,15 @@ public final class PushCommand extends RepositoryCommand<Revision> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseRevision, author, summary, detail, markup, changes) * 31 + super.hashCode();
+        return Objects.hash(baseRevision, commitTimeMillis,
+                            author, summary, detail, markup, changes) * 31 + super.hashCode();
     }
 
     @Override
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
                     .add("baseRevision", baseRevision)
+                    .add("commitTimeMillis", commitTimeMillis)
                     .add("author", author)
                     .add("summary", summary)
                     .add("markup", markup);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/StandaloneCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/StandaloneCommandExecutor.java
@@ -107,7 +107,7 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
 
     private CompletableFuture<Void> createProject(CreateProjectCommand c) {
         return CompletableFuture.supplyAsync(() -> {
-            projectManager.create(c.projectName());
+            projectManager.create(c.projectName(), c.creationTimeMillis());
             return null;
         }, repositoryWorker);
     }
@@ -130,7 +130,7 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
 
     private CompletableFuture<Void> createRepository(CreateRepositoryCommand c) {
         return CompletableFuture.supplyAsync(() -> {
-            projectManager.get(c.projectName()).repos().create(c.repositoryName());
+            projectManager.get(c.projectName()).repos().create(c.repositoryName(), c.creationTimeMillis());
             return null;
         }, repositoryWorker);
     }
@@ -150,11 +150,13 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
     }
 
     private CompletableFuture<Revision> push(PushCommand c) {
-        return repo(c).commit(c.baseRevision(), c.author(), c.summary(), c.detail(), c.markup(), c.changes());
+        return repo(c).commit(c.baseRevision(), c.commitTimeMillis(),
+                              c.author(), c.summary(), c.detail(), c.markup(), c.changes());
     }
 
     private CompletableFuture<Void> createRunspace(CreateRunspaceCommand c) {
-        return repo(c).createRunspace(c.author(), c.baseRevision()).thenApply(revision -> null);
+        return repo(c).createRunspace(c.baseRevision(), c.creationTimeMillis(),
+                                      c.author()).thenApply(revision -> null);
     }
 
     private CompletableFuture<Void> removeRunspace(RemoveRunspaceCommand c) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/StorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/StorageManager.java
@@ -27,9 +27,11 @@ public interface StorageManager<T> extends AutoCloseable {
 
     T get(String name);
 
-    T getOrCreate(String name);
+    default T create(String name) {
+        return create(name, System.currentTimeMillis());
+    }
 
-    T create(String name);
+    T create(String name, long creationTimeMillis);
 
     Map<String, T> list();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
@@ -61,7 +61,7 @@ public class DefaultProjectManager extends DirectoryBasedStorageManager<Project>
     }
 
     @Override
-    protected Project createChild(File childDir, Object[] childArgs) throws Exception {
+    protected Project createChild(File childDir, Object[] childArgs, long creationTimeMillis) throws Exception {
         return new DefaultProject(childDir, true, (Executor) childArgs[0], (RepositoryCache) childArgs[1]);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.project;
 
+import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.server.internal.plugin.PluginManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.MetaRepository;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
@@ -26,6 +27,14 @@ public interface Project {
     String REPO_MAIN = "main";
 
     String name();
+
+    default long creationTimeMillis() {
+        return metaRepo().creationTimeMillis();
+    }
+
+    default Author author() {
+        return metaRepo().author();
+    }
 
     MetaRepository metaRepo();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -61,15 +61,9 @@ public class SafeProjectManager implements ProjectManager {
     }
 
     @Override
-    public Project getOrCreate(String name) {
+    public Project create(String name, long creationTimeMillis) {
         validateProjectName(name);
-        return delegate().getOrCreate(name);
-    }
-
-    @Override
-    public Project create(String name) {
-        validateProjectName(name);
-        return delegate().create(name);
+        return delegate().create(name, creationTimeMillis);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
@@ -270,9 +270,9 @@ public interface Repository {
      *
      * @return the {@link Revision} of the new {@link Commit}
      */
-    default CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author, String summary, Iterable<Change<?>> changes) {
-        return commit(baseRevision, author, summary, "", Markup.PLAINTEXT, changes);
+    default CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                               Author author, String summary, Iterable<Change<?>> changes) {
+        return commit(baseRevision, commitTimeMillis, author, summary, "", Markup.PLAINTEXT, changes);
     }
 
     /**
@@ -280,9 +280,9 @@ public interface Repository {
      *
      * @return the {@link Revision} of the new {@link Commit}
      */
-    default CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author, String summary, Change<?>... changes) {
-        return commit(baseRevision, author, summary, "", Markup.PLAINTEXT, changes);
+    default CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                               Author author, String summary, Change<?>... changes) {
+        return commit(baseRevision, commitTimeMillis, author, summary, "", Markup.PLAINTEXT, changes);
     }
 
     /**
@@ -290,12 +290,11 @@ public interface Repository {
      *
      * @return the {@link Revision} of the new {@link Commit}
      */
-    default CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author,
-            String summary, String detail, Markup markup, Change<?>... changes) {
-
+    default CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                               Author author, String summary, String detail, Markup markup,
+                                               Change<?>... changes) {
         requireNonNull(changes, "changes");
-        return commit(baseRevision, author, summary, detail, markup, Arrays.asList(changes));
+        return commit(baseRevision, commitTimeMillis, author, summary, detail, markup, Arrays.asList(changes));
     }
 
     /**
@@ -303,9 +302,9 @@ public interface Repository {
      *
      * @return the {@link Revision} of the new {@link Commit}
      */
-    CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author,
-            String summary, String detail, Markup markup, Iterable<Change<?>> changes);
+    CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                       Author author, String summary, String detail, Markup markup,
+                                       Iterable<Change<?>> changes);
 
     /**
      * Get a list of {@link Commit} for given pathPattern.
@@ -340,18 +339,27 @@ public interface Repository {
      * Awaits and retrieves the latest revision of the commit that changed the file that matches the specified
      * {@code pathPattern} since the specified last known revision.
      */
-    CompletableFuture<Revision> watch(Revision lastKnownRev, String pathPattern);
+    CompletableFuture<Revision> watch(Revision lastKnownRevision, String pathPattern);
 
     /**
      * Awaits and retrieves the change in the query result of the specified file asynchronously since the
      * specified last known revision.
      */
-    default <T> CompletableFuture<QueryResult<T>> watch(Revision lastKnownRev, Query<T> query) {
-        return RepositoryUtil.watch(this, lastKnownRev, query);
+    default <T> CompletableFuture<QueryResult<T>> watch(Revision lastKnownRevision, Query<T> query) {
+        return RepositoryUtil.watch(this, lastKnownRevision, query);
     }
 
-    CompletableFuture<Revision> createRunspace(Author author, int majorRevision);
+    /**
+     * Creates a new runspace at {@code majorRevision}.
+     *
+     * @param author the author who creates this runspace
+     * @return the {@link Revision} for newly created runspace
+     */
+    CompletableFuture<Revision> createRunspace(int majorRevision, long creationTimeMillis, Author author);
 
+    /**
+     * Removes the runspace associated with the specified {@code majorRevision}.
+     */
     CompletableFuture<Void> removeRunspace(int majorRevision);
 
     CompletableFuture<Set<Revision>> listRunspaces();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -66,14 +66,8 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     }
 
     @Override
-    public Repository getOrCreate(String name) {
-        ensureOpen();
-        return repos.computeIfAbsent(name, n -> repoWrapper.apply(delegate.getOrCreate(n)));
-    }
-
-    @Override
-    public Repository create(String name) {
-        return repos.compute(name, (n, v) -> repoWrapper.apply(delegate.create(name)));
+    public Repository create(String name, long creationTimeMillis) {
+        return repos.compute(name, (n, v) -> repoWrapper.apply(delegate.create(name, creationTimeMillis)));
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -132,44 +132,45 @@ public class RepositoryWrapper implements Repository {
     }
 
     @Override
-    public CompletableFuture<Revision> commit(Revision baseRevision, Author author,
-                                              String summary, Iterable<Change<?>> changes) {
-        return unwrap().commit(baseRevision, author, summary, changes);
+    public CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                              Author author, String summary, Iterable<Change<?>> changes) {
+        return unwrap().commit(baseRevision, commitTimeMillis, author, summary, changes);
     }
 
     @Override
-    public CompletableFuture<Revision> commit(Revision baseRevision, Author author,
-                                              String summary, Change<?>... changes) {
-        return unwrap().commit(baseRevision, author, summary, changes);
+    public CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                              Author author, String summary, Change<?>... changes) {
+        return unwrap().commit(baseRevision, commitTimeMillis, author, summary, changes);
     }
 
     @Override
-    public CompletableFuture<Revision> commit(Revision baseRevision, Author author,
-                                              String summary, String detail, Markup markup,
+    public CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                              Author author, String summary, String detail, Markup markup,
                                               Iterable<Change<?>> changes) {
-        return unwrap().commit(baseRevision, author, summary, detail, markup, changes);
+        return unwrap().commit(baseRevision, commitTimeMillis, author, summary, detail, markup, changes);
     }
 
     @Override
-    public CompletableFuture<Revision> commit(Revision baseRevision, Author author,
-                                              String summary, String detail, Markup markup,
+    public CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                              Author author, String summary, String detail, Markup markup,
                                               Change<?>... changes) {
-        return unwrap().commit(baseRevision, author, summary, detail, markup, changes);
+        return unwrap().commit(baseRevision, commitTimeMillis, author, summary, detail, markup, changes);
     }
 
     @Override
-    public CompletableFuture<Revision> watch(Revision lastKnownRev, String pathPattern) {
-        return unwrap().watch(lastKnownRev, pathPattern);
+    public CompletableFuture<Revision> watch(Revision lastKnownRevision, String pathPattern) {
+        return unwrap().watch(lastKnownRevision, pathPattern);
     }
 
     @Override
-    public <T> CompletableFuture<QueryResult<T>> watch(Revision lastKnownRev, Query<T> query) {
-        return unwrap().watch(lastKnownRev, query);
+    public <T> CompletableFuture<QueryResult<T>> watch(Revision lastKnownRevision, Query<T> query) {
+        return unwrap().watch(lastKnownRevision, query);
     }
 
     @Override
-    public CompletableFuture<Revision> createRunspace(Author author, int majorRevision) {
-        return unwrap().createRunspace(author, majorRevision);
+    public CompletableFuture<Revision> createRunspace(int majorRevision, long creationTimeMillis,
+                                                      Author author) {
+        return unwrap().createRunspace(majorRevision, creationTimeMillis, author);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -58,6 +58,16 @@ public class RepositoryWrapper implements Repository {
     }
 
     @Override
+    public long creationTimeMillis() {
+        return unwrap().creationTimeMillis();
+    }
+
+    @Override
+    public Author author() {
+        return unwrap().author();
+    }
+
+    @Override
     public CompletableFuture<Revision> normalize(Revision revision) {
         return unwrap().normalize(revision);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
@@ -45,7 +45,6 @@ import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 final class CachingRepository implements Repository {
 
     private final Repository repo;
-    private volatile Revision headRevision;
 
     @SuppressWarnings("rawtypes")
     private final AsyncLoadingCache<CacheableCall, Object> cache;
@@ -53,7 +52,6 @@ final class CachingRepository implements Repository {
     CachingRepository(Repository repo, RepositoryCache cache) {
         this.repo = requireNonNull(repo, "repo");
         this.cache = requireNonNull(cache, "cache").cache;
-        repo.normalize(Revision.HEAD).thenAccept(headRevision -> this.headRevision = headRevision);
     }
 
     @Override
@@ -167,21 +165,22 @@ final class CachingRepository implements Repository {
     }
 
     @Override
-    public CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author, String summary,
-            String detail, Markup markup, Iterable<Change<?>> changes) {
+    public CompletableFuture<Revision> commit(Revision baseRevision, long commitTimeMillis,
+                                              Author author, String summary, String detail, Markup markup,
+                                              Iterable<Change<?>> changes) {
 
-        return repo.commit(baseRevision, author, summary, detail, markup, changes);
+        return repo.commit(baseRevision, commitTimeMillis, author, summary, detail, markup, changes);
     }
 
     @Override
-    public CompletableFuture<Revision> watch(Revision lastKnownRev, String pathPattern) {
-        return repo.watch(lastKnownRev, pathPattern);
+    public CompletableFuture<Revision> watch(Revision lastKnownRevision, String pathPattern) {
+        return repo.watch(lastKnownRevision, pathPattern);
     }
 
     @Override
-    public CompletableFuture<Revision> createRunspace(Author author, int majorRevision) {
-        return repo.createRunspace(author, majorRevision);
+    public CompletableFuture<Revision> createRunspace(int majorRevision, long creationTimeMillis,
+                                                      Author author) {
+        return repo.createRunspace(majorRevision, creationTimeMillis, author);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
@@ -23,12 +23,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.google.common.base.Throwables;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -38,6 +40,7 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryResult;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.internal.storage.StorageException;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.server.internal.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
@@ -49,9 +52,30 @@ final class CachingRepository implements Repository {
     @SuppressWarnings("rawtypes")
     private final AsyncLoadingCache<CacheableCall, Object> cache;
 
+    private final Commit firstCommit;
+
     CachingRepository(Repository repo, RepositoryCache cache) {
         this.repo = requireNonNull(repo, "repo");
         this.cache = requireNonNull(cache, "cache").cache;
+
+        try {
+            final List<Commit> history = repo.history(Revision.INIT, Revision.INIT, ALL_PATH, 1).join();
+            firstCommit = history.get(0);
+        } catch (CompletionException e) {
+            final Throwable cause = Throwables.getRootCause(e);
+            Throwables.throwIfUnchecked(cause);
+            throw new StorageException("failed to retrieve the initial commit", cause);
+        }
+    }
+
+    @Override
+    public long creationTimeMillis() {
+        return firstCommit.when();
+    }
+
+    @Override
+    public Author author() {
+        return firstCommit.author();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitWatchers.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitWatchers.java
@@ -76,12 +76,12 @@ final class CommitWatchers {
                     // Committed to the main lane; find only those who watches the main lane.
                     for (Iterator<Watch> i = watches.iterator(); i.hasNext();) {
                         final Watch w = i.next();
-                        final Revision lastKnownRev = w.lastKnownRev;
-                        if (lastKnownRev.onMainLane()) {
-                            if (lastKnownRev.compareTo(revision) < 0) {
+                        final Revision lastKnownRevision = w.lastKnownRevision;
+                        if (lastKnownRevision.onMainLane()) {
+                            if (lastKnownRevision.compareTo(revision) < 0) {
                                 eligibleWatches = move(eligibleWatches, i, w);
                             } else {
-                                logIneligibleFuture(lastKnownRev, revision);
+                                logIneligibleFuture(lastKnownRevision, revision);
                             }
                         }
                     }
@@ -89,7 +89,7 @@ final class CommitWatchers {
                     // Committed to a runspace; find only those who watches the matching runspace.
                     for (Iterator<Watch> i = watches.iterator(); i.hasNext();) {
                         final Watch p = i.next();
-                        final Revision lastKnownRev = p.lastKnownRev;
+                        final Revision lastKnownRev = p.lastKnownRevision;
                         if (lastKnownRev.major() == revision.major() && lastKnownRev.minor() != 0) {
                             if (lastKnownRev.compareTo(revision) < 0) {
                                 eligibleWatches = move(eligibleWatches, i, p);
@@ -126,9 +126,9 @@ final class CommitWatchers {
         return watches;
     }
 
-    private static void logIneligibleFuture(Revision lastKnownRev, Revision newRevision) {
-        logger.debug("Not notifying a future with same or newer lastKnownRevision: {} (new revision: {})",
-                     lastKnownRev, newRevision);
+    private static void logIneligibleFuture(Revision lastKnownRevision, Revision newRevision) {
+        logger.debug("Not notifying a future with same or newer lastKnownRevision: {} (newRevision: {})",
+                     lastKnownRevision, newRevision);
     }
 
     private static final class WatcherMap
@@ -152,12 +152,12 @@ final class CommitWatchers {
 
     private static final class Watch {
 
-        final Revision lastKnownRev;
+        final Revision lastKnownRevision;
         final CompletableFuture<Revision> future;
         volatile boolean removed;
 
-        Watch(Revision lastKnownRev, CompletableFuture<Revision> future) {
-            this.lastKnownRev = lastKnownRev;
+        Watch(Revision lastKnownRevision, CompletableFuture<Revision> future) {
+            this.lastKnownRevision = lastKnownRevision;
             this.future = future;
         }
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -16,14 +16,22 @@
 
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_CORE_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_DIFF_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_ALGORITHM;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_FILEMODE;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_HIDEDOTFILES;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_RENAMES;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_REPO_FORMAT_VERSION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_SYMLINKS;
 
 import java.io.File;
-import java.io.IOError;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,6 +56,7 @@ import org.eclipse.jgit.dircache.DirCacheEntry;
 import org.eclipse.jgit.dircache.DirCacheIterator;
 import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.CoreConfig.HideDotFiles;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.ObjectInserter;
@@ -58,6 +67,7 @@ import org.eclipse.jgit.lib.RefRename;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.lib.RefUpdate.Result;
 import org.eclipse.jgit.lib.RepositoryBuilder;
+import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -72,6 +82,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.MoreObjects;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -117,6 +128,7 @@ class GitRepository implements Repository {
     private final Executor repositoryWorker;
     private final String name;
     private final org.eclipse.jgit.lib.Repository jGitRepository;
+    private final GitRepositoryFormat format;
     private final CommitWatchers commitWatchers = new CommitWatchers();
 
     /**
@@ -129,30 +141,81 @@ class GitRepository implements Repository {
      *
      * @param repoDir the location of this repository
      * @param repositoryWorker the {@link Executor} which will perform the blocking repository operations
+     * @param creationTimeMillis the creation time
      * @param author the user who initiated the creation of this repository
      *
      * @throws StorageException if failed to create a new repository
      */
-    GitRepository(Project parent, File repoDir, Executor repositoryWorker, Author author) {
+    GitRepository(Project parent, File repoDir, Executor repositoryWorker,
+                  long creationTimeMillis, Author author) {
+        this(parent, repoDir, GitRepositoryFormat.V1, repositoryWorker, creationTimeMillis, author);
+    }
+
+    /**
+     * Creates a new Git-backed repository.
+     *
+     * @param repoDir the location of this repository
+     * @param format the repository format
+     * @param repositoryWorker the {@link Executor} which will perform the blocking repository operations
+     * @param creationTimeMillis the creation time
+     * @param author the user who initiated the creation of this repository
+     *
+     * @throws StorageException if failed to create a new repository
+     */
+    GitRepository(Project parent, File repoDir, GitRepositoryFormat format, Executor repositoryWorker,
+                  long creationTimeMillis, Author author) {
+
         this.parent = requireNonNull(parent, "parent");
         name = requireNonNull(repoDir, "repoDir").getName();
         this.repositoryWorker = requireNonNull(repositoryWorker, "repositoryWorker");
+        this.format = requireNonNull(format, "format");
 
         requireNonNull(author, "author");
 
-        RepositoryBuilder repositoryBuilder = new RepositoryBuilder().setGitDir(repoDir).setBare();
+        final RepositoryBuilder repositoryBuilder = new RepositoryBuilder().setGitDir(repoDir).setBare();
         boolean success = false;
         try {
-            jGitRepository = repositoryBuilder.build();
-            if (exist(repoDir)) {
-                throw new StorageException(
-                        "failed to create a repository at: " + repoDir + " (exists already)");
+            // Create an empty repository with format version 0 first.
+            try (org.eclipse.jgit.lib.Repository initRepo = repositoryBuilder.build()) {
+                if (exist(repoDir)) {
+                    throw new StorageException(
+                            "failed to create a repository at: " + repoDir + " (exists already)");
+                }
+
+                initRepo.create(true);
+
+                final StoredConfig config = initRepo.getConfig();
+                if (format == GitRepositoryFormat.V1) {
+                    // Update the repository settings to upgrade to format version 1 and reftree.
+                    config.setInt(CONFIG_CORE_SECTION, null, CONFIG_KEY_REPO_FORMAT_VERSION, 1);
+                    config.setString("extensions", null, "refStorage", "reftree");
+                }
+
+                // Disable hidden files, symlinks and file modes we do not use.
+                config.setEnum(CONFIG_CORE_SECTION, null, CONFIG_KEY_HIDEDOTFILES, HideDotFiles.FALSE);
+                config.setBoolean(CONFIG_CORE_SECTION, null, CONFIG_KEY_SYMLINKS, false);
+                config.setBoolean(CONFIG_CORE_SECTION, null, CONFIG_KEY_FILEMODE, false);
+
+                // Set the diff algorithm.
+                config.setString(CONFIG_DIFF_SECTION, null, CONFIG_KEY_ALGORITHM, "histogram");
+
+                // Disable rename detection which we do not use.
+                config.setBoolean(CONFIG_DIFF_SECTION, null, CONFIG_KEY_RENAMES, false);
+
+                config.save();
             }
 
-            jGitRepository.create(true);
+            // Re-open the repository with the updated settings and format version.
+            jGitRepository = new RepositoryBuilder().setGitDir(repoDir).build();
 
-            // Insert the initial commit.
-            commit0(null, Revision.INIT, author, "Create a new repository", "", Markup.PLAINTEXT,
+            // Initialize the master branch.
+            final RefUpdate head = jGitRepository.updateRef(Constants.HEAD);
+            head.disableRefLog();
+            head.link(Constants.R_HEADS + Constants.MASTER);
+
+            // Insert the initial commit into the master branch.
+            commit0(null, Revision.INIT, creationTimeMillis, author,
+                    "Create a new repository", "", Markup.PLAINTEXT,
                     Collections.emptyList(), true);
 
             headRevision = Revision.INIT;
@@ -162,11 +225,7 @@ class GitRepository implements Repository {
         } finally {
             if (!success) {
                 // Failed to create a repository. Remove any cruft so that it is not loaded on the next run.
-                try {
-                    deltree(repoDir);
-                } catch (IOError e) {
-                    logger.warn("Failed to delete a half-created repository at: {}", repoDir, e);
-                }
+                deleteCruft(repoDir);
             }
         }
     }
@@ -190,6 +249,20 @@ class GitRepository implements Repository {
             if (!exist(repoDir)) {
                 throw new StorageException("failed to open a repository at: " + repoDir + " (does not exist)");
             }
+
+            // Retrieve the tag format.
+            final int formatVersion = jGitRepository.getConfig().getInt(
+                    CONFIG_CORE_SECTION, null, CONFIG_KEY_REPO_FORMAT_VERSION, 0);
+            switch (formatVersion) {
+                case 0:
+                    format = GitRepositoryFormat.V0;
+                    break;
+                case 1:
+                    format = GitRepositoryFormat.V1;
+                    break;
+                default:
+                    throw new StorageException("unknown repository format version: " + formatVersion);
+            }
         } catch (IOException e) {
             throw new StorageException("failed to open a repository at: " + repoDir, e);
         }
@@ -210,19 +283,6 @@ class GitRepository implements Repository {
         }
     }
 
-    /**
-     * Deletes the specified {@code directory} recursively.
-     */
-    private static void deltree(File directory) {
-        if (directory.exists()) {
-            try {
-                Files.walkFileTree(directory.toPath(), DeletingFileVisitor.INSTANCE);
-            } catch (IOException e) {
-                throw new IOError(e);
-            }
-        }
-    }
-
     void close() {
         jGitRepository.close();
     }
@@ -235,6 +295,10 @@ class GitRepository implements Repository {
     @Override
     public String name() {
         return name;
+    }
+
+    public GitRepositoryFormat format() {
+        return format;
     }
 
     @Override
@@ -502,18 +566,18 @@ class GitRepository implements Repository {
                 revWalk.markUninteresting(toCommit);
             }
 
-            final List<Commit> revisionList = new ArrayList<>();
+            final List<Commit> commitList = new ArrayList<>();
             boolean needsLastCommit = true;
             for (RevCommit revCommit : revWalk) {
                 final Commit c = toCommit(revCommit);
                 if (c != null) {
-                    revisionList.add(c);
+                    commitList.add(c);
                 } else {
                     // Probably garbage (e.g. deleted runspace)
                     continue;
                 }
 
-                if (revCommit.getId().equals(toCommitId) || revisionList.size() == maxCommits) {
+                if (revCommit.getId().equals(toCommitId) || commitList.size() == maxCommits) {
                     // Visited the last commit or can't retrieve beyond maxCommits
                     needsLastCommit = false;
                     break;
@@ -529,16 +593,16 @@ class GitRepository implements Repository {
                     final Revision lastCommitRevision =
                             CommitUtil.extractRevision(lastRevCommit.getFullMessage());
                     if (lastCommitRevision.major() == 1 || lastCommitRevision.minor() == 1) {
-                        revisionList.add(toCommit(lastRevCommit));
+                        commitList.add(toCommit(lastRevCommit));
                     }
                 }
             }
 
             if (ascending) {
-                Collections.reverse(revisionList);
+                Collections.reverse(commitList);
             }
 
-            return revisionList;
+            return commitList;
         } catch (StorageException e) {
             throw e;
         } catch (Exception e) {
@@ -700,15 +764,16 @@ class GitRepository implements Repository {
 
     @Override
     public CompletableFuture<Revision> commit(
-            Revision baseRevision, Author author, String summary,
+            Revision baseRevision, long commitTimeMillis, Author author, String summary,
             String detail, Markup markup, Iterable<Change<?>> changes) {
 
         return CompletableFuture.supplyAsync(
-                () -> blockingCommit(baseRevision, author, summary, detail, markup, changes), repositoryWorker);
+                () -> blockingCommit(baseRevision, commitTimeMillis,
+                                     author, summary, detail, markup, changes), repositoryWorker);
     }
 
     private Revision blockingCommit(
-            Revision baseRevision, Author author, String summary,
+            Revision baseRevision, long commitTimeMillis, Author author, String summary,
             String detail, Markup markup, Iterable<Change<?>> changes) {
 
         requireNonNull(baseRevision, "baseRevision");
@@ -739,7 +804,8 @@ class GitRepository implements Repository {
                 nextRevision = new Revision(headRevision.major() + 1);
             }
 
-            res = commit0(headRevision, nextRevision, author, summary, detail, markup, changes, false);
+            res = commit0(headRevision, nextRevision, commitTimeMillis,
+                          author, summary, detail, markup, changes, false);
 
             if (!pushToRunspace) {
                 this.headRevision = res.revision;
@@ -753,7 +819,7 @@ class GitRepository implements Repository {
         return res.revision;
     }
 
-    private CommitResult commit0(Revision prevRevision, Revision nextRevision,
+    private CommitResult commit0(Revision prevRevision, Revision nextRevision, long commitTimeMillis,
                                  Author author, String summary, String detail, Markup markup,
                                  Iterable<Change<?>> changes, boolean allowEmpty) {
 
@@ -803,13 +869,14 @@ class GitRepository implements Repository {
 
             // build a commit object
             final PersonIdent personIdent = new PersonIdent(author.name(), author.email(),
-                                                            System.currentTimeMillis() / 1000L * 1000L, 0);
+                                                            commitTimeMillis / 1000L * 1000L, 0);
 
             final CommitBuilder commitBuilder = new CommitBuilder();
 
             commitBuilder.setAuthor(personIdent);
             commitBuilder.setCommitter(personIdent);
             commitBuilder.setTreeId(nextTreeId);
+            commitBuilder.setEncoding(StandardCharsets.UTF_8);
 
             // Write summary, detail and revision to commit's message as JSON format.
             commitBuilder.setMessage(CommitUtil.toJsonString(summary, detail, markup, nextRevision));
@@ -1154,29 +1221,29 @@ class GitRepository implements Repository {
     }
 
     @Override
-    public CompletableFuture<Revision> watch(Revision lastKnownRev, String pathPattern) {
-        requireNonNull(lastKnownRev, "lastKnownRev");
+    public CompletableFuture<Revision> watch(Revision lastKnownRevision, String pathPattern) {
+        requireNonNull(lastKnownRevision, "lastKnownRevision");
         requireNonNull(pathPattern, "pathPattern");
         requireNonNull(repositoryWorker, "executor");
 
         final CompletableFuture<Revision> future = new CompletableFuture<>();
 
-        normalize(lastKnownRev).thenAccept(normalizedLastKnownRev -> {
-            final Revision headRev;
-            if (normalizedLastKnownRev.onMainLane()) {
-                headRev = cachedMainLaneHeadRevision();
+        normalize(lastKnownRevision).thenAccept(normLastKnownRevision -> {
+            final Revision headRevision;
+            if (normLastKnownRevision.onMainLane()) {
+                headRevision = cachedMainLaneHeadRevision();
             } else {
-                headRev = runspaceHeadRevision(normalizedLastKnownRev.major());
+                headRevision = runspaceHeadRevision(normLastKnownRevision.major());
             }
 
             final PathPatternFilter filter = PathPatternFilter.of(pathPattern);
 
-            // If lastKnownRev is outdated already and the recent changes match, there's no need to watch.
-            if (!normalizedLastKnownRev.equals(headRev) &&
-                hasMatchingChanges(normalizedLastKnownRev, headRev, filter)) {
-                future.complete(headRev);
+            // If lastKnownRevision is outdated already and the recent changes match, there's no need to watch.
+            if (!normLastKnownRevision.equals(headRevision) &&
+                hasMatchingChanges(normLastKnownRevision, headRevision, filter)) {
+                future.complete(headRevision);
             } else {
-                commitWatchers.add(normalizedLastKnownRev, filter, future);
+                commitWatchers.add(normLastKnownRevision, filter, future);
             }
         }).exceptionally(cause -> {
             future.completeExceptionally(cause);
@@ -1230,20 +1297,15 @@ class GitRepository implements Repository {
         }
     }
 
-    /**
-     * Creates a new runspace at {@code majorRevision}.
-     *
-     * @param author author who creates this runspace
-     * @param majorRevision the major revision number based on which the runspace is created
-     * @return the {@link Revision} for newly created runspace
-     */
     @Override
-    public CompletableFuture<Revision> createRunspace(Author author, int majorRevision) {
-        return CompletableFuture.supplyAsync(() -> blockingCreateRunspace(author, majorRevision),
-                                             repositoryWorker);
+    public CompletableFuture<Revision> createRunspace(int majorRevision, long creationTimeMillis,
+                                                      Author author) {
+        return CompletableFuture.supplyAsync(
+                () -> blockingCreateRunspace(majorRevision, creationTimeMillis, author),
+                repositoryWorker);
     }
 
-    private Revision blockingCreateRunspace(Author author, int majorRevision) {
+    private Revision blockingCreateRunspace(int majorRevision, long creationTimeMillis, Author author) {
         if (majorRevision <= 0) {
             throw new IllegalArgumentException("majorRevision " + majorRevision + " (expected: > 0)");
         }
@@ -1254,27 +1316,25 @@ class GitRepository implements Repository {
         writeLock.lock();
         try {
             if (resolveExactRef(runspaceRef(majorRevision)) != null) {
-                throw new StorageException("runspace exists already (majorRevision: " + majorRevision + ')');
+                throw new StorageException("runspace exists already (major revision: " + majorRevision + ')');
             }
 
             prevRevision = new Revision(majorRevision);
 
             if (resolveExactRef(revisionRef(prevRevision)) == null) {
-                throw new RevisionNotFoundException("non-existent majorRevision: " + majorRevision);
+                throw new RevisionNotFoundException("non-existent major revision: " + majorRevision);
             }
 
             nextRevision = new Revision(majorRevision, 1);
 
-            return commit0(prevRevision, nextRevision, author, "Create a new runspace from " + majorRevision,
+            return commit0(prevRevision, nextRevision, creationTimeMillis,
+                           author, "Create a new runspace from major revision " + majorRevision,
                            "", Markup.PLAINTEXT, Collections.emptyList(), true).revision;
         } finally {
             writeLock.unlock();
         }
     }
 
-    /**
-     * Removes the runspace associated with the specified {@code majorRevision}.
-     */
     @Override
     public CompletableFuture<Void> removeRunspace(int majorRevision) {
         return CompletableFuture.supplyAsync(() -> {
@@ -1300,8 +1360,19 @@ class GitRepository implements Repository {
                         " (result: " + result + ')');
             }
 
-            final Map<String, Ref> refMap = jGitRepository.getRefDatabase().getRefs(
-                    Constants.R_TAGS + TagUtil.byteHexDirName(majorRevision));
+            final String prefix;
+            switch (format) {
+                case V0:
+                    prefix = Constants.R_TAGS + TagUtil.byteHexDirName(majorRevision);
+                    break;
+                case V1:
+                    prefix = Constants.R_TAGS + "runspaces/" + majorRevision + '/';
+                    break;
+                default:
+                    throw new Error("unknown repository format: " + format);
+            }
+
+            final Map<String, Ref> refMap = jGitRepository.getRefDatabase().getRefs(prefix);
 
             for (Map.Entry<String, Ref> refEntry : refMap.entrySet()) {
                 final Revision revision = new Revision(refEntry.getKey());
@@ -1330,8 +1401,8 @@ class GitRepository implements Repository {
         try (RevWalk revWalk = new RevWalk(jGitRepository)) {
             final Map<String, Ref> refMap = jGitRepository.getRefDatabase().getRefs(R_HEADS_RUNSPACES);
             for (Ref ref : refMap.values()) {
-                RevCommit revCommit = revWalk.parseCommit(ref.getObjectId());
-                Revision revision = CommitUtil.extractRevision(revCommit.getFullMessage());
+                final RevCommit revCommit = revWalk.parseCommit(ref.getObjectId());
+                final Revision revision = CommitUtil.extractRevision(revCommit.getFullMessage());
                 runspaces.add(revision);
             }
             return runspaces;
@@ -1366,22 +1437,22 @@ class GitRepository implements Repository {
     }
 
     /**
-     * Get the latest revision for given runspace specified by {@code major}.
+     * Get the latest revision for given runspace specified by {@code majorRevision}.
      */
-    private Revision runspaceHeadRevision(int major) {
-        if (major == 0) {
-            throw new IllegalArgumentException("major: 0 (expected: a positive integer)");
+    private Revision runspaceHeadRevision(int majorRevision) {
+        if (majorRevision == 0) {
+            throw new IllegalArgumentException("majorRevision: 0 (expected: a positive integer)");
         }
 
         try (RevWalk revWalk = new RevWalk(jGitRepository)) {
-            ObjectId commitId = toRunspaceHeadCommitId(major);
+            ObjectId commitId = toRunspaceHeadCommitId(majorRevision);
             RevCommit revCommit = revWalk.parseCommit(commitId);
             return CommitUtil.extractRevision(revCommit.getFullMessage());
         } catch (StorageException e) {
             throw e;
         } catch (Exception e) {
             throw new StorageException(
-                    "failed to get the latest runspace revision for major revision " + major, e);
+                    "failed to get the latest runspace revision for major revision " + majorRevision, e);
         }
     }
 
@@ -1434,9 +1505,20 @@ class GitRepository implements Repository {
         }
     }
 
-    private static String revisionRef(Revision revision) {
-        return Constants.R_TAGS + TagUtil.byteHexDirName(revision.major()) +
-               (revision.minor() == 0 ? revision.text() + ".0" : revision.text());
+    private String revisionRef(Revision revision) {
+        switch (format) {
+            case V0:
+                return Constants.R_TAGS + TagUtil.byteHexDirName(revision.major()) +
+                       (revision.minor() == 0 ? revision.text() + ".0" : revision.text());
+            case V1:
+                if (revision.minor() == 0) {
+                    return Constants.R_TAGS + revision.major();
+                } else {
+                    return Constants.R_TAGS + "runspaces/" + revision.major() + '/' + revision.minor();
+                }
+        }
+
+        throw new Error("unknown repository format: " + format);
     }
 
     private static String runspaceRef(int majorRevision) {
@@ -1447,9 +1529,73 @@ class GitRepository implements Repository {
         return R_HEADS_RUNSPACES_REMOVED + majorRevision;
     }
 
+    /**
+     * Clones this repository into a new one.
+     */
+    public void cloneTo(File newRepoDir) {
+        cloneTo(newRepoDir, GitRepositoryFormat.V1);
+    }
+
+    /**
+     * Clones this repository into a new one.
+     *
+     * @param format the repository format
+     */
+    public void cloneTo(File newRepoDir, GitRepositoryFormat format) {
+        // Create a new repository with the initial commit using the identical author.
+        final Commit firstCommit = blockingHistory(Revision.INIT, Revision.INIT, Repository.ALL_PATH, 1).get(0);
+        final GitRepository newRepo = new GitRepository(parent, newRepoDir, format, repositoryWorker,
+                                                        firstCommit.when(), firstCommit.author());
+
+        boolean success = false;
+        try {
+            // Replay all commits.
+            final Revision endRevision = blockingNormalize(Revision.HEAD);
+            for (int i = 2; i <= endRevision.major();) {
+                // Fetch up to 16 commits at once.
+                final int batch = 16;
+                final List<Commit> commits = blockingHistory(
+                        new Revision(i), new Revision(Math.min(endRevision.major(), i + batch - 1)),
+                        Repository.ALL_PATH, batch);
+                checkState(!commits.isEmpty(), "empty commits");
+
+                for (Commit c : commits) {
+                    final Revision revision = c.revision();
+                    checkState(revision.major() == i,
+                               "mismatching revision: %s (expected: %s)", revision.major(), i);
+
+                    final Revision baseRevision = revision.backward(1);
+                    final Collection<Change<?>> changes =
+                            blockingDiff(baseRevision, revision, Repository.ALL_PATH).values();
+                    newRepo.blockingCommit(
+                            baseRevision, c.when(), c.author(), c.summary(), c.detail(), c.markup(), changes);
+                    i++;
+                }
+            }
+
+            success = true;
+        } finally {
+            newRepo.close();
+            if (!success) {
+                deleteCruft(newRepoDir);
+            }
+        }
+    }
+
+    private static void deleteCruft(File repoDir) {
+        try {
+            Util.deleteFileTree(repoDir);
+        } catch (IOException e) {
+            logger.error("Failed to delete a half-created repository at: {}", repoDir, e);
+        }
+    }
+
     @Override
     public String toString() {
-        return "GitRepository(" + jGitRepository.getDirectory() + ')';
+        return MoreObjects.toStringHelper(this)
+                          .add("dir", jGitRepository.getDirectory())
+                          .add("format", format)
+                          .toString();
     }
 
     private static final class CommitResult {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -1543,11 +1543,8 @@ class GitRepository implements Repository {
      * @param format the repository format
      */
     public void cloneTo(File newRepoDir, GitRepositoryFormat format) {
-        // Create a new repository with the initial commit using the identical author.
-        final Commit firstCommit = blockingHistory(Revision.INIT, Revision.INIT, Repository.ALL_PATH, 1).get(0);
         final GitRepository newRepo = new GitRepository(parent, newRepoDir, format, repositoryWorker,
-                                                        firstCommit.when(), firstCommit.author());
-
+                                                        creationTimeMillis(), author());
         boolean success = false;
         try {
             // Replay all commits.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryFormat.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryFormat.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+public enum GitRepositoryFormat {
+    V0,
+    V1
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.server.internal.thrift;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
+import static com.linecorp.centraldogma.common.Author.SYSTEM;
 import static com.linecorp.centraldogma.server.internal.thrift.Converter.convert;
 import static com.spotify.futures.CompletableFutures.allAsList;
 import static java.util.Objects.requireNonNull;
@@ -120,7 +121,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
 
     @Override
     public void createProject(String name, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.createProject(name)), resultHandler);
+        handle(executor.execute(Command.createProject(name, SYSTEM)), resultHandler);
     }
 
     @Override
@@ -152,7 +153,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void createRepository(
             String projectName, String repositoryName, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.createRepository(projectName, repositoryName)), resultHandler);
+        handle(executor.execute(Command.createRepository(projectName, repositoryName, SYSTEM)),
+               resultHandler);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
@@ -23,11 +23,12 @@ import org.junit.Test;
 public class CreateProjectCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateProjectCommand("foo"),
+        assertJsonConversion(new CreateProjectCommand("foo", 1234L),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_PROJECT\"," +
-                             "  \"projectName\": \"foo\"" +
+                             "  \"projectName\": \"foo\"," +
+                             "  \"creationTimeMillis\": 1234" +
                              '}');
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
@@ -20,15 +20,21 @@ import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConv
 
 import org.junit.Test;
 
+import com.linecorp.centraldogma.common.Author;
+
 public class CreateProjectCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateProjectCommand("foo", 1234L),
+        assertJsonConversion(new CreateProjectCommand("foo", 1234L, new Author("foo", "bar@baz.com")),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_PROJECT\"," +
                              "  \"projectName\": \"foo\"," +
-                             "  \"creationTimeMillis\": 1234" +
+                             "  \"creationTimeMillis\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"foo\"," +
+                             "    \"email\": \"bar@baz.com\"" +
+                             "  }" +
                              '}');
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
@@ -20,16 +20,22 @@ import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConv
 
 import org.junit.Test;
 
+import com.linecorp.centraldogma.common.Author;
+
 public class CreateRepositoryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateRepositoryCommand("foo", "bar", 1234L),
+        assertJsonConversion(new CreateRepositoryCommand("foo", "bar", 1234L, new Author("foo", "bar@baz.com")),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_REPOSITORY\"," +
                              "  \"projectName\": \"foo\"," +
                              "  \"repositoryName\": \"bar\"," +
-                             "  \"creationTimeMillis\": 1234" +
+                             "  \"creationTimeMillis\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"foo\"," +
+                             "    \"email\": \"bar@baz.com\"" +
+                             "  }" +
                              '}');
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
@@ -23,12 +23,13 @@ import org.junit.Test;
 public class CreateRepositoryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateRepositoryCommand("foo", "bar"),
+        assertJsonConversion(new CreateRepositoryCommand("foo", "bar", 1234L),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_REPOSITORY\"," +
                              "  \"projectName\": \"foo\"," +
-                             "  \"repositoryName\": \"bar\"" +
+                             "  \"repositoryName\": \"bar\"," +
+                             "  \"creationTimeMillis\": 1234" +
                              '}');
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommandTest.java
@@ -25,18 +25,19 @@ import com.linecorp.centraldogma.common.Author;
 public class CreateRunspaceCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateRunspaceCommand("foo", "bar",
-                                                       new Author("John Doe", "john@doe.com"), 42),
+        assertJsonConversion(new CreateRunspaceCommand("foo", "bar", 42, 1234L,
+                                                       new Author("John Doe", "john@doe.com")),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_RUNSPACE\"," +
                              "  \"projectName\": \"foo\"," +
+                             "  \"baseRevision\": 42," +
+                             "  \"creationTimeMillis\": 1234," +
                              "  \"repositoryName\": \"bar\"," +
                              "  \"author\": {" +
                              "    \"name\": \"John Doe\"," +
                              "    \"email\": \"john@doe.com\"" +
-                             "  }," +
-                             "  \"baseRevision\": 42" +
+                             "  }" +
                              '}');
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
@@ -32,7 +32,7 @@ public class PushCommandTest {
     @Test
     public void testJsonConversion() {
         assertJsonConversion(
-                new PushCommand("foo", "bar", new Revision(42),
+                new PushCommand("foo", "bar", new Revision(42), 1234L,
                                 new Author("Marge Simpson", "marge@simpsonsworld.com"),
                                 "baz", "qux", Markup.MARKDOWN,
                                 Collections.singletonList(Change.ofTextUpsert("/memo.txt", "Bon voyage!"))),
@@ -45,6 +45,7 @@ public class PushCommandTest {
                 "    \"major\": 42," +
                 "    \"minor\": 0" +
                 "  }," +
+                "  \"commitTimeMillis\": 1234," +
                 "  \"author\": {" +
                 "    \"name\": \"Marge Simpson\"," +
                 "    \"email\": \"marge@simpsonsworld.com\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
@@ -113,7 +113,7 @@ public class PluginTest {
         final Project p = pm.create(testName.getMethodName());
         p.repos().create(REPO_META);
         p.repos().create(REPO_MAIN);
-        p.metaRepo().commit(Revision.HEAD, Author.SYSTEM, "", loadChanges("meta"));
+        p.metaRepo().commit(Revision.HEAD, 0L, Author.SYSTEM, "", loadChanges("meta"));
         p.plugins().reload();
         return p;
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
@@ -27,15 +27,22 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.internal.command.Command;
 
 public class ReplicationLogTest {
+
+    private static final Author AUTHOR = new Author("foo", "bar@baz.com");
+
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject("foo", 1234), null),
+        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject("foo", 1234L, AUTHOR), null),
                              '{' +
                              "  \"replicaId\": \"r1\"," +
                              "  \"command\": {" +
                              "    \"type\": \"CREATE_PROJECT\"," +
                              "    \"projectName\": \"foo\"," +
-                             "    \"creationTimeMillis\": 1234" +
+                             "    \"creationTimeMillis\": 1234," +
+                             "    \"author\": {" +
+                             "      \"name\": \"foo\"," +
+                             "      \"email\": \"bar@baz.com\"" +
+                             "    }" +
                              "  }," +
                              "  \"result\": null" +
                              '}');

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
@@ -29,18 +29,19 @@ import com.linecorp.centraldogma.server.internal.command.Command;
 public class ReplicationLogTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject("foo"), null),
+        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject("foo", 1234), null),
                              '{' +
                              "  \"replicaId\": \"r1\"," +
                              "  \"command\": {" +
                              "    \"type\": \"CREATE_PROJECT\"," +
-                             "    \"projectName\": \"foo\"" +
+                             "    \"projectName\": \"foo\"," +
+                             "    \"creationTimeMillis\": 1234" +
                              "  }," +
                              "  \"result\": null" +
                              '}');
 
         Command<Revision> pushCommand = Command.push(
-                "foo", "bar", Revision.HEAD, new Author("Sedol Lee", "sedol@lee.com"),
+                "foo", "bar", Revision.HEAD, 1234, new Author("Sedol Lee", "sedol@lee.com"),
                 "4:1", "L-L-L-W-L", Markup.PLAINTEXT, Change.ofTextUpsert("/result.txt", "too soon to tell"));
 
         assertJsonConversion(new ReplicationLog<>("r2", pushCommand, new Revision(43)),
@@ -54,6 +55,7 @@ public class ReplicationLogTest {
                              "      \"major\": -1," +
                              "      \"minor\": 0" +
                              "    }," +
+                             "    \"commitTimeMillis\": 1234," +
                              "    \"author\": {" +
                              "      \"name\": \"Sedol Lee\"," +
                              "      \"email\": \"sedol@lee.com\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -87,7 +87,7 @@ public class ZooKeeperCommandExecutorTest {
         Replica replica4 = null;
 
         try {
-            final Command<Void> command1 = Command.createRepository("project", "repo1");
+            final Command<Void> command1 = Command.createRepository("project", "repo1", Author.SYSTEM);
             replica1.rm.execute(command1).join();
 
             final Optional<ReplicationLog<?>> commandResult2 = replica1.rm.loadLog(0, false);
@@ -106,7 +106,7 @@ public class ZooKeeperCommandExecutorTest {
             //stop replay m3
             replica3.rm.stop();
 
-            final Command<?> command2 = Command.createProject("foo");
+            final Command<?> command2 = Command.createProject("foo", Author.SYSTEM);
             replica1.rm.execute(command2).join();
             Thread.sleep(100);
             verify(replica1.delegate, times(1)).apply(eq(command2));

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
@@ -104,11 +104,11 @@ public class DefaultMetaRepositoryTest {
         assertThat(metaRepo.mirrors()).isEmpty();
 
         // should return an empty result when /credentials.json exists and /mirrors.json does not.
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "", Change.ofJsonUpsert("/credentials.json", "[]"));
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "", Change.ofJsonUpsert("/credentials.json", "[]"));
         assertThat(metaRepo.mirrors()).isEmpty();
 
         // should return an empty result when both /credentials.json and /mirrors.json exist.
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "", Change.ofJsonUpsert("/mirrors.json", "[]"));
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "", Change.ofJsonUpsert("/mirrors.json", "[]"));
         assertThat(metaRepo.mirrors()).isEmpty();
     }
 
@@ -118,24 +118,24 @@ public class DefaultMetaRepositoryTest {
     @Test
     public void testInvalidMirrors() {
         // not an array but an object
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "",
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "",
                         Change.ofJsonUpsert(PATH_MIRRORS, "{}")).join();
         assertThatThrownBy(() -> metaRepo.mirrors()).isInstanceOf(RepositoryMetadataException.class);
 
         // not an array but a value
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "",
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "",
                         Change.ofJsonUpsert(PATH_MIRRORS, "\"oops\"")).join();
         assertThatThrownBy(() -> metaRepo.mirrors()).isInstanceOf(RepositoryMetadataException.class);
 
         // an array that contains null.
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "",
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "",
                         Change.ofJsonUpsert(PATH_MIRRORS, "[ null ]")).join();
         assertThatThrownBy(() -> metaRepo.mirrors()).isInstanceOf(RepositoryMetadataException.class);
     }
 
     @Test
     public void testSingleTypeMirror() {
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "",
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "",
                         Change.ofJsonUpsert(
                                 PATH_MIRRORS,
                                 "[{" +
@@ -231,7 +231,7 @@ public class DefaultMetaRepositoryTest {
     @Test
     public void testMultipleTypeMirror() {
 
-        metaRepo.commit(Revision.HEAD, Author.SYSTEM, "",
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "",
                         Change.ofJsonUpsert(
                                 PATH_MIRRORS,
                                 "[{" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -81,15 +81,6 @@ public class RepositoryManagerWrapperTest {
     }
 
     @Test
-    public void testGetOrCreate() {
-        String name = testName.getMethodName();
-        assertTrue(!m.exists(name));
-        Repository repo = m.getOrCreate(name);
-        Repository repo2 = m.getOrCreate(name);
-        assertSame(repo, repo2);
-    }
-
-    @Test
     public void testRemove() {
         String name = testName.getMethodName();
         m.create(name);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ public class CachingRepositoryTest {
     @Test
     @SuppressWarnings("unchecked")
     public void query() {
-        final Repository repo = setMockNames(newCachingRepo(10));
+        final Repository repo = setMockNames(newCachingRepo());
         final Query<Object> query = Query.identity("/baz.txt");
         final QueryResult<Object> queryResult = new QueryResult<>(new Revision(10), EntryType.TEXT, "qux");
 
@@ -89,9 +90,8 @@ public class CachingRepositoryTest {
     @Test
     @SuppressWarnings("unchecked")
     public void queryMissingEntry() {
-        final Repository repo = setMockNames(newCachingRepo(10));
+        final Repository repo = setMockNames(newCachingRepo());
         final Query<Object> query = Query.identity("/baz.txt");
-        final QueryResult<Object> queryResult = CacheableQueryCall.EMPTY;
 
         doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(new Revision(10));
         doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(HEAD);
@@ -113,7 +113,7 @@ public class CachingRepositoryTest {
 
     @Test
     public void find() {
-        final Repository repo = setMockNames(newCachingRepo(10));
+        final Repository repo = setMockNames(newCachingRepo());
         final Map<String, Entry<?>> entries = ImmutableMap.of("/baz.txt", Entry.ofText("/baz.txt", "qux"));
 
         doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(new Revision(10));
@@ -135,7 +135,7 @@ public class CachingRepositoryTest {
 
     @Test
     public void history() {
-        final Repository repo = setMockNames(newCachingRepo(3));
+        final Repository repo = setMockNames(newCachingRepo());
         final List<Commit> commits = ImmutableList.of(
                 new Commit(new Revision(3), SYSTEM, "third",  "", Markup.MARKDOWN),
                 new Commit(new Revision(3), SYSTEM, "second", "", Markup.MARKDOWN),
@@ -165,7 +165,7 @@ public class CachingRepositoryTest {
     @Test
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void singleDiff() {
-        final Repository repo = setMockNames(newCachingRepo(10));
+        final Repository repo = setMockNames(newCachingRepo());
         final Query query = Query.identity("/foo.txt");
         final Change change = Change.ofTextUpsert(query.path(), "bar");
 
@@ -192,7 +192,7 @@ public class CachingRepositoryTest {
 
     @Test
     public void multiDiff() {
-        final Repository repo = setMockNames(newCachingRepo(10));
+        final Repository repo = setMockNames(newCachingRepo());
         final Map<String, Change<?>> changes = ImmutableMap.of(
                 "/foo.txt", Change.ofTextUpsert("/foo.txt", "bar"));
 
@@ -217,8 +217,15 @@ public class CachingRepositoryTest {
         verifyNoMoreInteractions(delegateRepo);
     }
 
-    private Repository newCachingRepo(int headRevision) {
+    private Repository newCachingRepo() {
+        when(delegateRepo.history(INIT, INIT, Repository.ALL_PATH, 1)).thenReturn(completedFuture(
+                ImmutableList.of(new Commit(INIT, SYSTEM, "", "", Markup.PLAINTEXT))));
+
         Repository cachingRepo = new CachingRepository(delegateRepo, new RepositoryCache("maximumSize=1000"));
+
+        // Verify that CachingRepository calls delegateRepo.history() once to retrieve the initial commit.
+        verify(delegateRepo, times(1)).history(INIT, INIT, Repository.ALL_PATH, 1);
+
         verifyNoMoreInteractions(delegateRepo);
         clearInvocations(delegateRepo);
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -219,11 +218,7 @@ public class CachingRepositoryTest {
     }
 
     private Repository newCachingRepo(int headRevision) {
-        when(delegateRepo.normalize(HEAD)).thenReturn(completedFuture(new Revision(headRevision)));
-
         Repository cachingRepo = new CachingRepository(delegateRepo, new RepositoryCache("maximumSize=1000"));
-
-        verify(delegateRepo, times(1)).normalize(HEAD);
         verifyNoMoreInteractions(delegateRepo);
         clearInvocations(delegateRepo);
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryMigrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryMigrationTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepositoryFormat.V0;
+import static com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepositoryFormat.V1;
+import static java.util.concurrent.ForkJoinPool.commonPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Commit;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
+
+public class GitRepositoryMigrationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(GitRepositoryMigrationTest.class);
+
+    private static final Project proj = mock(Project.class);
+
+    @Rule
+    public final TemporaryFolder tempDir = new TemporaryFolder();
+
+    /**
+     * Makes sure {@link GitRepository} can create the legacy format repository, with Git repository format
+     * version 0 and hexadecimal tag encoding.
+     */
+    @Test
+    public void legacyFormatCreation() {
+        final File repoDir0 = tempDir.getRoot();
+        final GitRepository repo0 = new GitRepository(proj, repoDir0, V0, commonPool(), 0L, Author.SYSTEM);
+        try {
+            assertThat(repo0.format()).isSameAs(V0);
+            assertThat(Paths.get(repoDir0.getPath(), "refs", "tags", "01", "1.0"))
+                    .existsNoFollowLinks()
+                    .isRegularFile();
+            assertThat(Paths.get(repoDir0.getPath(), "refs", "heads", "master"))
+                    .existsNoFollowLinks()
+                    .isRegularFile();
+        } finally {
+            repo0.close();
+        }
+    }
+
+    /**
+     * Makes sure {@link GitRepository} can create the modern format repository, with Git repository format
+     * version 1 and simple tag encoding.
+     */
+    @Test
+    public void modernFormatCreation() {
+        final File repoDir1 = tempDir.getRoot();
+        final GitRepository repo1 = new GitRepository(proj, repoDir1, commonPool(), 0L, Author.SYSTEM);
+        try {
+            assertThat(repo1.format()).isSameAs(V1);
+            assertThat(Paths.get(repoDir1.getPath(), "refs", "tags", "01", "1.0")).doesNotExist();
+            assertThat(Paths.get(repoDir1.getPath(), "refs", "heads", "master")).doesNotExist();
+            assertThat(Paths.get(repoDir1.getPath(), "refs", "txn", "committed"))
+                    .existsNoFollowLinks()
+                    .isRegularFile();
+        } finally {
+            repo1.close();
+        }
+    }
+
+    /**
+     * Makes sure a legacy {@link GitRepository} is migrated to the modern format.
+     */
+    @Test
+    public void singleRepositoryMigration() {
+        final File repoDir0 = new File(tempDir.getRoot(), "legacy");
+        final File repoDir1 = new File(tempDir.getRoot(), "modern");
+        final GitRepository repo0 = new GitRepository(proj, repoDir0, V0, commonPool(), 0, Author.SYSTEM);
+        try {
+            assertThat(repo0.format()).isSameAs(V0);
+
+            // Put some commits into the legacy repo.
+            for (int i = 1; i < 128; i++) {
+                repo0.commit(new Revision(i), i * 1000, new Author("user" + rnd() + "@example.com"),
+                             "Summary " + rnd(), "Detail " + rnd(), Markup.PLAINTEXT,
+                             Change.ofTextUpsert("/file_" + rnd() + ".txt", "content " + i)).join();
+            }
+
+            // Build a clone in modern format.
+            repo0.cloneTo(repoDir1);
+
+            final GitRepository repo1 = new GitRepository(proj, repoDir1, commonPool());
+            try {
+                assertThat(repo1.format()).isSameAs(V1);
+
+                // Make sure all commits are identical.
+                final List<Commit> commits0 = repo0.history(
+                        Revision.INIT, Revision.HEAD, Repository.ALL_PATH, Integer.MAX_VALUE).join();
+                final List<Commit> commits1 = repo1.history(
+                        Revision.INIT, Revision.HEAD, Repository.ALL_PATH, Integer.MAX_VALUE).join();
+
+                assertThat(commits1).isEqualTo(commits0);
+
+                // Make sure all commits are ordered correctly.
+                for (int i = 0; i < commits0.size(); i++) {
+                    assertThat(commits0.get(i).revision().major()).isEqualTo(i + 1);
+                }
+
+                // Make sure the changes of all commits are identical.
+                for (Commit c : commits0) {
+                    if (c.revision().major() == 1) {
+                        continue;
+                    }
+
+                    final Map<String, Change<?>> changes0 = repo0.diff(
+                            c.revision().backward(1), c.revision(), Repository.ALL_PATH).join();
+                    final Map<String, Change<?>> changes1 = repo0.diff(
+                            c.revision().backward(1), c.revision(), Repository.ALL_PATH).join();
+
+                    if (changes0.equals(changes1)) {
+                        logger.debug("{}: {}", c.revision().major(), changes0);
+                    } else {
+                        logger.warn("{}: {} vs. {}", c.revision().major(), changes0, changes1);
+                    }
+
+                    assertThat(changes1)
+                            .withFailMessage("mismatching changes for revision %s", c.revision().major())
+                            .isEqualTo(changes0);
+                }
+            } finally {
+                repo1.close();
+            }
+        } finally {
+            repo0.close();
+        }
+    }
+
+    /**
+     * Makes sure {@link GitRepositoryManager} performs migration.
+     */
+    @Test
+    public void multipleRepositoryMigration() {
+        final File tempDir = this.tempDir.getRoot();
+        // Create repositories of older format.
+        try (GitRepositoryManager manager = new GitRepositoryManager(proj, tempDir, V0, commonPool())) {
+            assertThat(((GitRepository) manager.create("foo")).format()).isSameAs(V0);
+            assertThat(((GitRepository) manager.create("bar")).format()).isSameAs(V0);
+        }
+
+        // Load the repositories with newer format to trigger automatic migration.
+        try (GitRepositoryManager manager = new GitRepositoryManager(proj, tempDir, commonPool())) {
+            assertThat(((GitRepository) manager.get("foo")).format()).isSameAs(V1);
+            assertThat(((GitRepository) manager.get("bar")).format()).isSameAs(V1);
+        }
+    }
+
+    private static int rnd() {
+        return ThreadLocalRandom.current().nextInt(10);
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -45,6 +45,7 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RefUpdate;
+import org.eclipse.jgit.revwalk.RevWalk;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -1206,19 +1207,20 @@ public class GitRepositoryTest {
 
     private static void testDoUpdateRef(String ref, ObjectId commitId, boolean tagExists) throws Exception {
         final org.eclipse.jgit.lib.Repository jGitRepo = mock(org.eclipse.jgit.lib.Repository.class);
+        final RevWalk revWalk = mock(RevWalk.class);
         final RefUpdate refUpdate = mock(RefUpdate.class);
 
         when(jGitRepo.exactRef(ref)).thenReturn(tagExists ? mock(Ref.class) : null);
         when(jGitRepo.updateRef(ref)).thenReturn(refUpdate);
 
-        when(refUpdate.update()).thenReturn(RefUpdate.Result.NEW);
-        GitRepository.doRefUpdate(jGitRepo, ref, commitId);
+        when(refUpdate.update(revWalk)).thenReturn(RefUpdate.Result.NEW);
+        GitRepository.doRefUpdate(jGitRepo, revWalk, ref, commitId);
 
-        when(refUpdate.update()).thenReturn(RefUpdate.Result.FAST_FORWARD);
-        GitRepository.doRefUpdate(jGitRepo, ref, commitId);
+        when(refUpdate.update(revWalk)).thenReturn(RefUpdate.Result.FAST_FORWARD);
+        GitRepository.doRefUpdate(jGitRepo, revWalk, ref, commitId);
 
-        when(refUpdate.update()).thenReturn(RefUpdate.Result.LOCK_FAILURE);
-        assertThatThrownBy(() -> GitRepository.doRefUpdate(jGitRepo, ref, commitId))
+        when(refUpdate.update(revWalk)).thenReturn(RefUpdate.Result.LOCK_FAILURE);
+        assertThatThrownBy(() -> GitRepository.doRefUpdate(jGitRepo, revWalk, ref, commitId))
                 .isInstanceOf(StorageException.class);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
+import static com.linecorp.centraldogma.common.Revision.HEAD;
 import static java.util.concurrent.ForkJoinPool.commonPool;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ import com.linecorp.centraldogma.server.internal.storage.repository.RevisionNotF
 
 public class GitRepositoryTest {
 
-    private static final String TEST_MESSAGE_SUMMARY = "summary";
+    private static final String SUMMARY = "summary";
 
     private static final int NUM_ITERATIONS = 3;
 
@@ -92,13 +93,13 @@ public class GitRepositoryTest {
 
     @BeforeClass
     public static void init() throws Exception {
-        repo = new GitRepository(mock(Project.class), repoDir.getRoot(), commonPool(), Author.SYSTEM) {
+        repo = new GitRepository(mock(Project.class), repoDir.getRoot(), commonPool(), 0L, Author.SYSTEM) {
             /**
              * Used by {@link GitRepositoryTest#testWatchWithQueryCancellation()}.
              */
             @Override
-            public CompletableFuture<Revision> watch(Revision lastKnownRev, String pathPattern) {
-                final CompletableFuture<Revision> f = super.watch(lastKnownRev, pathPattern);
+            public CompletableFuture<Revision> watch(Revision lastKnownRevision, String pathPattern) {
+                final CompletableFuture<Revision> f = super.watch(lastKnownRevision, pathPattern);
                 if (watchConsumer != null) {
                     watchConsumer.accept(f);
                 }
@@ -165,16 +166,15 @@ public class GitRepositoryTest {
     }
 
     private void testUpsert(Change<?>[] upserts, EntryType entryType) {
-        final Revision oldHeadRev = repo.normalize(Revision.HEAD).join();
+        final Revision oldHeadRev = repo.normalize(HEAD).join();
         for (int i = 0; i < upserts.length; i++) {
             final Change<?> change = upserts[i];
 
-            final Revision revision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, change)
-                                          .join();
+            final Revision revision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, change).join();
 
             // Ensure the revision is incremented.
             assertThat(revision.major()).isEqualTo(oldHeadRev.major() + i + 1);
-            assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(revision);
+            assertThat(repo.normalize(HEAD).join()).isEqualTo(revision);
             assertThat(revision.minor()).isZero();
 
             // Ensure that the entries which were created in the previous revisions are retrieved
@@ -187,7 +187,7 @@ public class GitRepositoryTest {
         }
 
         // Check the content of all entries.
-        Map<String, Entry<?>> entries = Util.unsafeCast(repo.find(Revision.HEAD, allPattern).join());
+        Map<String, Entry<?>> entries = Util.unsafeCast(repo.find(HEAD, allPattern).join());
         for (Change<?> c : upserts) {
             final String path = c.path();
             assertThat(entries).containsEntry(path, Entry.of(path, c.content(), entryType));
@@ -198,10 +198,10 @@ public class GitRepositoryTest {
     public void testJsonPatch_safeReplace() throws JsonProcessingException {
         String jsonFilePath = String.format("/test_%s.json", testName.getMethodName());
         Change<JsonNode> change = Change.ofJsonUpsert(jsonFilePath, "{\"key\":1}");
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, change).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, change).join();
         Change<JsonNode> nextChange = Change.ofJsonPatch(jsonFilePath, "{\"key\":2}", "{\"key\":3}");
         assertThatThrownBy(
-                () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, nextChange).join())
+                () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, nextChange).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
     }
@@ -221,29 +221,27 @@ public class GitRepositoryTest {
         for (int i = 0; i < NUM_ITERATIONS; i++) {
             assert path.equals(patches[i].path());
 
-            final Revision rev = repo.normalize(Revision.HEAD).join();
+            final Revision rev = repo.normalize(HEAD).join();
 
             // Ensure that we cannot apply patched in an incorrect order.
             for (int j = i + 1; j < NUM_ITERATIONS; j++) {
                 final int finalJ = j;
                 assertThatThrownBy(
-                        () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, patches[finalJ])
-                                  .join())
+                        () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, patches[finalJ]).join())
                         .isInstanceOf(CompletionException.class)
                         .hasCauseInstanceOf(StorageException.class);
             }
 
             // Ensure that the failed commit does not change the revision.
-            assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(rev);
+            assertThat(repo.normalize(HEAD).join()).isEqualTo(rev);
 
             // Ensure that the successful commit changes the revision.
-            Revision newRev = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, patches[i])
-                                  .join();
-            assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(newRev);
+            Revision newRev = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, patches[i]).join();
+            assertThat(repo.normalize(HEAD).join()).isEqualTo(newRev);
             assertThat(newRev).isEqualTo(new Revision(rev.major() + 1));
 
             // Ensure the entry has been patched as expected.
-            Entry<?> e = repo.get(Revision.HEAD, path).join();
+            Entry<?> e = repo.get(HEAD, path).join();
             if (e.type() == EntryType.JSON) {
                 assertThatJson(e.content()).isEqualTo(upserts[i].content());
             } else {
@@ -256,24 +254,20 @@ public class GitRepositoryTest {
     public void testRemoval() throws Exception {
         // A removal should fail when there's no such entry.
         assertThatThrownBy(() -> repo
-                .commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRemoval(jsonPaths[0]))
-                .join())
+                .commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
-        Revision revision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0])
-                                .join();
+        Revision revision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
         assertThat(repo.exists(revision, jsonPaths[0]).join()).isTrue();
 
         // A removal should succeed when there's an entry.
-        revision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
-                               Change.ofRemoval(jsonPaths[0])).join();
+        revision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(jsonPaths[0])).join();
         assertThat(repo.exists(revision, jsonPaths[0]).join()).isFalse();
 
         // A removal should fail when there's no such entry.
         assertThatThrownBy(() -> repo
-                .commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRemoval(jsonPaths[0]))
-                .join())
+                .commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
     }
@@ -283,90 +277,86 @@ public class GitRepositoryTest {
         // A recursive removal should fail when there's no such entry.
         final String curDir = prefix.substring(0, prefix.length() - 1); // Remove trailing '/'.
         assertThatThrownBy(
-                () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRemoval(curDir))
-                          .join())
+                () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(curDir)).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
         // Add some files
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts).join();
-        assertThat(repo.find(Revision.HEAD, allPattern).join()).hasSize(jsonUpserts.length);
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts).join();
+        assertThat(repo.find(HEAD, allPattern).join()).hasSize(jsonUpserts.length);
 
         // Perform a recursive removal
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRemoval(curDir)).join();
-        assertThat(repo.find(Revision.HEAD, allPattern).join()).isEmpty();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(curDir)).join();
+        assertThat(repo.find(HEAD, allPattern).join()).isEmpty();
     }
 
     @Test
     public void testRename() throws Exception {
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         // Rename without content modification.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
-                    Change.ofRename(jsonPaths[0], jsonPaths[1])).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRename(jsonPaths[0], jsonPaths[1])).join();
 
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[0]).join()).isFalse();
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[1]).join()).isTrue();
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[2]).join()).isFalse();
-        assertThatJson(repo.get(Revision.HEAD, jsonPaths[1]).join().content())
+        assertThat(repo.exists(HEAD, jsonPaths[0]).join()).isFalse();
+        assertThat(repo.exists(HEAD, jsonPaths[1]).join()).isTrue();
+        assertThat(repo.exists(HEAD, jsonPaths[2]).join()).isFalse();
+        assertThatJson(repo.get(HEAD, jsonPaths[1]).join().content())
                 .isEqualTo(jsonUpserts[0].content());
 
         // Rename with content modification.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                     Change.ofRename(jsonPaths[1], jsonPaths[2]),
                     Change.ofJsonPatch(jsonPaths[2], jsonPatches[1].content()),
                     Change.ofJsonPatch(jsonPaths[2], jsonPatches[2].content())).join();
 
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[0]).join()).isFalse();
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[1]).join()).isFalse();
-        assertThat(repo.exists(Revision.HEAD, jsonPaths[2]).join()).isTrue();
-        assertThatJson(repo.get(Revision.HEAD, jsonPaths[2]).join().content())
+        assertThat(repo.exists(HEAD, jsonPaths[0]).join()).isFalse();
+        assertThat(repo.exists(HEAD, jsonPaths[1]).join()).isFalse();
+        assertThat(repo.exists(HEAD, jsonPaths[2]).join()).isTrue();
+        assertThatJson(repo.get(HEAD, jsonPaths[2]).join().content())
                 .isEqualTo(jsonUpserts[2].content());
     }
 
     @Test
     public void testRecursiveRename() throws Exception {
         // Add some files under a directory.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts).join();
-        assertThat(repo.find(Revision.HEAD, allPattern).join()).hasSize(jsonUpserts.length);
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts).join();
+        assertThat(repo.find(HEAD, allPattern).join()).hasSize(jsonUpserts.length);
 
         // Rename the directory and ensure all files were moved.
         final String oldDir = prefix.substring(0, prefix.length() - 1); // Strip the trailing '/'.
         final String newDir = "/re_" + oldDir.substring(1) + "_named";
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRename(oldDir, newDir))
-            .join();
-        assertThat(repo.find(Revision.HEAD, allPattern).join()).isEmpty();
-        assertThat(repo.find(Revision.HEAD, newDir + "/**").join()).hasSize(jsonUpserts.length);
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRename(oldDir, newDir)).join();
+        assertThat(repo.find(HEAD, allPattern).join()).isEmpty();
+        assertThat(repo.find(HEAD, newDir + "/**").join()).hasSize(jsonUpserts.length);
 
         // Add some files under a directory again.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts).join();
-        assertThat(repo.find(Revision.HEAD, allPattern).join()).hasSize(jsonUpserts.length);
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts).join();
+        assertThat(repo.find(HEAD, allPattern).join()).hasSize(jsonUpserts.length);
 
         // Attempt to rename the directory again, which should fail because the target directory exists now.
         assertThatThrownBy(() -> repo
-                .commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRename(oldDir, newDir))
-                .join())
+                .commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRename(oldDir, newDir)).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
     }
 
     @Test
     public void testRenameFailure() throws Exception {
-        assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                              jsonUpserts[0], jsonUpserts[1],
                                              Change.ofRename(jsonPaths[0], jsonPaths[1])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
         // Renaming to its own path.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
-        assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                              Change.ofRename(jsonPaths[0], jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
         // Renaming to its own path, when the file is not committed yet.
-        assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                              jsonUpserts[1], Change.ofRename(jsonPaths[1], jsonPaths[1]))
                                      .join())
                 .isInstanceOf(CompletionException.class)
@@ -379,12 +369,11 @@ public class GitRepositoryTest {
     @Test
     public void testLateCommit() throws Exception {
         // Increase the head revision by one by pushing one commit.
-        Revision rev = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        Revision rev = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         // Attempt to commit again with an old revision.
         assertThatThrownBy(() -> repo
-                .commit(new Revision(rev.major() - 1), Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[1])
-                .join())
+                .commit(new Revision(rev.major() - 1), 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[1]).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
     }
@@ -392,8 +381,7 @@ public class GitRepositoryTest {
     @Test
     public void testEmptyCommit() {
         assertThatThrownBy(
-                () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Collections.emptyList())
-                          .join())
+                () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Collections.emptyList()).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(RedundantChangeException.class);
     }
@@ -401,10 +389,10 @@ public class GitRepositoryTest {
     @Test
     public void testEmptyCommitWithRedundantRenames() throws Exception {
         // Create a file to produce redundant changes.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         // Ensure redundant changes do not count as a valid change.
-        assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                              Change.ofRename(jsonPaths[0], jsonPaths[1]),
                                              Change.ofRename(jsonPaths[1], jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
@@ -414,17 +402,16 @@ public class GitRepositoryTest {
     @Test
     public void testEmptyCommitWithRedundantUpsert() throws Exception {
         assertThatThrownBy(
-                () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Collections.emptyList())
-                          .join())
+                () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, Collections.emptyList()).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(RedundantChangeException.class);
 
         // Create a file to produce redundant changes.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         // Ensure redundant changes do not count as a valid change.
         assertThatThrownBy(
-                () -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join())
+                () -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(RedundantChangeException.class);
     }
@@ -437,9 +424,9 @@ public class GitRepositoryTest {
             changes.add(jsonPatches[i]);
         }
 
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, changes).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, changes).join();
 
-        Map<String, Entry<?>> entries = repo.find(Revision.HEAD, allPattern).join();
+        Map<String, Entry<?>> entries = repo.find(HEAD, allPattern).join();
 
         assertThat(entries).hasSize(jsonUpserts.length);
         for (int i = 0; i < jsonUpserts.length; i++) {
@@ -458,10 +445,10 @@ public class GitRepositoryTest {
     @Test
     public void testRenameWithConflict() throws Exception {
         // Create a file to produce redundant changes.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         // Attempt to rename to itself.
-        assertThatThrownBy(() -> repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                              Change.ofRename(jsonPaths[0], jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
@@ -470,8 +457,7 @@ public class GitRepositoryTest {
     @Test
     public void testMultipleChangesWithConflict() throws Exception {
         assertThatThrownBy(() -> repo
-                .commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0], jsonPatches[2])
-                .join())
+                .commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0], jsonPatches[2]).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(ChangeConflictException.class);
     }
@@ -482,10 +468,10 @@ public class GitRepositoryTest {
     @Test
     public void testDiff_invalidParameters() throws Exception {
         final String path = jsonPatches[0].path();
-        final Revision revision1 =
-                repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[0]).join();
-        final Revision revision2 =
-                repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[1]).join();
+        final Revision revision1 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                                               jsonPatches[0]).join();
+        final Revision revision2 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                                               jsonPatches[1]).join();
 
         assertThat(repo.diff(revision1, revision2, "non_existing_path").join()).isEmpty();
 
@@ -508,16 +494,16 @@ public class GitRepositoryTest {
 
     @Test
     public void testPreviewDiff() {
-        Map<String, Change<?>> changeMap = repo.previewDiff(Revision.HEAD, jsonUpserts[0]).join();
+        Map<String, Change<?>> changeMap = repo.previewDiff(HEAD, jsonUpserts[0]).join();
         assertThat(changeMap).containsEntry(jsonPaths[0], jsonUpserts[0]);
 
         // Invalid patch
-        assertThatThrownBy(() -> repo.previewDiff(Revision.HEAD, jsonPatches[1]).join())
+        assertThatThrownBy(() -> repo.previewDiff(HEAD, jsonPatches[1]).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StorageException.class);
 
         // Invalid removal
-        assertThatThrownBy(() -> repo.previewDiff(Revision.HEAD, Change.ofRemoval(jsonPaths[0])).join())
+        assertThatThrownBy(() -> repo.previewDiff(HEAD, Change.ofRemoval(jsonPaths[0])).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StorageException.class);
 
@@ -525,7 +511,7 @@ public class GitRepositoryTest {
         List<Change<?>> changes = Arrays.asList(jsonUpserts[0], jsonPatches[1], jsonPatches[2],
                                                 Change.ofRename(jsonPaths[0], jsonPaths[1]),
                                                 Change.ofRemoval(jsonPaths[1]));
-        Map<String, Change<?>> returnedChangeMap = repo.previewDiff(Revision.HEAD, changes).join();
+        Map<String, Change<?>> returnedChangeMap = repo.previewDiff(HEAD, changes).join();
         assertThat(returnedChangeMap).isEmpty();
         assertThatThrownBy(() -> repo.previewDiff(new Revision(Integer.MAX_VALUE), changes).join())
                 .isInstanceOf(CompletionException.class)
@@ -534,8 +520,8 @@ public class GitRepositoryTest {
         assertThat(repo.previewDiff(new Revision(-1), Collections.emptyList()).join()).isEmpty();
 
         // Test upsert on an existing path
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[0], jsonPatches[1]).join();
-        returnedChangeMap = repo.previewDiff(Revision.HEAD, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[0], jsonPatches[1]).join();
+        returnedChangeMap = repo.previewDiff(HEAD, jsonUpserts[0]).join();
         assertThat(returnedChangeMap.get(jsonPaths[0]).type()).isEqualTo(ChangeType.APPLY_JSON_PATCH);
     }
 
@@ -547,11 +533,11 @@ public class GitRepositoryTest {
         final String jsonPath = jsonUpserts[0].path();
         final String textPath = textUpserts[0].path();
 
-        Revision prevRevison = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        Revision prevRevison = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                            jsonUpserts[0], textUpserts[0]).join();
 
         for (int i = 1; i < NUM_ITERATIONS; i++) {
-            Revision currRevision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+            Revision currRevision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                                 jsonPatches[i], textPatches[i]).join();
 
             Map<String, Change<?>> diff = repo.diff(prevRevison, currRevision, Repository.ALL_PATH).join();
@@ -561,7 +547,7 @@ public class GitRepositoryTest {
                             .containsEntry(textPath, textPatches[i]);
 
             Map<String, Change<?>> diff2 =
-                    repo.diff(Revision.HEAD.backward(1), Revision.HEAD, Repository.ALL_PATH).join();
+                    repo.diff(HEAD.backward(1), HEAD, Repository.ALL_PATH).join();
 
             assertThat(diff2).isEqualTo(diff);
 
@@ -577,7 +563,7 @@ public class GitRepositoryTest {
         // add all files into repository
         Revision lastRevision = null;
         for (int i = 0; i < NUM_ITERATIONS; i++) {
-            lastRevision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+            lastRevision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                        jsonUpserts[i], textUpserts[i]).join();
         }
 
@@ -589,18 +575,17 @@ public class GitRepositoryTest {
             final Change<Void> jsonRemoval = Change.ofRemoval(jsonPath);
             final Change<Void> textRemoval = Change.ofRemoval(textPath);
 
-            final Revision currRevision =
-                    repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonRemoval, textRemoval)
-                        .join();
-            final Map<String, Change<?>> changes = repo.diff(prevRevison, currRevision, Repository.ALL_PATH)
-                                                       .join();
+            final Revision currRevision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                                                      jsonRemoval, textRemoval).join();
+            final Map<String, Change<?>> changes = repo.diff(prevRevison, currRevision,
+                                                             Repository.ALL_PATH).join();
 
             assertThat(changes).hasSize(2)
                                .containsEntry(jsonPath, jsonRemoval)
                                .containsEntry(textPath, textRemoval);
 
             final Map<String, Change<?>> changesRelative =
-                    repo.diff(Revision.HEAD.backward(1), Revision.HEAD, allPattern).join();
+                    repo.diff(HEAD.backward(1), HEAD, allPattern).join();
 
             assertThat(changesRelative).isEqualTo(changes);
 
@@ -617,11 +602,11 @@ public class GitRepositoryTest {
         final String textNodePath = textPatches[0].path();
 
         // initial commit
-        Revision prevRevision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        Revision prevRevision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                             jsonPatches[0], textPatches[0]).join();
 
         for (int i = 1; i < NUM_ITERATIONS; i++) {
-            final Revision currRevision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+            final Revision currRevision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                                       jsonPatches[i], textPatches[i]).join();
 
             final Map<String, Change<?>> changes = repo.diff(prevRevision, currRevision, allPattern).join();
@@ -631,7 +616,7 @@ public class GitRepositoryTest {
                                .containsEntry(textNodePath, textPatches[i]);
 
             final Map<String, Change<?>> changesRelative =
-                    repo.diff(Revision.HEAD.backward(1), Revision.HEAD, allPattern).join();
+                    repo.diff(HEAD.backward(1), HEAD, allPattern).join();
 
             assertThat(changesRelative).isEqualTo(changes);
 
@@ -651,18 +636,18 @@ public class GitRepositoryTest {
 
         // Start at oldPath with value set to false.
         Revision rev0 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofJsonUpsert(oldPath, "{ \"value\": false }")).join();
 
         // Move to newPath with the same value.
         Revision rev1 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofRemoval(oldPath),
                 Change.ofJsonUpsert(newPath, "{ \"value\": false }")).join();
 
         // Set 'value' to true.
         Revision rev2 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofJsonUpsert(newPath, "{ \"value\": true }")).join();
 
         // Get the diff between rev0 and rev2.
@@ -688,22 +673,22 @@ public class GitRepositoryTest {
         final String jsonPath = jsonPatches[0].path();
         final String textPath = textPatches[0].path();
 
-        final Revision firstJsonCommit = repo.normalize(Revision.HEAD).join().forward(1);
+        final Revision firstJsonCommit = repo.normalize(HEAD).join().forward(1);
         Revision lastJsonCommit = null;
         for (Change<JsonNode> c : jsonPatches) {
-            lastJsonCommit = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, c).join();
+            lastJsonCommit = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, c).join();
         }
 
         final Revision firstTextCommit = lastJsonCommit.forward(1);
         Revision lastTextCommit = null;
         for (Change<String> c : textPatches) {
-            lastTextCommit = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, c).join();
+            lastTextCommit = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, c).join();
         }
 
         final Revision firstJsonCommitRel = new Revision(-(jsonPatches.length + textPatches.length));
         final Revision lastJsonCommitRel = new Revision(-(textPatches.length + 1));
         final Revision firstTextCommitRel = new Revision(-textPatches.length);
-        final Revision lastTextCommitRel = Revision.HEAD;
+        final Revision lastTextCommitRel = HEAD;
 
         assertThat(repo.normalize(firstJsonCommitRel).join()).isEqualTo(firstJsonCommit);
         assertThat(repo.normalize(lastJsonCommitRel).join()).isEqualTo(lastJsonCommit);
@@ -765,13 +750,11 @@ public class GitRepositoryTest {
         Revision lastJsonCommit = null;
         Revision lastTextCommit = null;
         for (int i = 0; i < NUM_ITERATIONS; i++) {
-            lastJsonCommit = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[i])
-                                 .join();
-            lastTextCommit = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, textPatches[i])
-                                 .join();
+            lastJsonCommit = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[i]).join();
+            lastTextCommit = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, textPatches[i]).join();
         }
 
-        List<Commit> jsonCommits = repo.history(Revision.HEAD, new Revision(1), jsonPath).join();
+        List<Commit> jsonCommits = repo.history(HEAD, new Revision(1), jsonPath).join();
         // # of JSON commits + the initial empty commit
         assertThat(jsonCommits).hasSize(jsonPatches.length + 1);
 
@@ -782,7 +765,7 @@ public class GitRepositoryTest {
             }
         }
 
-        List<Commit> textCommits = repo.history(Revision.HEAD, new Revision(1), textPath).join();
+        List<Commit> textCommits = repo.history(HEAD, new Revision(1), textPath).join();
         // # of text commits + the initial empty commit
         assertThat(textCommits).hasSize(textPatches.length + 1);
 
@@ -797,18 +780,18 @@ public class GitRepositoryTest {
     @Test
     public void testHistory_parameterCheck() throws Exception {
         // Make sure that we added at least one non-initial commit.
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
-        final Revision head = repo.normalize(Revision.HEAD).join();
+        final Revision head = repo.normalize(HEAD).join();
 
         List<Commit> commits;
 
         // Should include the initial empty commit as long as the range contains 1.
-        commits = repo.history(Revision.HEAD, new Revision(1), "non_existing_path").join();
+        commits = repo.history(HEAD, new Revision(1), "non_existing_path").join();
         assertThat(commits).hasSize(1);
 
         // Should not include the initial empty commit if the range does not contain 1.
-        commits = repo.history(Revision.HEAD, Revision.HEAD, "non_existing_path").join();
+        commits = repo.history(HEAD, HEAD, "non_existing_path").join();
         assertThat(commits).isEmpty();
 
         assertThatThrownBy(() -> repo.history(head.forward(1), head.forward(2), "non_existing_path").join())
@@ -819,16 +802,16 @@ public class GitRepositoryTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(StorageException.class);
 
-        assertThatThrownBy(() -> repo.history(null, Revision.HEAD, "non_existing_path").join())
+        assertThatThrownBy(() -> repo.history(null, HEAD, "non_existing_path").join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(NullPointerException.class);
 
-        assertThatThrownBy(() -> repo.history(Revision.HEAD, null, "non_existing_path").join())
+        assertThatThrownBy(() -> repo.history(HEAD, null, "non_existing_path").join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(NullPointerException.class);
 
-        Revision r1rev = repo.createRunspace(Author.UNKNOWN, head.backward(1).major()).join();
-        Revision r2rev = repo.createRunspace(Author.UNKNOWN, head.major()).join();
+        Revision r1rev = repo.createRunspace(head.backward(1).major(), 0L, Author.UNKNOWN).join();
+        Revision r2rev = repo.createRunspace(head.major(), 0L, Author.UNKNOWN).join();
 
         // Attempt to fetch the history between different runspaces.
         assertThatThrownBy(() -> repo.history(r1rev, r2rev, allPattern).join())
@@ -875,7 +858,7 @@ public class GitRepositoryTest {
             Change<JsonNode> jsonChange = Change.ofJsonPatch(jsonNodePath, oldJsonString, newJsonString);
             Change<String> textChange = Change.ofTextPatch(textNodePath, oldTextString, newTextString);
 
-            revision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+            revision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                                    Arrays.asList(jsonChange, textChange)).join();
         }
 
@@ -894,8 +877,8 @@ public class GitRepositoryTest {
 
     @Test
     public void testFindNone() {
-        assertThat(repo.find(Revision.HEAD, "/non-existent").join()).isEmpty();
-        assertThat(repo.find(Revision.HEAD, "non-existent").join()).isEmpty();
+        assertThat(repo.find(HEAD, "/non-existent").join()).isEmpty();
+        assertThat(repo.find(HEAD, "non-existent").join()).isEmpty();
     }
 
     /**
@@ -906,7 +889,7 @@ public class GitRepositoryTest {
         String jsonNodePath = "/node.json";
         String jsonString = "{\"key\":\"value\"}";
         Change<JsonNode> jsonChange = Change.ofJsonUpsert(jsonNodePath, jsonString);
-        Revision revision = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonChange).join();
+        Revision revision = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonChange).join();
 
         assertThatThrownBy(() -> repo.find(new Revision(revision.major() + 1), jsonNodePath).join())
                 .isInstanceOf(CompletionException.class)
@@ -922,7 +905,7 @@ public class GitRepositoryTest {
         //               +- bb
         //
 
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                     Change.ofTextUpsert(prefix + "a/file", ""),
                     Change.ofTextUpsert(prefix + "b/ba/file", ""),
                     Change.ofTextUpsert(prefix + "b/bb/file", "")).join();
@@ -933,21 +916,21 @@ public class GitRepositoryTest {
         final Entry<Void> b_bb = Entry.ofDirectory(prefix + "b/bb");
 
         // Recursive search
-        final Collection<Entry<?>> entries = repo.find(Revision.HEAD, allPattern).join().entrySet().stream()
+        final Collection<Entry<?>> entries = repo.find(HEAD, allPattern).join().entrySet().stream()
                                                  .filter(e -> !e.getKey().endsWith("/file"))
                                                  .map(Map.Entry::getValue).collect(Collectors.toList());
         assertThat(entries).containsExactly(a, b, b_ba, b_bb);
 
         // Non-recursive search
-        assertThat(repo.find(Revision.HEAD, prefix + '*').join().values()).containsExactly(a, b);
+        assertThat(repo.find(HEAD, prefix + '*').join().values()).containsExactly(a, b);
 
         // Single get
-        assertThat(repo.find(Revision.HEAD, prefix + 'b').join().values()).containsExactly(b);
+        assertThat(repo.find(HEAD, prefix + 'b').join().values()).containsExactly(b);
     }
 
     @Test
     public void testJsonPathQuery() throws Exception {
-        repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
                     Change.ofJsonUpsert("/instances.json",
                                         '[' +
                                         "  {" +
@@ -971,7 +954,7 @@ public class GitRepositoryTest {
                                         "  }" +
                                         ']')).join();
 
-        final QueryResult<JsonNode> res1 = repo.get(Revision.HEAD, Query.ofJsonPath(
+        final QueryResult<JsonNode> res1 = repo.get(HEAD, Query.ofJsonPath(
                 "/instances.json", "$[?(@.name == 'b')]")).join();
 
         assertThatJson(res1.content()).isEqualTo("[{" +
@@ -985,7 +968,7 @@ public class GitRepositoryTest {
                                                  "  }]" +
                                                  "}]");
 
-        final QueryResult<JsonNode> res2 = repo.get(Revision.HEAD, Query.ofJsonPath(
+        final QueryResult<JsonNode> res2 = repo.get(HEAD, Query.ofJsonPath(
                 "/instances.json", "$..groups[?(@.type == 'not_phase' && @.name == 'alpha')]")).join();
 
         assertThatJson(res2.content()).isEqualTo("[{" +
@@ -993,7 +976,7 @@ public class GitRepositoryTest {
                                                  "  \"name\": \"alpha\"" +
                                                  "}]");
 
-        final QueryResult<JsonNode> res3 = repo.get(Revision.HEAD, Query.ofJsonPath(
+        final QueryResult<JsonNode> res3 = repo.get(HEAD, Query.ofJsonPath(
                 "/instances.json", "$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]"))
                                                .join();
 
@@ -1011,26 +994,26 @@ public class GitRepositoryTest {
 
     @Test
     public void testRunspace() throws Exception {
-        final Revision r1 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[0])
+        final Revision r1 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[0])
                                 .join();
-        final Revision r2 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[1])
+        final Revision r2 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[1])
                                 .join();
-        final Revision r3 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[2])
+        final Revision r3 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[2])
                                 .join();
 
-        final Revision r11 = repo.createRunspace(Author.UNKNOWN, r1.major()).join();
+        final Revision r11 = repo.createRunspace(r1.major(), 0L, Author.UNKNOWN).join();
         assertThat(repo.listRunspaces().join()).contains(r11);
         assertThat(r11).isEqualTo(new Revision(r1.major(), 1));
         assertThat(repo.find(r11, allPattern).join()).isEqualTo(repo.find(r1, allPattern).join());
 
-        final Revision r12 = repo.commit(r11, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[1]).join();
+        final Revision r12 = repo.commit(r11, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[1]).join();
         assertThat(r12).isEqualTo(new Revision(r1.major(), 2));
         assertThat(repo.listRunspaces().join()).contains(r12);
         assertThat(repo.find(r12, allPattern).join()).isNotEqualTo(repo.find(r11, allPattern).join());
         assertThat(repo.find(r12, allPattern).join()).isNotEqualTo(repo.find(r1, allPattern).join());
         assertThat(repo.find(r12, allPattern).join()).isEqualTo(repo.find(r2, allPattern).join());
 
-        final Revision r13 = repo.commit(r12, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches[2]).join();
+        final Revision r13 = repo.commit(r12, 0L, Author.UNKNOWN, SUMMARY, jsonPatches[2]).join();
         assertThat(r13).isEqualTo(new Revision(r1.major(), 3));
         assertThat(repo.listRunspaces().join()).contains(r13);
         assertThat(repo.find(r13, allPattern).join()).isNotEqualTo(repo.find(r12, allPattern).join());
@@ -1045,43 +1028,43 @@ public class GitRepositoryTest {
 
     @Test
     public void testWatch() throws Exception {
-        Revision rev1 = repo.normalize(Revision.HEAD).join();
+        Revision rev1 = repo.normalize(HEAD).join();
         Revision rev2 = rev1.forward(1);
 
         final CompletableFuture<Revision> f = repo.watch(rev1, Repository.ALL_PATH);
         assertThat(f).isNotDone();
 
-        repo.commit(rev1, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]);
+        repo.commit(rev1, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]);
         assertThat(f.get(3, TimeUnit.SECONDS)).isEqualTo(rev2);
 
-        assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(rev2);
+        assertThat(repo.normalize(HEAD).join()).isEqualTo(rev2);
     }
 
     @Test
     public void testWatchWithPathPattern() throws Exception {
-        final Revision rev1 = repo.normalize(Revision.HEAD).join();
+        final Revision rev1 = repo.normalize(HEAD).join();
         final Revision rev2 = rev1.forward(1);
         final Revision rev3 = rev2.forward(1);
 
         final CompletableFuture<Revision> f = repo.watch(rev1, jsonPaths[1]);
 
         // Should not notify when the path pattern does not match.
-        repo.commit(rev1, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0]).join();
-        assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(rev2);
+        repo.commit(rev1, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
+        assertThat(repo.normalize(HEAD).join()).isEqualTo(rev2);
         assertThatThrownBy(() -> f.get(500, TimeUnit.MILLISECONDS))
                 .isInstanceOf(TimeoutException.class);
 
         // Should notify when the path pattern matches.
-        repo.commit(rev2, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[1]).join();
-        assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(rev3);
+        repo.commit(rev2, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[1]).join();
+        assertThat(repo.normalize(HEAD).join()).isEqualTo(rev3);
         assertThat(f.get(3, TimeUnit.SECONDS)).isEqualTo(rev3);
     }
 
     @Test
     public void testWatchWithOldRevision() throws Exception {
-        final Revision lastKnownRev = repo.normalize(Revision.HEAD).join();
-        repo.commit(lastKnownRev, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts).join();
-        final Revision latestRev = repo.normalize(Revision.HEAD).join();
+        final Revision lastKnownRev = repo.normalize(HEAD).join();
+        repo.commit(lastKnownRev, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts).join();
+        final Revision latestRev = repo.normalize(HEAD).join();
         assertThat(latestRev).isNotEqualTo(lastKnownRev);
 
         // Should notify very soon.
@@ -1091,9 +1074,9 @@ public class GitRepositoryTest {
 
     @Test
     public void testWatchWithOldRevisionAndPathPattern() throws Exception {
-        final Revision lastKnownRev = repo.normalize(Revision.HEAD).join();
-        repo.commit(lastKnownRev, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonPatches).join();
-        final Revision latestRev = repo.normalize(Revision.HEAD).join();
+        final Revision lastKnownRev = repo.normalize(HEAD).join();
+        repo.commit(lastKnownRev, 0L, Author.UNKNOWN, SUMMARY, jsonPatches).join();
+        final Revision latestRev = repo.normalize(HEAD).join();
         assertThat(latestRev).isNotEqualTo(lastKnownRev);
 
         // Should not return a successful future because the changes in the prior commit did not affect
@@ -1102,16 +1085,16 @@ public class GitRepositoryTest {
         assertThatThrownBy(() -> f.get(500, TimeUnit.MILLISECONDS))
                 .isInstanceOf(TimeoutException.class);
 
-        final Revision newLatestRev = repo.commit(latestRev, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+        final Revision newLatestRev = repo.commit(latestRev, 0L, Author.UNKNOWN, SUMMARY,
                                                   jsonUpserts[1]).join();
-        assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(newLatestRev);
+        assertThat(repo.normalize(HEAD).join()).isEqualTo(newLatestRev);
         assertThat(f.get(3, TimeUnit.SECONDS)).isEqualTo(newLatestRev);
     }
 
     @Test
     public void testWatchWithQuery() throws Exception {
         final Revision rev1 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"mars\" }")).join();
 
         CompletableFuture<QueryResult<JsonNode>> f =
@@ -1123,7 +1106,7 @@ public class GitRepositoryTest {
 
         // Make sure the change that does not affect the query result does not trigger a notification.
         repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"mars\", \"goodbye\": \"venus\" }"));
 
         assertThatThrownBy(() -> f.get(500, TimeUnit.MILLISECONDS))
@@ -1131,7 +1114,7 @@ public class GitRepositoryTest {
 
         // Here comes the interesting change; make sure notification is triggered.
         final Revision rev3 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY,
+                HEAD, 0L, Author.UNKNOWN, SUMMARY,
                 Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"jupiter\", \"goodbye\": \"mars\" }")).join();
 
         final QueryResult<JsonNode> res = f.get(3, TimeUnit.SECONDS);
@@ -1142,14 +1125,12 @@ public class GitRepositoryTest {
 
     @Test(timeout = 10000)
     public void testWatchWithIdentityQuery() throws Exception {
-        final Revision rev1 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, textUpserts[0])
-                                  .join();
+        final Revision rev1 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, textUpserts[0]).join();
 
         CompletableFuture<QueryResult<Object>> f =
                 repo.watch(rev1, Query.identity(textPaths[0]));
 
-        final Revision rev2 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, textPatches[1])
-                                  .join();
+        final Revision rev2 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, textPatches[1]).join();
         final QueryResult<Object> res = f.get(3, TimeUnit.SECONDS);
         assertThat(res.revision()).isEqualTo(rev2);
         assertThat(res.type()).isEqualTo(EntryType.TEXT);
@@ -1158,15 +1139,14 @@ public class GitRepositoryTest {
 
     @Test
     public void testWatchRemoval() throws Exception {
-        final Revision rev1 = repo.commit(Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, jsonUpserts[0])
-                                  .join();
+        final Revision rev1 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, jsonUpserts[0]).join();
 
         CompletableFuture<QueryResult<JsonNode>> f =
                 repo.watch(rev1, Query.ofJsonPath(jsonPaths[0], "$"));
 
         // Remove the file being watched.
         final Revision rev2 = repo.commit(
-                Revision.HEAD, Author.UNKNOWN, TEST_MESSAGE_SUMMARY, Change.ofRemoval(jsonPaths[0])).join();
+                HEAD, 0L, Author.UNKNOWN, SUMMARY, Change.ofRemoval(jsonPaths[0])).join();
         final QueryResult<JsonNode> res = f.get(3, TimeUnit.SECONDS);
         assertThat(res.revision()).isEqualTo(rev2);
         assertThat(res.type()).isNull();
@@ -1191,7 +1171,7 @@ public class GitRepositoryTest {
 
         // Start a watch that never finishes.
         final CompletableFuture<QueryResult<JsonNode>> f =
-                repo.watch(Revision.HEAD, Query.ofJsonPath(jsonPaths[0], "$"));
+                repo.watch(HEAD, Query.ofJsonPath(jsonPaths[0], "$"));
         assertThatThrownBy(() -> f.get(500, TimeUnit.MILLISECONDS))
                 .isInstanceOf(TimeoutException.class);
 
@@ -1216,11 +1196,11 @@ public class GitRepositoryTest {
         final ObjectId commitId = mock(ObjectId.class);
 
         // A commit on the mainlane
-        testDoUpdateRef(Constants.R_TAGS + "01/1.0", commitId, false);
+        testDoUpdateRef(Constants.R_TAGS + '1', commitId, false);
         testDoUpdateRef(Constants.R_HEADS + Constants.MASTER, commitId, false);
 
         // A commit on a runspace
-        testDoUpdateRef(Constants.R_TAGS + "01/1.1", commitId, false);
+        testDoUpdateRef(Constants.R_TAGS + "runspaces/1/1", commitId, false);
         testDoUpdateRef(Constants.R_HEADS + "runspaces/1", commitId, false);
     }
 


### PR DESCRIPTION
Motivation:

We were using Git repository format version 0, which forced us to stick
to the directory-based ref database implementation. By upgrading to the
format version 1, we can use tree-based ref database implementation
which is more scalable, also potentially a better ref database
implementation such as reftable in the future.

Modifications:

- When creating a new Git repository, use repository format version 1
- Make sure some configuration properties are not affected by user's
  ~/.gitconfig file, such as diff algorithm, by setting them explicitly
- Use reftree RefDatabase implementation for better tagging performance
- Use simpler tag encoding for reftree-based repositories
- Add GitRepositoryFormat and GitRepository.format()
- Implement automatic repository format migration
  - Add GitRepository.cloneTo() which implements the repository format
    migration for individual repository
  - Implement automatic multi-repository migration in GitRepositoryManager
  - Add GitRepositoryMigrationTest
- Added creationTimeMillis and commitTimeMillis to:
  - Project creation
  - Repository creation
  - Runspace creation
  - Push (Commit)
  - .. so that we can preserve the exact timestamp during migration.
- Miscellaneous:
  - Move GitRepository.deltree(File) to Util so it can be used outside
    of GitRepository
  - rev -> revision, for consistency

Result:

- Potentially better performance
- Future-proof