### PR TITLE
Add author and timestamp property to all Commands

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/CentralDogmaSessionDAO.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/CentralDogmaSessionDAO.java
@@ -108,7 +108,7 @@ public class CentralDogmaSessionDAO implements SessionDAO, CacheManagerAware {
             final String username = currentUser != null ? currentUser.name() : "<unknown>";
             final String value = serialize(session);
             executor.execute(
-                    push(INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME, Revision.HEAD, Author.SYSTEM,
+                    push(Author.SYSTEM, INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME, Revision.HEAD,
                          "Login: " + username, "",
                          Markup.PLAINTEXT, Change.ofTextUpsert(sessionPath(sessionId), value)))
                     .thenRun(() -> {
@@ -183,7 +183,7 @@ public class CentralDogmaSessionDAO implements SessionDAO, CacheManagerAware {
     public void delete(Session session) {
         ensureNotInEventLoop();
         executor.execute(
-                push(INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME, Revision.HEAD, Author.SYSTEM,
+                push(Author.SYSTEM, INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME, Revision.HEAD,
                      "Logout: " + AuthenticationUtil.currentUser(), "",
                      Markup.PLAINTEXT, Change.ofRemoval(sessionPath(session.getId()))))
                 .thenRun(() -> {
@@ -232,8 +232,8 @@ public class CentralDogmaSessionDAO implements SessionDAO, CacheManagerAware {
         if (changesOfRemoval != null && !changesOfRemoval.isEmpty()) {
             try {
                 executor.execute(
-                        push(INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME, Revision.HEAD,
-                             Author.SYSTEM, "Logout", "", Markup.PLAINTEXT,
+                        push(Author.SYSTEM, INTERNAL_PROJECT_NAME, SESSION_REPOSITORY_NAME,
+                             Revision.HEAD, "Logout", "", Markup.PLAINTEXT,
                              changesOfRemoval));
             } catch (Exception e) {
                 logger.warn("Failed to remove invalid formatted sessions", cause(e));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/ProjectService.java
@@ -64,6 +64,6 @@ public class ProjectService extends AbstractService {
     public CompletionStage<ProjectDto> createProject(AggregatedHttpMessage message) throws IOException {
         final Author author = AuthenticationUtil.currentAuthor();
         final ProjectDto dto = Jackson.readValue(message.content().toStringAscii(), ProjectDto.class);
-        return execute(Command.createProject(dto.getName(), author)).thenApply(unused -> dto);
+        return execute(Command.createProject(author, dto.getName())).thenApply(unused -> dto);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -104,7 +104,7 @@ public class RepositoryService extends AbstractService {
         final Author author = AuthenticationUtil.currentAuthor();
         final RepositoryDto dto =
                 Jackson.readValue(message.content().toStringAscii(), RepositoryDto.class);
-        return execute(Command.createRepository(projectName, dto.getName(), author))
+        return execute(Command.createRepository(author, projectName, dto.getName()))
                 .thenApply(unused -> dto);
     }
 
@@ -281,7 +281,7 @@ public class RepositoryService extends AbstractService {
                 projectManager(), projectName, repositoryName, normalizedRev, ImmutableList.of(change));
 
         return f.thenCompose(
-                changes -> execute(Command.push(projectName, repositoryName, normalizedRev, author,
+                changes -> execute(Command.push(author, projectName, repositoryName, normalizedRev,
                                                 commitSummary, commitDetail, commitMarkup, changes.values())));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryUtil.java
@@ -57,7 +57,7 @@ final class RepositoryUtil {
 
         return f.thenCompose(
                 changes -> service.execute(
-                        Command.push(projectName, repositoryName, normalizedRev, author,
+                        Command.push(author, projectName, repositoryName, normalizedRev,
                                      commitSummary, commitDetail, commitMarkup, changes.values())));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/AbstractCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/AbstractCommand.java
@@ -18,19 +18,39 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
+
+import com.linecorp.centraldogma.common.Author;
 
 abstract class AbstractCommand<T> implements Command<T> {
 
     private final CommandType type;
+    private final long timestamp;
+    private final Author author;
 
-    protected AbstractCommand(CommandType type) {
+    protected AbstractCommand(CommandType type, @Nullable Long timestamp, @Nullable Author author) {
         this.type = requireNonNull(type, "type");
+        this.timestamp = timestamp != null ? timestamp : System.currentTimeMillis();
+        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @Override
     public final CommandType type() {
         return type;
+    }
+
+    @Override
+    public final long timestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public final Author author() {
+        return author;
     }
 
     @Override
@@ -44,12 +64,14 @@ abstract class AbstractCommand<T> implements Command<T> {
         }
 
         final AbstractCommand<?> that = (AbstractCommand<?>) obj;
-        return type == that.type;
+        return type == that.type &&
+               timestamp == that.timestamp &&
+               author.equals(that.author);
     }
 
     @Override
     public int hashCode() {
-        return type.hashCode();
+        return Objects.hash(type, timestamp, author);
     }
 
     @Override
@@ -58,6 +80,9 @@ abstract class AbstractCommand<T> implements Command<T> {
     }
 
     MoreObjects.ToStringHelper toStringHelper() {
-        return MoreObjects.toStringHelper(this).add("type", type);
+        return MoreObjects.toStringHelper(this)
+                          .add("type", type)
+                          .add("timestamp", timestamp)
+                          .add("author", author);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/Command.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -50,107 +51,180 @@ import com.linecorp.centraldogma.common.Revision;
 })
 public interface Command<T> {
 
-    static Command<Void> createProject(String name, Author author) {
-        return createProject(name, null, author);
+    static Command<Void> createProject(Author author, String name) {
+        return createProject(null, author, name);
     }
 
-    static Command<Void> createProject(String name, @Nullable Long creationTimeMillis, Author author) {
+    static Command<Void> createProject(@Nullable Long timestamp, Author author, String name) {
         requireNonNull(author, "author");
-        return new CreateProjectCommand(name, creationTimeMillis, author);
+        return new CreateProjectCommand(timestamp, author, name);
     }
 
-    static Command<Void> removeProject(String name) {
-        return new RemoveProjectCommand(name);
+    static Command<Void> removeProject(Author author, String name) {
+        return removeProject(null, author, name);
     }
 
-    static Command<Void> unremoveProject(String name) {
-        return new UnremoveProjectCommand(name);
-    }
-
-    static Command<Void> createRepository(String projectName, String repositoryName, Author author) {
-        return createRepository(projectName, repositoryName, null, author);
-    }
-
-    static Command<Void> createRepository(String projectName, String repositoryName,
-                                          @Nullable Long creationTimeMillis, Author author) {
+    static Command<Void> removeProject(@Nullable Long timestamp, Author author, String name) {
         requireNonNull(author, "author");
-        return new CreateRepositoryCommand(projectName, repositoryName, creationTimeMillis, author);
+        return new RemoveProjectCommand(timestamp, author, name);
     }
 
-    static Command<Void> removeRepository(String projectName, String repositoryName) {
-        return new RemoveRepositoryCommand(projectName, repositoryName);
+    static Command<Void> unremoveProject(Author author, String name) {
+        return unremoveProject(null, author, name);
     }
 
-    static Command<Void> unremoveRepository(String projectName, String repositoryName) {
-        return new UnremoveRepositoryCommand(projectName, repositoryName);
+    static Command<Void> unremoveProject(@Nullable Long timestamp, Author author, String name) {
+        requireNonNull(author, "author");
+        return new UnremoveProjectCommand(timestamp, author, name);
     }
 
-    static Command<Revision> push(String projectName, String repositoryName,
-                                  Revision baseRevision, Author author, String summary, String detail,
+    static Command<Void> createRepository(Author author, String projectName, String repositoryName) {
+        return createRepository(null, author, projectName, repositoryName);
+    }
+
+    static Command<Void> createRepository(@Nullable Long timestamp, Author author,
+                                          String projectName, String repositoryName) {
+        requireNonNull(author, "author");
+        return new CreateRepositoryCommand(timestamp, author, projectName, repositoryName);
+    }
+
+    static Command<Void> removeRepository(Author author, String projectName, String repositoryName) {
+        return removeRepository(null, author, projectName, repositoryName);
+    }
+
+    static Command<Void> removeRepository(@Nullable Long timestamp, Author author,
+                                          String projectName, String repositoryName) {
+        requireNonNull(author, "author");
+        return new RemoveRepositoryCommand(timestamp, author, projectName, repositoryName);
+    }
+
+    static Command<Void> unremoveRepository(Author author, String projectName, String repositoryName) {
+        return unremoveRepository(null, author, projectName, repositoryName);
+    }
+
+    static Command<Void> unremoveRepository(@Nullable Long timestamp, Author author,
+                                            String projectName, String repositoryName) {
+        requireNonNull(author, "author");
+        return new UnremoveRepositoryCommand(timestamp, author, projectName, repositoryName);
+    }
+
+    static Command<Revision> push(Author author, String projectName, String repositoryName,
+                                  Revision baseRevision, String summary, String detail,
                                   Markup markup, Change<?>... changes) {
 
-        requireNonNull(changes, "changes");
-        return new PushCommand(projectName, repositoryName, baseRevision, null,
-                               author, summary, detail, markup, Arrays.asList(changes));
+        return push(null, author, projectName, repositoryName, baseRevision, summary, detail, markup, changes);
     }
 
-    static Command<Revision> push(String projectName, String repositoryName,
-                                  Revision baseRevision, long commitTimeMillis,
-                                  Author author, String summary, String detail,
+    static Command<Revision> push(@Nullable Long timestamp, Author author,
+                                  String projectName, String repositoryName,
+                                  Revision baseRevision, String summary, String detail,
                                   Markup markup, Change<?>... changes) {
 
+        requireNonNull(author, "author");
         requireNonNull(changes, "changes");
-        return new PushCommand(projectName, repositoryName, baseRevision, commitTimeMillis,
-                               author, summary, detail, markup, Arrays.asList(changes));
+        return new PushCommand(timestamp, author, projectName, repositoryName, baseRevision,
+                               summary, detail, markup, Arrays.asList(changes));
     }
 
-    static Command<Revision> push(String projectName, String repositoryName,
-                                  Revision baseRevision, Author author, String summary, String detail,
+    static Command<Revision> push(Author author, String projectName, String repositoryName,
+                                  Revision baseRevision, String summary, String detail,
                                   Markup markup, Iterable<Change<?>> changes) {
 
-        return new PushCommand(projectName, repositoryName, baseRevision, null,
-                               author, summary, detail, markup, changes);
+        return push(null, author, projectName, repositoryName, baseRevision, summary, detail, markup, changes);
     }
 
-    static Command<Revision> push(String projectName, String repositoryName,
-                                  Revision baseRevision, long commitTimeMillis,
-                                  Author author, String summary, String detail,
+    static Command<Revision> push(@Nullable Long timestamp, Author author,
+                                  String projectName, String repositoryName,
+                                  Revision baseRevision, String summary, String detail,
                                   Markup markup, Iterable<Change<?>> changes) {
 
-        return new PushCommand(projectName, repositoryName, baseRevision, commitTimeMillis,
-                               author, summary, detail, markup, changes);
+        requireNonNull(author, "author");
+        return new PushCommand(timestamp, author, projectName, repositoryName, baseRevision,
+                               summary, detail, markup, changes);
     }
 
-    static Command<Void> createRunspace(String projectName, String repositoryName,
-                                        int baseRevision, Author author) {
+    static Command<Void> createRunspace(Author author, String projectName, String repositoryName,
+                                        int baseRevision) {
 
-        return new CreateRunspaceCommand(projectName, repositoryName, baseRevision, null, author);
+        return createRunspace(null, author, projectName, repositoryName, baseRevision);
     }
 
-    static Command<Void> removeRunspace(String projectName, String repositoryName, int baseRevision) {
-        return new RemoveRunspaceCommand(projectName, repositoryName, baseRevision);
+    static Command<Void> createRunspace(@Nullable Long timestamp, Author author,
+                                        String projectName, String repositoryName, int baseRevision) {
+
+        requireNonNull(author, "author");
+        return new CreateRunspaceCommand(timestamp, author, projectName, repositoryName, baseRevision);
     }
 
-    static Command<Void> saveNamedQuery(String projectName, String queryName, boolean enabled,
-                                        String repositoryName, Query<?> query, String comment, Markup markup) {
+    static Command<Void> removeRunspace(Author author, String projectName, String repositoryName,
+                                        int baseRevision) {
 
-        return new SaveNamedQueryCommand(projectName, queryName, enabled,
-                                         repositoryName, query, comment, markup);
+        return removeRunspace(null, author, projectName, repositoryName, baseRevision);
     }
 
-    static Command<Void> removeNamedQuery(String projectName, String name) {
-        return new RemoveNamedQueryCommand(projectName, name);
+    static Command<Void> removeRunspace(@Nullable Long timestamp, Author author,
+                                        String projectName, String repositoryName, int baseRevision) {
+
+        requireNonNull(author, "author");
+        return new RemoveRunspaceCommand(timestamp, author, projectName, repositoryName, baseRevision);
     }
 
-    static Command<Void> savePlugin(String projectName, String pluginName, String path) {
-        return new SavePluginCommand(projectName, pluginName, path);
+    static Command<Void> saveNamedQuery(Author author, String projectName,
+                                        String queryName, boolean enabled, String repositoryName,
+                                        Query<?> query, String comment, Markup markup) {
+
+        return saveNamedQuery(null, author, projectName,
+                              queryName, enabled, repositoryName,
+                              query, comment, markup);
     }
 
-    static Command<Void> removePlugin(String projectName, String pluginName) {
-        return new RemovePluginCommand(projectName, pluginName);
+    static Command<Void> saveNamedQuery(@Nullable Long timestamp, Author author, String projectName,
+                                        String queryName, boolean enabled, String repositoryName,
+                                        Query<?> query, String comment, Markup markup) {
+
+        requireNonNull(author, "author");
+        return new SaveNamedQueryCommand(timestamp, author, projectName,
+                                         queryName, enabled, repositoryName,
+                                         query, comment, markup);
+    }
+
+    static Command<Void> removeNamedQuery(Author author, String projectName, String name) {
+        return removeNamedQuery(null, author, projectName, name);
+    }
+
+    static Command<Void> removeNamedQuery(@Nullable Long timestamp, Author author,
+                                          String projectName, String name) {
+        requireNonNull(author, "author");
+        return new RemoveNamedQueryCommand(timestamp, author, projectName, name);
+    }
+
+    static Command<Void> savePlugin(Author author, String projectName, String pluginName, String path) {
+        return savePlugin(null, author, projectName, pluginName, path);
+    }
+
+    static Command<Void> savePlugin(@Nullable Long timestamp, Author author,
+                                    String projectName, String pluginName, String path) {
+        requireNonNull(author, "author");
+        return new SavePluginCommand(timestamp, author, projectName, pluginName, path);
+    }
+
+    static Command<Void> removePlugin(Author author, String projectName, String pluginName) {
+        return removePlugin(null, author, projectName, pluginName);
+    }
+
+    static Command<Void> removePlugin(@Nullable Long timestamp, Author author,
+                                      String projectName, String pluginName) {
+        requireNonNull(author, "author");
+        return new RemovePluginCommand(timestamp, author, projectName, pluginName);
     }
 
     CommandType type();
+
+    @JsonProperty
+    long timestamp();
+
+    @JsonProperty
+    Author author();
 
     String executionPath();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommand.java
@@ -18,8 +18,6 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -31,32 +29,18 @@ import com.linecorp.centraldogma.common.Author;
 public final class CreateProjectCommand extends RootCommand<Void> {
 
     private final String projectName;
-    private final long creationTimeMillis;
-    private final Author author;
 
     @JsonCreator
-    CreateProjectCommand(@JsonProperty("projectName") String projectName,
-                         @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
-                         @JsonProperty("author") @Nullable Author author) {
-        super(CommandType.CREATE_PROJECT);
+    CreateProjectCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                         @JsonProperty("author") @Nullable Author author,
+                         @JsonProperty("projectName") String projectName) {
+        super(CommandType.CREATE_PROJECT, timestamp, author);
         this.projectName = requireNonNull(projectName, "projectName");
-        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
-        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
     public String projectName() {
         return projectName;
-    }
-
-    @JsonProperty
-    public long creationTimeMillis() {
-        return creationTimeMillis;
-    }
-
-    @JsonProperty
-    public Author author() {
-        return author;
     }
 
     @Override
@@ -71,20 +55,17 @@ public final class CreateProjectCommand extends RootCommand<Void> {
 
         final CreateProjectCommand that = (CreateProjectCommand) obj;
         return super.equals(obj) &&
-               projectName.equals(that.projectName) &&
-               creationTimeMillis == that.creationTimeMillis &&
-               author.equals(that.author);
+               projectName.equals(that.projectName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(projectName, creationTimeMillis, author) * 31 + super.hashCode();
+        return projectName.hashCode() * 31 + super.hashCode();
     }
 
     @Override
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
-                    .add("projectName", projectName)
-                    .add("creationTimeMillis", creationTimeMillis);
+                    .add("projectName", projectName);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommand.java
@@ -18,8 +18,6 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -31,34 +29,20 @@ import com.linecorp.centraldogma.common.Author;
 public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
     private final String repositoryName;
-    private final long creationTimeMillis;
-    private final Author author;
 
     @JsonCreator
-    CreateRepositoryCommand(@JsonProperty("projectName") String projectName,
-                            @JsonProperty("repositoryName") String repositoryName,
-                            @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
-                            @JsonProperty("author") @Nullable Author author) {
+    CreateRepositoryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                            @JsonProperty("author") @Nullable Author author,
+                            @JsonProperty("projectName") String projectName,
+                            @JsonProperty("repositoryName") String repositoryName) {
 
-        super(CommandType.CREATE_REPOSITORY, projectName);
+        super(CommandType.CREATE_REPOSITORY, timestamp, author, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
-        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
-        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
     public String repositoryName() {
         return repositoryName;
-    }
-
-    @JsonProperty
-    public long creationTimeMillis() {
-        return creationTimeMillis;
-    }
-
-    @JsonProperty
-    public Author author() {
-        return author;
     }
 
     @Override
@@ -73,20 +57,17 @@ public final class CreateRepositoryCommand extends ProjectCommand<Void> {
 
         final CreateRepositoryCommand that = (CreateRepositoryCommand) obj;
         return super.equals(obj) &&
-               repositoryName.equals(that.repositoryName) &&
-               creationTimeMillis == that.creationTimeMillis &&
-               author.equals(that.author);
+               repositoryName.equals(that.repositoryName);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(repositoryName, creationTimeMillis, author) * 31 + super.hashCode();
+        return repositoryName.hashCode() * 31 + super.hashCode();
     }
 
     @Override
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
-                    .add("repositoryName", repositoryName)
-                    .add("creationTimeMillis", creationTimeMillis);
+                    .add("repositoryName", repositoryName);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CreateRunspaceCommand.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
-import java.util.Objects;
-
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -29,35 +27,21 @@ import com.linecorp.centraldogma.common.Author;
 public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
 
     private final int baseRevision;
-    private final long creationTimeMillis;
-    private final Author author;
 
     @JsonCreator
-    CreateRunspaceCommand(@JsonProperty("projectName") String projectName,
+    CreateRunspaceCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                          @JsonProperty("author") @Nullable Author author,
+                          @JsonProperty("projectName") String projectName,
                           @JsonProperty("repositoryName") String repositoryName,
-                          @JsonProperty("baseRevision") int baseRevision,
-                          @JsonProperty("creationTimeMillis") @Nullable Long creationTimeMillis,
-                          @JsonProperty("author") @Nullable Author author) {
+                          @JsonProperty("baseRevision") int baseRevision) {
 
-        super(CommandType.CREATE_RUNSPACE, projectName, repositoryName);
+        super(CommandType.CREATE_RUNSPACE, timestamp, author, projectName, repositoryName);
         this.baseRevision = baseRevision;
-        this.creationTimeMillis = creationTimeMillis != null ? creationTimeMillis : System.currentTimeMillis();
-        this.author = author != null ? author : Author.SYSTEM;
     }
 
     @JsonProperty
     public int baseRevision() {
         return baseRevision;
-    }
-
-    @JsonProperty
-    public long creationTimeMillis() {
-        return creationTimeMillis;
-    }
-
-    @JsonProperty
-    public Author author() {
-        return author;
     }
 
     @Override
@@ -72,21 +56,17 @@ public final class CreateRunspaceCommand extends RepositoryCommand<Void> {
 
         final CreateRunspaceCommand that = (CreateRunspaceCommand) obj;
         return super.equals(that) &&
-               baseRevision == that.baseRevision &&
-               creationTimeMillis == that.creationTimeMillis &&
-               author.equals(that.author);
+               baseRevision == that.baseRevision;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseRevision, creationTimeMillis, author) * 31 + super.hashCode();
+        return baseRevision * 31 + super.hashCode();
     }
 
     @Override
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
-                    .add("baseRevision", baseRevision)
-                    .add("creationTimeMillis", creationTimeMillis)
-                    .add("author", author);
+                    .add("baseRevision", baseRevision);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectCommand.java
@@ -18,15 +18,20 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public abstract class ProjectCommand<T> extends AbstractCommand<T> {
 
     private final String projectName;
 
-    ProjectCommand(CommandType commandType, String projectName) {
-        super(commandType);
+    ProjectCommand(CommandType commandType, @Nullable Long timestamp,
+                   @Nullable Author author, String projectName) {
+        super(commandType, timestamp, author);
         this.projectName = requireNonNull(projectName, "projectName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -129,7 +129,7 @@ public final class ProjectInitializer {
                 Change.ofJsonUpsert("/samples/qux.json", SAMPLE_JSON_ARRAY));
 
         return executor.execute(Command.push(
-                projectName, repositoryName, Revision.HEAD, Author.SYSTEM,
+                Author.SYSTEM, projectName, repositoryName, Revision.HEAD,
                 "Add the sample files", "", Markup.PLAINTEXT, changes));
     }
 
@@ -138,7 +138,7 @@ public final class ProjectInitializer {
      */
     public static void initializeInternalProject(CommandExecutor executor) {
         try {
-            executor.execute(createProject(INTERNAL_PROJECT_NAME, Author.SYSTEM))
+            executor.execute(createProject(Author.SYSTEM, INTERNAL_PROJECT_NAME))
                     .get();
         } catch (Exception e) {
             if (!(e.getCause() instanceof ProjectExistsException)) {
@@ -149,7 +149,7 @@ public final class ProjectInitializer {
                                                   SESSION_REPOSITORY_NAME,
                                                   TOKEN_REPOSITORY_NAME)) {
             try {
-                executor.execute(createRepository(INTERNAL_PROJECT_NAME, repo, Author.SYSTEM))
+                executor.execute(createRepository(Author.SYSTEM, INTERNAL_PROJECT_NAME, repo))
                         .get();
             } catch (Exception e) {
                 if (!(e.getCause() instanceof RepositoryExistsException)) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -38,14 +38,16 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
 
         final CreateProjectCommand c = (CreateProjectCommand) command;
         final String projectName = c.projectName();
-        final long creationTimeMillis = c.creationTimeMillis();
+        final long creationTimeMillis = c.timestamp();
         final Author author = c.author();
 
         final CompletableFuture<Void> f = delegate().execute(c);
-        return f.thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_META,
-                                                                                   creationTimeMillis, author)))
-                .thenCompose(unused -> delegate().execute(Command.createRepository(projectName, REPO_MAIN,
-                                                                                   creationTimeMillis, author)))
+        return f.thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
+                                                                                   projectName, REPO_META
+        )))
+                .thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
+                                                                                   projectName, REPO_MAIN
+                )))
                 .thenCompose(unused -> generateSampleFiles(delegate(), projectName, REPO_MAIN))
                 .thenApply(unused -> null);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/PushCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/PushCommand.java
@@ -38,29 +38,25 @@ import com.linecorp.centraldogma.common.Revision;
 public final class PushCommand extends RepositoryCommand<Revision> {
 
     private final Revision baseRevision;
-    private final long commitTimeMillis;
-    private final Author author;
     private final String summary;
     private final String detail;
     private final Markup markup;
     private final List<Change<?>> changes;
 
     @JsonCreator
-    PushCommand(@JsonProperty("projectName") String projectName,
+    PushCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                @JsonProperty("author") @Nullable Author author,
+                @JsonProperty("projectName") String projectName,
                 @JsonProperty("repositoryName") String repositoryName,
                 @JsonProperty("baseRevision") Revision baseRevision,
-                @JsonProperty("commitTimeMillis") @Nullable Long commitTimeMillis,
-                @JsonProperty("author") Author author,
                 @JsonProperty("summary") String summary,
                 @JsonProperty("detail") String detail,
                 @JsonProperty("markup") Markup markup,
                 @JsonProperty("changes") Iterable<Change<?>> changes) {
 
-        super(CommandType.PUSH, projectName, repositoryName);
+        super(CommandType.PUSH, timestamp, author, projectName, repositoryName);
 
         this.baseRevision = requireNonNull(baseRevision, "baseRevision");
-        this.commitTimeMillis = commitTimeMillis != null ? commitTimeMillis : System.currentTimeMillis();
-        this.author = requireNonNull(author, "author");
         this.summary = requireNonNull(summary, "summary");
         this.detail = requireNonNull(detail, "detail");
         this.markup = requireNonNull(markup, "markup");
@@ -73,16 +69,6 @@ public final class PushCommand extends RepositoryCommand<Revision> {
     @JsonProperty
     public Revision baseRevision() {
         return baseRevision;
-    }
-
-    @JsonProperty
-    public long commitTimeMillis() {
-        return commitTimeMillis;
-    }
-
-    @JsonProperty
-    public Author author() {
-        return author;
     }
 
     @JsonProperty
@@ -118,8 +104,6 @@ public final class PushCommand extends RepositoryCommand<Revision> {
         final PushCommand that = (PushCommand) obj;
         return super.equals(that) &&
                baseRevision.equals(that.baseRevision) &&
-               commitTimeMillis == that.commitTimeMillis &&
-               author.equals(that.author) &&
                summary.equals(that.summary) &&
                detail.equals(that.detail) &&
                markup == that.markup &&
@@ -128,16 +112,13 @@ public final class PushCommand extends RepositoryCommand<Revision> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(baseRevision, commitTimeMillis,
-                            author, summary, detail, markup, changes) * 31 + super.hashCode();
+        return Objects.hash(baseRevision, summary, detail, markup, changes) * 31 + super.hashCode();
     }
 
     @Override
     ToStringHelper toStringHelper() {
         return super.toStringHelper()
                     .add("baseRevision", baseRevision)
-                    .add("commitTimeMillis", commitTimeMillis)
-                    .add("author", author)
                     .add("summary", summary)
                     .add("markup", markup);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveNamedQueryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveNamedQueryCommand.java
@@ -18,18 +18,24 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class RemoveNamedQueryCommand extends ProjectCommand<Void> {
 
     private final String queryName;
 
     @JsonCreator
-    RemoveNamedQueryCommand(@JsonProperty("projectName") String projectName,
+    RemoveNamedQueryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                            @JsonProperty("author") @Nullable Author author,
+                            @JsonProperty("projectName") String projectName,
                             @JsonProperty("queryName") String queryName) {
-        super(CommandType.REMOVE_NAMED_QUERY, projectName);
+        super(CommandType.REMOVE_NAMED_QUERY, timestamp, author, projectName);
         this.queryName = requireNonNull(queryName, "queryName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemovePluginCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemovePluginCommand.java
@@ -18,19 +18,25 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class RemovePluginCommand extends ProjectCommand<Void> {
 
     private final String pluginName;
 
     @JsonCreator
-    RemovePluginCommand(@JsonProperty("projectName") String projectName,
+    RemovePluginCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                        @JsonProperty("author") @Nullable Author author,
+                        @JsonProperty("projectName") String projectName,
                         @JsonProperty("pluginName") String pluginName) {
 
-        super(CommandType.REMOVE_PLUGIN, projectName);
+        super(CommandType.REMOVE_PLUGIN, timestamp, author, projectName);
         this.pluginName = requireNonNull(pluginName, "pluginName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveProjectCommand.java
@@ -18,17 +18,23 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public class RemoveProjectCommand extends RootCommand<Void> {
 
     private final String projectName;
 
     @JsonCreator
-    RemoveProjectCommand(@JsonProperty("projectName") String projectName) {
-        super(CommandType.REMOVE_PROJECT);
+    RemoveProjectCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                         @JsonProperty("author") @Nullable Author author,
+                         @JsonProperty("projectName") String projectName) {
+        super(CommandType.REMOVE_PROJECT, timestamp, author);
         this.projectName = requireNonNull(projectName, "projectName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveRepositoryCommand.java
@@ -18,18 +18,24 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class RemoveRepositoryCommand extends ProjectCommand<Void> {
 
     private final String repositoryName;
 
     @JsonCreator
-    RemoveRepositoryCommand(@JsonProperty("projectName") String projectName,
+    RemoveRepositoryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                            @JsonProperty("author") @Nullable Author author,
+                            @JsonProperty("projectName") String projectName,
                             @JsonProperty("repositoryName") String repositoryName) {
-        super(CommandType.REMOVE_REPOSITORY, projectName);
+        super(CommandType.REMOVE_REPOSITORY, timestamp, author, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveRunspaceCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RemoveRunspaceCommand.java
@@ -16,20 +16,26 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class RemoveRunspaceCommand extends RepositoryCommand<Void> {
 
     private final int baseRevision;
 
     @JsonCreator
-    RemoveRunspaceCommand(@JsonProperty("projectName") String projectName,
+    RemoveRunspaceCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                          @JsonProperty("author") @Nullable Author author,
+                          @JsonProperty("projectName") String projectName,
                           @JsonProperty("repositoryName") String repositoryName,
                           @JsonProperty("baseRevision") int baseRevision) {
 
-        super(CommandType.REMOVE_RUNSPACE, projectName, repositoryName);
+        super(CommandType.REMOVE_RUNSPACE, timestamp, author, projectName, repositoryName);
         this.baseRevision = baseRevision;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RepositoryCommand.java
@@ -20,16 +20,21 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public abstract class RepositoryCommand<T> extends AbstractCommand<T> {
 
     private final String projectName;
     private final String repositoryName;
 
-    RepositoryCommand(CommandType commandType, String projectName, String repositoryName) {
-        super(commandType);
+    RepositoryCommand(CommandType commandType, @Nullable Long timestamp, @Nullable Author author,
+                      String projectName, String repositoryName) {
+        super(commandType, timestamp, author);
         this.projectName = requireNonNull(projectName, "projectName");
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RootCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/RootCommand.java
@@ -16,9 +16,13 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
+import javax.annotation.Nullable;
+
+import com.linecorp.centraldogma.common.Author;
+
 public abstract class RootCommand<T> extends AbstractCommand<T> {
-    RootCommand(CommandType commandType) {
-        super(commandType);
+    RootCommand(CommandType commandType, @Nullable Long timestamp, @Nullable Author author) {
+        super(commandType, timestamp, author);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/SaveNamedQueryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/SaveNamedQueryCommand.java
@@ -20,10 +20,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
+import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Query;
 
@@ -37,7 +40,9 @@ public final class SaveNamedQueryCommand extends ProjectCommand<Void> {
     private final Markup markup;
 
     @JsonCreator
-    SaveNamedQueryCommand(@JsonProperty("projectName") String projectName,
+    SaveNamedQueryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                          @JsonProperty("author") @Nullable Author author,
+                          @JsonProperty("projectName") String projectName,
                           @JsonProperty("queryName") String queryName,
                           @JsonProperty("enabled") boolean enabled,
                           @JsonProperty("repositoryName") String repositoryName,
@@ -45,7 +50,7 @@ public final class SaveNamedQueryCommand extends ProjectCommand<Void> {
                           @JsonProperty("comment") String comment,
                           @JsonProperty("markup") Markup markup) {
 
-        super(CommandType.SAVE_NAMED_QUERY, projectName);
+        super(CommandType.SAVE_NAMED_QUERY, timestamp, author, projectName);
 
         this.queryName = requireNonNull(queryName, "queryName");
         this.enabled = enabled;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/SavePluginCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/SavePluginCommand.java
@@ -20,9 +20,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class SavePluginCommand extends ProjectCommand<Void> {
 
@@ -30,11 +34,13 @@ public final class SavePluginCommand extends ProjectCommand<Void> {
     private final String path;
 
     @JsonCreator
-    SavePluginCommand(@JsonProperty("projectName") String projectName,
+    SavePluginCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                      @JsonProperty("author") @Nullable Author author,
+                      @JsonProperty("projectName") String projectName,
                       @JsonProperty("pluginName") String pluginName,
                       @JsonProperty("path") String path) {
 
-        super(CommandType.SAVE_PLUGIN, projectName);
+        super(CommandType.SAVE_PLUGIN, timestamp, author, projectName);
         this.pluginName = requireNonNull(pluginName, "pluginName");
         this.path = requireNonNull(path, "path");
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/StandaloneCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/StandaloneCommandExecutor.java
@@ -107,7 +107,7 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
 
     private CompletableFuture<Void> createProject(CreateProjectCommand c) {
         return CompletableFuture.supplyAsync(() -> {
-            projectManager.create(c.projectName(), c.creationTimeMillis());
+            projectManager.create(c.projectName(), c.timestamp());
             return null;
         }, repositoryWorker);
     }
@@ -130,7 +130,7 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
 
     private CompletableFuture<Void> createRepository(CreateRepositoryCommand c) {
         return CompletableFuture.supplyAsync(() -> {
-            projectManager.get(c.projectName()).repos().create(c.repositoryName(), c.creationTimeMillis());
+            projectManager.get(c.projectName()).repos().create(c.repositoryName(), c.timestamp());
             return null;
         }, repositoryWorker);
     }
@@ -150,12 +150,12 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
     }
 
     private CompletableFuture<Revision> push(PushCommand c) {
-        return repo(c).commit(c.baseRevision(), c.commitTimeMillis(),
+        return repo(c).commit(c.baseRevision(), c.timestamp(),
                               c.author(), c.summary(), c.detail(), c.markup(), c.changes());
     }
 
     private CompletableFuture<Void> createRunspace(CreateRunspaceCommand c) {
-        return repo(c).createRunspace(c.baseRevision(), c.creationTimeMillis(),
+        return repo(c).createRunspace(c.baseRevision(), c.timestamp(),
                                       c.author()).thenApply(revision -> null);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/UnremoveProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/UnremoveProjectCommand.java
@@ -18,17 +18,23 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class UnremoveProjectCommand extends RootCommand<Void> {
 
     private final String projectName;
 
     @JsonCreator
-    UnremoveProjectCommand(@JsonProperty("projectName") String projectName) {
-        super(CommandType.UNREMOVE_PROJECT);
+    UnremoveProjectCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                           @JsonProperty("author") @Nullable Author author,
+                           @JsonProperty("projectName") String projectName) {
+        super(CommandType.UNREMOVE_PROJECT, timestamp, author);
         this.projectName = requireNonNull(projectName, "projectName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/UnremoveRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/UnremoveRepositoryCommand.java
@@ -18,19 +18,25 @@ package com.linecorp.centraldogma.server.internal.command;
 
 import static java.util.Objects.requireNonNull;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
 
 public final class UnremoveRepositoryCommand extends ProjectCommand<Void> {
 
     private final String repositoryName;
 
     @JsonCreator
-    UnremoveRepositoryCommand(@JsonProperty("projectName") String projectName,
+    UnremoveRepositoryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                              @JsonProperty("author") @Nullable Author author,
+                              @JsonProperty("projectName") String projectName,
                               @JsonProperty("repositoryName") String repositoryName) {
 
-        super(CommandType.UNREMOVE_REPOSITORY, projectName);
+        super(CommandType.UNREMOVE_REPOSITORY, timestamp, author, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -217,8 +217,8 @@ public final class GitMirror extends Mirror {
             });
 
             executor.execute(Command.push(
-                    localRepo().parent().name(), localRepo().name(),
-                    Revision.HEAD, MIRROR_AUTHOR, summary, "", Markup.PLAINTEXT, changes.values())).join();
+                    MIRROR_AUTHOR, localRepo().parent().name(), localRepo().name(),
+                    Revision.HEAD, summary, "", Markup.PLAINTEXT, changes.values())).join();
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -121,17 +121,17 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
 
     @Override
     public void createProject(String name, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.createProject(name, SYSTEM)), resultHandler);
+        handle(executor.execute(Command.createProject(SYSTEM, name)), resultHandler);
     }
 
     @Override
     public void removeProject(String name, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.removeProject(name)), resultHandler);
+        handle(executor.execute(Command.removeProject(SYSTEM, name)), resultHandler);
     }
 
     @Override
     public void unremoveProject(String name, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.unremoveProject(name)), resultHandler);
+        handle(executor.execute(Command.unremoveProject(SYSTEM, name)), resultHandler);
     }
 
     @Override
@@ -153,20 +153,21 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void createRepository(
             String projectName, String repositoryName, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.createRepository(projectName, repositoryName, SYSTEM)),
+        handle(executor.execute(Command.createRepository(SYSTEM, projectName, repositoryName)),
                resultHandler);
     }
 
     @Override
     public void removeRepository(
             String projectName, String repositoryName, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.removeRepository(projectName, repositoryName)), resultHandler);
+        handle(executor.execute(Command.removeRepository(SYSTEM, projectName, repositoryName)), resultHandler);
     }
 
     @Override
     public void unremoveRepository(
             String projectName, String repositoryName, AsyncMethodCallback resultHandler) {
-        handle(executor.execute(Command.unremoveRepository(projectName, repositoryName)), resultHandler);
+        handle(executor.execute(Command.unremoveRepository(SYSTEM, projectName, repositoryName)),
+               resultHandler);
     }
 
     @Override
@@ -260,10 +261,9 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                      String summary, Comment detail, List<Change> changes, AsyncMethodCallback resultHandler) {
 
         // TODO(trustin): Change Repository.commit() to return a Commit.
-        handle(executor.execute(Command.push(projectName, repositoryName, convert(baseRevision),
-                                             convert(author), summary, detail.getContent(),
-                                             convert(detail.getMarkup()),
-                                             convert(changes, Converter::convert)))
+        handle(executor.execute(Command.push(convert(author), projectName, repositoryName,
+                                             convert(baseRevision), summary, detail.getContent(),
+                                             convert(detail.getMarkup()), convert(changes, Converter::convert)))
                        .thenCompose(newRev -> projectManager.get(projectName).repos().get(repositoryName)
                                                             .history(newRev, newRev, "/**"))
                        .thenApply(commits -> convert(commits.get(0))),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateProjectCommandTest.java
@@ -17,24 +17,39 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
 import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class CreateProjectCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateProjectCommand("foo", 1234L, new Author("foo", "bar@baz.com")),
+        assertJsonConversion(new CreateProjectCommand(1234L, new Author("foo", "bar@baz.com"), "foo"),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_PROJECT\"," +
-                             "  \"projectName\": \"foo\"," +
-                             "  \"creationTimeMillis\": 1234," +
+                             "  \"timestamp\": 1234," +
                              "  \"author\": {" +
                              "    \"name\": \"foo\"," +
                              "    \"email\": \"bar@baz.com\"" +
-                             "  }" +
+                             "  }," +
+                             "  \"projectName\": \"foo\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final CreateProjectCommand c = (CreateProjectCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"CREATE_PROJECT\"," +
+                "  \"projectName\": \"foo\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/CreateRepositoryCommandTest.java
@@ -17,25 +17,42 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
 import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class CreateRepositoryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new CreateRepositoryCommand("foo", "bar", 1234L, new Author("foo", "bar@baz.com")),
+        assertJsonConversion(new CreateRepositoryCommand(1234L, new Author("foo", "bar@baz.com"), "foo", "bar"),
                              Command.class,
                              '{' +
                              "  \"type\": \"CREATE_REPOSITORY\"," +
-                             "  \"projectName\": \"foo\"," +
-                             "  \"repositoryName\": \"bar\"," +
-                             "  \"creationTimeMillis\": 1234," +
+                             "  \"timestamp\": 1234," +
                              "  \"author\": {" +
                              "    \"name\": \"foo\"," +
                              "    \"email\": \"bar@baz.com\"" +
-                             "  }" +
+                             "  }," +
+                             "  \"projectName\": \"foo\"," +
+                             "  \"repositoryName\": \"bar\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final CreateRepositoryCommand c = (CreateRepositoryCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"CREATE_REPOSITORY\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/PushCommandTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
@@ -26,23 +27,49 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class PushCommandTest {
 
     @Test
     public void testJsonConversion() {
         assertJsonConversion(
-                new PushCommand("foo", "bar", new Revision(42), 1234L,
-                                new Author("Marge Simpson", "marge@simpsonsworld.com"),
-                                "baz", "qux", Markup.MARKDOWN,
+                new PushCommand(1234L, new Author("Marge Simpson", "marge@simpsonsworld.com"),
+                                "foo", "bar", new Revision(42), "baz", "qux", Markup.MARKDOWN,
                                 Collections.singletonList(Change.ofTextUpsert("/memo.txt", "Bon voyage!"))),
                 Command.class,
                 '{' +
                 "  \"type\": \"PUSH\"," +
+                "  \"timestamp\": 1234," +
+                "  \"author\": {" +
+                "    \"name\": \"Marge Simpson\"," +
+                "    \"email\": \"marge@simpsonsworld.com\"" +
+                "  }," +
                 "  \"projectName\": \"foo\"," +
                 "  \"repositoryName\": \"bar\"," +
                 "  \"baseRevision\": 42," +
-                "  \"commitTimeMillis\": 1234," +
+                "  \"summary\": \"baz\"," +
+                "  \"detail\": \"qux\"," +
+                "  \"markup\": \"MARKDOWN\"," +
+                "  \"changes\": [{" +
+                "    \"type\": \"UPSERT_TEXT\"," +
+                "    \"path\": \"/memo.txt\"," +
+                "    \"content\": \"Bon voyage!\"" +
+                "  }]" +
+                '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final PushCommand c = (PushCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"PUSH\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"," +
+                "  \"baseRevision\": {" +
+                "    \"major\": 42," +
+                "    \"minor\": 0" +
+                "  }," +
                 "  \"author\": {" +
                 "    \"name\": \"Marge Simpson\"," +
                 "    \"email\": \"marge@simpsonsworld.com\"" +
@@ -55,6 +82,16 @@ public class PushCommandTest {
                 "    \"path\": \"/memo.txt\"," +
                 "    \"content\": \"Bon voyage!\"" +
                 "  }]" +
-                '}');
+                '}', Command.class);
+
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
+        assertThat(c.baseRevision()).isEqualTo(new Revision(42));
+        assertThat(c.author()).isEqualTo(new Author("Marge Simpson", "marge@simpsonsworld.com"));
+        assertThat(c.summary()).isEqualTo("baz");
+        assertThat(c.detail()).isEqualTo("qux");
+        assertThat(c.markup()).isSameAs(Markup.MARKDOWN);
+        assertThat(c.changes()).containsExactly(Change.ofTextUpsert("/memo.txt", "Bon voyage!"));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveNamedQueryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveNamedQueryCommandTest.java
@@ -17,18 +17,42 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class RemoveNamedQueryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new RemoveNamedQueryCommand("foo", "bar"),
+        assertJsonConversion(new RemoveNamedQueryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
                              "  \"type\": \"REMOVE_NAMED_QUERY\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"queryName\": \"bar\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final RemoveNamedQueryCommand c = (RemoveNamedQueryCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"REMOVE_NAMED_QUERY\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"queryName\": \"bar\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.queryName()).isEqualTo("bar");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemovePluginCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemovePluginCommandTest.java
@@ -17,18 +17,42 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class RemovePluginCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new RemovePluginCommand("foo", "my_plugin"),
+        assertJsonConversion(new RemovePluginCommand(1234L, Author.SYSTEM, "foo", "my_plugin"),
                              Command.class,
                              '{' +
                              "  \"type\": \"REMOVE_PLUGIN\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"pluginName\": \"my_plugin\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final RemovePluginCommand c = (RemovePluginCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"REMOVE_PLUGIN\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"pluginName\": \"my_plugin\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.pluginName()).isEqualTo("my_plugin");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveProjectCommandTest.java
@@ -17,17 +17,39 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class RemoveProjectCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new RemoveProjectCommand("foo"),
+        assertJsonConversion(new RemoveProjectCommand(1234L, Author.SYSTEM, "foo"),
                              Command.class,
                              '{' +
                              "  \"type\": \"REMOVE_PROJECT\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final RemoveProjectCommand c = (RemoveProjectCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"REMOVE_PROJECT\"," +
+                "  \"projectName\": \"foo\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveRepositoryCommandTest.java
@@ -17,18 +17,42 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class RemoveRepositoryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new RemoveRepositoryCommand("foo", "bar"),
+        assertJsonConversion(new RemoveRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
                              "  \"type\": \"REMOVE_REPOSITORY\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"repositoryName\": \"bar\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final RemoveRepositoryCommand c = (RemoveRepositoryCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"REMOVE_REPOSITORY\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveRunspaceCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/RemoveRunspaceCommandTest.java
@@ -17,19 +17,45 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class RemoveRunspaceCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new RemoveRunspaceCommand("foo", "bar", 42),
+        assertJsonConversion(new RemoveRunspaceCommand(1234L, Author.SYSTEM, "foo", "bar", 42),
                              Command.class,
                              '{' +
                              "  \"type\": \"REMOVE_RUNSPACE\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"repositoryName\": \"bar\"," +
                              "  \"baseRevision\": 42" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final RemoveRunspaceCommand c = (RemoveRunspaceCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"REMOVE_RUNSPACE\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"," +
+                "  \"baseRevision\": 42" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
+        assertThat(c.baseRevision()).isEqualTo(42);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/SavePluginCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/SavePluginCommandTest.java
@@ -17,19 +17,45 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class SavePluginCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new SavePluginCommand("foo", "my_plugin", "/plugin.json"),
+        assertJsonConversion(new SavePluginCommand(1234L, Author.SYSTEM, "foo", "my_plugin", "/plugin.json"),
                              Command.class,
                              '{' +
                              "  \"type\": \"SAVE_PLUGIN\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"pluginName\": \"my_plugin\"," +
                              "  \"path\": \"/plugin.json\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final SavePluginCommand c = (SavePluginCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"SAVE_PLUGIN\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"pluginName\": \"my_plugin\"," +
+                "  \"path\": \"/plugin.json\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.pluginName()).isEqualTo("my_plugin");
+        assertThat(c.path()).isEqualTo("/plugin.json");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/UnremoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/UnremoveProjectCommandTest.java
@@ -17,17 +17,39 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class UnremoveProjectCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new UnremoveProjectCommand("foo"),
+        assertJsonConversion(new UnremoveProjectCommand(1234L, Author.SYSTEM, "foo"),
                              Command.class,
                              '{' +
                              "  \"type\": \"UNREMOVE_PROJECT\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final UnremoveProjectCommand c = (UnremoveProjectCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"UNREMOVE_PROJECT\"," +
+                "  \"projectName\": \"foo\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/command/UnremoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/command/UnremoveRepositoryCommandTest.java
@@ -17,18 +17,42 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
 
 public class UnremoveRepositoryCommandTest {
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new UnremoveRepositoryCommand("foo", "bar"),
+        assertJsonConversion(new UnremoveRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
                              "  \"type\": \"UNREMOVE_REPOSITORY\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
                              "  \"projectName\": \"foo\"," +
                              "  \"repositoryName\": \"bar\"" +
                              '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final UnremoveRepositoryCommand c = (UnremoveRepositoryCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"UNREMOVE_REPOSITORY\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
@@ -32,13 +32,13 @@ public class ReplicationLogTest {
 
     @Test
     public void testJsonConversion() {
-        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject("foo", 1234L, AUTHOR), null),
+        assertJsonConversion(new ReplicationLog<>("r1", Command.createProject(1234L, AUTHOR, "foo"), null),
                              '{' +
                              "  \"replicaId\": \"r1\"," +
                              "  \"command\": {" +
                              "    \"type\": \"CREATE_PROJECT\"," +
                              "    \"projectName\": \"foo\"," +
-                             "    \"creationTimeMillis\": 1234," +
+                             "    \"timestamp\": 1234," +
                              "    \"author\": {" +
                              "      \"name\": \"foo\"," +
                              "      \"email\": \"bar@baz.com\"" +
@@ -48,7 +48,7 @@ public class ReplicationLogTest {
                              '}');
 
         Command<Revision> pushCommand = Command.push(
-                "foo", "bar", Revision.HEAD, 1234, new Author("Sedol Lee", "sedol@lee.com"),
+                1234L, new Author("Sedol Lee", "sedol@lee.com"), "foo", "bar", Revision.HEAD,
                 "4:1", "L-L-L-W-L", Markup.PLAINTEXT, Change.ofTextUpsert("/result.txt", "too soon to tell"));
 
         assertJsonConversion(new ReplicationLog<>("r2", pushCommand, new Revision(43)),
@@ -59,7 +59,7 @@ public class ReplicationLogTest {
                              "    \"projectName\": \"foo\"," +
                              "    \"repositoryName\": \"bar\"," +
                              "    \"baseRevision\": -1," +
-                             "    \"commitTimeMillis\": 1234," +
+                             "    \"timestamp\": 1234," +
                              "    \"author\": {" +
                              "      \"name\": \"Sedol Lee\"," +
                              "      \"email\": \"sedol@lee.com\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -88,7 +88,7 @@ public class ZooKeeperCommandExecutorTest {
         Replica replica4 = null;
 
         try {
-            final Command<Void> command1 = Command.createRepository("project", "repo1", Author.SYSTEM);
+            final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.rm.execute(command1).join();
 
             final Optional<ReplicationLog<?>> commandResult2 = replica1.rm.loadLog(0, false);
@@ -107,7 +107,7 @@ public class ZooKeeperCommandExecutorTest {
             //stop replay m3
             replica3.rm.stop();
 
-            final Command<?> command2 = Command.createProject("foo", Author.SYSTEM);
+            final Command<?> command2 = Command.createProject(Author.SYSTEM, "foo");
             replica1.rm.execute(command2).join();
             verify(replica1.delegate, timeout(300).times(1)).apply(eq(command2));
             verify(replica2.delegate, timeout(300).times(1)).apply(eq(command2));
@@ -172,7 +172,7 @@ public class ZooKeeperCommandExecutorTest {
 
         try {
             final Command<Revision> command =
-                    Command.push("foo", "bar", Revision.HEAD, Author.SYSTEM, "", "", Markup.PLAINTEXT);
+                    Command.push(Author.SYSTEM, "foo", "bar", Revision.HEAD, "", "", Markup.PLAINTEXT);
 
             final int COMMANDS_PER_REPLICA = 3;
             final List<CompletableFuture<Void>> futures = new ArrayList<>(replicas.length);


### PR DESCRIPTION
Motivation:

We should keep who issued a command when in our API so that we can make
use of such information later.

Modifications:

- Add Command.author() and Command.timestamp()
- Replace creationTimeMillis() in some Command classes
  - Note that this isn't backward compatibility risk because we never
    released the version with this propery yet.
- Add backward compatibility tests

Result:

- Possibility of thorough audit