### PR TITLE
Fix TTEXT backward compatibility issue with `from` and `to` parameters

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,3 +54,22 @@ tasks.trimShadedJar.configure {
     // Prevent ProGuard from removing all enum values from Option because otherwise it becomes a non-enum class.
     keep "class com.linecorp.centraldogma.internal.shaded.jsonpath.Option { *; }"
 }
+
+tasks.compileThrift.doLast {
+    // Replace 'fromRevision' with 'from' (and 'toRevision' with 'to') because Thrift compiler
+    // does not let us use the parameter name 'from' complaining it's a reserved keyword.
+    // We can't rename it because renaming a field or a parameter is a backward-incompatible
+    // change in TText protocol.
+    project.fileTree("${project.projectDir}/gen-src/main/java") {
+        include '**/*.java'
+    }.each { sourceFile ->
+        def encoding = 'UTF-8'
+        def oldContent = sourceFile.getText(encoding)
+        def content = oldContent
+                .replaceAll('fromRevision', 'from')
+                .replaceAll('toRevision', 'to')
+        if (content != oldContent) {
+            sourceFile.write(content, encoding)
+        }
+    }
+}


### PR DESCRIPTION
Motivation:

I mistakenly reverted the commit 60db63163e55601c7935a5574a8639dd0ccdd1f6
when I push the commit c1801821ae15bd5d15aca82f35d640dd8f4c5e47. As a
result, the legacy clients who used Thrift TEXT serialization format are
getting errors due to mismatching parameter names.

Modifications:

- Rename the parameters `fromRevision` and `toRevision` to `from` and
  `to` respectively at build time, by reverting the revert.

Result:

TTEXT backward compatibility is back.