### PR TITLE
Add Repository.normalizeNow()

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
@@ -98,15 +98,12 @@ public class TokenService extends AbstractService {
     @Post("/tokens")
     public CompletionStage<Token> createToken(@Param("appId") String appId) {
         validateFileName(appId, "appId");
-        return projectManager()
-                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
-                .normalize(Revision.HEAD)
-                .thenCompose(revision -> {
-                    final Token token =
-                            new Token(appId, SECRET_PREFIX + UUID.randomUUID(),
+        final Token token = new Token(appId, SECRET_PREFIX + UUID.randomUUID(),
                                       AuthenticationUtil.currentUser(), new Date());
-                    return createToken0(revision, token);
-                });
+        final Revision normalizedRevision = projectManager().get(INTERNAL_PROJECT_NAME).repos()
+                                                            .get(TOKEN_REPOSITORY_NAME)
+                                                            .normalizeNow(Revision.HEAD);
+        return createToken0(normalizedRevision, token);
     }
 
     private CompletionStage<Token> createToken0(Revision revision, Token newToken) {
@@ -132,10 +129,10 @@ public class TokenService extends AbstractService {
      */
     @Delete("/tokens/{id}")
     public CompletionStage<Token> deleteToken(@Param("id") String id) {
-        return projectManager()
-                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
-                .normalize(Revision.HEAD)
-                .thenCompose(revision -> deleteToken0(revision, id));
+        final Revision normalizedRevision = projectManager().get(INTERNAL_PROJECT_NAME).repos()
+                                                            .get(TOKEN_REPOSITORY_NAME)
+                                                            .normalizeNow(Revision.HEAD);
+        return deleteToken0(normalizedRevision, id);
     }
 
     private CompletionStage<Token> deleteToken0(Revision revision, String id) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -70,6 +70,7 @@ import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.internal.storage.repository.RedundantChangeException;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
+import com.linecorp.centraldogma.server.internal.storage.repository.Repository.NormalizedFromToRevision;
 
 /**
  * Annotated service object for managing and watching contents.
@@ -133,25 +134,22 @@ public class ContentServiceV1 extends AbstractService {
                                      @RequestObject CommitMessageDto commitMessage,
                                      @RequestObject(ChangesRequestConverter.class)
                                              Iterable<Change<?>> changes) {
-        final CompletableFuture<Revision> normalizeFuture = repository.normalize(new Revision(revision));
+        final Revision normalizedRevision = repository.normalizeNow(new Revision(revision));
 
-        return normalizeFuture.thenCompose(normalizedRevision -> {
-            final CompletableFuture<Map<String, Change<?>>> changesFuture =
-                    repository.previewDiff(normalizedRevision, changes);
+        final CompletableFuture<Map<String, Change<?>>> changesFuture =
+                repository.previewDiff(normalizedRevision, changes);
 
+        return changesFuture.thenCompose(previewDiffs -> {
             final long commitTimeMillis = System.currentTimeMillis();
-            final CompletableFuture<Revision> resultRevisionFuture = changesFuture.thenCompose(
-                    previewDiffs -> {
-                        if (previewDiffs.size() == 0) {
-                            throw new RedundantChangeException("changes did not change anything: " + changes);
-                        }
-                        return push(commitTimeMillis, author, repository, normalizedRevision,
-                                    commitMessage, previewDiffs.values());
-                    });
+            if (previewDiffs.size() == 0) {
+                throw new RedundantChangeException("changes did not change anything: " + changes);
+            }
+            final CompletableFuture<Revision> resultRevisionFuture =
+                    push(commitTimeMillis, author, repository, normalizedRevision,
+                         commitMessage, previewDiffs.values()).toCompletableFuture();
             final String pathPattern = joinPaths(changes);
-
-            final CompletableFuture<Map<String, Entry<?>>> findFuture =
-                    resultRevisionFuture.thenCompose(result -> repository.find(result, pathPattern));
+            final CompletableFuture<Map<String, Entry<?>>> findFuture = resultRevisionFuture.thenCompose(
+                    result -> repository.find(result, pathPattern));
 
             return findFuture.thenApply(entries -> objectOrList(
                     entries.values(), Iterables.size(changes) != 1, (collections) -> convertEntry(
@@ -167,10 +165,9 @@ public class ContentServiceV1 extends AbstractService {
         final String detail = commitMessage.detail();
         final Markup markup = commitMessage.markup();
 
-        return repository.normalize(revision).thenCompose(normalizedRevision -> execute(
-                Command.push(commitTimeMills, author, repository.parent().name(), repository.name(),
-                             normalizedRevision,
-                             summary, detail, markup, changes)));
+        return execute(Command.push(
+                commitTimeMills, author, repository.parent().name(), repository.name(),
+                revision, summary, detail, markup, changes));
     }
 
     private static String joinPaths(Iterable<Change<?>> changes) {
@@ -303,8 +300,11 @@ public class ContentServiceV1 extends AbstractService {
             toRevision = to.map(Revision::new).orElse(fromRevision);
         }
 
+        final NormalizedFromToRevision normalizedFromToRevision = repository.normalizeFromToRevision(
+                fromRevision, toRevision);
+
         return repository
-                .history(fromRevision, toRevision, path)
+                .history(normalizedFromToRevision.from(), normalizedFromToRevision.to(), path)
                 .thenApply(commits -> {
                     final boolean toList = isNullOrEmpty(revision) || "/".equalsIgnoreCase(revision) ||
                                            to.isPresent();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -51,7 +51,7 @@ final class DtoConverter {
 
     public static RepositoryDto convert(Repository repository) {
         requireNonNull(repository, "repository");
-        final Revision headRevision = repository.normalize(Revision.HEAD).join();
+        final Revision headRevision = repository.normalizeNow(Revision.HEAD);
         final String projectName = repository.parent().name();
         final String repoName = repository.name();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -90,6 +92,14 @@ public final class WatchRequestConverter implements RequestConverterFunction {
 
         public long timeoutMillis() {
             return timeoutMillis;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("lastKnownRevision", lastKnownRevision)
+                              .add("timeoutMillis", timeoutMillis)
+                              .toString();
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -102,7 +102,7 @@ public final class GitMirror extends Mirror {
             refUpdate.setNewObjectId(id);
             refUpdate.update();
 
-            final Revision localRev = localRepo().normalize(Revision.HEAD).join();
+            final Revision localRev = localRepo().normalizeNow(Revision.HEAD);
 
             try (ObjectReader reader = git.getRepository().newObjectReader();
                  TreeWalk treeWalk = new TreeWalk(reader);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/plugin/PluginManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/plugin/PluginManager.java
@@ -54,7 +54,7 @@ public final class PluginManager {
 
     public Revision reload() {
         final Repository metaRepo = project.metaRepo();
-        final Revision revision = metaRepo.normalize(Revision.HEAD).join();
+        final Revision revision = metaRepo.normalizeNow(Revision.HEAD);
         plugins = loadPlugins(metaRepo, revision);
         return revision;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -86,7 +86,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         mirrorLock.lock();
         try {
             // TODO(trustin): Asynchronization
-            final int headRev = normalize(Revision.HEAD).join().major();
+            final int headRev = normalizeNow(Revision.HEAD).major();
             final Set<String> repos = parent().repos().list().keySet();
             if (headRev > mirrorRev || !mirrorRepos.equals(repos)) {
                 mirrors = loadMirrors(headRev);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -72,6 +72,11 @@ public class RepositoryWrapper implements Repository {
     }
 
     @Override
+    public Revision normalizeNow(Revision revision) {
+        return unwrap().normalizeNow(revision);
+    }
+
+    @Override
     public CompletableFuture<Boolean> exists(Revision revision, String path) {
         return unwrap().exists(revision, path);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableSingleDiffCall.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableSingleDiffCall.java
@@ -63,10 +63,9 @@ final class CacheableSingleDiffCall extends CacheableCall<Change<?>> {
         return weight;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     CompletableFuture<Change<?>> execute() {
-        return (CompletableFuture<Change<?>>) (CompletableFuture) repo.diff(from, to, query);
+        return repo.diff(from, to, query);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository;
+
+import static com.linecorp.centraldogma.common.Revision.HEAD;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.concurrent.ForkJoinPool;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestName;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.internal.storage.project.DefaultProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.internal.storage.repository.Repository.NormalizedFromToRevision;
+
+public class RepositoryTest {
+
+    @ClassRule
+    public static final TemporaryFolder rootDir = new TemporaryFolder();
+
+    private static ProjectManager pm;
+
+    @Rule
+    public final TestName testName = new TestName();
+
+    private Project project;
+    private Repository repo;
+
+    @BeforeClass
+    public static void init() throws Exception {
+        pm = new DefaultProjectManager(rootDir.getRoot(), ForkJoinPool.commonPool(), null);
+    }
+
+    @AfterClass
+    public static void destroy() {
+        pm.close();
+    }
+
+    @Before
+    public void setUp() {
+        project = pm.create(testName.getMethodName());
+        project.repos().create(Project.REPO_MAIN);
+        repo = project.mainRepo();
+
+        for (int i = 0; i < 4; i++) {
+            repo.commit(HEAD, 0L, Author.UNKNOWN, "summary",
+                        Change.ofJsonUpsert("/" + i + ".json", "{ \"" + i + "\": " + i + " }")).join();
+        }
+    }
+
+    @Test
+    public void normalizeFromToRevision() {
+        final Revision revisionNegativeTwo = new Revision(-2);
+        final Revision revisionTwo = new Revision(2);
+
+        NormalizedFromToRevision normalizedFromToRevision =
+                repo.normalizeFromToRevision(revisionNegativeTwo, revisionTwo);
+        assertThat(normalizedFromToRevision.from()).isEqualTo(new Revision(4));
+        assertThat(normalizedFromToRevision.to()).isEqualTo(new Revision(2));
+
+        normalizedFromToRevision = repo.normalizeFromToRevision(revisionNegativeTwo, revisionTwo, true);
+        assertThat(normalizedFromToRevision.from()).isEqualTo(new Revision(2));
+        assertThat(normalizedFromToRevision.to()).isEqualTo(new Revision(4));
+
+        normalizedFromToRevision = repo.normalizeFromToRevision(revisionNegativeTwo, revisionTwo, false);
+        assertThat(normalizedFromToRevision.from()).isEqualTo(new Revision(4));
+        assertThat(normalizedFromToRevision.to()).isEqualTo(new Revision(2));
+
+        normalizedFromToRevision = repo.normalizeFromToRevision(revisionTwo, revisionNegativeTwo, true);
+        assertThat(normalizedFromToRevision.from()).isEqualTo(new Revision(2));
+        assertThat(normalizedFromToRevision.to()).isEqualTo(new Revision(4));
+
+        normalizedFromToRevision = repo.normalizeFromToRevision(revisionTwo, revisionNegativeTwo, false);
+        assertThat(normalizedFromToRevision.from()).isEqualTo(new Revision(4));
+        assertThat(normalizedFromToRevision.to()).isEqualTo(new Revision(2));
+
+        assertThatThrownBy(() -> repo.normalizeFromToRevision(new Revision(-6), revisionTwo, true))
+                .isExactlyInstanceOf(RevisionNotFoundException.class);
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -141,10 +141,10 @@ public class CachingRepositoryTest {
                 new Commit(new Revision(3), SYSTEM, "second", "", Markup.MARKDOWN),
                 new Commit(new Revision(3), SYSTEM, "first",  "", Markup.MARKDOWN));
 
-        doReturn(completedFuture(new Revision(3))).when(delegateRepo).normalize(new Revision(3));
-        doReturn(completedFuture(new Revision(3))).when(delegateRepo).normalize(HEAD);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(INIT);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(new Revision(-3));
+        doReturn(new Revision(3)).when(delegateRepo).normalizeNow(new Revision(3));
+        doReturn(new Revision(3)).when(delegateRepo).normalizeNow(HEAD);
+        doReturn(INIT).when(delegateRepo).normalizeNow(INIT);
+        doReturn(INIT).when(delegateRepo).normalizeNow(new Revision(-3));
 
         // Uncached
         when(delegateRepo.history(any(), any(), any(), anyInt())).thenReturn(completedFuture(commits));
@@ -169,15 +169,15 @@ public class CachingRepositoryTest {
         final Query query = Query.identity("/foo.txt");
         final Change change = Change.ofTextUpsert(query.path(), "bar");
 
-        doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(new Revision(10));
-        doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(HEAD);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(INIT);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(new Revision(-10));
+        doReturn(new Revision(10)).when(delegateRepo).normalizeNow(new Revision(10));
+        doReturn(new Revision(10)).when(delegateRepo).normalizeNow(HEAD);
+        doReturn(INIT).when(delegateRepo).normalizeNow(INIT);
+        doReturn(INIT).when(delegateRepo).normalizeNow(new Revision(-10));
 
         // Uncached
         when(delegateRepo.diff(any(), any(), any(Query.class))).thenReturn(completedFuture(change));
         assertThat(repo.diff(HEAD, INIT, query).join()).isEqualTo(change);
-        verify(delegateRepo).diff(new Revision(10), INIT, query);
+        verify(delegateRepo).diff(INIT, new Revision(10), query);
         verifyNoMoreInteractions(delegateRepo);
 
         // Cached
@@ -196,15 +196,15 @@ public class CachingRepositoryTest {
         final Map<String, Change<?>> changes = ImmutableMap.of(
                 "/foo.txt", Change.ofTextUpsert("/foo.txt", "bar"));
 
-        doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(new Revision(10));
-        doReturn(completedFuture(new Revision(10))).when(delegateRepo).normalize(HEAD);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(INIT);
-        doReturn(completedFuture(INIT)).when(delegateRepo).normalize(new Revision(-10));
+        doReturn(new Revision(10)).when(delegateRepo).normalizeNow(new Revision(10));
+        doReturn(new Revision(10)).when(delegateRepo).normalizeNow(HEAD);
+        doReturn(INIT).when(delegateRepo).normalizeNow(INIT);
+        doReturn(INIT).when(delegateRepo).normalizeNow(new Revision(-10));
 
         // Uncached
         when(delegateRepo.diff(any(), any(), any(String.class))).thenReturn(completedFuture(changes));
         assertThat(repo.diff(HEAD, INIT, "/**").join()).isEqualTo(changes);
-        verify(delegateRepo).diff(new Revision(10), INIT, "/**");
+        verify(delegateRepo).diff(INIT, new Revision(10), "/**");
         verifyNoMoreInteractions(delegateRepo);
 
         // Cached

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
@@ -160,7 +160,7 @@ public class CommitIdDatabaseTest {
         // Open the repository again to see if the commit ID database is regenerated automatically.
         repo = new GitRepository(mock(Project.class), repoDir, commonPool());
         try {
-            assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(headRevision);
+            assertThat(repo.normalizeNow(Revision.HEAD)).isEqualTo(headRevision);
             for (int i = 1; i <= numCommits; i++) {
                 assertThat(repo.find(new Revision(i + 1), "/" + i + ".txt").join()).hasSize(1);
             }


### PR DESCRIPTION
Motivation:
`Repository.normalize()` does not have to be asynchronous. But it's hard to change the API
because it is used from everywhere.
Therefore, I decided to add `Repository.normalizeNow()` which returns the normalized `Revision`
right away instead. The `Repository.normalize()` will be removed when we remove the RPC API.

Also in our current `Repository` API, fetching many commits can cause memory spike or OOME.
We need a mechanism to restrict the maximum number of commits at a time.

Modifications:
- Limit the maximum number of commits
- Add `Repository.normalizeNow()` that returns `Revision` immediately

Result:
- Less memory spike
  
  