### PR TITLE
Expose TLS configuration

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -89,6 +89,59 @@ public interface CentralDogma {
     }
 
     /**
+     * Returns a newly-created {@link CentralDogma} instance which connects to the given host at port 36462
+     * using the default {@link ClientFactory}. This {@link CentralDogma} instance connects to the server
+     * with TLS enabled.
+     *
+     * @param host the host name or IP address of the Central Dogma server
+     */
+    static CentralDogma forTlsHost(String host) {
+        return new CentralDogmaBuilder().host(host).useTls().build();
+    }
+
+    /**
+     * Returns a newly-created {@link CentralDogma} instance which connects to the given host and port
+     * using the default {@link ClientFactory}. This {@link CentralDogma} instance connects to the server
+     * with TLS enabled.
+     *
+     * @param host the host name or IP address of the Central Dogma server
+     * @param port the port number of the Central Dogma server
+     */
+    static CentralDogma forTlsHost(String host, int port) {
+        return new CentralDogmaBuilder().host(host, port).useTls().build();
+    }
+
+    /**
+     * Returns a newly-created {@link CentralDogma} instance which connects to the given host at port 36462
+     * using the specified {@link ClientFactory}. This {@link CentralDogma} instance connects to the server
+     * with TLS enabled.
+     *
+     * @param clientFactory the {@link ClientFactory} that will manage the connections
+     * @param host the host name or IP address of the Central Dogma server
+     */
+    static CentralDogma forTlsHost(ClientFactory clientFactory, String host) {
+        return new CentralDogmaBuilder().clientFactory(clientFactory)
+                                        .host(host)
+                                        .useTls()
+                                        .build();
+    }
+
+    /**
+     * Returns a newly-created {@link CentralDogma} instance which connects to the given host and port
+     * using the specified {@link ClientFactory}. This {@link CentralDogma} instance connects to the server
+     * with TLS enabled.
+     *
+     * @param clientFactory the {@link ClientFactory} that will manage the connections
+     * @param host the host name or IP address of the Central Dogma server
+     */
+    static CentralDogma forTlsHost(ClientFactory clientFactory, String host, int port) {
+        return new CentralDogmaBuilder().clientFactory(clientFactory)
+                                        .host(host, port)
+                                        .useTls()
+                                        .build();
+    }
+
+    /**
      * Returns a newly-created {@link CentralDogma} instance with the given profile names and the default
      * {@link ClientFactory}.
      *

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaBuilder.java
@@ -65,6 +65,7 @@ public class CentralDogmaBuilder {
 
     private ClientFactory clientFactory = ClientFactory.DEFAULT;
     private List<Endpoint> endpoints = new ArrayList<>();
+    private boolean useTls;
     private String selectedProfile;
     private ArmeriaClientConfigurator clientConfigurator = cb -> {
     };
@@ -119,6 +120,21 @@ public class CentralDogmaBuilder {
 
         checkState(selectedProfile == null, "profile() and host() cannot be used together.");
         endpoints.add(Endpoint.parse(host + ':' + port));
+        return this;
+    }
+
+    /**
+     * Sets the client to use TLS.
+     */
+    public CentralDogmaBuilder useTls() {
+        return useTls(true);
+    }
+
+    /**
+     * Sets whether the client uses TLS or not.
+     */
+    public CentralDogmaBuilder useTls(boolean useTls) {
+        this.useTls = useTls;
         return this;
     }
 
@@ -301,7 +317,8 @@ public class CentralDogmaBuilder {
             endpoint = Endpoint.ofGroup(groupName);
         }
 
-        final String uri = "tbinary+http://" + endpoint.authority() + "/cd/thrift/v1";
+        final String scheme = "tbinary+" + (useTls ? "https" : "http") + "://";
+        final String uri = scheme + endpoint.authority() + "/cd/thrift/v1";
         final ClientBuilder builder = new ClientBuilder(uri)
                 .factory(clientFactory)
                 .decorator(RpcRequest.class, RpcResponse.class,

--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -9,6 +9,7 @@
       "protocol": "http"
     }
   ],
