### PR TITLE
Add a configuration for writing an access log

### DIFF
--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -24,5 +24,6 @@
   "replication": {
     "method": "NONE"
   },
-  "securityEnabled": false
+  "securityEnabled": false,
+  "accessLogFormat": "common"
 }

--- a/dist/src/conf/logback.xml
+++ b/dist/src/conf/logback.xml
@@ -37,8 +37,26 @@
     <export>req.http_headers.x-forwarded-for</export>
   </appender>
 
+  <appender name="ACCESS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${APP_LOG_DIR:-.}/access.log</file>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <!-- daily rollover -->
+      <fileNamePattern>${APP_LOG_DIR:-.}/access.%d{yyyy-MM-dd}-%i.log</fileNamePattern>
+      <!-- each file should be at most 1GB, keep 30 days worth of history, but at most 30GB -->
+      <maxFileSize>1GB</maxFileSize>
+      <maxHistory>30</maxHistory>
+      <totalSizeCap>30GB</totalSizeCap>
+    </rollingPolicy>
+    <encoder>
+      <pattern>%msg%n</pattern>
+    </encoder>
+  </appender>
+
   <logger name="com.linecorp" level="INFO" />
   <logger name="com.linecorp.centraldogma" level="DEBUG" />
+  <logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
+    <appender-ref ref="ACCESS"/>
+  </logger>
   <logger name="io.netty" level="INFO" />
 
   <root level="WARN">

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.initializeInternalProject;
 import static java.util.Objects.requireNonNull;
@@ -66,6 +67,7 @@ import com.linecorp.armeria.server.docs.DocServiceBuilder;
 import com.linecorp.armeria.server.file.AbstractHttpVfs;
 import com.linecorp.armeria.server.file.HttpFileService;
 import com.linecorp.armeria.server.healthcheck.HttpHealthCheckService;
+import com.linecorp.armeria.server.logging.AccessLogWriters;
 import com.linecorp.armeria.server.thrift.THttpService;
 import com.linecorp.armeria.server.thrift.ThriftCallService;
 import com.linecorp.centraldogma.internal.CsrfToken;
@@ -395,6 +397,17 @@ public class CentralDogma {
                                                .build());
 
         configureHttpApi(sb, pm, executor, watchService, securityManager);
