### PR TITLE
Add metadata management service

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,6 +38,14 @@ managedDependencies {
     jmh 'org.mockito:mockito-core'
 }
 
+dependencies {
+    // Logging
+    runtime ("ch.qos.logback:logback-classic:" +
+            "${rootProject.ext.dependencyManagement ['ch.qos.logback']['logback-classic'].version}") {
+        ext.optional = true
+    }
+}
+
 clientDependencies {
     installDir = "${project.projectDir}/src/main/resources/webapp/vendor"
     copyExcludes = ['**/Gruntfile.js', 'gulpfile.js', 'source/**', 'test', 'karma.conf.js', 'index.js']

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/ApplicationTokenAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/ApplicationTokenAuthorizer.java
@@ -64,8 +64,8 @@ public class ApplicationTokenAuthorizer implements Authorizer<HttpRequest> {
                                login.append('@').append(((InetSocketAddress) ra).getHostString());
                            }
 
-                           final User user = new User(login.toString(), User.USER_ROLE);
-                           AuthenticationUtil.setCurrentUser(ctx, user);
+                           AuthenticationUtil.setCurrentUser(
+                                   ctx, new UserWithToken(login.toString(), token.accessToken()));
                            res.complete(true);
                        })
                        // Should be authorized by the next authorizer.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionTokenAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionTokenAuthorizer.java