+  "tls": null,
   "numWorkers": null,
   "maxNumConnections": null,
   "requestTimeoutMillis": null,

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -63,6 +63,7 @@ public final class CentralDogmaBuilder {
     // Note that we use nullable types here for optional properties.
     // When a property is null, the default value will be used implicitly.
     private final List<ServerPort> ports = new ArrayList<>(2);
+    private TlsConfig tls;
     private Integer numWorkers;
     private Integer maxNumConnections;
     private Long requestTimeoutMillis;
@@ -120,6 +121,14 @@ public final class CentralDogmaBuilder {
      */
     public CentralDogmaBuilder port(ServerPort port) {
         ports.add(requireNonNull(port, "port"));
+        return this;
+    }
+
+    /**
+     * Sets a {@link TlsConfig} for supporting TLS on the server.
+     */
+    public CentralDogmaBuilder tls(TlsConfig tls) {
+        this.tls = requireNonNull(tls, "tls");
         return this;
     }
 
@@ -337,7 +346,7 @@ public final class CentralDogmaBuilder {
         final List<ServerPort> ports = !this.ports.isEmpty() ? this.ports
                                                              : Collections.singletonList(DEFAULT_PORT);
 
-        return new CentralDogmaConfig(dataDir, ports, numWorkers, maxNumConnections,
+        return new CentralDogmaConfig(dataDir, ports, tls, numWorkers, maxNumConnections,
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
                                       numRepositoryWorkers, cacheSpec, gracefulShutdownTimeout,
                                       webAppEnabled, webAppSessionTimeoutMillis,

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -33,6 +33,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
@@ -58,7 +60,6 @@ import com.linecorp.centraldogma.server.internal.storage.repository.cache.Reposi
 
 import io.netty.util.NetUtil;
 
-// TODO(trustin): Expose SSL configuration properties.
 final class CentralDogmaConfig {
 
     private final File dataDir;
@@ -70,6 +71,7 @@ final class CentralDogmaConfig {
     private final Long requestTimeoutMillis;
     private final Long idleTimeoutMillis;
     private final Integer maxFrameLength;
+    private final TlsConfig tls;
 
     // Repository
     private final Integer numRepositoryWorkers;
@@ -107,6 +109,7 @@ final class CentralDogmaConfig {
                        @JsonProperty(value = "ports", required = true)
                        @JsonDeserialize(contentUsing = ServerPortDeserializer.class)
                                List<ServerPort> ports,
+                       @JsonProperty("tls") TlsConfig tls,
                        @JsonProperty("numWorkers") Integer numWorkers,
                        @JsonProperty("maxNumConnections") Integer maxNumConnections,
                        @JsonProperty("requestTimeoutMillis") Long requestTimeoutMillis,
@@ -131,6 +134,7 @@ final class CentralDogmaConfig {
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
         checkArgument(!ports.isEmpty(), "ports must have at least one port.");
+        this.tls = tls;
         this.numWorkers = numWorkers;
 
         this.maxNumConnections = maxNumConnections;
@@ -174,6 +178,12 @@ final class CentralDogmaConfig {
     @JsonSerialize(contentUsing = ServerPortSerializer.class)
     List<ServerPort> ports() {
         return ports;
+    }
+
+    @Nullable
+    @JsonProperty
+    TlsConfig tls() {
+        return tls;
     }
 
     @JsonProperty

--- a/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.File;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+/**
+ * TLS configuration.
+ */
+public final class TlsConfig {
+
+    private final File keyCertChainFile;
+    private final File keyFile;
+    @Nullable
+    private final String keyPassword;
+
+    /**
+     * Creates an instance with the specified {@code keyCertChainFilePath}, {@code keyFilePath} and
+     * {@code keyPassword}.
+     */
+    @JsonCreator
+    public TlsConfig(@JsonProperty(value = "keyCertChainFile", required = true) File keyCertChainFile,
+                     @JsonProperty(value = "keyFile", required = true) File keyFile,
+                     @JsonProperty("keyPassword") @Nullable String keyPassword) {
+        this.keyCertChainFile = requireNonNull(keyCertChainFile, "keyCertChainFile");
+        this.keyFile = requireNonNull(keyFile, "keyFile");
+        this.keyPassword = keyPassword;
+    }
+
+    /**
+     * Returns a certificates file which is created with the given {@code keyCertChainFilePath}.
+     */
+    @JsonProperty
+    public File keyCertChainFile() {
+        return keyCertChainFile;
+    }
+
+    /**
+     * Returns a private key file which is created with the given {@code keyFilePath}.
+     */
+    @JsonProperty
+    public File keyFile() {
+        return keyFile;
+    }
+
+    /**
+     * Returns a password for the private key file. Return {@code null} if no password is set.
+     */
+    @JsonProperty
+    @Nullable
+    public String keyPassword() {
+        return keyPassword;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("keyCertChainFile", keyCertChainFile)
+                          .add("keyFile", keyFile)
+                          .add("keyPassword", keyPassword)
+                          .toString();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.linecorp.centraldogma.internal.Jackson;
+
+public class ConfigDeserializationTest {
+
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void tlsConfig() throws Exception {
+        final String cert = Jackson.escapeText(folder.newFile().getAbsolutePath());
+        final String key = Jackson.escapeText(folder.newFile().getAbsolutePath());
+
+        final String jsonConfig = String.format("{\"tls\": {" +
+                                                "\"keyCertChainFile\": \"%s\", " +
+                                                "\"keyFile\": \"%s\", " +
+                                                "\"keyPassword\": null " +
+                                                "}}", cert, key);
+        final ParentConfig parentConfig = Jackson.readValue(jsonConfig, ParentConfig.class);
+        final TlsConfig tlsConfig = parentConfig.tlsConfig;
+
+        assertThat(tlsConfig.keyCertChainFile()).isNotNull();
+        assertThat(tlsConfig.keyCertChainFile().canRead()).isTrue();
+
+        assertThat(tlsConfig.keyFile()).isNotNull();
+        assertThat(tlsConfig.keyFile().canRead()).isTrue();
+
+        assertThat(tlsConfig.keyPassword()).isNull();
+    }
+
+    static class ParentConfig {
+        private final TlsConfig tlsConfig;
+
+        @JsonCreator
+        ParentConfig(@JsonProperty("tls") TlsConfig tlsConfig) {
+            this.tlsConfig = tlsConfig;
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/TlsServerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/TlsServerTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+public class TlsServerTest {
+
+    @ClassRule
+    public static CentralDogmaRule rule = new CentralDogmaRule(true);
+
+    @Test
+    public void tls() {
+        rule.client().createProject("overTls").join();
+        assertThat(rule.client().listProjects().join()).contains("overTls");
+    }
+}

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -20,6 +20,7 @@ defaults:
           "protocol": "http"
         }
       ],
+      "tls": null,
       "numWorkers": null,
       "maxNumConnections": null,
       "requestTimeoutMillis": null,
@@ -67,7 +68,12 @@ Core properties
 
   - ``protocol`` (string)
 
-    - the protocol. ``http`` is the only supported protocol at the moment.
+    - the protocol. ``http`` and ``https`` are supported.
+
+- ``tls``
+
+  - the configuration for Transport Layer Security(TLS) support. Specify ``null`` to disable TLS.
+    See :ref:`tls` for more information.
 
 - ``numWorkers`` (integer)
 
@@ -140,8 +146,8 @@ Core properties
   - the replication configuration.
   - ``method`` (string)
 
-    - the replication method. ``NONE`` indicates 'standalone mode' without replication. ZooKeeper-based
-      multi-master replication will be explained later in this page.
+    - the replication method. ``NONE`` indicates 'standalone mode' without replication. See :ref:`replication`
+      to learn how to configure ZooKeeper-based multi-master replication.
 
 - ``securityEnabled`` (boolean)
 
@@ -187,6 +193,8 @@ Core properties
   - login IDs of the administrators. They are valid only if ``securityEnabled`` is ``true``.
     Please refer to :ref:`auth` for more information.
 
+.. _replication:
+
 Configuring replication
 -----------------------
 Central Dogma features multi-master replication based on `Apache ZooKeeper <https://zookeeper.apache.org/>`_
@@ -215,6 +223,7 @@ Once you have an access to a ZooKeeper cluster, update the ``replication`` secti
           "protocol": "http"
         }
       ],
+      "tls": null,
       "numWorkers": null,
       "maxNumConnections": null,
       "requestTimeoutMillis": null,
@@ -275,3 +284,83 @@ Once you have an access to a ZooKeeper cluster, update the ``replication`` secti
 
   -  the minimum allowed age of log items before they are removed from ZooKeeper. If ``null`` the default
      value of '3600000 milliseconds' (1 hour) is used.
+
+.. _tls:
+
+Configuring TLS
+---------------
+Central Dogma supports TLS for its API and web pages. To enable TLS, a user may configure ``tls`` property
+in ``dogma.json`` as follows.
+
+.. code-block:: json
+
+    {
+      "dataDir": "./data",
+      "ports": [
+        {
+          "localAddress": {
+            "host": "*",
+            "port": 36462
+          },
+          "protocol": "https"
+        }
+      ],
+      "tls": {
+        "keyCertChainFile": "./cert/centraldogma.crt",
+        "keyFile": "./cert/centraldogma.key",
+        "keyPassword": null
+      },
+      "numWorkers": null,
+      "maxNumConnections": null,
+      "requestTimeoutMillis": null,
+      "idleTimeoutMillis": null,
+      "maxFrameLength": null,
+      "numRepositoryWorkers": 16,
+      "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "webAppEnabled": true,
+      "gracefulShutdownTimeout": {
+        "quietPeriodMillis": 1000,
+        "timeoutMillis": 10000
+      },
+      "replication": {
+        "method": "NONE"
+      },
+      "securityEnabled": false,
+      "mirroringEnabled": true,
+      "numMirroringThreads": null,
+      "maxNumFilesPerMirror": null,
+      "maxNumBytesPerMirror": null,
+      "accessLogFormat": "common"
+    }
+
+- ``tls``
+
+  - the configuration for TLS support. It will be applied to the port which is configured with ``https``
+    protocol. If ``null``, a self-signed certificate will be generated for ``https`` protocol.
+  - ``keyCertChainFile`` (string)
+
+    - the path to the certificate chain file.
+
+  - ``keyFile`` (string)
+
+    - the path to the private key file.
+
+  - ``keyPassword`` (string)
+
+    - the password of the private key file. Specify ``null`` if no password is set. Note that ``null``
+      (no password) and ``"null"`` (password is 'null') are different.
+
+If you run your Central Dogma with TLS, you need to enable TLS of your ``CentralDogma`` client instance.
+You can get it by ``CentralDogma.forTlsHost()`` methods.
+
+.. code-block:: java
+
+    CentralDogma dogma = CentralDogma.forTlsHost("centraldogma.example.com", 36462);
+
+Also, ``CentralDogmaBuilder`` provides ``useTls()`` method.
+
+.. code-block:: java
+
+    CentralDogma dogma = new CentralDogmaBuilder().host("centraldogma.example.com", 36462)
+                                                  .useTls()
+                                                  .build();


### PR DESCRIPTION
Motivation:
Some user may feel anxiety when sending their login password via cleartext protocol such as http and h2c.
So we need to provide a way to protect their data from the network.

Modifications:
- Add `tls` property to `dogma.json` for specifying paths of certificates file and a key file.

Result:
- Closes #146
