### PR TITLE
Add Repository.normalizeNow()

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/RevisionRange.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RevisionRange.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.common;
+
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A class which contains {@link Revision}s of {@code from} and {@code to}.
+ */
+public class RevisionRange {
+
+    private final Revision from;
+
+    private final Revision to;
+
+    /**
+     * Creates a new instance with the specified integer value of {@code from} and {@code to}.
+     */
+    public RevisionRange(int from, int to) {
+        this(new Revision(from), new Revision(to));
+    }
+
+    /**
+     * Creates a new instance with the specified {@code from} {@link Revision} and {@code to} {@link Revision}.
+     */
+    public RevisionRange(Revision from, Revision to) {
+        this.from = requireNonNull(from, "from");
+        this.to = requireNonNull(to, "to");
+    }
+
+    public Revision from() {
+        return from;
+    }
+
+    public Revision to() {
+        return to;
+    }
+
+    /**
+     * Returns a {@link RevisionRange} whose major value of {@code from} {@link Revision} is lower than
+     * or equal to the major value of {@code to} {@link Revision}.
+     *
+     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     */
+    public RevisionRange toAscending() {
+        if (isAscending() || from.equals(to)) {
+            return this;
+        }
+
+        return new RevisionRange(to, from);
+    }
+
+    /**
+     * Returns a {@link RevisionRange} whose major value of {@code from} {@link Revision} is greater than
+     * or equal to the major value of {@code to} {@link Revision}.
+     *
+     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     */
+    public RevisionRange toDescending() {
+        if (isAscending()) {
+            return new RevisionRange(to, from);
+        }
+
+        return this;
+    }
+
+    /**
+     * Returns {@code true} if the major value of {@code from} {@link Revision} is lower than the major
+     * value of {@code to} {@link Revision}.
+     *
+     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     */
+    public boolean isAscending() {
+        if (isRelative()) {
+            throw new UnsupportedOperationException("contains relative revision. from: " +
+                                                    from + ", to: " + to + " (expected: absolute revision)");
+        }
+
+        return from.compareTo(to) < 0;
+    }
+
+    /**
+     * Returns {@code true} if the major value of {@code from} {@link Revision} or {@code to} {@link Revision}
+     * is a negative integer.
+     */
+    public boolean isRelative() {
+        return from.isRelative() || to.isRelative();
+    }
+
+    @Override
+    public int hashCode() {
+        return from.hashCode() * 31 + to.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final RevisionRange that = (RevisionRange) o;
+        return from.equals(that.from) && to.equals(that.to);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("from", from)
+                          .add("to", to)
+                          .toString();
+    }
+}

--- a/common/src/main/java/com/linecorp/centraldogma/common/RevisionRange.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RevisionRange.java
@@ -43,19 +43,26 @@ public class RevisionRange {
         this.to = requireNonNull(to, "to");
     }
 
+    /**
+     * Returns the {@code from} {@link Revision}.
+     */
     public Revision from() {
         return from;
     }
 
