### PR TITLE
Fix incorrect JSON patch generation, redundant upsert and repository format migration failure

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.nio.file.Files;
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -121,10 +121,10 @@ public final class Util {
     }
 
     public static List<String> stringToLines(String str) {
-        BufferedReader reader = new BufferedReader(new StringReader(str));
-        List<String> lines = new LinkedList<>();
-        String line;
+        final BufferedReader reader = new BufferedReader(new StringReader(str));
+        final List<String> lines = new ArrayList<>(128);
         try {
+            String line;
             while ((line = reader.readLine()) != null) {
                 lines.add(line);
             }

--- a/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatch.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatch.java
@@ -128,6 +128,13 @@ public final class JsonPatch
     }
 
     /**
+     * Returns whether this patch is empty.
+     */
+    public boolean isEmpty() {
+        return operations.isEmpty();
+    }
+
+    /**
      * Apply this patch to a JSON value
      *
      * @param node the value to apply the patch to

--- a/common/src/test/resources/jsonpatch/diff/diff.json
+++ b/common/src/test/resources/jsonpatch/diff/diff.json
@@ -115,7 +115,7 @@
         ]
     },
     {
-        "message": "similar element is copied instead of added",
+        "message": "similar element is not copied if it's not a container",
         "first": {
             "a": "c"
         },
@@ -124,15 +124,20 @@
             "d": "c"
         },
         "patch": [
-            { "op": "copy", "path": "/d", "from": "/a" }
+            { "op": "add", "path": "/d", "value": "c" }
         ]
     },
     {
-        "message": "similar element removed then added is moved instead",
-        "first": { "a": "b" },
-        "second": { "c": "b" },
+        "message": "similar element is copied if it's a container",
+        "first": {
+            "a": [ "1", "2" ]
+        },
+        "second": {
+            "a": [ "1", "2" ],
+            "c": [ "1", "2" ]
+        },
         "patch": [
-            { "op": "move", "path": "/c", "from": "/a" }
+            { "op": "copy", "path": "/c", "from": "/a" }
         ]
     }
 ]

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -170,7 +170,7 @@ public class GitMirrorTest {
         assertThat(client.getFiles(projName, REPO_MAIN, rev3, "/**").join().values())
                 .containsExactlyInAnyOrder(expectedSecondMirrorState,
                                            Entry.ofDirectory("/first"),
-                                           Entry.ofText("/first/light.txt", "26-Aug-2014"),
+                                           Entry.ofText("/first/light.txt", "26-Aug-2014\n"),
                                            Entry.ofDirectory("/second"),
                                            Entry.ofJson("/second/son.json",
                                                         "{\"release_date\": \"21-Mar-2014\"}"));
@@ -190,7 +190,7 @@ public class GitMirrorTest {
         //// Make sure the rewritten content is mirrored.
         assertThat(client.getFiles(projName, REPO_MAIN, rev4, "/**").join().values())
                 .containsExactlyInAnyOrder(expectedThirdMirrorState,
-                                           Entry.ofText("/final_fantasy_xv.txt", "29-Nov-2016"));
+                                           Entry.ofText("/final_fantasy_xv.txt", "29-Nov-2016\n"));
     }
 
     @Test
@@ -231,7 +231,7 @@ public class GitMirrorTest {
         assertThat(client.getFiles(projName, REPO_MAIN, rev2, "/target/**").join().values())
                 .containsExactlyInAnyOrder(expectedSecondMirrorState,
                                            Entry.ofDirectory("/target/first"),
-                                           Entry.ofText("/target/first/light.txt", "26-Aug-2014"));
+                                           Entry.ofText("/target/first/light.txt", "26-Aug-2014\n"));
 
         //// Make sure the files not under '/target' are not touched. (sample files)
         assertThat(client.getFiles(projName, REPO_MAIN, rev2, "/samples/**").join().values())

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionSerializationUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/SessionSerializationUtil.java
@@ -48,7 +48,7 @@ final class SessionSerializationUtil {
      */
     static SimpleSession deserialize(String base64Encoded) {
         try (ByteArrayInputStream bais =
-                     new ByteArrayInputStream(Base64.getDecoder().decode(base64Encoded));
+                     new ByteArrayInputStream(Base64.getDecoder().decode(base64Encoded.trim()));
              ObjectInputStream ois = new ObjectInputStream(bais)) {
             return (SimpleSession) ois.readObject();
         } catch (Exception e) {


### PR DESCRIPTION
Motivation:

- DiffProcessor, which is responsible for generating a JSON patch,
  generates an incorrect 'move' operation if the moved value is an
  element of an array or an array's descendant.
- APPLY_TEXT_PATCH sometimes fails if old content does not end with an
  empty line.
- GitRepository.commit() allows a redundant upsert, which is not an
  expected behavior.

Modifications:

- Do not use 'move' operation at all.
- Do not count a redundant upsert so that a commit with redundant
  upserts are considered as empty.
- Sanitize TEXT entries so that all TEXT entries have UNIX line endings
  and the last line always ends with \n.
- Make sure GitRepository.diff() does not add an APPLY_JSON_PATCH change
  with empty content.
- Implement the workaround for the empty commits in GitRepository.cloneTo()
- Add progress listener to GitRepository.cloneTo()
  - Log repository format migration progress periodically.

Result:

- GitRepository.diff() produces correct JSON patch.
- GitRepository.commit() does not allow a redundant upsert.
- GitRepository.cloneTo() does not fail with ChangeConflictException.