### PR TITLE
Expose web session timeout configuration

### DIFF
--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -17,6 +17,7 @@
   "numRepositoryWorkers": 16,
   "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
   "webAppEnabled": true,
+  "webAppSessionTimeoutMillis": 604800000,
   "gracefulShutdownTimeout": {
     "quietPeriodMillis": 1000,
     "timeoutMillis": 10000

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -235,7 +235,8 @@ public class CentralDogma {
                                                            cfg.maxNumBytesPerMirror());
 
             if (cfg.isSecurityEnabled()) {
-                securityManager = new CentralDogmaSecurityManager(cfg.dataDir(), securityConfig);
+                securityManager = new CentralDogmaSecurityManager(cfg.dataDir(), securityConfig,
+                                                                  cfg.webAppSessionTimeoutMillis());
             }
 
             logger.info("Starting the command executor ..");

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -55,6 +55,7 @@ public final class CentralDogmaBuilder {
     static final long DEFAULT_MAX_NUM_BYTES_PER_MIRROR = 32 * 1048576; // 32 MiB
     static final String DEFAULT_CACHE_SPEC = "maximumWeight=134217728," + // Cache up to apx. 128-megachars
                                              "expireAfterAccess=5m";      // Expire on 5 minutes of inactivity
+    static final long DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS = 604800000;   // 7 days
 
     // Armeria properties
     // Note that we use nullable types here for optional properties.
@@ -71,6 +72,7 @@ public final class CentralDogmaBuilder {
     private int numRepositoryWorkers = DEFAULT_NUM_REPOSITORY_WORKERS;
     private String cacheSpec = DEFAULT_CACHE_SPEC;
     private boolean webAppEnabled = true;
+    private long webAppSessionTimeoutMillis = DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS;
     private boolean mirroringEnabled = true;
     private int numMirroringThreads = DEFAULT_NUM_MIRRORING_THREADS;
     private int maxNumFilesPerMirror = DEFAULT_MAX_NUM_FILES_PER_MIRROR;
@@ -207,6 +209,24 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Sets the session timeout for administrative web application, in milliseconds.
+     * If unspecified, {@value #DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS} is used.
+     */
+    public CentralDogmaBuilder webAppSessionTimeoutMillis(long webAppSessionTimeoutMillis) {
+        this.webAppSessionTimeoutMillis = webAppSessionTimeoutMillis;
+        return this;
+    }
+
+    /**
+     * Sets the session timeout for administrative web application.
+     * If unspecified, {@value #DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS} is used.
+     */
+    public CentralDogmaBuilder webAppSessionTimeout(Duration webAppSessionTimeout) {
+        return webAppSessionTimeoutMillis(
+                requireNonNull(webAppSessionTimeout, "webAppSessionTimeout").toMillis());
+    }
+
+    /**
      * Sets whether {@link MirroringService} is enabled or not.
      * If unspecified, {@link MirroringService} is enabled.
      */
@@ -286,7 +306,8 @@ public final class CentralDogmaBuilder {
         return new CentralDogmaConfig(dataDir, ports, numWorkers, maxNumConnections,
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
                                       numRepositoryWorkers, cacheSpec, gracefulShutdownTimeout,
-                                      webAppEnabled, mirroringEnabled, numMirroringThreads,
+                                      webAppEnabled, webAppSessionTimeoutMillis,
+                                      mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
                                       securityConfig != null, null);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -23,6 +23,7 @@ import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_N
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_NUM_FILES_PER_MIRROR;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_MIRRORING_THREADS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_REPOSITORY_WORKERS;
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -76,6 +77,7 @@ final class CentralDogmaConfig {
 
     // Web dashboard
     private final boolean webAppEnabled;
+    private final long webAppSessionTimeoutMillis;
 
     // Mirroring
     private final boolean mirroringEnabled;
@@ -96,7 +98,7 @@ final class CentralDogmaConfig {
     CentralDogmaConfig(@JsonProperty(value = "dataDir", required = true) File dataDir,
                        @JsonProperty(value = "ports", required = true)
                        @JsonDeserialize(contentUsing = ServerPortDeserializer.class)
-                       List<ServerPort> ports,
+                               List<ServerPort> ports,
                        @JsonProperty("numWorkers") Integer numWorkers,
                        @JsonProperty("maxNumConnections") Integer maxNumConnections,
                        @JsonProperty("requestTimeoutMillis") Long requestTimeoutMillis,
@@ -105,8 +107,9 @@ final class CentralDogmaConfig {
                        @JsonProperty("numRepositoryWorkers") Integer numRepositoryWorkers,
                        @JsonProperty("cacheSpec") String cacheSpec,
                        @JsonProperty("gracefulShutdownTimeout")
-                       GracefulShutdownTimeout gracefulShutdownTimeout,
+                               GracefulShutdownTimeout gracefulShutdownTimeout,
                        @JsonProperty("webAppEnabled") Boolean webAppEnabled,
+                       @JsonProperty("webAppSessionTimeoutMillis") Long webAppSessionTimeoutMillis,
                        @JsonProperty("mirroringEnabled") Boolean mirroringEnabled,
                        @JsonProperty("numMirroringThreads") Integer numMirroringThreads,
                        @JsonProperty("maxNumFilesPerMirror") Integer maxNumFilesPerMirror,
@@ -129,6 +132,10 @@ final class CentralDogmaConfig {
                       "numRepositoryWorkers: %s (expected: > 0)", this.numRepositoryWorkers);
         this.cacheSpec = RepositoryCache.validateCacheSpec(firstNonNull(cacheSpec, DEFAULT_CACHE_SPEC));
         this.webAppEnabled = firstNonNull(webAppEnabled, true);
+        this.webAppSessionTimeoutMillis = firstNonNull(webAppSessionTimeoutMillis,
+                                                       DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS);
+        checkArgument(this.webAppSessionTimeoutMillis > 0,
+                      "webAppSessionTimeoutMillis: %s (expected: > 0)", this.webAppSessionTimeoutMillis);
         this.mirroringEnabled = firstNonNull(mirroringEnabled, true);
         this.numMirroringThreads = firstNonNull(numMirroringThreads, DEFAULT_NUM_MIRRORING_THREADS);
         checkArgument(this.numMirroringThreads > 0,
@@ -205,6 +212,11 @@ final class CentralDogmaConfig {
     @JsonProperty
     boolean isWebAppEnabled() {
         return webAppEnabled;
+    }
+
+    @JsonProperty
+    long webAppSessionTimeoutMillis() {
+        return webAppSessionTimeoutMillis;
     }
 
     @JsonProperty

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -28,6 +28,7 @@ defaults:
       "numRepositoryWorkers": 16,
       "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
       "webAppEnabled": true,
+      "webAppSessionTimeoutMillis": 604800000,
       "gracefulShutdownTimeout": {
         "quietPeriodMillis": 1000,
         "timeoutMillis": 10000
@@ -111,6 +112,11 @@ Core properties
 - ``webAppEnabled`` (boolean)
 
   - whether to enable the web-based administrative console. Enabled by default.
+
+- ``webAppSessionTimeoutMillis`` (integer)
+
+  - the session timeout for web-based administrative console, in milliseconds. If ``null``, the default value
+    of '604800000 milliseconds' (7 days) is used.
 
 - ``gracefulShutdownTimeout``
 
@@ -203,6 +209,7 @@ Once you have an access to a ZooKeeper cluster, update the ``replication`` secti
       "numRepositoryWorkers": 16,
       "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
       "webAppEnabled": true,
+      "webAppSessionTimeoutMillis": 604800000,
       "gracefulShutdownTimeout": {
         "quietPeriodMillis": 1000,
         "timeoutMillis": 10000


### PR DESCRIPTION
Modifications:
- Add `webAppSessionTimeoutMillis` property to `dogma.json`
- Fix incorrect usage of setting session expiration time.
- Change default session timeout to 7 days. (was: 30 minutes)

Result:
- Close #138 