+    /**
+     * Returns the {@code to} {@link Revision}.
+     */
     public Revision to() {
         return to;
     }
 
     /**
-     * Returns a {@link RevisionRange} whose major value of {@code from} {@link Revision} is lower than
+     * Returns the {@link RevisionRange} whose major value of {@code from} {@link Revision} is lower than
      * or equal to the major value of {@code to} {@link Revision}.
      *
-     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     * @throws IllegalStateException if the {@code from} and {@code to} {@link Revision}s are in the
+     *                               different state. They should be either absolute or relative.
      */
     public RevisionRange toAscending() {
         if (isAscending() || from.equals(to)) {
@@ -66,10 +73,11 @@ public class RevisionRange {
     }
 
     /**
-     * Returns a {@link RevisionRange} whose major value of {@code from} {@link Revision} is greater than
+     * Returns the {@link RevisionRange} whose major value of {@code from} {@link Revision} is greater than
      * or equal to the major value of {@code to} {@link Revision}.
      *
-     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     * @throws IllegalStateException if the {@code from} and {@code to} {@link Revision}s are in the
+     *                               different state. They should be either absolute or relative.
      */
     public RevisionRange toDescending() {
         if (isAscending()) {
@@ -83,12 +91,13 @@ public class RevisionRange {
      * Returns {@code true} if the major value of {@code from} {@link Revision} is lower than the major
      * value of {@code to} {@link Revision}.
      *
-     * @throws UnsupportedOperationException if {@link #isRelative()} returns {@code true}
+     * @throws IllegalStateException if the {@code from} and {@code to} {@link Revision}s are in the
+     *                               different state. They should be either absolute or relative.
      */
     public boolean isAscending() {
-        if (isRelative()) {
-            throw new UnsupportedOperationException("contains relative revision. from: " +
-                                                    from + ", to: " + to + " (expected: absolute revision)");
+        if (from.isRelative() != to.isRelative()) {
+            throw new IllegalStateException("both of from: '" + from + "' and to: '" + to +
+                                            "' should be absolute or relative.");
         }
 
         return from.compareTo(to) < 0;

--- a/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.common;
+
+import static com.linecorp.centraldogma.common.Revision.HEAD;
+import static com.linecorp.centraldogma.common.Revision.INIT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class RevisionRangeTest {
+
+    @Test
+    public void revisionRange() {
+        RevisionRange range = new RevisionRange(2, 4);
+
+        assertThat(range.isAscending()).isTrue();
+        assertThat(range.isRelative()).isFalse();
+        assertThat(range.toAscending()).isSameAs(range);
+        assertThat(range.toDescending()).isEqualTo(new RevisionRange(4, 2));
+
+        final Revision revisionTen = new Revision(10);
+        range = new RevisionRange(revisionTen, INIT);
+
+        assertThat(range.isAscending()).isFalse();
+        assertThat(range.isRelative()).isFalse();
+        assertThat(range.toAscending()).isEqualTo(new RevisionRange(INIT, revisionTen));
+        assertThat(range.toDescending()).isSameAs(range);
+
+        range = new RevisionRange(revisionTen, revisionTen);
+
+        assertThat(range.isAscending()).isFalse();
+        assertThat(range.isRelative()).isFalse();
+        assertThat(range.toAscending()).isSameAs(range);
+        assertThat(range.toDescending()).isSameAs(range);
+
+        final RevisionRange relativeRange = new RevisionRange(INIT, HEAD);
+
+        assertThat(relativeRange.isRelative()).isTrue();
+        assertThat(relativeRange.from()).isSameAs(INIT);
+        assertThat(relativeRange.to()).isSameAs(HEAD);
+        assertThatThrownBy(relativeRange::isAscending)
+                .isExactlyInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(relativeRange::toAscending)
+                .isExactlyInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(relativeRange::toDescending)
+                .isExactlyInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
@@ -48,16 +48,26 @@ public class RevisionRangeTest {
         assertThat(range.toAscending()).isSameAs(range);
         assertThat(range.toDescending()).isSameAs(range);
 
+        final Revision revisionNegativeThree = new Revision(-3);
+        final Revision revisionNegativeTen = new Revision(-10);
+        range = new RevisionRange(revisionNegativeTen, revisionNegativeThree);
+
+        assertThat(range.isAscending()).isTrue();
+        assertThat(range.isRelative()).isTrue();
+        assertThat(range.toAscending()).isSameAs(range);
+        assertThat(range.toDescending()).isEqualTo(
+                new RevisionRange(revisionNegativeThree, revisionNegativeTen));
+
         final RevisionRange relativeRange = new RevisionRange(INIT, HEAD);
 
         assertThat(relativeRange.isRelative()).isTrue();
         assertThat(relativeRange.from()).isSameAs(INIT);
         assertThat(relativeRange.to()).isSameAs(HEAD);
         assertThatThrownBy(relativeRange::isAscending)
-                .isExactlyInstanceOf(UnsupportedOperationException.class);
+                .isExactlyInstanceOf(IllegalStateException.class);
         assertThatThrownBy(relativeRange::toAscending)
-                .isExactlyInstanceOf(UnsupportedOperationException.class);
+                .isExactlyInstanceOf(IllegalStateException.class);
         assertThatThrownBy(relativeRange::toDescending)
-                .isExactlyInstanceOf(UnsupportedOperationException.class);
+                .isExactlyInstanceOf(IllegalStateException.class);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/TokenService.java
@@ -98,15 +98,12 @@ public class TokenService extends AbstractService {
     @Post("/tokens")
     public CompletionStage<Token> createToken(@Param("appId") String appId) {
         validateFileName(appId, "appId");
-        return projectManager()
-                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
-                .normalize(Revision.HEAD)
-                .thenCompose(revision -> {
-                    final Token token =
-                            new Token(appId, SECRET_PREFIX + UUID.randomUUID(),
+        final Token token = new Token(appId, SECRET_PREFIX + UUID.randomUUID(),
                                       AuthenticationUtil.currentUser(), new Date());
-                    return createToken0(revision, token);
-                });
+        final Revision normalizedRevision = projectManager().get(INTERNAL_PROJECT_NAME).repos()
+                                                            .get(TOKEN_REPOSITORY_NAME)
+                                                            .normalizeNow(Revision.HEAD);
+        return createToken0(normalizedRevision, token);
     }
 
     private CompletionStage<Token> createToken0(Revision revision, Token newToken) {
@@ -132,10 +129,10 @@ public class TokenService extends AbstractService {
      */
     @Delete("/tokens/{id}")
     public CompletionStage<Token> deleteToken(@Param("id") String id) {
-        return projectManager()
-                .get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPOSITORY_NAME)
-                .normalize(Revision.HEAD)
-                .thenCompose(revision -> deleteToken0(revision, id));
+        final Revision normalizedRevision = projectManager().get(INTERNAL_PROJECT_NAME).repos()
+                                                            .get(TOKEN_REPOSITORY_NAME)
+                                                            .normalizeNow(Revision.HEAD);
+        return deleteToken0(normalizedRevision, id);
     }
 
     private CompletionStage<Token> deleteToken0(Revision revision, String id) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -51,7 +51,7 @@ final class DtoConverter {
 
     public static RepositoryDto convert(Repository repository) {
         requireNonNull(repository, "repository");
-        final Revision headRevision = repository.normalize(Revision.HEAD).join();
+        final Revision headRevision = repository.normalizeNow(Revision.HEAD);
         final String projectName = repository.parent().name();
         final String repoName = repository.name();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -100,7 +100,7 @@ final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
 
     @SuppressWarnings("unused")
     static HttpResponse handleRedundantChange(RequestContext ctx, HttpRequest req, Throwable cause) {
-        return newResponseWithErrorMessage(HttpStatus.BAD_REQUEST, cause.getMessage());
+        return newResponseWithErrorMessage(HttpStatus.BAD_REQUEST, "changes did not change anything.");
     }
 
     @SuppressWarnings("unused")

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -22,6 +22,8 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -90,6 +92,14 @@ public final class WatchRequestConverter implements RequestConverterFunction {
 
         public long timeoutMillis() {
             return timeoutMillis;
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("lastKnownRevision", lastKnownRevision)
+                              .add("timeoutMillis", timeoutMillis)
+                              .toString();
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -102,7 +102,7 @@ public final class GitMirror extends Mirror {
             refUpdate.setNewObjectId(id);
             refUpdate.update();
 
-            final Revision localRev = localRepo().normalize(Revision.HEAD).join();
+            final Revision localRev = localRepo().normalizeNow(Revision.HEAD);
 
             try (ObjectReader reader = git.getRepository().newObjectReader();
                  TreeWalk treeWalk = new TreeWalk(reader);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/plugin/PluginManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/plugin/PluginManager.java
@@ -54,7 +54,7 @@ public final class PluginManager {
 
     public Revision reload() {
         final Repository metaRepo = project.metaRepo();
-        final Revision revision = metaRepo.normalize(Revision.HEAD).join();
+        final Revision revision = metaRepo.normalizeNow(Revision.HEAD);
         plugins = loadPlugins(metaRepo, revision);
         return revision;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -85,7 +85,6 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
     public Set<Mirror> mirrors() {
         mirrorLock.lock();
         try {
-            // TODO(trustin): Asynchronization
             final int headRev = normalizeNow(Revision.HEAD).major();
             final Set<String> repos = parent().repos().list().keySet();
             if (headRev > mirrorRev || !mirrorRepos.equals(repos)) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -86,7 +86,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         mirrorLock.lock();
         try {
             // TODO(trustin): Asynchronization
-            final int headRev = normalize(Revision.HEAD).join().major();
+            final int headRev = normalizeNow(Revision.HEAD).major();
             final Set<String> repos = parent().repos().list().keySet();
             if (headRev > mirrorRev || !mirrorRepos.equals(repos)) {
                 mirrors = loadMirrors(headRev);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
@@ -45,6 +45,7 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryException;
 import com.linecorp.centraldogma.common.QueryResult;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.RevisionRange;
 import com.linecorp.centraldogma.server.internal.storage.StorageException;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
@@ -52,6 +53,8 @@ import com.linecorp.centraldogma.server.internal.storage.project.Project;
  * Revision-controlled filesystem-like repository.
  */
 public interface Repository {
+
+    int DEFAULT_MAX_COMMITS = 1024;
 
     String ALL_PATH = "/**";
 
@@ -94,9 +97,35 @@ public interface Repository {
     }
 
     /**
-     * Validates the specified {@link Revision} and converts it into an absolute {@link Revision}.
+     * Returns the {@link CompletableFuture} whose value is the absolute {@link Revision} of the
+     * specified {@link Revision}.
+     *
+     * @see #normalizeNow(Revision)
      */
-    CompletableFuture<Revision> normalize(Revision revision);
+    default CompletableFuture<Revision> normalize(Revision revision) {
+        try {
+            return CompletableFuture.completedFuture(normalizeNow(revision));
+        } catch (Exception e) {
+            return CompletableFutures.exceptionallyCompletedFuture(e);
+        }
+    }
+
+    /**
+     * Returns the absolute {@link Revision} of the specified {@link Revision}.
+     *
+     * @throws RevisionNotFoundException it the specified {@link Revision} is not found
+     *
+     * @see #normalize(Revision)
+     */
+    Revision normalizeNow(Revision revision);
+
+    /**
+     * Returns a {@link RevisionRange} which contains the absolute {@link Revision}s of the specified
+     * {@code from} and {@code to}.
+     *
+     * @throws RevisionNotFoundException it the specified {@code from} or {@code to} is not found
+     */
+    RevisionRange normalizeNow(Revision from, Revision to);
 
     /**
      * Returns {@code true} if and only if an {@link Entry} exists at the specified {@code path}.
@@ -219,20 +248,11 @@ public interface Repository {
         requireNonNull(to, "to");
         requireNonNull(query, "query");
 
-        Revision normalizedFrom = normalize(from).join();
-        Revision normalizedTo = normalize(to).join();
-
-        // If the from revision is newer than the to revision,
-        // swap them to compare from old to new one always.
-        if (normalizedFrom.major() > normalizedTo.major()) {
-            Revision temp = normalizedFrom;
-            normalizedFrom = normalizedTo;
-            normalizedTo = temp;
-        }
+        final RevisionRange range = normalizeNow(from, to).toAscending();
 
         final String path = query.path();
-        final CompletableFuture<Entry<?>> fromEntryFuture = getOrElse(normalizedFrom, path, null);
-        final CompletableFuture<Entry<?>> toEntryFuture = getOrElse(normalizedTo, path, null);
+        final CompletableFuture<Entry<?>> fromEntryFuture = getOrElse(range.from(), path, null);
+        final CompletableFuture<Entry<?>> toEntryFuture = getOrElse(range.to(), path, null);
 
         final CompletableFuture<Change<?>> future =
                 CompletableFutures.combine(fromEntryFuture, toEntryFuture, (fromEntry, toEntry) -> {
@@ -358,7 +378,7 @@ public interface Repository {
      * @throws StorageException when any internal error occurs.
      */
     default CompletableFuture<List<Commit>> history(Revision from, Revision to, String pathPattern) {
-        return history(from, to, pathPattern, Integer.MAX_VALUE);
+        return history(from, to, pathPattern, DEFAULT_MAX_COMMITS);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
@@ -100,8 +100,9 @@ public interface Repository {
      * Returns the {@link CompletableFuture} whose value is the absolute {@link Revision} of the
      * specified {@link Revision}.
      *
-     * @see #normalizeNow(Revision)
+     * @deprecated Use {@link #normalizeNow(Revision)} instead.
      */
+    @Deprecated
     default CompletableFuture<Revision> normalize(Revision revision) {
         try {
             return CompletableFuture.completedFuture(normalizeNow(revision));
@@ -113,9 +114,7 @@ public interface Repository {
     /**
      * Returns the absolute {@link Revision} of the specified {@link Revision}.
      *
-     * @throws RevisionNotFoundException it the specified {@link Revision} is not found
-     *
-     * @see #normalize(Revision)
+     * @throws RevisionNotFoundException if the specified {@link Revision} is not found
      */
     Revision normalizeNow(Revision revision);
 
@@ -123,7 +122,7 @@ public interface Repository {
      * Returns a {@link RevisionRange} which contains the absolute {@link Revision}s of the specified
      * {@code from} and {@code to}.
      *
-     * @throws RevisionNotFoundException it the specified {@code from} or {@code to} is not found
+     * @throws RevisionNotFoundException if the specified {@code from} or {@code to} is not found
      */
     RevisionRange normalizeNow(Revision from, Revision to);
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -30,6 +30,7 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryResult;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.RevisionRange;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
@@ -67,8 +68,13 @@ public class RepositoryWrapper implements Repository {
     }
 
     @Override
-    public CompletableFuture<Revision> normalize(Revision revision) {
-        return unwrap().normalize(revision);
+    public Revision normalizeNow(Revision revision) {
+        return unwrap().normalizeNow(revision);
+    }
+
+    @Override
+    public RevisionRange normalizeNow(Revision from, Revision to) {
+        return unwrap().normalizeNow(from, to);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableSingleDiffCall.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableSingleDiffCall.java
@@ -63,10 +63,9 @@ final class CacheableSingleDiffCall extends CacheableCall<Change<?>> {
         return weight;
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     CompletableFuture<Change<?>> execute() {
-        return (CompletableFuture<Change<?>>) (CompletableFuture) repo.diff(from, to, query);
+        return repo.diff(from, to, query);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
@@ -160,7 +160,7 @@ public class CommitIdDatabaseTest {
         // Open the repository again to see if the commit ID database is regenerated automatically.
         repo = new GitRepository(mock(Project.class), repoDir, commonPool());
         try {
-            assertThat(repo.normalize(Revision.HEAD).join()).isEqualTo(headRevision);
+            assertThat(repo.normalizeNow(Revision.HEAD)).isEqualTo(headRevision);
             for (int i = 1; i <= numCommits; i++) {
                 assertThat(repo.find(new Revision(i + 1), "/" + i + ".txt").join()).hasSize(1);
             }


### PR DESCRIPTION
Motivation:
`Repository.normalize()` does not have to be asynchronous. But it's hard to change the API
because it is used from everywhere.
Therefore, I decided to add `Repository.normalizeNow()` which returns the normalized `Revision`
right away instead. The `Repository.normalize()` will be removed when we remove the RPC API.

Also in our current `Repository` API, fetching many commits can cause memory spike or OOME.
We need a mechanism to restrict the maximum number of commits at a time.

Modifications:
- Limit the maximum number of commits
- Add `Repository.normalizeNow()` that returns `Revision` immediately

Result:
- Less memory spike
