### PR TITLE
Use simpler JSON form for a Revision

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/Revision.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Revision.java
@@ -21,9 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 import com.linecorp.centraldogma.internal.Util;
 
@@ -43,6 +42,8 @@ import com.linecorp.centraldogma.internal.Util;
  * <p>A revision with a negative integer is called 'relative revision'. By contrast, a revision with
  * a positive integer is called 'absolute revision'.
  */
+@JsonSerialize(using = RevisionJsonSerializer.class)
+@JsonDeserialize(using = RevisionJsonDeserializer.class)
 public class Revision implements Comparable<Revision> {
 
     private static final Pattern REVISION_PATTERN = Pattern.compile("^(-?[0-9]+)(?:\\.([0-9]+))?$");
@@ -74,10 +75,7 @@ public class Revision implements Comparable<Revision> {
      * @deprecated Use {@link #Revision(int)} instead. Minor revisions are not used anymore.
      */
     @Deprecated
-    @JsonCreator
-    public Revision(@JsonProperty("major") int major,
-                    @JsonProperty(value = "minor", defaultValue = "0") int minor) {
-
+    public Revision(int major, int minor) {
         if (major == 0) {
             throw new IllegalArgumentException("major: 0 (expected: a non-zero integer)");
         }
@@ -118,7 +116,6 @@ public class Revision implements Comparable<Revision> {
     /**
      * Returns the revision number.
      */
-    @JsonProperty
     public int major() {
         return major;
     }
@@ -129,7 +126,6 @@ public class Revision implements Comparable<Revision> {
      * @deprecated Do not use. Minor revisions are not used anymore.
      */
     @Deprecated
-    @JsonProperty
     public int minor() {
         return minor;
     }
@@ -274,7 +270,6 @@ public class Revision implements Comparable<Revision> {
     /**
      * Returns whether this {@link Revision} is relative.
      */
-    @JsonIgnore
     public boolean isRelative() {
         return isMajorRelative() || isMinorRelative();
     }

--- a/common/src/main/java/com/linecorp/centraldogma/common/RevisionJsonDeserializer.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RevisionJsonDeserializer.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.common;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Deserializes JSON into a {@link Revision}.
+ *
+ * @see RevisionJsonSerializer
+ */
+public class RevisionJsonDeserializer extends StdDeserializer<Revision> {
+
+    private static final long serialVersionUID = -2337105643062794190L;
+
+    public RevisionJsonDeserializer() {
+        super(Revision.class);
+    }
+
+    @Override
+    public Revision deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
+        final JsonNode node = p.readValueAsTree();
+        if (node.isNumber()) {
+            validateRevisionNumber(ctx, node, "major", false);
+            return new Revision(node.intValue());
+        }
+
+        if (node.isTextual()) {
+            try {
+                return new Revision(node.textValue());
+            } catch (IllegalArgumentException e) {
+                ctx.reportInputMismatch(Revision.class, e.getMessage());
+                // Should never reach here.
+                throw new Error();
+            }
+        }
+
+        if (!node.isObject()) {
+            ctx.reportInputMismatch(Revision.class,
+                                    "A revision must be a non-zero integer or " +
+                                    "an object that contains \"major\" and \"minor\" properties.");
+            // Should never reach here.
+            throw new Error();
+        }
+
+        final JsonNode majorNode = node.get("major");
+        final JsonNode minorNode = node.get("minor");
+        final int major;
+        final int minor;
+
+        validateRevisionNumber(ctx, majorNode, "major", false);
+        major = majorNode.intValue();
+        if (minorNode != null) {
+            validateRevisionNumber(ctx, minorNode, "minor", true);
+            minor = minorNode.intValue();
+        } else {
+            minor = 0;
+        }
+
+        return new Revision(major, minor);
+    }
+
+    private static void validateRevisionNumber(DeserializationContext ctx, JsonNode node,
+                                               String type, boolean zeroAllowed) throws JsonMappingException {
+        if (node == null) {
+            ctx.reportInputMismatch(Revision.class, "missing %s revision number", type);
+            // Should never reach here.
+            throw new Error();
+        }
+
+        if (!node.canConvertToInt() || !zeroAllowed && node.intValue() == 0) {
+            ctx.reportInputMismatch(Revision.class,
+                                    "A %s revision number must be %s integer.",
+                                    type, zeroAllowed ? "an" : "a non-zero");
+            // Should never reach here.
+            throw new Error();
+        }
+    }
+}

--- a/common/src/main/java/com/linecorp/centraldogma/common/RevisionJsonSerializer.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RevisionJsonSerializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.common;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+/**
+ * Serializes a {@link Revision} into JSON.
+ *
+ * @see RevisionJsonDeserializer
+ */
+public class RevisionJsonSerializer extends StdSerializer<Revision> {
+
+    private static final long serialVersionUID = 1536427117293976073L;
+
+    public RevisionJsonSerializer() {
+        super(Revision.class);
+    }
+
+    @Override
+    public void serialize(Revision value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        final int major = value.major();
+        final int minor = value.minor();
+        if (minor == 0) {
+            gen.writeNumber(major);
+        } else {
+            gen.writeStartObject();
+            gen.writeNumberField("major", major);
+            gen.writeNumberField("minor", minor);
+            gen.writeEndObject();
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitUtil.java
@@ -58,7 +58,7 @@ final class CommitUtil {
     static Revision extractRevision(String jsonString) {
         try {
             JsonNode jsonNode = Jackson.readTree(jsonString);
-            return new Revision(Jackson.textValue(jsonNode.get(FIELD_NAME_REVISION),""));
+            return new Revision(Jackson.textValue(jsonNode.get(FIELD_NAME_REVISION), ""));
         } catch (Exception e) {
             throw new StorageException("failed to extract revision from " + jsonString, e);
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
@@ -41,10 +41,7 @@ public class PushCommandTest {
                 "  \"type\": \"PUSH\"," +
                 "  \"projectName\": \"foo\"," +
                 "  \"repositoryName\": \"bar\"," +
-                "  \"baseRevision\": {" +
-                "    \"major\": 42," +
-                "    \"minor\": 0" +
-                "  }," +
+                "  \"baseRevision\": 42," +
                 "  \"commitTimeMillis\": 1234," +
                 "  \"author\": {" +
                 "    \"name\": \"Marge Simpson\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
@@ -58,10 +58,7 @@ public class ReplicationLogTest {
                              "    \"type\": \"PUSH\"," +
                              "    \"projectName\": \"foo\"," +
                              "    \"repositoryName\": \"bar\"," +
-                             "    \"baseRevision\": {" +
-                             "      \"major\": -1," +
-                             "      \"minor\": 0" +
-                             "    }," +
+                             "    \"baseRevision\": -1," +
                              "    \"commitTimeMillis\": 1234," +
                              "    \"author\": {" +
                              "      \"name\": \"Sedol Lee\"," +
@@ -76,10 +73,7 @@ public class ReplicationLogTest {
                              "      \"content\": \"too soon to tell\"" +
                              "    }]" +
                              "  }," +
-                             "  \"result\": {" +
-                             "    \"major\": 43," +
-                             "    \"minor\": 0" +
-                             "  }" +
+                             "  \"result\": 43" +
                              '}');
     }
 }


### PR DESCRIPTION
Motivation:

We do not and will not use the minor revision number in a Revision, and
thus there's no point of serializing the minor revision number if it's
zero.

Modification:

- Write the dedicated JsonSerializer and JsonDeserializer for Revision
  - A revision, whose minor is 0, is serialized into a number.
  - A revision with non-zero minor is serialized into an object just
    like before.
  - The deserializer understands various forms for backward
    compatibility.

Result:

Simpler JSON representation