### PR TITLE
Choose the last matching client profile

### DIFF
--- a/client/java/src/test/resources/centraldogma-profile-qux.properties
+++ b/client/java/src/test/resources/centraldogma-profile-qux.properties
@@ -1,0 +1,2 @@
+centraldogma.hosts.0=alice.com
+centraldogma.hosts.1=bob.com


### PR DESCRIPTION
Motivation:

- Spring Boot uses the last matching profile, which is opposed to
  CentralDogmaBuilder.profile(), which chooses the first matching one.

Modifications:

- Choose the last matching client profile.
- Make profile matching more robust by ignoring problematic profiles
  instead of raising an exception

Result:

- Works better with Spring Boot
- Deals better with poorly written profile