### PR TITLE
Annotate all public packages with ParametersAreNonnullByDefault

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/package-info.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/package-info.java
@@ -16,4 +16,7 @@
 /**
  * <a href="https://spring.io/">Spring framework</a> integration for Central Dogma client.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.client.spring;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/package-info.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/package-info.java
@@ -18,4 +18,7 @@
  *
  * @see <a href="https://line.github.io/centraldogma/client-java.html" target="_blank">Java client library</a>
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.client;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/package-info.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Creates a Java bean whose properties are mirrored from Central Dogma automatically.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.client.updater;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/linecorp/centraldogma/common/package-info.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Common data types and exceptions.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.common;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/package-info.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/package-info.java
@@ -46,4 +46,7 @@
  * representation (as a {@link com.fasterxml.jackson.databind.JsonNode}).</p>
  *
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.internal.jsonpatch;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Central Dogma authentication services and their utilities.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server.internal.admin.authentication;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/dto/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/dto/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Data Transfer Objects used by Central Dogma admin services.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server.internal.admin.dto;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/exception/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/exception/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Central Dogma exceptions.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server.internal.admin.exception;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/package-info.java
@@ -17,4 +17,7 @@
 /**
  * Central Dogma admin services which are implemented by Armeria annotated service.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server.internal.admin.service;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Central Dogma server.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/support/shiro/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/support/shiro/package-info.java
@@ -17,4 +17,7 @@
  * Extra <a href="https://shiro.apache.org/">Apache Shiro</a> {@link org.apache.shiro.realm.Realm}s
  * which may be useful for configuring security.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.server.support.shiro;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/settings/checkstyle/checkstyle-suppressions.xml
+++ b/settings/checkstyle/checkstyle-suppressions.xml
@@ -11,4 +11,6 @@
   <suppress checks="UncommentedMain" files="[\\/]Main\.java$" />
   <!-- Suppress all checks in generated sources -->
   <suppress checks=".*" files="[\\/]gen-java[\\/]" />
+  <!-- Enable 'PackageNonnullAnnotation' for package-info.java only -->
+  <suppress id="PackageNonnullAnnotation" files="(?&lt;![\\/]package-info\.java)$" />
 </suppressions>

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -30,6 +30,14 @@
     <property name="maximum" value="1"/>
     <property name="message" value="missing copyright header"/>
   </module>
+  <!-- All packages must be annotated with @ParametersAreNonnullByDefault -->
+  <module name="RegexpSingleline">
+    <property name="id" value="PackageNonnullAnnotation"/>
+    <property name="format" value="^\s*@(?:javax\.annotation\.)?ParametersAreNonnullByDefault"/>
+    <property name="minimum" value="1"/>
+    <property name="maximum" value="1"/>
+    <property name="message" value="A package must be annotated with @ParametersAreNonnullByDefault."/>
+  </module>
   <!-- Unmaintainable Javadoc tags -->
   <module name="RegexpSingleline">
     <property name="format" value="(?:@version|\(non-Javadoc\))"/>
@@ -233,7 +241,7 @@
     <module name="EmptyLineSeparator">
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
       <property name="tokens"
-                value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+                value="IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="GenericWhitespace">
       <message key="ws.followed"

--- a/testing/src/main/java/com/linecorp/centraldogma/testing/package-info.java
+++ b/testing/src/main/java/com/linecorp/centraldogma/testing/package-info.java
@@ -16,4 +16,7 @@
 /**
  * Simplifies the integration testing with Central Dogma.
  */
+@ParametersAreNonnullByDefault
 package com.linecorp.centraldogma.testing;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Motivation:

Some languages such as Kotlin assumes all Java API are nullable unless
annotated with `@Nonnull`. Our API assumes non-null unless annotated
with `@Nullable`.  As a result, Kotlin complains about Armeria usage.

Modifications:

- Add and require `@ParametersAreNonnullByDefault` annotation for all
  packages so that Kotlin assumes non-nullness of Armeria API
- Miscellaneous
  - Remove STATIC_INIT token from EmptyLineSeparator checkstyle rule
    - See https://github.com/line/armeria/issues/700

Result:

- Better Kotlin interop