### PR TITLE
Change the default security configuration file to shiro.ini

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/Main.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/Main.java
@@ -55,7 +55,7 @@ public final class Main implements Daemon {
     private static final File DEFAULT_SECURITY_CONFIG_FILE =
             new File(System.getProperty("user.dir", ".") +
                      File.separatorChar + "conf" +
-                     File.separatorChar + "security.ini");
+                     File.separatorChar + "shiro.ini");
 
     @Parameter(names = "-config", description = "The path to the config file", converter = FileConverter.class)
     private File configFile;

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -140,7 +140,7 @@ Core properties
   - whether to enable authentication. It's disabled by default so that a user can play with Central Dogma
     without hassle. However, it is strongly encouraged to enable authentication because the authorship of
     a commit is filled in automatically based on the principal of the current user. Central Dogma uses
-    `Apache Shiro`_ as its authentication layer and uses the ``conf/security.ini`` file as its security
+    `Apache Shiro`_ as its authentication layer and uses the ``conf/shiro.ini`` file as its security
     configuration. For more information about how to configure `Apache Shiro`_, read
     `this page <https://shiro.apache.org/configuration.html#ini-sections>`_ or check the example configuration
     files under the ``conf/`` directory in the distribution.


### PR DESCRIPTION
Motivation:

We forgot to update the default security configuration file name from
'security.ini' to 'shiro.ini'. As you find in the 'conf' directory of
the distribution, the example files have been renamed to 'shiro.example.*.ini'
already long time ago.

Modificiation:

- Change the default security configuration file name from security.ini
  to shiro.ini

Result:

- Consistency