### PR TITLE
Use fsync only when really necessary

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -209,7 +209,7 @@ class GitRepository implements Repository {
             head.link(Constants.R_HEADS + Constants.MASTER);
 
             // Initialize the commit ID database.
-            commitIdDatabase = new CommitIdDatabase(repoDir);
+            commitIdDatabase = new CommitIdDatabase(jGitRepository);
 
             // Insert the initial commit into the master branch.
             commit0(null, Revision.INIT, creationTimeMillis, author,
@@ -269,7 +269,7 @@ class GitRepository implements Repository {
         boolean success = false;
         try {
             headRevision = uncachedMainLaneHeadRevision();
-            commitIdDatabase = new CommitIdDatabase(repoDir);
+            commitIdDatabase = new CommitIdDatabase(jGitRepository);
             if (!headRevision.equals(commitIdDatabase.headRevision())) {
                 commitIdDatabase.rebuild(jGitRepository);
                 assert headRevision.equals(commitIdDatabase.headRevision());


### PR DESCRIPTION
Motivation:

By default, Git repository has fsync turned off, according to its
manpage:

    core.fsyncObjectFiles

        This boolean will enable fsync() when writing object files.

        This is a total waste of time and effort on a filesystem that
        orders data writes properly, but can be useful for filesystems
        that do not use journalling (traditional UNIX filesystems) or
        that only journal metadata and not file contents (OS X’s HFS+,
        or Linux ext3 with "data=writeback").

Modifications:

- Make CommitIdDatabase respect the core.fsyncObjectFiles option.
  because there's no point of doing fsync only on this file when the
  Git repository does not.

Result:

- Better commit performance