+
+        final String accessLogFormat = cfg.accessLogFormat();
+        if (isNullOrEmpty(accessLogFormat)) {
+            sb.accessLogWriter(AccessLogWriters.disabled());
+        } else if ("common".equals(accessLogFormat)) {
+            sb.accessLogWriter(AccessLogWriters.common());
+        } else if ("combined".equals(accessLogFormat)) {
+            sb.accessLogWriter(AccessLogWriters.combined());
+        } else {
+            sb.accessLogFormat(accessLogFormat);
+        }
 
         final Server s = sb.build();
         s.start().join();

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -78,6 +78,7 @@ public final class CentralDogmaBuilder {
     private GracefulShutdownTimeout gracefulShutdownTimeout;
     private ReplicationConfig replicationConfig = ReplicationConfig.NONE;
     private Ini securityConfig;
+    private String accessLogFormat;
 
     /**
      * Creates a new builder with the specified data directory.
@@ -273,6 +274,16 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Configures a format of an access log. It will work only if any logging framework is configured.
+     * Read the <a href="https://line.github.io/armeria/server-access-log.html">Writing an access log</a>
+     * document for more information.
+     */
+    public CentralDogmaBuilder accessLogFormat(String accessLogFormat) {
+        this.accessLogFormat = requireNonNull(accessLogFormat, "accessLogFormat");
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link CentralDogma} server.
      */
     public CentralDogma build() {
@@ -288,6 +299,7 @@ public final class CentralDogmaBuilder {
                                       numRepositoryWorkers, cacheSpec, gracefulShutdownTimeout,
                                       webAppEnabled, mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
-                                      securityConfig != null, null);
+                                      securityConfig != null, null,
+                                      accessLogFormat);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -93,10 +93,13 @@ final class CentralDogmaConfig {
     private final boolean securityEnabled;
     private final boolean csrfTokenRequiredForThrift;
 
+    // Access log
+    private final String accessLogFormat;
+
     CentralDogmaConfig(@JsonProperty(value = "dataDir", required = true) File dataDir,
                        @JsonProperty(value = "ports", required = true)
                        @JsonDeserialize(contentUsing = ServerPortDeserializer.class)
-                       List<ServerPort> ports,
+                               List<ServerPort> ports,
                        @JsonProperty("numWorkers") Integer numWorkers,
                        @JsonProperty("maxNumConnections") Integer maxNumConnections,
                        @JsonProperty("requestTimeoutMillis") Long requestTimeoutMillis,
@@ -105,7 +108,7 @@ final class CentralDogmaConfig {
                        @JsonProperty("numRepositoryWorkers") Integer numRepositoryWorkers,
                        @JsonProperty("cacheSpec") String cacheSpec,
                        @JsonProperty("gracefulShutdownTimeout")
-                       GracefulShutdownTimeout gracefulShutdownTimeout,
+                               GracefulShutdownTimeout gracefulShutdownTimeout,
                        @JsonProperty("webAppEnabled") Boolean webAppEnabled,
                        @JsonProperty("mirroringEnabled") Boolean mirroringEnabled,
                        @JsonProperty("numMirroringThreads") Integer numMirroringThreads,
@@ -113,7 +116,8 @@ final class CentralDogmaConfig {
                        @JsonProperty("maxNumBytesPerMirror") Long maxNumBytesPerMirror,
                        @JsonProperty("replication") ReplicationConfig replicationConfig,
                        @JsonProperty("securityEnabled") Boolean securityEnabled,
-                       @JsonProperty("csrfTokenRequiredForThrift") Boolean csrfTokenRequiredForThrift) {
+                       @JsonProperty("csrfTokenRequiredForThrift") Boolean csrfTokenRequiredForThrift,
+                       @JsonProperty("accessLogFormat") String accessLogFormat) {
 
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
@@ -143,6 +147,7 @@ final class CentralDogmaConfig {
         this.replicationConfig = firstNonNull(replicationConfig, ReplicationConfig.NONE);
         this.securityEnabled = firstNonNull(securityEnabled, false);
         this.csrfTokenRequiredForThrift = firstNonNull(csrfTokenRequiredForThrift, true);
+        this.accessLogFormat = accessLogFormat;
     }
 
     @JsonProperty
@@ -240,6 +245,11 @@ final class CentralDogmaConfig {
     @JsonProperty
     boolean isCsrfTokenRequiredForThrift() {
         return csrfTokenRequiredForThrift;
+    }
+
+    @JsonProperty
+    String accessLogFormat() {
+        return accessLogFormat;
     }
 
     @Override

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -39,7 +39,8 @@ defaults:
       "mirroringEnabled": true,
       "numMirroringThreads": null,
       "maxNumFilesPerMirror": null,
-      "maxNumBytesPerMirror": null
+      "maxNumBytesPerMirror": null,
+      "accessLogFormat": "common"
     }
 
 Core properties
@@ -167,6 +168,13 @@ Core properties
     this, Central Dogma will reject to mirror the Git repository. If ``null``, the default value of
     '33554432 bytes' (32 MiB) is used.
 
+- ``accessLogFormat`` (string)
+
+  - the format to be used for writing an access log. ``common`` and ``combined`` are pre-defined for NCSA
+    common log format and NCSA combined log format, respectively. Also, a custom log format can be specified
+    here. Read `Writing an access log <https://line.github.io/armeria/server-access-log.html>`_ for more
+    information. Specify ``null`` to disable access logging feature.
+
 Configuring replication
 -----------------------
 Central Dogma features multi-master replication based on `Apache ZooKeeper <https://zookeeper.apache.org/>`_
@@ -216,7 +224,8 @@ Once you have an access to a ZooKeeper cluster, update the ``replication`` secti
         "maxLogCount": null,
         "minLogAgeMillis": null
       },
-      "securityEnabled": false
+      "securityEnabled": false,
+      "accessLogFormat": "common"
     }
 
 - ``method`` (string)


### PR DESCRIPTION
Modifications:
- Add `accessLogFormat` property to `dogma.json`.
- Add access logging configuration to `dist/src/conf/logback.xml`.
- Documentation.