### PR TITLE
Implement read-only mode

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatch.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatch.java
@@ -47,6 +47,7 @@ import java.util.TreeSet;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializable;
 import com.fasterxml.jackson.databind.SerializerProvider;
@@ -134,7 +135,11 @@ public final class JsonPatch implements JsonSerializable {
      */
     public static JsonPatch fromJson(final JsonNode node) throws IOException {
         requireNonNull(node, "node");
-        return Jackson.treeToValue(node, JsonPatch.class);
+        try {
+            return Jackson.treeToValue(node, JsonPatch.class);
+        } catch (JsonMappingException e) {
+            throw new JsonPatchException("invalid JSON patch", e);
+        }
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -83,6 +83,7 @@ import com.linecorp.centraldogma.server.internal.admin.service.RepositoryService
 import com.linecorp.centraldogma.server.internal.admin.service.TokenService;
 import com.linecorp.centraldogma.server.internal.admin.service.UserService;
 import com.linecorp.centraldogma.server.internal.admin.util.RestfulJsonResponseConverter;
+import com.linecorp.centraldogma.server.internal.api.AdministrativeService;
 import com.linecorp.centraldogma.server.internal.api.ContentServiceV1;
 import com.linecorp.centraldogma.server.internal.api.ProjectServiceV1;
 import com.linecorp.centraldogma.server.internal.api.RepositoryServiceV1;
@@ -508,6 +509,9 @@ public class CentralDogma {
         final HttpApiRequestConverter v1RequestConverter = new HttpApiRequestConverter(safePm);
         final HttpApiResponseConverter v1ResponseConverter = new HttpApiResponseConverter();
 
+        sb.annotatedService(API_V1_PATH_PREFIX,
+                            new AdministrativeService(safePm, executor), decorator,
+                            v1RequestConverter, v1ResponseConverter);
         sb.annotatedService(API_V1_PATH_PREFIX,
                             new ProjectServiceV1(safePm, executor, mds), decorator,
                             v1RequestConverter, v1ResponseConverter);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.annotation.ConsumeType;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Patch;
+import com.linecorp.armeria.server.annotation.RequestObject;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.jsonpatch.JsonPatch;
+import com.linecorp.centraldogma.internal.jsonpatch.JsonPatchException;
+import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
+
+public final class AdministrativeService extends AbstractService {
+
+    private static final Logger logger = LoggerFactory.getLogger(AdministrativeService.class);
+
+    public AdministrativeService(ProjectManager projectManager, CommandExecutor executor) {
+        super(projectManager, executor);
+    }
+
+    /**
+     * GET /status
+     *
+     * <p>Returns the server status.
+     */
+    @Get("/status")
+    public ServerStatus status() {
+        return new ServerStatus(executor().isStarted());
+    }
+
+    /**
+     * PATCH /status
+     *
+     * <p>Patches the server status with a JSON patch. Currently used only for entering read-only.
+     */
+    @Patch("/status")
+    @ConsumeType("application/json-patch+json")
+    public ServerStatus updateStatus(@RequestObject JsonNode patch) throws Exception {
+        // TODO(trustin): Consider extracting this into common utility or Armeria.
+        final ServerStatus oldStatus = status();
+        final JsonNode oldValue = Jackson.valueToTree(oldStatus);
+        final JsonNode newValue;
+        try {
+            newValue = JsonPatch.fromJson(patch).apply(oldValue);
+        } catch (JsonPatchException e) {
+            // Failed to apply the given JSON patch.
+            return rejectStatusPatch(patch);
+        }
+
+        if (!newValue.isObject()) {
+            return rejectStatusPatch(patch);
+        }
+
+        final JsonNode writableNode = newValue.get("writable");
+        if (!writableNode.isBoolean()) {
+            return rejectStatusPatch(patch);
+        }
+
+        if (writableNode.asBoolean()) {
+            if (!oldStatus.writable) {
+                // TODO(trustin): Implement exiting read-only mode.
+                throw HttpStatusException.of(HttpStatus.NOT_IMPLEMENTED);
+            }
+        } else {
+            if (oldStatus.writable) {
+                logger.warn("Entering read-only mode ..");
+                executor().stop();
+                logger.info("Entered read-only mode");
+                return status();
+            }
+        }
+
+        throw HttpStatusException.of(HttpStatus.NOT_MODIFIED);
+    }
+
+    private static ServerStatus rejectStatusPatch(JsonNode patch) {
+        throw new IllegalArgumentException("Invalid JSON patch: " + patch);
+    }
+
+    // TODO(trustin): Add more properties, e.g. method, host name, isLeader and config.
+    private static final class ServerStatus {
+        @JsonProperty
+        final boolean writable;
+
+        ServerStatus(boolean writable) {
+            this.writable = writable;
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+public class AdministrativeServiceTest {
+
+    @Rule
+    public final CentralDogmaRule dogma = new CentralDogmaRule();
+
+    private static HttpClient httpClient;
+
+    @Before
+    public void init() {
+        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
+        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        httpClient = new HttpClientBuilder(serverUri)
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+    }
+
+    @Test
+    public void status() {
+        final AggregatedHttpMessage res = httpClient.get(API_V1_PATH_PREFIX + "status").aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+                "{ \"writable\": true }");
+    }
+
+    @Test
+    public void updateStatus() {
+        final AggregatedHttpMessage res = httpClient.execute(
+                HttpHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status")
+                           .contentType(MediaType.JSON_PATCH),
+                "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }]").aggregate().join();
+
+        assertThat(res.status()).isEqualTo(HttpStatus.OK);
+        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+                "{ \"writable\": false }");
+    }
+
+    @Test
+    public void redundantUpdateStatus() {
+        final AggregatedHttpMessage res = httpClient.execute(
+                HttpHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status")
+                           .contentType(MediaType.JSON_PATCH),
+                "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();
+
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_MODIFIED);
+    }
+
+    @Test
+    public void unimplementedUpdateStatus() {
+        // Enter read-only mode.
+        updateStatus();
+        // Try to enter writable mode.
+        final AggregatedHttpMessage res = httpClient.execute(
+                HttpHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status")
+                           .contentType(MediaType.JSON_PATCH),
+                "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();
+
+        assertThat(res.status()).isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+    }
+}


### PR DESCRIPTION
Motivation:

An administrator may want to ensure no commit is pushed during
maintenance.

Modifications:

- Add AdministrativeService:
  - Expose whether the server is writable or not
  - Accept a JSON patch to enter read-only mode
- Miscellaneous:
  - Fix a bug where JsonPatch.fromJson() raises a Jackson exception
    instead of JsonPatchException when Jackson failed to map the input
    node due to invalid format.

Result:

- Ability to enter read-only mode without shutting down