### PR TITLE
Add normalizeRevision/ Fix to receive more than one JSON path on HTTP…

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -190,8 +190,8 @@ public class ContentServiceV1 extends AbstractService {
     }
 
     /**
-     * GET /projects/{projectName}/repos/{repoName}/contents{path}?revision={revision}&
-     * queryType={queryType}&expression={expression}
+     * GET /projects/{projectName}/repos/{repoName}/contents{path}?revision={revision}&amp;
+     * jsonpath={jsonpath}
      *
      * <p>Returns the entry of files in the path. This is same with
      * {@link #listFiles(String, String, Repository)} except that containing the content of the files.
@@ -274,7 +274,7 @@ public class ContentServiceV1 extends AbstractService {
     }
 
     /**
-     * GET /projects/{projectName}/repos/{repoName}/commits/{revision}?path={path}&to={to}
+     * GET /projects/{projectName}/repos/{repoName}/commits/{revision}?path={path}&amp;to={to}
      *
      * <p>Returns a commit or the list of commits in the path. If the user specify the {@code revision} only,
      * this will return the corresponding commit. If the user does not specify the {@code revision} or
@@ -312,8 +312,8 @@ public class ContentServiceV1 extends AbstractService {
     }
 
     /**
-     * GET /projects/{projectName}/repos/{repoName}/compare?path={path}&from={from}&to={to}&
-     * queryType={queryType}&expression={expression}
+     * GET /projects/{projectName}/repos/{repoName}/compare?
+     * path={path}&amp;from={from}&amp;to={to}&amp;jsonpath={jsonpath}
      *
      * <p>Returns the diffs.
      */

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -324,7 +324,8 @@ public class ContentServiceV1Test {
     public void getFileWithJsonPath() {
         addFooJson();
         final AggregatedHttpMessage aRes = httpClient
-                .get(CONTENTS_PREFIX + "/foo.json?expression=$.a").aggregate().join();
+                .get(CONTENTS_PREFIX + "/foo.json?jsonpath=$[?(@.a == \"bar\")]&jsonpath=$[0].a")
+                .aggregate().join();
 
         final String expectedJson =
                 '{' +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -256,8 +256,9 @@ public class ListCommitsAndDiffTest {
     public void getJsonDiff() {
         editFooFile();
         final AggregatedHttpMessage aRes = httpClient
-                .get("/api/v1/projects/myPro/repos/myRepo/compare?" +
-                     "path=/foo0.json&queryType=JSON_PATH&expression=$.a&from=3&to=4").aggregate().join();
+                .get("/api/v1/projects/myPro/repos/myRepo/compare?path=/foo0.json&jsonpath=$.a&from=3&to=4")
+                .aggregate().join();
+
         final String expectedJson =
                 '{' +
                 "   \"path\": \"/foo0.json\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/QueryRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/QueryRequestConverterTest.java
@@ -62,7 +62,7 @@ public class QueryRequestConverterTest {
         final String jsonFilePath = "/a.json";
         when(ctx.pathParam("path")).thenReturn(jsonFilePath);
 
-        final String httpQuery = "?expression=%22%24.a%22";  // "$.a"
+        final String httpQuery = "?jsonpath=%22%24.a%22";  // "$.a"
         when(ctx.query()).thenReturn(httpQuery);
 
         final Optional<Query<?>> query = convert(ctx);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -246,4 +246,14 @@ public class RepositoryServiceV1Test {
         final AggregatedHttpMessage aRes = httpClient.execute(headers, unremovePatch).aggregate().join();
         assertThat(aRes.headers().status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
+
+    @Test
+    public void normalizeRevision() {
+        createRepository("foo");
+        final AggregatedHttpMessage res = httpClient.get(REPOS_PREFIX + "/foo/revision/-1")
+                                                    .aggregate().join();
+        final String expectedJson = "{\"revision\":1}";
+        final String actualJson = res.content().toStringUtf8();
+        assertThatJson(actualJson).isEqualTo(expectedJson);
+    }
 }


### PR DESCRIPTION
… API

Modifications:
- Add `nomalizeRevision` to HTTP API
- Fix to receive more than one JSON path in `QueryRequestConverter`

Result:
- A client can nomalize revision now