@@ -60,7 +60,7 @@ public class SessionTokenAuthorizer implements Authorizer<HttpRequest> {
                 final Object principal = currentUser != null ? currentUser.getPrincipal()
                                                              : null;
                 if (principal != null) {
-                    final User user = new User(principal.toString(), User.USER_ROLE);
+                    final User user = new User(principal.toString());
                     AuthenticationUtil.setCurrentUser(ctx, user);
                     isAuthenticated = true;
                 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/Token.java
@@ -29,6 +29,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.util.ISO8601Utils;
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.centraldogma.server.internal.admin.model.TokenInfo;
+
+/**
+ * Specifies details of an application token.
+ * This will be replaced with {@link TokenInfo}.
+ */
 @JsonInclude(Include.NON_NULL)
 public final class Token {
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/User.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/User.java
@@ -33,18 +33,35 @@ public class User implements Serializable {
 
     private static final long serialVersionUID = -5429782019985526549L;
 
-    public static final String ADMIN = "ROLE_ADMIN";
-    public static final String USER = "ROLE_USER";
+    // TODO(hyangtack) Will change the word "role" to something other to avoid conflicting with project "role".
+    // System-wide roles for a user. It is different from the role in a project.
+    public static final List<String> USER_ROLE = ImmutableList.of("ROLE_USER");
+    public static final List<String> ADMIN_ROLE = ImmutableList.of("ROLE_ADMIN");
 
-    public static final List<String> USER_ROLE = ImmutableList.of(USER);
     public static final User DEFAULT = new User("User@localhost.localdomain", USER_ROLE);
+    public static final User ADMIN = new User("Admin@localhost.localdomain", ADMIN_ROLE);
 
     private String login;
     private String name;
     private String email;
     private List<String> roles;
 
-    public User(String login, List<String> roles) {
+    @JsonCreator
+    public User(@JsonProperty("login") String login,
+                @JsonProperty("name") String name,
+                @JsonProperty("email") String email,
+                @JsonProperty("roles") List<String> roles) {
+        this.login = requireNonNull(login, "login");
+        this.name = requireNonNull(name, "name");
+        this.email = requireNonNull(email, "email");
+        this.roles = ImmutableList.copyOf(requireNonNull(roles, "roles"));
+    }
+
+    public User(String login) {
+        this(login, USER_ROLE);
+    }
+
+    private User(String login, List<String> roles) {
         requireNonNull(roles, "roles");
 
         if (Strings.isNullOrEmpty(login)) {
@@ -60,17 +77,6 @@ public class User implements Serializable {
         }
 
         this.roles = roles;
-    }
-
-    @JsonCreator
-    public User(@JsonProperty("login") String login,
-                @JsonProperty("name") String name,
-                @JsonProperty("email") String email,
-                @JsonProperty("roles") List<String> roles) {
-        this.login = requireNonNull(login, "login");
-        this.name = requireNonNull(name, "name");
-        this.email = requireNonNull(email, "email");
-        this.roles = ImmutableList.copyOf(requireNonNull(roles, "roles"));
     }
 
     @JsonProperty
@@ -114,10 +120,10 @@ public class User implements Serializable {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("login", login)
-                          .add("name", name)
-                          .add("email", email)
-                          .add("roles", roles)
+                          .add("login", login())
+                          .add("name", name())
+                          .add("email", email())
+                          .add("roles", roles())
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/UserWithToken.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/UserWithToken.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.authentication;
+
+import static java.util.Objects.requireNonNull;
+
+public class UserWithToken extends User {
+
+    private static final long serialVersionUID = 6021146546653491444L;
+
+    private final String secret;
+
+    public UserWithToken(String login, String secret) {
+        super(login);
+        this.secret = requireNonNull(secret, "secret");
+    }
+
+    public String secret() {
+        return secret;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/AdministratorsOnly.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/AdministratorsOnly.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+
+/**
+ * A decorator only to allow a request from administrator.
+ */
+public class AdministratorsOnly extends ProjectAccessController {
+
+    @Override
+    protected boolean isAllowedRole(User user, ProjectRole projectRole) {
+        return User.ADMIN == user;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectAccessController.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectAccessController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.DecoratingServiceFunction;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+
+/**
+ * A decorator only to allow a request with a proper user role. It will be work only if the request has a
+ * {@code projectName} path variable.
+ */
+abstract class ProjectAccessController implements DecoratingServiceFunction<HttpRequest, HttpResponse> {
+
+    @Override
+    public HttpResponse serve(Service<HttpRequest, HttpResponse> delegate,
+                              ServiceRequestContext ctx,
+                              HttpRequest req) throws Exception {
+        final String projectName = ctx.pathParam("projectName");
+        checkArgument(!isNullOrEmpty(projectName),
+                      "No project name is specified");
+
+        final Function<String, ProjectRole> map = ctx.attr(RoleResolvingDecorator.ROLE_MAP).get();
+        if (map == null) {
+            throw new HttpResponseException(HttpStatus.UNAUTHORIZED);
+        }
+
+        final User user = AuthenticationUtil.currentUser();
+        final ProjectRole projectRole = map.apply(projectName);
+        if (projectRole == null || !isAllowedRole(user, projectRole)) {
+            throw new HttpResponseException(HttpStatus.UNAUTHORIZED);
+        }
+
+        return delegate.serve(ctx, req);
+    }
+
+    protected abstract boolean isAllowedRole(User user, ProjectRole projectRole);
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectMembersOnly.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectMembersOnly.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+
+/**
+ * A decorator for access control. It only allows a request from an administrator and a user who has
+ * one of the following roles:
+ * <ul>
+ *     <li>{@link ProjectRole#OWNER}</li>
+ *     <li>{@link ProjectRole#MEMBER}</li>
+ * </ul>
+ */
+public class ProjectMembersOnly extends ProjectAccessController {
+
+    @Override
+    protected boolean isAllowedRole(User user, ProjectRole projectRole) {
+        return User.ADMIN == user || projectRole != ProjectRole.NONE;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectOwnersOnly.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/ProjectOwnersOnly.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+
+/**
+ * A decorator for access control. It only allows a request from an administrator and a user who has
+ * a {@link ProjectRole#OWNER} role.
+ */
+public class ProjectOwnersOnly extends ProjectAccessController {
+
+    @Override
+    protected boolean isAllowedRole(User user, ProjectRole projectRole) {
+        return User.ADMIN == user || ProjectRole.OWNER == projectRole;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/RoleResolvingDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/decorator/RoleResolvingDecorator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.authentication.UserWithToken;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+import com.linecorp.centraldogma.server.internal.admin.service.MetadataService;
+
+import io.netty.util.AttributeKey;
+
+/**
+ * Resolves every {@link ProjectRole} of the current user.
+ */
+public class RoleResolvingDecorator extends SimpleDecoratingService<HttpRequest, HttpResponse> {
+
+    public static Function<Service<HttpRequest, HttpResponse>,
+            RoleResolvingDecorator> newDecorator(MetadataService mds) {
+        requireNonNull(mds, "mds");
+        return service -> new RoleResolvingDecorator(service, mds);
+    }
+
+    static final AttributeKey<Function<String, ProjectRole>> ROLE_MAP =
+            AttributeKey.valueOf(RoleResolvingDecorator.class, "ROLE_MAP");
+
+    private final MetadataService mds;
+
+    public RoleResolvingDecorator(Service<HttpRequest, HttpResponse> delegate,
+                                  MetadataService mds) {
+        super(delegate);
+        this.mds = requireNonNull(mds, "mds");
+    }
+
+    /**
+     * Resolves all {@link ProjectRole}s of the current user and puts them into {@link RequestContext}
+     * attributes.
+     */
+    @Override
+    public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
+
+        final User user = AuthenticationUtil.currentUser();
+
+        final CompletionStage<Map<String, ProjectRole>> future;
+        if (user instanceof UserWithToken) {
+            future = mds.findRole(((UserWithToken) user).secret());
+        } else {
+            future = mds.findRoles(AuthenticationUtil.currentUser());
+        }
+
+        return HttpResponse.from(future.thenApplyAsync(map -> {
+            try {
+                ctx.attr(ROLE_MAP).set(map::get);
+                return delegate().serve(ctx, req);
+            } catch (Exception e) {
+                return Exceptions.throwUnsafely(e);
+            }
+        }, ctx.contextAwareEventLoop()));
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/MemberInfo.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/MemberInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+
+/**
+ * Specifies details of a member who belongs to the {@link Project}.
+ */
+public class MemberInfo {
+
+    private final String login;
+    private final ProjectRole role;
+    private final UserAndTimestamp creation;
+
+    @JsonCreator
+    public MemberInfo(@JsonProperty("login") String login,
+                      @JsonProperty("role") ProjectRole role,
+                      @JsonProperty("creation") UserAndTimestamp creation) {
+        this.login = requireNonNull(login, "login");
+        this.role = requireNonNull(role, "role");
+        this.creation = requireNonNull(creation, "creation");
+    }
+
+    @JsonProperty
+    public String login() {
+        return login;
+    }
+
+    @JsonProperty
+    public ProjectRole role() {
+        return role;
+    }
+
+    @JsonProperty
+    public UserAndTimestamp creation() {
+        return creation;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("login", login())
+                          .add("role", role())
+                          .add("creation", creation())
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/ProjectInfo.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/ProjectInfo.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+
+/**
+ * Specifies details of a {@link Project}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(Include.NON_NULL)
+public class ProjectInfo {
+
+    private final String name;
+    private final List<RepoInfo> repos;
+    private final List<MemberInfo> members;
+    private final List<TokenInfo> tokens;
+
+    private final UserAndTimestamp creation;
+
+    @Nullable
+    private final UserAndTimestamp removal;
+
+    public ProjectInfo(String name, UserAndTimestamp creation) {
+        this(name, ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), creation, null);
+    }
+
+    @JsonCreator
+    public ProjectInfo(@JsonProperty("name") String name,
+                       @JsonProperty("repos") List<RepoInfo> repos,
+                       @JsonProperty("members") List<MemberInfo> members,
+                       @JsonProperty("tokens") List<TokenInfo> tokens,
+                       @JsonProperty("creation") UserAndTimestamp creation,
+                       @JsonProperty("removal") @Nullable UserAndTimestamp removal) {
+        this.name = requireNonNull(name, "name");
+        this.repos = ImmutableList.sortedCopyOf(Comparator.comparing(RepoInfo::name),
+                                                requireNonNull(repos, "repos"));
+        this.members = ImmutableList.sortedCopyOf(Comparator.comparing(MemberInfo::login),
+                                                  requireNonNull(members, "members"));
+        this.tokens = ImmutableList.sortedCopyOf(Comparator.comparing(TokenInfo::appId),
+                                                 requireNonNull(tokens, "tokens"));
+        this.creation = requireNonNull(creation, "creation");
+        this.removal = removal;
+    }
+
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    @JsonProperty
+    public List<RepoInfo> repos() {
+        return repos;
+    }
+
+    @JsonProperty
+    public List<MemberInfo> members() {
+        return members;
+    }
+
+    @JsonProperty
+    public List<TokenInfo> tokens() {
+        return tokens;
+    }
+
+    @JsonProperty
+    public UserAndTimestamp creation() {
+        return creation;
+    }
+
+    @Nullable
+    @JsonProperty
+    public UserAndTimestamp removal() {
+        return removal;
+    }
+
+    @JsonProperty
+    public boolean isRemoved() {
+        return removal() != null;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name())
+                          .add("repos", repos())
+                          .add("members", members())
+                          .add("tokens", tokens())
+                          .add("creation", creation())
+                          .add("removal", removal())
+                          .add("removed", isRemoved())
+                          .toString();
+    }
+
+    public ProjectInfo duplicateWithRepos(List<RepoInfo> newRepos) {
+        return new ProjectInfo(name(),
+                               requireNonNull(newRepos, "newRepos"),
+                               members(),
+                               tokens(),
+                               creation(),
+                               removal());
+    }
+
+    public ProjectInfo duplicateWithMembers(List<MemberInfo> newMembers) {
+        return new ProjectInfo(name(),
+                               repos(),
+                               requireNonNull(newMembers, "newMembers"),
+                               tokens(),
+                               creation(),
+                               removal());
+    }
+
+    public ProjectInfo duplicateWithTokens(List<TokenInfo> newTokens) {
+        return new ProjectInfo(name(),
+                               repos(),
+                               members(),
+                               requireNonNull(newTokens, "newTokens"),
+                               creation(),
+                               removal());
+    }
+
+    public ProjectInfo duplicateWithoutTokenSecret() {
+        return duplicateWithTokens(tokens().stream()
+                                           .map(TokenInfo::withoutSecret)
+                                           .collect(Collectors.toList()));
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/ProjectRole.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/ProjectRole.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+
+/**
+ * Roles of a {@link User} in a project.
+ */
+public enum ProjectRole {
+    OWNER,
+    MEMBER,
+    NONE;
+
+    /**
+     * Returns a {@link ProjectRole} matched with the specified {@code str}.
+     *
+     * @throws IllegalArgumentException if there is no matched {@link ProjectRole}.
+     */
+    public static ProjectRole of(String str) {
+        requireNonNull(str, "str");
+        return valueOf(str.toUpperCase());
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/RepoInfo.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/RepoInfo.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
+
+/**
+ * Specifies details of a {@link Repository}.
+ */
+public class RepoInfo {
+
+    private final String name;
+    private final UserAndTimestamp creation;
+
+    @JsonCreator
+    public RepoInfo(@JsonProperty("name") String name,
+                    @JsonProperty("creation") UserAndTimestamp creation) {
+        this.name = requireNonNull(name, "name");
+        this.creation = requireNonNull(creation, "creation");
+    }
+
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    @JsonProperty
+    public UserAndTimestamp creation() {
+        return creation;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name())
+                          .add("creation", creation())
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/TokenInfo.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/TokenInfo.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+/**
+ * Specifies details of an application token.
+ */
+@JsonInclude(Include.NON_NULL)
+public class TokenInfo {
+
+    private final String appId;
+    private final String secret;
+    private final ProjectRole role;
+    private final UserAndTimestamp creation;
+
+    @JsonCreator
+    public TokenInfo(@JsonProperty("appId") String appId,
+                     @JsonProperty("secret") String secret,
+                     @JsonProperty("role") ProjectRole role,
+                     @JsonProperty("creation") UserAndTimestamp creation) {
+        this.appId = requireNonNull(appId, "appId");
+        this.secret = requireNonNull(secret, "secret");
+        this.role = requireNonNull(role, "role");
+        this.creation = requireNonNull(creation, "creation");
+    }
+
+    private TokenInfo(String appId, ProjectRole role, UserAndTimestamp creation) {
+        this.appId = requireNonNull(appId, "appId");
+        this.role = requireNonNull(role, "role");
+        this.creation = requireNonNull(creation, "creation");
+        secret = null;
+    }
+
+    @JsonProperty
+    public String appId() {
+        return appId;
+    }
+
+    @JsonProperty
+    public String secret() {
+        return secret;
+    }
+
+    @JsonProperty
+    public ProjectRole role() {
+        return role;
+    }
+
+    @JsonProperty
+    public UserAndTimestamp creation() {
+        return creation;
+    }
+
+    @Override
+    public String toString() {
+        // Do not add "secret" to prevent it from logging.
+        return MoreObjects.toStringHelper(this)
+                          .add("appId", appId())
+                          .add("role", role())
+                          .add("creation", creation())
+                          .toString();
+    }
+
+    /**
+     * Returns a new {@link TokenInfo} instance without its secret.
+     */
+    public TokenInfo withoutSecret() {
+        return new TokenInfo(appId(), role(), creation());
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/UserAndTimestamp.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/model/UserAndTimestamp.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+/**
+ * Specifies when an object is accessed by whom.
+ */
+public class UserAndTimestamp {
+
+    private final String user;
+    private final ZonedDateTime timestamp;
+    private String timestampAsText;
+
+    public UserAndTimestamp(String user) {
+        this(user, ZonedDateTime.now());
+    }
+
+    public UserAndTimestamp(String user, ZonedDateTime timestamp) {
+        this.user = requireNonNull(user, "user");
+        this.timestamp = requireNonNull(timestamp, "timestamp");
+    }
+
+    @JsonCreator
+    UserAndTimestamp(@JsonProperty("user") String user,
+                     @JsonProperty("timestamp") String timestampAsText) {
+        this.user = requireNonNull(user, "user");
+        this.timestampAsText = requireNonNull(timestampAsText, "timestampAsText");
+        timestamp = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(timestampAsText)).atZone(ZoneId.of("GMT"));
+    }
+
+    /**
+     * Returns a {@code login} name who took any action on this object.
+     */
+    @JsonProperty
+    public String user() {
+        return user;
+    }
+
+    /**
+     * Returns a date and time string which is formatted as ISO-8601.
+     */
+    @JsonProperty
+    public String timestamp() {
+        if (timestampAsText == null) {
+            timestampAsText = DateTimeFormatter.ISO_INSTANT.format(timestamp);
+        }
+        return timestampAsText;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("user", user())
+                          .add("timestamp", timestamp())
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/MetadataService.java
@@ -1,0 +1,450 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.service;
+
+import static com.linecorp.centraldogma.server.internal.admin.service.RepositoryUtil.push;
+import static java.util.Objects.requireNonNull;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.QueryResult;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.MemberInfo;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectInfo;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+import com.linecorp.centraldogma.server.internal.admin.model.RepoInfo;
+import com.linecorp.centraldogma.server.internal.admin.model.TokenInfo;
+import com.linecorp.centraldogma.server.internal.admin.model.UserAndTimestamp;
+import com.linecorp.centraldogma.server.internal.command.Command;
+import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.command.ProjectInitializer;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectNotFoundException;
+import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
+
+/**
+ * A service class for metadata management. This service stores metadata into the {@value METADATA_PROJECT}
+ * project which is internally used, so it uses the {@link ProjectManager} given by the caller, not wrapped
+ * by {@link SafeProjectManager}.
+ */
+public class MetadataService extends AbstractService {
+
+    public static final String METADATA_PROJECT = ProjectInitializer.INTERNAL_PROJECT_NAME;
+    public static final String REPO = Project.REPO_MAIN;
+    public static final String METADATA_JSON = "/metadata.json";
+
+    private static final TypeReference<List<ProjectInfo>>
+            PROJECT_LIST_TYPE_REF = new TypeReference<List<ProjectInfo>>() {};
+    private static final TypeReference<List<TokenInfo>>
+            TOKEN_LIST_TYPE_REF = new TypeReference<List<TokenInfo>>() {};
+
+    public MetadataService(ProjectManager projectManager, CommandExecutor executor) {
+        super(projectManager, executor);
+    }
+
+    /**
+     * Initializes a repository by creating a {@value METADATA_JSON} file in {@value REPO} repository.
+     * The file would be created only if it does not exist.
+     */
+    public void initialize() {
+        synchronized (MetadataService.class) {
+            final Repository repo = projectManager().get(METADATA_PROJECT).repos()
+                                                    .get(REPO);
+            repo.normalize(Revision.HEAD).thenAccept(
+                    revision -> repo.find(revision, "/*").thenAccept(entries -> {
+                        if (!entries.containsKey(METADATA_JSON)) {
+                            //TODO(hyangtack) Need to make metadata of the existing projects in the next PRs.
+                            execute(Command.push(Author.SYSTEM,
+                                                 METADATA_PROJECT, REPO, revision,
+                                                 "Create " + METADATA_JSON, "",
+                                                 Markup.PLAINTEXT,
+                                                 Change.ofJsonUpsert(METADATA_JSON, "[]"))).join();
+                        }
+                    }).join()
+            ).join();
+        }
+    }
+
+    /**
+     * Returns all {@link ProjectInfo} as a {@link List}.
+     */
+    public CompletionStage<List<ProjectInfo>> getAllProjects() {
+        return query("$.*").thenApply(MetadataService::toProjectInfoList);
+    }
+
+    /**
+     * Returns valid {@link ProjectInfo} as a {@link List}.
+     */
+    public CompletionStage<List<ProjectInfo>> getValidProjects() {
+        return query("$[?(@.removed != true)]").thenApply(MetadataService::toProjectInfoList);
+    }
+
+    /**
+     * Returns a {@link ProjectInfo} whose name equals to the specified {@code projectName}.
+     */
+    public CompletionStage<ProjectInfo> getProject(String projectName) {
+        requireNonNull(projectName, "projectName");
+        return query("$[?(@.name == \"" + projectName + "\" && @.removed != true)]")
+                .thenApply(result -> toSingleProjectInfo(projectName, result));
+    }
+
+    /**
+     * Returns {@link ProjectInfo}s belonging to the specified {@link User}.
+     */
+    public CompletionStage<List<ProjectInfo>> findProjects(User user) {
+        requireNonNull(user, "user");
+        final String q = "$[?(@.members[?(@.login == \"" + user.name() +
+                         "\")] empty false && @.removed != true)]";
+        return query(q).thenApply(MetadataService::toProjectInfoList);
+    }
+
+    /**
+     * Returns {@link ProjectRole}s of the specified {@link User}.
+     */
+    public CompletionStage<Map<String, ProjectRole>> findRoles(User user) {
+        return findProjects(user).thenApply(list -> {
+            final ImmutableMap.Builder<String, ProjectRole> builder = new ImmutableMap.Builder<>();
+            list.forEach(p -> p.members().stream()
+                               .filter(m -> user.name().equals(m.login()))
+                               .findFirst()
+                               .ifPresent(m -> builder.put(p.name(), m.role())));
+            return builder.build();
+        });
+    }
+
+    /**
+     * Returns {@link ProjectRole}s of the specified secret of a {@link TokenInfo}.
+     */
+    public CompletionStage<Map<String, ProjectRole>> findRole(String secret) {
+        requireNonNull(secret, "secret");
+        final String q = "$[?(@.tokens[?(@.secret == \"" + secret +
+                         "\")] empty false && @.removed != true)]";
+        return query(q)
+                .thenApply(MetadataService::toProjectInfoList)
+                .thenApply(list -> {
+                    final ImmutableMap.Builder<String, ProjectRole> builder = new ImmutableMap.Builder<>();
+                    list.forEach(p -> p.tokens().stream()
+                                       .filter(t -> t.secret().equals(secret))
+                                       .findFirst()
+                                       .ifPresent(m -> builder.put(p.name(), m.role())));
+                    return builder.build();
+                });
+    }
+
+    /**
+     * Returns {@link ProjectRole} of the specified {@link User} in the specified {@code projectName}.
+     */
+    public CompletionStage<ProjectRole> findRole(String projectName, User user) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(user, "user");
+        final String q = "$[?(@.members[?(@.login == \"" + user.name() +
+                         "\")] empty false && @.name == \"" + projectName +
+                         "\" && @.removed != true)]";
+        return query(q).thenApply(MetadataService::toProjectInfoList)
+                       .thenApply(list -> {
+                           if (list == null || list.isEmpty()) {
+                               return ProjectRole.NONE;
+                           }
+                           return list.get(0)
+                                      .members().stream()
+                                      .filter(e -> user.name().equals(e.login()))
+                                      .findFirst()
+                                      .map(MemberInfo::role)
+                                      .orElse(ProjectRole.NONE);
+                       });
+    }
+
+    /**
+     * Adds a {@link ProjectInfo} object to metadata and returns it. We do not check the pattern of
+     * the {@code name} here. It should be done by the caller before calling this method.
+     */
+    public CompletionStage<ProjectInfo> createProject(String projectName, Author author) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        return getAllProjects().thenCompose(list -> {
+            final boolean isExist = list.stream().anyMatch(e -> projectName.equals(e.name()));
+            if (isExist) {
+                throw new IllegalArgumentException("Project '" + projectName + "' already exists.");
+            }
+            final List<ProjectInfo> oldList = ImmutableList.copyOf(list);
+            final ProjectInfo newProject = new ProjectInfo(projectName, new UserAndTimestamp(author.name()));
+            list.add(newProject);
+            list.sort(Comparator.comparing(ProjectInfo::name));
+            final Change<JsonNode> change = Change.ofJsonPatch(METADATA_JSON,
+                                                               Jackson.valueToTree(oldList),
+                                                               Jackson.valueToTree(list));
+            return pushChanges(change, author, "Create a project " + projectName);
+        }).thenCompose(unused -> getProject(projectName));
+    }
+
+    /**
+     * Removes a {@link ProjectInfo} whose name equals to the specified {@code name}.
+     */
+    public CompletionStage<ProjectInfo> removeProject(String projectName, Author author) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        final String commitSummary = "Remove a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        new ProjectInfo(p.name(),
+                                        p.repos(), p.members(), p.tokens(),
+                                        p.creation(),
+                                        new UserAndTimestamp(author.name()))));
+    }
+
+    /**
+     * Adds a {@link User} to the {@link ProjectInfo} which name is {@code name}.
+     */
+    public CompletionStage<ProjectInfo> addMember(String projectName, Author author,
+                                                  User member, ProjectRole projectRole) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(member, "member");
+        requireNonNull(projectRole, "projectRole");
+        final String commitSummary = "Add a member " + member.name() + " to a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithMembers(ImmutableList.<MemberInfo>builder()
+                                                       .addAll(p.members())
+                                                       .add(new MemberInfo(member.name(), projectRole,
+                                                                           new UserAndTimestamp(author.name())))
+                                                       .build())));
+    }
+
+    /**
+     * Removes a {@link User} from the {@link ProjectInfo} which name is {@code name}.
+     */
+    public CompletionStage<ProjectInfo> removeMember(String projectName, Author author, User member) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(member, "member");
+        final String commitSummary = "Remove a member " + member.name() + " from a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithMembers(collect(p.members(), e -> !e.login().equals(member.name()))
+                                                       .build())));
+    }
+
+    /**
+     * Changes a {@link ProjectRole} of a {@link User}.
+     */
+    public CompletionStage<ProjectInfo> changeRole(String projectName, Author author,
+                                                   User member, ProjectRole projectRole) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(member, "member");
+        requireNonNull(projectRole, "projectRole");
+        final String commitSummary = "Change a projectRole of " + member.name() + " to " + projectRole +
+                                     " from a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithMembers(collect(p.members(), e -> !e.login().equals(member.name()))
+                                                       .add(new MemberInfo(member.name(), projectRole,
+                                                                           new UserAndTimestamp(author.name())))
+                                                       .build())));
+    }
+
+    /**
+     * Adds a {@link RepoInfo} named as {@code repoName} to a {@link ProjectInfo}.
+     */
+    public CompletionStage<ProjectInfo> addRepo(String projectName, Author author, String repoName) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(repoName, "repoName");
+        final String commitSummary = "Add a repo " + repoName + " to a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithRepos(ImmutableList.<RepoInfo>builder()
+                                                     .addAll(p.repos())
+                                                     .add(new RepoInfo(repoName,
+                                                                       new UserAndTimestamp(author.name())))
+                                                     .build())));
+    }
+
+    /**
+     * Removes a {@link RepoInfo} named as {@code repoName} from a {@link ProjectInfo}.
+     */
+    public CompletionStage<ProjectInfo> removeRepo(String projectName, Author author, String repoName) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(repoName, "repoName");
+        final String commitSummary = "Remove a repo " + repoName + " from a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithRepos(collect(p.repos(), e -> !e.name().equals(repoName))
+                                                     .build())));
+    }
+
+    /**
+     * Returns a {@link TokenInfo} belonging to the specified {@code appId}.
+     */
+    public CompletionStage<TokenInfo> findToken(String projectName, String appId) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(appId, "appId");
+        final String q = "$[?(@.name == \"" + projectName +
+                         "\" && @.removed != true)].tokens[?(@.appId == \"" + appId + "\")]";
+        return query(q).thenApply(MetadataService::toTokenInfoList)
+                       .thenApply(list -> list != null && !list.isEmpty() ? list.get(0) : null);
+    }
+
+    /**
+     * Adds a new {@link TokenInfo} to a {@link ProjectInfo}.
+     */
+    public CompletionStage<ProjectInfo> addToken(String projectName, Author author,
+                                                 String appId, String secret, ProjectRole projectRole) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(appId, "appId");
+        requireNonNull(secret, "secret");
+        requireNonNull(projectRole, "projectRole");
+        final String commitSummary = "Add a token " + appId + " to a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithTokens(ImmutableList.<TokenInfo>builder()
+                                                      .addAll(p.tokens())
+                                                      .add(new TokenInfo(appId, secret, projectRole,
+                                                                         new UserAndTimestamp(author.name())))
+                                                      .build())));
+    }
+
+    /**
+     * Removes the {@link TokenInfo} belonging to {@code appId} from {@link ProjectInfo} of {@code projectName}.
+     */
+    public CompletionStage<ProjectInfo> removeToken(String projectName, Author author, String appId) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(author, "author");
+        requireNonNull(appId, "appId");
+        final String commitSummary = "Remove a token " + appId + " from a project " + projectName;
+        return getAllProjects().thenCompose(
+                list -> updateProjectInfo(author, commitSummary, list, projectName, p ->
+                        p.duplicateWithTokens(collect(p.tokens(), e -> !e.appId().equals(appId))
+                                                      .build())));
+    }
+
+    @VisibleForTesting
+    CompletionStage<String> getRawMetadata() {
+        return projectManager()
+                .get(METADATA_PROJECT).repos().get(REPO)
+                .get(Revision.HEAD, METADATA_JSON)
+                .thenApply(entry -> {
+                    try {
+                        return Jackson.writeValueAsPrettyString(entry.content());
+                    } catch (JsonProcessingException ignore) {
+                        return "";
+                    }
+                });
+    }
+
+    private CompletionStage<ProjectInfo> updateProjectInfo(Author author, String commitSummary,
+                                                           List<ProjectInfo> list, String projectName,
+                                                           Function<ProjectInfo, ProjectInfo> updater) {
+        final ImmutableList.Builder<ProjectInfo> newList = ImmutableList.builder();
+        ProjectInfo target = null;
+        for (ProjectInfo p : list) {
+            if (!p.isRemoved() && p.name().equals(projectName)) {
+                p = updater.apply(p);
+                if (target != null) {
+                    throw new IllegalStateException("Project '" + projectName + "' is not unique.");
+                }
+                target = p;
+            }
+            newList.add(p);
+        }
+        if (target == null) {
+            throw new ProjectNotFoundException("Project '" + projectName + "' does not exist.");
+        }
+
+        final ProjectInfo ret = target;
+        final Change<JsonNode> change = Change.ofJsonPatch(METADATA_JSON,
+                                                           Jackson.valueToTree(list),
+                                                           Jackson.valueToTree(newList.build()));
+        return pushChanges(change, author, commitSummary)
+                .thenApply(unused -> ret);
+    }
+
+    private CompletableFuture<QueryResult<JsonNode>> query(String query) {
+        return projectManager()
+                .get(METADATA_PROJECT).repos().get(REPO)
+                .get(Revision.HEAD, Query.ofJsonPath(METADATA_JSON, query));
+    }
+
+    private CompletionStage<?> pushChanges(Change<JsonNode> change,
+                                           Author author, String commitSummary) {
+        return push(this, METADATA_PROJECT, REPO, Revision.HEAD,
+                    author, commitSummary, "", Markup.PLAINTEXT, change);
+    }
+
+    private static <T> ImmutableList.Builder<T> collect(List<T> list,
+                                                        Predicate<? super T> predicate) {
+        final ImmutableList.Builder<T> builder = new Builder<>();
+        list.stream().filter(predicate).forEach(builder::add);
+        return builder;
+    }
+
+    private static ProjectInfo toSingleProjectInfo(String projectName,
+                                                   QueryResult<JsonNode> result) {
+        final List<ProjectInfo> list = toProjectInfoList(result);
+        if (list.isEmpty()) {
+            throw new ProjectNotFoundException("Project '" + projectName + "' does not exist.");
+        }
+        if (list.size() > 1) {
+            throw new IllegalStateException("Project '" + projectName + "' is not unique.");
+        }
+        return list.get(0);
+    }
+
+    private static List<ProjectInfo> toProjectInfoList(QueryResult<JsonNode> result) {
+        if (!isValid(result)) {
+            return null;
+        }
+        return Jackson.convertValue(result.content(), PROJECT_LIST_TYPE_REF);
+    }
+
+    private static List<TokenInfo> toTokenInfoList(QueryResult<JsonNode> result) {
+        if (!isValid(result)) {
+            return null;
+        }
+        return Jackson.convertValue(result.content(), TOKEN_LIST_TYPE_REF);
+    }
+
+    private static boolean isValid(QueryResult<JsonNode> result) {
+        return !result.isRemoved() && result.type() == EntryType.JSON;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
@@ -39,9 +39,13 @@ import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectMana
  */
 public class ProjectService extends AbstractService {
 
+    private final MetadataService mds;
+
     public ProjectService(ProjectManager projectManager,
                           CommandExecutor executor) {
         super(new SafeProjectManager(projectManager), executor);
+        mds = new MetadataService(projectManager, executor);
+        mds.initialize();
     }
 
     /**
@@ -66,4 +70,57 @@ public class ProjectService extends AbstractService {
         final ProjectDto dto = Jackson.readValue(message.content().toStringAscii(), ProjectDto.class);
         return execute(Command.createProject(author, dto.getName())).thenApply(unused -> dto);
     }
+
+    // TODO(hyangtack) Test APIs to manipulate metadata.
+    //                 These test APIs would be merged into existing HTTP APIs.
+    /*
+    @Get("/mds/projects")
+    public CompletionStage<List<ProjectInfo>> listProjectInfo() {
+        return mds.findProjects(AuthenticationUtil.currentUser());
+    }
+
+    @Post("/mds/projects/{projectName}")
+    public CompletionStage<ProjectInfo> createProjectInfo(@Param("projectName") String projectName) {
+        return mds.createProject(projectName, AuthenticationUtil.currentAuthor());
+    }
+
+    @Delete("/mds/projects/{projectName}")
+    public CompletionStage<ProjectInfo> removeProjectInfo(@Param("projectName") String projectName) {
+        return mds.removeProject(projectName, AuthenticationUtil.currentAuthor());
+    }
+
+    @Post("/mds/projects/{projectName}/repos/{repoName}")
+    public CompletionStage<ProjectInfo> addRepo(@Param("projectName") String projectName,
+                                                @Param("repoName") String repoName) {
+        return mds.addRepo(projectName, AuthenticationUtil.currentAuthor(), repoName);
+    }
+
+    @Delete("/mds/projects/{projectName}/repos/{repoName}")
+    public CompletionStage<ProjectInfo> removeRepo(@Param("projectName") String projectName,
+                                                   @Param("repoName") String repoName) {
+        return mds.removeRepo(projectName, AuthenticationUtil.currentAuthor(), repoName);
+    }
+
+    @Post("/mds/projects/{projectName}/members/{user}")
+    public CompletionStage<ProjectInfo> addMember(@Param("projectName") String projectName,
+                                                  @Param("user") String user,
+                                                  @Param("role") Optional<String> role) {
+        return mds.addMember(projectName, AuthenticationUtil.currentAuthor(), new User(user),
+                             role.map(ProjectRole::of).orElse(ProjectRole.MEMBER));
+    }
+
+    @Delete("/mds/projects/{projectName}/members/{user}")
+    public CompletionStage<ProjectInfo> removeMember(@Param("projectName") String projectName,
+                                                     @Param("user") String user) {
+        return mds.removeMember(projectName, AuthenticationUtil.currentAuthor(), new User(user));
+    }
+
+    @Patch("/mds/projects/{projectName}/members/{user}")
+    public CompletionStage<ProjectInfo> changeRole(@Param("projectName") String projectName,
+                                                   @Param("user") String user,
+                                                   @Param("role") String role) {
+        return mds.changeRole(projectName, AuthenticationUtil.currentAuthor(), new User(user),
+                              ProjectRole.of(role));
+    }
+    */
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -146,6 +146,7 @@ public final class ProjectInitializer {
             }
         }
         for (final String repo : ImmutableList.of(Project.REPO_META,
+                                                  Project.REPO_MAIN,
                                                   SESSION_REPOSITORY_NAME,
                                                   TOKEN_REPOSITORY_NAME)) {
             try {

--- a/server/src/main/resources/webapp/scripts/app/user/logout/logout.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/user/logout/logout.controller.js
@@ -2,6 +2,7 @@
 
 angular.module('CentralDogmaAdmin')
     .controller('LogoutController', function (Auth, $state) {
-                  Auth.logout();
-                  $state.go($state.current.name, {}, {reload: true});
+                  Auth.logout().then(function() {
+                    $state.go('home', {}, {reload: true});
+                  });
                 });

--- a/server/src/main/resources/webapp/scripts/components/auth/auth.service.js
+++ b/server/src/main/resources/webapp/scripts/components/auth/auth.service.js
@@ -24,10 +24,12 @@ angular.module('CentralDogmaAdmin')
                  },
 
                  logout: function () {
-                   AuthServerProvider.logout();
-                   if (Principal.clear()) {
+                   var deferred = $q.defer();
+                   AuthServerProvider.logout().then(function () {
                      NotificationUtil.success("login.logged_out");
-                   }
+                     deferred.resolve(null);
+                   });
+                   return deferred.promise;
                  },
 
                  isEnabled: function () {

--- a/server/src/main/resources/webapp/scripts/components/auth/provider/auth.session.service.js
+++ b/server/src/main/resources/webapp/scripts/components/auth/provider/auth.session.service.js
@@ -21,7 +21,7 @@ angular.module('CentralDogmaAdmin')
                  },
 
                  logout: function () {
-                   ApiService.post('logout', '').then(function (data) {
+                   return ApiService.post('logout', '').then(function (data) {
                      $window.sessionStorage.clear();
                      Principal.refresh(); // Clear user info.
                      return data;

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
@@ -12,7 +12,8 @@ angular.module('CentralDogmaAdmin')
                   });
 
                   $scope.logout = function () {
-                    Auth.logout();
-                    $state.go('home');
+                    Auth.logout().then(function() {
+                      $state.go('home', {}, {reload: true});
+                    });
                   };
                 });

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/decorator/DecoratorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/decorator/DecoratorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.decorator;
+
+import static com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil.CURRENT_USER_KEY;
+import static com.linecorp.centraldogma.server.internal.admin.decorator.RoleResolvingDecorator.ROLE_MAP;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.internal.DefaultAttributeMap;
+import com.linecorp.armeria.server.HttpResponseException;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+import com.linecorp.centraldogma.server.internal.admin.service.MetadataService;
+
+import io.netty.channel.DefaultEventLoop;
+
+public class DecoratorTest {
+
+    private static final Map<String, ProjectRole> roleMap = ImmutableMap.of("A", ProjectRole.OWNER,
+                                                                            "B", ProjectRole.MEMBER);
+
+    private static final Service<HttpRequest, HttpResponse> delegate =
+            (ctx, req) -> HttpResponse.of(HttpStatus.OK);
+
+    @Test
+    public void testRoleResolvingDecorator() throws Exception {
+        final MetadataService mds = mock(MetadataService.class);
+
+        when(mds.findRoles(any(User.class))).thenReturn(CompletableFuture.completedFuture(roleMap));
+
+        final RoleResolvingDecorator decorator =
+                new RoleResolvingDecorator((ctx, req) -> HttpResponse.of(HttpStatus.OK), mds);
+
+        final DefaultAttributeMap attrs = new DefaultAttributeMap();
+        attrs.attr(CURRENT_USER_KEY).set(User.DEFAULT);
+
+        final ServiceRequestContext ctx = spy(mock(ServiceRequestContext.class));
+        final DefaultEventLoop eventLoop = new DefaultEventLoop();
+
+        when(ctx.contextAwareEventLoop()).thenReturn(eventLoop);
+        when(ctx.attr(CURRENT_USER_KEY)).thenReturn(attrs.attr(CURRENT_USER_KEY));
+        when(ctx.attr(ROLE_MAP)).thenReturn(attrs.attr(ROLE_MAP));
+
+        try (SafeCloseable ignore = RequestContext.push(ctx)) {
+            decorator.serve(ctx, null);
+
+            await().until(() -> eventLoop.pendingTasks() == 0);
+
+            final Function<String, ProjectRole> func = attrs.attr(ROLE_MAP).get();
+            assertThat(func).isNotNull();
+
+            assertThat(func.apply("A")).isEqualTo(ProjectRole.OWNER);
+            assertThat(func.apply("B")).isEqualTo(ProjectRole.MEMBER);
+        }
+    }
+
+    @Test
+    public void testProjectAccessController() throws Exception {
+        final ServiceRequestContext ctx = spy(mock(ServiceRequestContext.class));
+
+        final DefaultAttributeMap attrs = new DefaultAttributeMap();
+        attrs.attr(ROLE_MAP).set(roleMap::get);
+        when(ctx.attr(CURRENT_USER_KEY)).thenReturn(attrs.attr(CURRENT_USER_KEY));
+        when(ctx.attr(ROLE_MAP)).thenReturn(attrs.attr(ROLE_MAP));
+
+        try (SafeCloseable ignore = RequestContext.push(ctx)) {
+
+            attrs.attr(CURRENT_USER_KEY).set(User.DEFAULT);
+
+            when(ctx.pathParam("projectName")).thenReturn("A");
+            assertThat(new ProjectMembersOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+            assertThat(new ProjectOwnersOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+
+            when(ctx.pathParam("projectName")).thenReturn("B");
+            assertThat(new ProjectMembersOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+            assertThatThrownBy(() -> new ProjectOwnersOnly().serve(delegate, ctx, null))
+                    .isInstanceOf(HttpResponseException.class)
+                    .satisfies(cause -> {
+                        assertThat(((HttpResponseException) cause).httpStatus())
+                                .isEqualTo(HttpStatus.UNAUTHORIZED);
+                    });
+
+            attrs.attr(CURRENT_USER_KEY).set(User.ADMIN);
+
+            assertThat(new AdministratorsOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+            assertThat(new ProjectMembersOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+            assertThat(new ProjectOwnersOnly().serve(delegate, ctx, null).aggregate().join().status())
+                    .isEqualTo(HttpStatus.OK);
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.model;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.internal.Jackson;
+
+public class SerializationTest {
+
+    @Test
+    public void testTimeSerialization() throws IOException {
+        final MemberInfo memberInfo =
+                new MemberInfo("armeria@dogma.org", ProjectRole.MEMBER, newAdditionTag());
+        assertThatJson(memberInfo).isEqualTo("{\n" +
+                                             "  \"login\" : \"armeria@dogma.org\",\n" +
+                                             "  \"role\" : \"MEMBER\",\n" +
+                                             "  \"creation\" : {\n" +
+                                             "    \"user\" : \"editor@dogma.org\",\n" +
+                                             "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                             "  }\n" +
+                                             '}');
+        final MemberInfo obj = Jackson.readValue(Jackson.writeValueAsString(memberInfo),
+                                                 MemberInfo.class);
+        assertThat(obj.login()).isEqualTo("armeria@dogma.org");
+        assertThat(obj.role()).isEqualTo(ProjectRole.MEMBER);
+        assertThat(obj.creation()).isNotNull();
+        assertThat(obj.creation().user()).isEqualTo("editor@dogma.org");
+        assertThat(obj.creation().timestamp()).isEqualTo("2017-01-01T00:00:00Z");
+    }
+
+    @Test
+    public void testValidProject() throws IOException {
+        final MemberInfo memberInfo = new MemberInfo("armeria@dogma.org", ProjectRole.MEMBER,
+                                                     newAdditionTag());
+        final RepoInfo repoInfo = new RepoInfo("sample", newAdditionTag());
+        final TokenInfo tokenInfo = new TokenInfo("testApp", "testSecret", ProjectRole.MEMBER,
+                                                  newAdditionTag());
+        final ProjectInfo projectInfo = new ProjectInfo("test",
+                                                        ImmutableList.of(repoInfo),
+                                                        ImmutableList.of(memberInfo),
+                                                        ImmutableList.of(tokenInfo),
+                                                        newAdditionTag(),
+                                                        null);
+        assertThatJson(projectInfo).isEqualTo("{\n" +
+                                              "  \"name\" : \"test\",\n" +
+                                              "  \"repos\" : [ {\n" +
+                                              "    \"name\" : \"sample\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"members\" : [ {\n" +
+                                              "    \"login\" : \"armeria@dogma.org\",\n" +
+                                              "    \"role\" : \"MEMBER\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"tokens\" : [ {\n" +
+                                              "    \"appId\" : \"testApp\",\n" +
+                                              "    \"secret\" : \"testSecret\",\n" +
+                                              "    \"role\" : \"MEMBER\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"creation\" : {\n" +
+                                              "    \"user\" : \"editor@dogma.org\",\n" +
+                                              "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "  },\n" +
+                                              "  \"removed\" : false\n" +
+                                              '}');
+
+        final ProjectInfo obj = Jackson.readValue(Jackson.writeValueAsString(projectInfo),
+                                                  ProjectInfo.class);
+        assertThat(obj.name()).isEqualTo("test");
+        assertThat(obj.repos().size()).isOne();
+        assertThat(obj.members().size()).isOne();
+        assertThat(obj.members().get(0).role()).isEqualTo(ProjectRole.MEMBER);
+        assertThat(obj.tokens().size()).isOne();
+        assertThat(obj.creation()).isNotNull();
+        assertThat(obj.creation().user()).isEqualTo("editor@dogma.org");
+        assertThat(obj.creation().timestamp()).isEqualTo("2017-01-01T00:00:00Z");
+        assertThat(obj.removal()).isNull();
+        assertThat(obj.isRemoved()).isFalse();
+    }
+
+    @Test
+    public void testRemovedProject() throws IOException {
+        final MemberInfo memberInfo = new MemberInfo("armeria@dogma.org", ProjectRole.MEMBER,
+                                                     newAdditionTag());
+        final RepoInfo repoInfo = new RepoInfo("sample", newAdditionTag());
+        final TokenInfo tokenInfo = new TokenInfo("testApp", "testSecret", ProjectRole.MEMBER,
+                                                  newAdditionTag());
+        final ProjectInfo projectInfo = new ProjectInfo("test",
+                                                        ImmutableList.of(repoInfo),
+                                                        ImmutableList.of(memberInfo),
+                                                        ImmutableList.of(tokenInfo),
+                                                        newAdditionTag(),
+                                                        newRemovalTag());
+        assertThatJson(projectInfo).isEqualTo("{\n" +
+                                              "  \"name\" : \"test\",\n" +
+                                              "  \"repos\" : [ {\n" +
+                                              "    \"name\" : \"sample\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"members\" : [ {\n" +
+                                              "    \"login\" : \"armeria@dogma.org\",\n" +
+                                              "    \"role\" : \"MEMBER\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"tokens\" : [ {\n" +
+                                              "    \"appId\" : \"testApp\",\n" +
+                                              "    \"secret\" : \"testSecret\",\n" +
+                                              "    \"role\" : \"MEMBER\",\n" +
+                                              "    \"creation\" : {\n" +
+                                              "      \"user\" : \"editor@dogma.org\",\n" +
+                                              "      \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "    }\n" +
+                                              "  } ],\n" +
+                                              "  \"creation\" : {\n" +
+                                              "    \"user\" : \"editor@dogma.org\",\n" +
+                                              "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "  },\n" +
+                                              "  \"removal\" : {\n" +
+                                              "    \"user\" : \"editor@dogma.org\",\n" +
+                                              "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                                              "  },\n" +
+                                              "  \"removed\" : true\n" +
+                                              '}');
+
+        final ProjectInfo obj = Jackson.readValue(Jackson.writeValueAsString(projectInfo),
+                                                  ProjectInfo.class);
+        assertThat(obj.name()).isEqualTo("test");
+        assertThat(obj.repos().size()).isOne();
+        assertThat(obj.members().size()).isOne();
+        assertThat(obj.members().get(0).role()).isEqualTo(ProjectRole.MEMBER);
+        assertThat(obj.tokens().size()).isOne();
+        assertThat(obj.creation()).isNotNull();
+        assertThat(obj.creation().user()).isEqualTo("editor@dogma.org");
+        assertThat(obj.creation().timestamp()).isEqualTo("2017-01-01T00:00:00Z");
+        assertThat(obj.isRemoved()).isTrue();
+    }
+
+    private UserAndTimestamp newAdditionTag() {
+        return new UserAndTimestamp("editor@dogma.org",
+                                    ZonedDateTime.of(2017, 1, 1,
+                                                     0, 0, 0, 0,
+                                                     ZoneId.of("GMT")));
+    }
+
+    private UserAndTimestamp newRemovalTag() {
+        return new UserAndTimestamp("editor@dogma.org",
+                                    ZonedDateTime.of(2017, 1, 1,
+                                                     0, 0, 0, 0,
+                                                     ZoneId.of("GMT")));
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/MetadataServiceTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.service;
+
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.initializeInternalProject;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ForkJoinPool;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectInfo;
+import com.linecorp.centraldogma.server.internal.admin.model.ProjectRole;
+import com.linecorp.centraldogma.server.internal.admin.model.TokenInfo;
+import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.command.StandaloneCommandExecutor;
+import com.linecorp.centraldogma.server.internal.storage.project.DefaultProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+
+public class MetadataServiceTest {
+
+    @ClassRule
+    public static final TemporaryFolder rootDir = new TemporaryFolder();
+
+    @Test
+    public void test() throws Exception {
+        final ProjectManager pm = new DefaultProjectManager(
+                rootDir.newFolder(), ForkJoinPool.commonPool(), null);
+        final CommandExecutor executor = new StandaloneCommandExecutor(pm, ForkJoinPool.commonPool());
+        executor.start(null, null);
+        initializeInternalProject(executor);
+
+        try {
+            final MetadataService mds = new MetadataService(pm, executor);
+            mds.initialize();
+
+            List<ProjectInfo> list;
+            ProjectInfo projectInfo;
+
+            // Projects
+            list = mds.getAllProjects().toCompletableFuture().join();
+            assertThat(list).isEmpty();
+
+            createOneProjectAndValidate(mds, "coconut");
+            createOneProjectAndValidate(mds, "apple");
+            createOneProjectAndValidate(mds, "banana");
+
+            list = mds.getAllProjects().toCompletableFuture().join();
+            assertThat(list.size()).isEqualTo(3);
+            assertThat(list.get(0).name()).isEqualTo("apple");
+            assertThat(list.get(1).name()).isEqualTo("banana");
+            assertThat(list.get(2).name()).isEqualTo("coconut");
+
+            projectInfo = mds.removeProject("banana", Author.DEFAULT)
+                             .toCompletableFuture().join();
+            assertThat(projectInfo.name()).isEqualTo("banana");
+
+            list = mds.getValidProjects().toCompletableFuture().join();
+            assertThat(list.size()).isEqualTo(2);
+            assertThat(list.get(0).name()).isEqualTo("apple");
+            assertThat(list.get(1).name()).isEqualTo("coconut");
+
+            final User user1 = new User("User1@localhost.localdomain");
+            final User user2 = new User("User2@localhost.localdomain");
+
+            // Members
+            projectInfo = mds.addMember("apple", Author.DEFAULT, user2, ProjectRole.MEMBER)
+                             .toCompletableFuture().join();
+            projectInfo = mds.addMember("apple", Author.DEFAULT, user1, ProjectRole.MEMBER)
+                             .toCompletableFuture().join();
+
+            assertThat(projectInfo.name()).isEqualTo("apple");
+            assertThat(projectInfo.members().size()).isEqualTo(2);
+            assertThat(projectInfo.members().get(0).login()).isEqualTo(user1.name());
+            assertThat(projectInfo.members().get(1).login()).isEqualTo(user2.name());
+
+            projectInfo = mds.removeMember("apple", Author.DEFAULT, user1)
+                             .toCompletableFuture().join();
+
+            assertThat(projectInfo.name()).isEqualTo("apple");
+            assertThat(projectInfo.members().size()).isOne();
+            assertThat(projectInfo.members().get(0).login()).isEqualTo(user2.name());
+
+            list = mds.findProjects(user2).toCompletableFuture().join();
+            assertThat(list.size()).isOne();
+            assertThat(list.get(0).name()).isEqualTo("apple");
+
+            projectInfo = mds.addMember("coconut", Author.DEFAULT, user2, ProjectRole.OWNER)
+                             .toCompletableFuture().join();
+
+            list = mds.findProjects(user2).toCompletableFuture().join();
+            assertThat(list.size()).isEqualTo(2);
+            assertThat(list.get(0).name()).isEqualTo("apple");
+            assertThat(list.get(1).name()).isEqualTo("coconut");
+
+            assertThat(mds.findRole("apple", user2).toCompletableFuture().join())
+                    .isEqualTo(ProjectRole.MEMBER);
+            assertThat(mds.findRole("coconut", user2).toCompletableFuture().join())
+                    .isEqualTo(ProjectRole.OWNER);
+            // Not a member
+            assertThat(mds.findRole("coconut", user1).toCompletableFuture().join())
+                    .isEqualTo(ProjectRole.NONE);
+            // Removed project
+            assertThat(mds.findRole("banana", user2).toCompletableFuture().join())
+                    .isEqualTo(ProjectRole.NONE);
+
+            final Map<String, ProjectRole> map = mds.findRoles(user2).toCompletableFuture().join();
+            assertThat(map.size()).isEqualTo(2);
+            assertThat(map.get("apple")).isEqualTo(ProjectRole.MEMBER);
+            assertThat(map.get("coconut")).isEqualTo(ProjectRole.OWNER);
+
+            // Repositories
+            projectInfo = mds.addRepo("coconut", Author.DEFAULT, "pie")
+                             .toCompletableFuture().join();
+            projectInfo = mds.addRepo("coconut", Author.DEFAULT, "juice")
+                             .toCompletableFuture().join();
+
+            assertThat(projectInfo.name()).isEqualTo("coconut");
+            assertThat(projectInfo.repos().size()).isEqualTo(2);
+            assertThat(projectInfo.repos().get(0).name()).isEqualTo("juice");
+            assertThat(projectInfo.repos().get(1).name()).isEqualTo("pie");
+
+            // Tokens
+            projectInfo = mds.addToken("apple", Author.DEFAULT, "jobs", "x", ProjectRole.OWNER)
+                             .toCompletableFuture().join();
+            projectInfo = mds.addToken("apple", Author.DEFAULT, "cook", "y", ProjectRole.MEMBER)
+                             .toCompletableFuture().join();
+            projectInfo = mds.addToken("apple", Author.DEFAULT, "ive", "z", ProjectRole.MEMBER)
+                             .toCompletableFuture().join();
+
+            assertThat(projectInfo.name()).isEqualTo("apple");
+            assertThat(projectInfo.tokens().size()).isEqualTo(3);
+            assertThat(projectInfo.tokens().get(0).appId()).isEqualTo("cook");
+            assertThat(projectInfo.tokens().get(0).role()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projectInfo.tokens().get(1).appId()).isEqualTo("ive");
+            assertThat(projectInfo.tokens().get(1).role()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projectInfo.tokens().get(2).appId()).isEqualTo("jobs");
+            assertThat(projectInfo.tokens().get(2).role()).isEqualTo(ProjectRole.OWNER);
+
+            final TokenInfo tokenInfo = mds.findToken("apple", "ive")
+                                           .toCompletableFuture().join();
+            assertThat(tokenInfo).isNotNull();
+            assertThat(tokenInfo.appId()).isEqualTo("ive");
+            assertThat(tokenInfo.secret()).isEqualTo("z");
+        } finally {
+            executor.stop();
+        }
+    }
+
+    private void createOneProjectAndValidate(MetadataService mds,
+                                             String projectName) {
+        final ProjectInfo p1 = mds.createProject(projectName, Author.DEFAULT)
+                                  .toCompletableFuture().join();
+        assertThat(p1).isNotNull();
+        assertThat(p1.name()).isEqualTo(projectName);
+        assertThat(p1.creation().user()).isEqualTo(Author.DEFAULT.name());
+
+        final ProjectInfo p2 = mds.getProject(projectName)
+                                  .toCompletableFuture().join();
+        assertThat(p2).isNotNull();
+        assertThat(p2.name()).isEqualTo(projectName);
+        assertThat(p2.creation().user()).isEqualTo(Author.DEFAULT.name());
+
+        final List<ProjectInfo> list = mds.getAllProjects()
+                                          .toCompletableFuture().join();
+        assertThat(list.stream().anyMatch(e -> e.name().equals(projectName))).isTrue();
+    }
+}


### PR DESCRIPTION
Motivation:
To easily add access control system to Central Dogma, we need to make a metadata management service which manages metadata of each project in one JSON file.

Modifications:
- Add MetadataService to manipulate a project.
- Add model classes to manage metadata.
- Add decorators to authorize a user.

Result:
Currently Central Dogma is not affected by this modification.
