### PR TITLE
Allow read-only mode API only to administrators

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/UserWithToken.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/UserWithToken.java
@@ -41,6 +41,11 @@ public class UserWithToken extends User {
     }
 
     @Override
+    public boolean isAdmin() {
+        return token.isAdmin();
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("token", token.withoutSecret())

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
@@ -25,12 +25,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.annotation.ConsumeType;
+import com.linecorp.armeria.server.annotation.Decorator;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.RequestObject;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.jsonpatch.JsonPatch;
 import com.linecorp.centraldogma.internal.jsonpatch.JsonPatchException;
+import com.linecorp.centraldogma.server.internal.api.auth.AdministratorsOnly;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
 
@@ -59,6 +61,7 @@ public final class AdministrativeService extends AbstractService {
      */
     @Patch("/status")
     @ConsumeType("application/json-patch+json")
+    @Decorator(AdministratorsOnly.class)
     public ServerStatus updateStatus(@RequestObject JsonNode patch) throws Exception {
         // TODO(trustin): Consider extracting this into common utility or Armeria.
         final ServerStatus oldStatus = status();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
@@ -24,7 +24,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CompletableFuture;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -76,9 +76,9 @@ public class MetadataApiService {
      */
     @Post("/metadata/{projectName}/members")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> addMember(@Param("projectName") String projectName,
-                                               @RequestObject IdentifierWithRole request,
-                                               @RequestObject Author author) {
+    public CompletableFuture<Revision> addMember(@Param("projectName") String projectName,
+                                                 @RequestObject IdentifierWithRole request,
+                                                 @RequestObject Author author) {
         final ProjectRole role = toProjectRole(request.role());
         return mds.addMember(author, projectName, new User(request.id()), role);
     }
@@ -92,10 +92,10 @@ public class MetadataApiService {
     @Patch("/metadata/{projectName}/members/{memberId}")
     @ConsumeType("application/json-patch+json")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> updateMember(@Param("projectName") String projectName,
-                                                  @Param("memberId") String memberId,
-                                                  @RequestObject JsonPatch jsonPatch,
-                                                  @RequestObject Author author) {
+    public CompletableFuture<Revision> updateMember(@Param("projectName") String projectName,
+                                                    @Param("memberId") String memberId,
+                                                    @RequestObject JsonPatch jsonPatch,
+                                                    @RequestObject Author author) {
         final ReplaceOperation operation = ensureSingleReplaceOperation(jsonPatch, "/role");
         final ProjectRole role = ProjectRole.of(operation.value());
         final User member = new User(urlDecode(memberId));
@@ -110,9 +110,9 @@ public class MetadataApiService {
      */
     @Delete("/metadata/{projectName}/members/{memberId}")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> removeMember(@Param("projectName") String projectName,
-                                                  @Param("memberId") String memberId,
-                                                  @RequestObject Author author) {
+    public CompletableFuture<Revision> removeMember(@Param("projectName") String projectName,
+                                                    @Param("memberId") String memberId,
+                                                    @RequestObject Author author) {
         final User member = new User(urlDecode(memberId));
         return mds.getMember(projectName, member)
                   .thenCompose(unused -> mds.removeMember(author, projectName, member));
@@ -125,9 +125,9 @@ public class MetadataApiService {
      */
     @Post("/metadata/{projectName}/tokens")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> addToken(@Param("projectName") String projectName,
-                                              @RequestObject IdentifierWithRole request,
-                                              @RequestObject Author author) {
+    public CompletableFuture<Revision> addToken(@Param("projectName") String projectName,
+                                                @RequestObject IdentifierWithRole request,
+                                                @RequestObject Author author) {
         final ProjectRole role = toProjectRole(request.role());
         return mds.findTokenByAppId(request.id())
                   .thenCompose(token -> mds.addToken(author, projectName, token.appId(), role));
@@ -142,10 +142,10 @@ public class MetadataApiService {
     @Patch("/metadata/{projectName}/tokens/{appId}")
     @ConsumeType("application/json-patch+json")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> updateTokenRole(@Param("projectName") String projectName,
-                                                     @Param("appId") String appId,
-                                                     @RequestObject JsonPatch jsonPatch,
-                                                     @RequestObject Author author) {
+    public CompletableFuture<Revision> updateTokenRole(@Param("projectName") String projectName,
+                                                       @Param("appId") String appId,
+                                                       @RequestObject JsonPatch jsonPatch,
+                                                       @RequestObject Author author) {
         final ReplaceOperation operation = ensureSingleReplaceOperation(jsonPatch, "/role");
         final ProjectRole role = ProjectRole.of(operation.value());
         return mds.findTokenByAppId(appId)
@@ -159,9 +159,9 @@ public class MetadataApiService {
      */
     @Delete("/metadata/{projectName}/tokens/{appId}")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> removeToken(@Param("projectName") String projectName,
-                                                 @Param("appId") String appId,
-                                                 @RequestObject Author author) {
+    public CompletableFuture<Revision> removeToken(@Param("projectName") String projectName,
+                                                   @Param("appId") String appId,
+                                                   @RequestObject Author author) {
         return mds.findTokenByAppId(appId)
                   .thenCompose(token -> mds.removeToken(author, projectName, token.appId()));
     }
@@ -174,10 +174,10 @@ public class MetadataApiService {
      */
     @Post("/metadata/{projectName}/repos/{repoName}/perm/role")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> updateRolePermission(@Param("projectName") String projectName,
-                                                          @Param("repoName") String repoName,
-                                                          @RequestObject PerRolePermissions newPermission,
-                                                          @RequestObject Author author) {
+    public CompletableFuture<Revision> updateRolePermission(@Param("projectName") String projectName,
+                                                            @Param("repoName") String repoName,
+                                                            @RequestObject PerRolePermissions newPermission,
+                                                            @RequestObject Author author) {
         return mds.updatePerRolePermissions(author, projectName, repoName, newPermission);
     }
 
@@ -189,11 +189,11 @@ public class MetadataApiService {
      */
     @Post("/metadata/{projectName}/repos/{repoName}/perm/users")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> addSpecificUserPermission(@Param("projectName") String projectName,
-                                                               @Param("repoName") String repoName,
-                                                               @RequestObject IdentifierWithPermissions
-                                                                       memberWithPermissions,
-                                                               @RequestObject Author author) {
+    public CompletableFuture<Revision> addSpecificUserPermission(@Param("projectName") String projectName,
+                                                                 @Param("repoName") String repoName,
+                                                                 @RequestObject IdentifierWithPermissions
+                                                                         memberWithPermissions,
+                                                                 @RequestObject Author author) {
         final User member = new User(urlDecode(memberWithPermissions.id()));
         return mds.addPerUserPermission(author, projectName, repoName,
                                         member, memberWithPermissions.permissions());
@@ -208,11 +208,11 @@ public class MetadataApiService {
     @Patch("/metadata/{projectName}/repos/{repoName}/perm/users/{memberId}")
     @ConsumeType("application/json-patch+json")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> updateSpecificUserPermission(@Param("projectName") String projectName,
-                                                                  @Param("repoName") String repoName,
-                                                                  @Param("memberId") String memberId,
-                                                                  @RequestObject JsonPatch jsonPatch,
-                                                                  @RequestObject Author author) {
+    public CompletableFuture<Revision> updateSpecificUserPermission(@Param("projectName") String projectName,
+                                                                    @Param("repoName") String repoName,
+                                                                    @Param("memberId") String memberId,
+                                                                    @RequestObject JsonPatch jsonPatch,
+                                                                    @RequestObject Author author) {
         final ReplaceOperation operation = ensureSingleReplaceOperation(jsonPatch, "/permissions");
         final Collection<Permission> permissions = Jackson.convertValue(operation.value(), permissionsTypeRef);
         final User user = new User(urlDecode(memberId));
@@ -230,10 +230,10 @@ public class MetadataApiService {
      */
     @Delete("/metadata/{projectName}/repos/{repoName}/perm/users/{memberId}")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> removeSpecificUserPermission(@Param("projectName") String projectName,
-                                                                  @Param("repoName") String repoName,
-                                                                  @Param("memberId") String memberId,
-                                                                  @RequestObject Author author) {
+    public CompletableFuture<Revision> removeSpecificUserPermission(@Param("projectName") String projectName,
+                                                                    @Param("repoName") String repoName,
+                                                                    @Param("memberId") String memberId,
+                                                                    @RequestObject Author author) {
         final User user = new User(urlDecode(memberId));
         return mds.findPermissions(projectName, repoName, user)
                   .thenCompose(unused -> mds.removePerUserPermission(author, projectName,
@@ -248,11 +248,11 @@ public class MetadataApiService {
      */
     @Post("/metadata/{projectName}/repos/{repoName}/perm/tokens")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> addSpecificTokenPermission(@Param("projectName") String projectName,
-                                                                @Param("repoName") String repoName,
-                                                                @RequestObject IdentifierWithPermissions
-                                                                        tokenWithPermissions,
-                                                                @RequestObject Author author) {
+    public CompletableFuture<Revision> addSpecificTokenPermission(@Param("projectName") String projectName,
+                                                                  @Param("repoName") String repoName,
+                                                                  @RequestObject IdentifierWithPermissions
+                                                                          tokenWithPermissions,
+                                                                  @RequestObject Author author) {
         return mds.addPerTokenPermission(author, projectName, repoName,
                                          tokenWithPermissions.id(), tokenWithPermissions.permissions());
     }
@@ -266,11 +266,11 @@ public class MetadataApiService {
     @Patch("/metadata/{projectName}/repos/{repoName}/perm/tokens/{appId}")
     @ConsumeType("application/json-patch+json")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> updateSpecificTokenPermission(@Param("projectName") String projectName,
-                                                                   @Param("repoName") String repoName,
-                                                                   @Param("appId") String appId,
-                                                                   @RequestObject JsonPatch jsonPatch,
-                                                                   @RequestObject Author author) {
+    public CompletableFuture<Revision> updateSpecificTokenPermission(@Param("projectName") String projectName,
+                                                                     @Param("repoName") String repoName,
+                                                                     @Param("appId") String appId,
+                                                                     @RequestObject JsonPatch jsonPatch,
+                                                                     @RequestObject Author author) {
         final ReplaceOperation operation = ensureSingleReplaceOperation(jsonPatch, "/permissions");
         final Collection<Permission> permissions = Jackson.convertValue(operation.value(), permissionsTypeRef);
         return mds.findTokenByAppId(appId)
@@ -286,10 +286,10 @@ public class MetadataApiService {
      */
     @Delete("/metadata/{projectName}/repos/{repoName}/perm/tokens/{appId}")
     @Decorator(ProjectOwnersOnly.class)
-    public CompletionStage<Revision> removeSpecificTokenPermission(@Param("projectName") String projectName,
-                                                                   @Param("repoName") String repoName,
-                                                                   @Param("appId") String appId,
-                                                                   @RequestObject Author author) {
+    public CompletableFuture<Revision> removeSpecificTokenPermission(@Param("projectName") String projectName,
+                                                                     @Param("repoName") String repoName,
+                                                                     @Param("appId") String appId,
+                                                                     @RequestObject Author author) {
         return mds.findTokenByAppId(appId)
                   .thenCompose(token -> mds.removePerTokenPermission(author,
                                                                      projectName, repoName, appId));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -107,7 +107,7 @@ public class TokenService extends AbstractService {
                                                                   @RequestObject Author author,
                                                                   @RequestObject User loginUser) {
         checkArgument(!isAdmin || loginUser.isAdmin(),
-                      "Only administrators are allowed to create admin-level token.");
+                      "Only administrators are allowed to create an admin-level token.");
         return mds.createToken(author, appId, isAdmin)
                   .thenCompose(unused -> mds.findTokenByAppId(appId))
                   .thenApply(token -> HolderWithLocation.of(token, "/tokens/" + appId));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
@@ -27,7 +27,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -98,19 +97,19 @@ public class MetadataService extends AbstractService {
     /**
      * Returns a {@link ProjectMetadata} whose name equals to the specified {@code projectName}.
      */
-    public CompletionStage<ProjectMetadata> getProject(String projectName) {
+    public CompletableFuture<ProjectMetadata> getProject(String projectName) {
         requireNonNull(projectName, "projectName");
         return fetchMetadata(projectName).thenApply(HolderWithRevision::object);
     }
 
-    private CompletionStage<HolderWithRevision<ProjectMetadata>> fetchMetadata(String projectName) {
+    private CompletableFuture<HolderWithRevision<ProjectMetadata>> fetchMetadata(String projectName) {
         return metadataRepo.fetch(projectName, METADATA_REPO, METADATA_JSON);
     }
 
     /**
      * Removes a {@link ProjectMetadata} whose name equals to the specified {@code projectName}.
      */
-    public CompletionStage<Revision> removeProject(Author author, String projectName) {
+    public CompletableFuture<Revision> removeProject(Author author, String projectName) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
 
@@ -126,7 +125,7 @@ public class MetadataService extends AbstractService {
     /**
      * Restores a {@link ProjectMetadata} whose name equals to the specified {@code projectName}.
      */
-    public CompletionStage<Revision> restoreProject(Author author, String projectName) {
+    public CompletableFuture<Revision> restoreProject(Author author, String projectName) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
 
@@ -139,7 +138,7 @@ public class MetadataService extends AbstractService {
     /**
      * Returns a {@link Member} if the specified {@link User} is a member of the specified {@code projectName}.
      */
-    public CompletionStage<Member> getMember(String projectName, User user) {
+    public CompletableFuture<Member> getMember(String projectName, User user) {
         requireNonNull(projectName, "projectName");
         requireNonNull(user, "user");
 
@@ -151,8 +150,8 @@ public class MetadataService extends AbstractService {
      * Adds the specified {@code member} to the {@link ProjectMetadata} of the specified {@code projectName}
      * with the specified {@code projectRole}.
      */
-    public CompletionStage<Revision> addMember(Author author, String projectName,
-                                               User member, ProjectRole projectRole) {
+    public CompletableFuture<Revision> addMember(Author author, String projectName,
+                                                 User member, ProjectRole projectRole) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(member, "member");
@@ -173,7 +172,7 @@ public class MetadataService extends AbstractService {
      * {@code projectName}. It also removes permission of the specified {@code member} from every
      * {@link RepositoryMetadata}.
      */
-    public CompletionStage<Revision> removeMember(Author author, String projectName, User member) {
+    public CompletableFuture<Revision> removeMember(Author author, String projectName, User member) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(member, "member");
@@ -200,8 +199,8 @@ public class MetadataService extends AbstractService {
     /**
      * Updates a {@link ProjectRole} for the specified {@code member} in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> updateMemberRole(Author author, String projectName,
-                                                      User member, ProjectRole projectRole) {
+    public CompletableFuture<Revision> updateMemberRole(Author author, String projectName,
+                                                        User member, ProjectRole projectRole) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(member, "member");
@@ -220,7 +219,7 @@ public class MetadataService extends AbstractService {
      * Returns a {@link RepositoryMetadata} of the specified {@code repoName} in the specified
      * {@code projectName}.
      */
-    public CompletionStage<RepositoryMetadata> getRepo(String projectName, String repoName) {
+    public CompletableFuture<RepositoryMetadata> getRepo(String projectName, String repoName) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
 
@@ -231,7 +230,7 @@ public class MetadataService extends AbstractService {
      * Adds a {@link RepositoryMetadata} of the specified {@code repoName} to the specified {@code projectName}
      * with a default {@link PerRolePermissions}.
      */
-    public CompletionStage<Revision> addRepo(Author author, String projectName, String repoName) {
+    public CompletableFuture<Revision> addRepo(Author author, String projectName, String repoName) {
         return addRepo(author, projectName, repoName, PerRolePermissions.DEFAULT);
     }
 
@@ -239,8 +238,8 @@ public class MetadataService extends AbstractService {
      * Adds a {@link RepositoryMetadata} of the specified {@code repoName} to the specified {@code projectName}
      * with the specified {@link PerRolePermissions}.
      */
-    public CompletionStage<Revision> addRepo(Author author, String projectName, String repoName,
-                                             PerRolePermissions permission) {
+    public CompletableFuture<Revision> addRepo(Author author, String projectName, String repoName,
+                                               PerRolePermissions permission) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -274,7 +273,7 @@ public class MetadataService extends AbstractService {
      * Removes a {@link RepositoryMetadata} of the specified {@code repoName} from the specified
      * {@code projectName}.
      */
-    public CompletionStage<Revision> removeRepo(Author author, String projectName, String repoName) {
+    public CompletableFuture<Revision> removeRepo(Author author, String projectName, String repoName) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -293,7 +292,7 @@ public class MetadataService extends AbstractService {
      * Restores a {@link RepositoryMetadata} of the specified {@code repoName} in the specified
      * {@code projectName}.
      */
-    public CompletionStage<Revision> restoreRepo(Author author, String projectName, String repoName) {
+    public CompletableFuture<Revision> restoreRepo(Author author, String projectName, String repoName) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -310,9 +309,9 @@ public class MetadataService extends AbstractService {
      * Updates a {@link PerRolePermissions} of the specified {@code repoName} in the specified
      * {@code projectName}.
      */
-    public CompletionStage<Revision> updatePerRolePermissions(Author author,
-                                                              String projectName, String repoName,
-                                                              PerRolePermissions perRolePermissions) {
+    public CompletableFuture<Revision> updatePerRolePermissions(Author author,
+                                                                String projectName, String repoName,
+                                                                PerRolePermissions perRolePermissions) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -331,16 +330,16 @@ public class MetadataService extends AbstractService {
     /**
      * Adds the specified {@link Token} to the specified {@code projectName}.
      */
-    public CompletionStage<Revision> addToken(Author author, String projectName,
-                                              Token token, ProjectRole role) {
+    public CompletableFuture<Revision> addToken(Author author, String projectName,
+                                                Token token, ProjectRole role) {
         return addToken(author, projectName, requireNonNull(token, "token").appId(), role);
     }
 
     /**
      * Adds a {@link Token} of the specified {@code appId} to the specified {@code projectName}.
      */
-    public CompletionStage<Revision> addToken(Author author, String projectName,
-                                              String appId, ProjectRole role) {
+    public CompletableFuture<Revision> addToken(Author author, String projectName,
+                                                String appId, ProjectRole role) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(appId, "appId");
@@ -367,7 +366,7 @@ public class MetadataService extends AbstractService {
      * Removes the specified {@link Token} from the specified {@code projectName}. It also removes
      * every token permission belonging to the {@link Token} from every {@link RepositoryMetadata}.
      */
-    public CompletionStage<Revision> removeToken(Author author, String projectName, Token token) {
+    public CompletableFuture<Revision> removeToken(Author author, String projectName, Token token) {
         return removeToken(author, projectName, requireNonNull(token, "token").appId());
     }
 
@@ -375,7 +374,7 @@ public class MetadataService extends AbstractService {
      * Removes the {@link Token} of the specified {@code appId} from the specified {@code projectName}.
      * It also removes every token permission belonging to {@link Token} from every {@link RepositoryMetadata}.
      */
-    public CompletionStage<Revision> removeToken(Author author, String projectName, String appId) {
+    public CompletableFuture<Revision> removeToken(Author author, String projectName, String appId) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(appId, "appId");
@@ -383,8 +382,8 @@ public class MetadataService extends AbstractService {
         return removeToken(projectName, author, appId, false);
     }
 
-    private CompletionStage<Revision> removeToken(String projectName, Author author, String appId,
-                                                  boolean quiet) {
+    private CompletableFuture<Revision> removeToken(String projectName, Author author, String appId,
+                                                    boolean quiet) {
         final String commitSummary = "Remove the token '" + appId + "' from the project " + projectName;
         return metadataRepo.push(
                 projectName, METADATA_REPO, author, commitSummary,
@@ -410,8 +409,8 @@ public class MetadataService extends AbstractService {
     /**
      * Updates a {@link ProjectRole} for the {@link Token} of the specified {@code appId}.
      */
-    public CompletionStage<Revision> updateTokenRole(Author author, String projectName,
-                                                     Token token, ProjectRole role) {
+    public CompletableFuture<Revision> updateTokenRole(Author author, String projectName,
+                                                       Token token, ProjectRole role) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(token, "token");
@@ -433,9 +432,9 @@ public class MetadataService extends AbstractService {
      * Adds {@link Permission}s for the specified {@code member} to the specified {@code repoName}
      * in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> addPerUserPermission(Author author, String projectName,
-                                                          String repoName, User member,
-                                                          Collection<Permission> permission) {
+    public CompletableFuture<Revision> addPerUserPermission(Author author, String projectName,
+                                                            String repoName, User member,
+                                                            Collection<Permission> permission) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -455,8 +454,8 @@ public class MetadataService extends AbstractService {
      * Removes {@link Permission}s for the specified {@code member} from the specified {@code repoName}
      * in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> removePerUserPermission(Author author, String projectName,
-                                                             String repoName, User member) {
+    public CompletableFuture<Revision> removePerUserPermission(Author author, String projectName,
+                                                               String repoName, User member) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -473,9 +472,9 @@ public class MetadataService extends AbstractService {
      * Updates {@link Permission}s for the specified {@code member} of the specified {@code repoName}
      * in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> updatePerUserPermission(Author author, String projectName,
-                                                             String repoName, User member,
-                                                             Collection<Permission> permission) {
+    public CompletableFuture<Revision> updatePerUserPermission(Author author, String projectName,
+                                                               String repoName, User member,
+                                                               Collection<Permission> permission) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -493,9 +492,9 @@ public class MetadataService extends AbstractService {
      * Adds {@link Permission}s for the {@link Token} of the specified {@code appId} to the specified
      * {@code repoName} in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> addPerTokenPermission(Author author, String projectName,
-                                                           String repoName, String appId,
-                                                           Collection<Permission> permission) {
+    public CompletableFuture<Revision> addPerTokenPermission(Author author, String projectName,
+                                                             String repoName, String appId,
+                                                             Collection<Permission> permission) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -515,8 +514,8 @@ public class MetadataService extends AbstractService {
      * Removes {@link Permission}s for the {@link Token} of the specified {@code appId} from the specified
      * {@code repoName} in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> removePerTokenPermission(Author author, String projectName,
-                                                              String repoName, String appId) {
+    public CompletableFuture<Revision> removePerTokenPermission(Author author, String projectName,
+                                                                String repoName, String appId) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -532,9 +531,9 @@ public class MetadataService extends AbstractService {
      * Updates {@link Permission}s for the {@link Token} of the specified {@code appId} of the specified
      * {@code repoName} in the specified {@code projectName}.
      */
-    public CompletionStage<Revision> updatePerTokenPermission(Author author, String projectName,
-                                                              String repoName, String appId,
-                                                              Collection<Permission> permission) {
+    public CompletableFuture<Revision> updatePerTokenPermission(Author author, String projectName,
+                                                                String repoName, String appId,
+                                                                Collection<Permission> permission) {
         requireNonNull(author, "author");
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
@@ -550,10 +549,10 @@ public class MetadataService extends AbstractService {
     /**
      * Adds {@link Permission}s to the specified {@code path}.
      */
-    private CompletionStage<Revision> addPermissionAtPointer(Author author,
-                                                             String projectName, JsonPointer path,
-                                                             Collection<Permission> permission,
-                                                             String commitSummary) {
+    private CompletableFuture<Revision> addPermissionAtPointer(Author author,
+                                                               String projectName, JsonPointer path,
+                                                               Collection<Permission> permission,
+                                                               String commitSummary) {
         final Change<JsonNode> change =
                 Change.ofJsonPatch(METADATA_JSON,
                                    asJsonArray(new TestAbsenceOperation(path),
@@ -564,8 +563,8 @@ public class MetadataService extends AbstractService {
     /**
      * Removes {@link Permission}s from the specified {@code path}.
      */
-    private CompletionStage<Revision> removePermissionAtPointer(Author author, String projectName,
-                                                                JsonPointer path, String commitSummary) {
+    private CompletableFuture<Revision> removePermissionAtPointer(Author author, String projectName,
+                                                                  JsonPointer path, String commitSummary) {
         final Change<JsonNode> change = Change.ofJsonPatch(METADATA_JSON,
                                                            new RemoveOperation(path).toJsonNode());
         return metadataRepo.push(projectName, METADATA_REPO, author, commitSummary, change);
@@ -574,10 +573,10 @@ public class MetadataService extends AbstractService {
     /**
      * Replaces {@link Permission}s of the specified {@code path} with the specified {@code permission}.
      */
-    private CompletionStage<Revision> replacePermissionAtPointer(Author author,
-                                                                 String projectName, JsonPointer path,
-                                                                 Collection<Permission> permission,
-                                                                 String commitSummary) {
+    private CompletableFuture<Revision> replacePermissionAtPointer(Author author,
+                                                                   String projectName, JsonPointer path,
+                                                                   Collection<Permission> permission,
+                                                                   String commitSummary) {
         final Change<JsonNode> change =
                 Change.ofJsonPatch(METADATA_JSON,
                                    new ReplaceOperation(path, Jackson.valueToTree(permission)).toJsonNode());
@@ -588,8 +587,8 @@ public class MetadataService extends AbstractService {
      * Finds {@link Permission}s which belong to the specified {@link User} or {@link UserWithToken}
      * from the specified {@code repoName} in the specified {@code projectName}.
      */
-    public CompletionStage<Collection<Permission>> findPermissions(String projectName, String repoName,
-                                                                   User user) {
+    public CompletableFuture<Collection<Permission>> findPermissions(String projectName, String repoName,
+                                                                     User user) {
         requireNonNull(user, "user");
         if (user.isAdmin()) {
             return CompletableFuture.completedFuture(PerRolePermissions.ALL_PERMISSION);
@@ -605,8 +604,8 @@ public class MetadataService extends AbstractService {
      * Finds {@link Permission}s which belong to the specified {@code appId} from the specified
      * {@code repoName} in the specified {@code projectName}.
      */
-    public CompletionStage<Collection<Permission>> findPermissions(String projectName, String repoName,
-                                                                   String appId) {
+    public CompletableFuture<Collection<Permission>> findPermissions(String projectName, String repoName,
+                                                                     String appId) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(appId, "appId");
@@ -631,8 +630,8 @@ public class MetadataService extends AbstractService {
      * Finds {@link Permission}s which belong to the specified {@link User} from the specified
      * {@code repoName} in the specified {@code projectName}.
      */
-    private CompletionStage<Collection<Permission>> findPermissions0(String projectName, String repoName,
-                                                                     User user) {
+    private CompletableFuture<Collection<Permission>> findPermissions0(String projectName, String repoName,
+                                                                       User user) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(user, "user");
@@ -668,7 +667,7 @@ public class MetadataService extends AbstractService {
     /**
      * Finds a {@link ProjectRole} of the specified {@link User} in the specified {@code projectName}.
      */
-    public CompletionStage<ProjectRole> findRole(String projectName, User user) {
+    public CompletableFuture<ProjectRole> findRole(String projectName, User user) {
         requireNonNull(projectName, "projectName");
         requireNonNull(user, "user");
 
@@ -690,7 +689,7 @@ public class MetadataService extends AbstractService {
     /**
      * Returns a {@link Tokens}.
      */
-    public CompletionStage<Tokens> getTokens() {
+    public CompletableFuture<Tokens> getTokens() {
         return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
                         .thenApply(HolderWithRevision::object);
     }
@@ -699,7 +698,7 @@ public class MetadataService extends AbstractService {
      * Creates a new user-level {@link Token} with the specified {@code appId}. A secret for the {@code appId}
      * will be automatically generated.
      */
-    public CompletionStage<Revision> createToken(Author author, String appId) {
+    public CompletableFuture<Revision> createToken(Author author, String appId) {
         return createToken(author, appId, false);
     }
 
@@ -707,21 +706,22 @@ public class MetadataService extends AbstractService {
      * Creates a new {@link Token} with the specified {@code appId}, {@code isAdmin} and an auto-generated
      * secret.
      */
-    public CompletionStage<Revision> createToken(Author author, String appId, boolean isAdmin) {
+    public CompletableFuture<Revision> createToken(Author author, String appId, boolean isAdmin) {
         return createToken(author, appId, SECRET_PREFIX + UUID.randomUUID(), isAdmin);
     }
 
     /**
      * Creates a new user-level {@link Token} with the specified {@code appId} and {@code secret}.
      */
-    public CompletionStage<Revision> createToken(Author author, String appId, String secret) {
+    public CompletableFuture<Revision> createToken(Author author, String appId, String secret) {
         return createToken(author, appId, secret, false);
     }
 
     /**
      * Creates a new {@link Token} with the specified {@code appId}, {@code secret} and {@code isAdmin}.
      */
-    public CompletionStage<Revision> createToken(Author author, String appId, String secret, boolean isAdmin) {
+    public CompletableFuture<Revision> createToken(Author author, String appId, String secret,
+                                                   boolean isAdmin) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
         requireNonNull(secret, "secret");
@@ -745,7 +745,7 @@ public class MetadataService extends AbstractService {
     /**
      * Removes the {@link Token} of the specified {@code appId} completely from the system.
      */
-    public CompletionStage<Revision> destroyToken(Author author, String appId) {
+    public CompletableFuture<Revision> destroyToken(Author author, String appId) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
@@ -777,7 +777,7 @@ public class MetadataService extends AbstractService {
     /**
      * Activates the {@link Token} of the specified {@code appId}.
      */
-    public CompletionStage<Revision> activateToken(Author author, String appId) {
+    public CompletableFuture<Revision> activateToken(Author author, String appId) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
@@ -804,7 +804,7 @@ public class MetadataService extends AbstractService {
     /**
      * Deactivates the {@link Token} of the specified {@code appId}.
      */
-    public CompletionStage<Revision> deactivateToken(Author author, String appId) {
+    public CompletableFuture<Revision> deactivateToken(Author author, String appId) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
@@ -831,7 +831,7 @@ public class MetadataService extends AbstractService {
     /**
      * Returns a {@link Token} which has the specified {@code appId}.
      */
-    public CompletionStage<Token> findTokenByAppId(String appId) {
+    public CompletableFuture<Token> findTokenByAppId(String appId) {
         requireNonNull(appId, "appId");
         return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().get(appId));
@@ -840,7 +840,7 @@ public class MetadataService extends AbstractService {
     /**
      * Returns a {@link Token} which has the specified {@code secret}.
      */
-    public CompletionStage<Token> findTokenBySecret(String secret) {
+    public CompletableFuture<Token> findTokenBySecret(String secret) {
         requireNonNull(secret, "secret");
         validateSecret(secret);
         return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtil.java
@@ -192,7 +192,7 @@ public final class MigrationUtil {
     }
 
     private static Token migrateToken(LegacyToken legacyToken) {
-        return new Token(legacyToken.appId(), legacyToken.secret(),
+        return new Token(legacyToken.appId(), legacyToken.secret(), false,
                          new UserAndTimestamp(legacyToken.creator().email(), legacyToken.creationTime()));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/RepositoryUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/RepositoryUtil.java
@@ -59,27 +59,27 @@ final class RepositoryUtil<T> {
         return projectManager;
     }
 
-    CompletionStage<HolderWithRevision<T>> fetch(String projectName, String repoName, String path) {
+    CompletableFuture<HolderWithRevision<T>> fetch(String projectName, String repoName, String path) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         return fetch(projectManager().get(projectName).repos().get(repoName), path);
     }
 
-    CompletionStage<HolderWithRevision<T>> fetch(String projectName, String repoName, String path,
-                                                 Revision revision) {
+    CompletableFuture<HolderWithRevision<T>> fetch(String projectName, String repoName, String path,
+                                                   Revision revision) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(revision, "revision");
         return fetch(projectManager().get(projectName).repos().get(repoName), path, revision);
     }
 
-    CompletionStage<HolderWithRevision<T>> fetch(Repository repository, String path) {
+    CompletableFuture<HolderWithRevision<T>> fetch(Repository repository, String path) {
         requireNonNull(path, "path");
         final Revision revision = normalize(repository);
         return fetch(repository, path, revision);
     }
 
-    CompletionStage<HolderWithRevision<T>> fetch(Repository repository, String path, Revision revision) {
+    CompletableFuture<HolderWithRevision<T>> fetch(Repository repository, String path, Revision revision) {
         requireNonNull(repository, "repository");
         requireNonNull(path, "path");
         requireNonNull(revision, "revision");
@@ -88,13 +88,13 @@ final class RepositoryUtil<T> {
                          .thenApply((T obj) -> HolderWithRevision.of(obj, revision));
     }
 
-    CompletionStage<Revision> push(String projectName, String repoName,
-                                   Author author, String commitSummary, Change<?> change) {
+    CompletableFuture<Revision> push(String projectName, String repoName,
+                                     Author author, String commitSummary, Change<?> change) {
         return push(projectName, repoName, author, commitSummary, change, Revision.HEAD);
     }
 
-    CompletionStage<Revision> push(String projectName, String repoName,
-                                   Author author, String commitSummary, Change<?> change, Revision revision) {
+    CompletableFuture<Revision> push(String projectName, String repoName,
+                                     Author author, String commitSummary, Change<?> change, Revision revision) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(author, "author");
@@ -109,8 +109,8 @@ final class RepositoryUtil<T> {
                              Markup.PLAINTEXT, changes.values())));
     }
 
-    CompletionStage<Revision> push(String projectName, String repoName, Author author, String commitSummary,
-                                   Supplier<CompletionStage<HolderWithRevision<Change<?>>>> changeSupplier) {
+    CompletableFuture<Revision> push(String projectName, String repoName, Author author, String commitSummary,
+                                     Supplier<CompletionStage<HolderWithRevision<Change<?>>>> changeSupplier) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(author, "author");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/Token.java
@@ -21,6 +21,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -47,6 +48,11 @@ public class Token implements Identifiable {
     private final String secret;
 
     /**
+     * Specifies whether this token is for administrators.
+     */
+    private final boolean isAdmin;
+
+    /**
      * Specifies when this token is created by whom.
      */
     private final UserAndTimestamp creation;
@@ -57,23 +63,27 @@ public class Token implements Identifiable {
     @Nullable
     private final UserAndTimestamp deactivation;
 
-    Token(String appId, String secret, UserAndTimestamp creation) {
-        this(appId, secret, creation, null);
+    Token(String appId, String secret, boolean isAdmin, UserAndTimestamp creation) {
+        this(appId, secret, isAdmin, creation, null);
     }
 
     @JsonCreator
     public Token(@JsonProperty("appId") String appId,
                  @JsonProperty("secret") String secret,
+                 @JsonProperty("admin") boolean isAdmin,
                  @JsonProperty("creation") UserAndTimestamp creation,
                  @JsonProperty("deactivation") @Nullable UserAndTimestamp deactivation) {
         this.appId = Util.validateFileName(appId, "appId");
         this.secret = Util.validateFileName(secret, "secret");
+        this.isAdmin = isAdmin;
         this.creation = requireNonNull(creation, "creation");
         this.deactivation = deactivation;
     }
 
-    private Token(String appId, UserAndTimestamp creation, @Nullable UserAndTimestamp deactivation) {
+    private Token(String appId, boolean isAdmin, UserAndTimestamp creation,
+                  @Nullable UserAndTimestamp deactivation) {
         this.appId = Util.validateFileName(appId, "appId");
+        this.isAdmin = isAdmin;
         this.creation = requireNonNull(creation, "creation");
         this.deactivation = deactivation;
         secret = null;
@@ -95,6 +105,11 @@ public class Token implements Identifiable {
     }
 
     @JsonProperty
+    public boolean isAdmin() {
+        return isAdmin;
+    }
+
+    @JsonProperty
     public UserAndTimestamp creation() {
         return creation;
     }
@@ -105,6 +120,7 @@ public class Token implements Identifiable {
         return deactivation;
     }
 
+    @JsonIgnore
     public boolean isActive() {
         return deactivation == null;
     }
@@ -114,6 +130,7 @@ public class Token implements Identifiable {
         // Do not add "secret" to prevent it from logging.
         return MoreObjects.toStringHelper(this)
                           .add("appId", appId())
+                          .add("isAdmin", isAdmin())
                           .add("creation", creation())
                           .add("deactivation", deactivation())
                           .toString();
@@ -123,6 +140,6 @@ public class Token implements Identifiable {
      * Returns a new {@link Token} instance without its secret.
      */
     public Token withoutSecret() {
-        return new Token(appId(), creation(), deactivation());
+        return new Token(appId(), isAdmin(), creation(), deactivation());
     }
 }

--- a/server/src/main/resources/webapp/i18n/en.main.json
+++ b/server/src/main/resources/webapp/i18n/en.main.json
@@ -127,6 +127,7 @@
     "title_delete_token": "Delete the application token '{{token}}'?",
     "title_generate_token": "Generate a new application token",
     "title_token_generated": "Application token generated",
+    "token_admin_level": "Administrator-Level Token",
     "token_application_id": "Application ID",
     "token_application_id.exist": "Application ID '{{appId}}' exists. Please try a different ID again.",
     "token_application_id.placeholder": "Your application name",
@@ -135,6 +136,7 @@
     "token_deactivation_time": "Deactivated At",
     "token_deactivator": "Deactivated By",
     "token_forbidden": "No permission for {{action}}",
+    "token_level": "Level",
     "token_role": "Role",
     "token_secret": "Secret",
     "token_status": "Status"

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.generated.html
@@ -14,6 +14,15 @@
         <td>{{newToken.secret}}</td>
       </tr>
       <tr>
+        <td><span translate>settings.token_level</span></td>
+        <td>
+          <div ng-switch="token.admin">
+            <div ng-switch-when="true">Admin</div>
+            <div ng-switch-default>User</div>
+          </div>
+        </td>
+      </tr>
+      <tr>
         <td><span translate>settings.token_creator</span></td>
         <td>{{newToken.creation.user}}</td>
       </tr>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.controller.js
@@ -3,8 +3,10 @@
 angular.module('CentralDogmaAdmin').controller('TokenNewController',
   function ($scope, $timeout, $uibModal, $uibModalInstance, $filter, SettingsService, NotificationUtil) {
 
-    $scope.generateToken = function () {
-      var data = 'appId=' + encodeURIComponent($scope.appId);
+    $scope.isAdmin = false;
+
+    $scope.generateToken = function (isAdmin) {
+      var data = 'appId=' + encodeURIComponent($scope.appId) + '&isAdmin=' + isAdmin;
 
       SettingsService.createToken(data).then(function (token) {
         $scope.newToken = token;

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/token.new.html
@@ -1,4 +1,4 @@
-<form name="genTokenForm" ng-submit="generateToken()">
+<form name="genTokenForm" ng-submit="generateToken(isAdmin)">
 <div class="modal-header">
     <h4 class="modal-title" translate>settings.title_generate_token</h4>
   </div>
@@ -8,6 +8,10 @@
       <input type="text" class="form-control" id="appId"
              placeholder="{{ 'settings.token_application_id.placeholder' | translate }}" ng-model="appId"
              required>
+      <div has-role="LEVEL_ADMIN" class="pull-right">
+        <input type="checkbox" id="isAdminToken" ng-model="isAdmin">
+        <label for="isAdminToken" translate>settings.token_admin_level</label>
+      </div>
     </div>
   </div>
   <div class="modal-footer">

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -5,14 +5,25 @@
     <thead>
     <tr>
       <th><span translate>settings.token_application_id</span></th>
+      <th><span translate>settings.token_level</span></th>
       <th><span translate>settings.token_creator</span></th>
       <th><span translate>settings.token_creation_time</span></th>
       <th><span translate>settings.token_status</span></th>
+      <th has-role="LEVEL_ADMIN"><span translate>settings.token_secret</span></th>
     </tr>
     </thead>
     <tbody>
     <tr ng-repeat="token in tokens" ng-click="selectToken(token)" ng-class="{info: token === selectedToken}">
-      <td>{{token.appId}}</td>
+      <td>
+        {{token.appId}}
+        <p class="collapse" id="secret-{{token.appId}}">{{token.secret}}</p>
+      </td>
+      <td>
+        <div ng-switch="token.admin">
+          <div ng-switch-when="true">Admin</div>
+          <div ng-switch-default>User</div>
+        </div>
+      </td>
       <td>{{sanitizeEmail(token.creation.user)}}</td>
       <td>{{token.creationTimeStr}}</td>
       <td>
@@ -20,6 +31,10 @@
           <div ng-switch-when="true">Active</div>
           <div ng-switch-default>Inactive</div>
         </div>
+      </td>
+      <td has-role="LEVEL_ADMIN">
+        <p><a class="btn-xs" data-toggle="collapse" data-target="#secret-{{token.appId}}">
+          <span class="glyphicon glyphicon-circle-arrow-down"></span></a></p>
       </td>
     </tr>
     </tbody>

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -63,11 +63,11 @@ public class SerializationTest {
 
     @Test
     public void testValidProject() throws IOException {
-        final Member member = new Member("armeria@dogma.org", ProjectRole.MEMBER,
-                                         newCreationTag());
+        final String userLogin = "armeria@dogma.org";
+        final Member member = new Member(userLogin, ProjectRole.MEMBER, newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.DEFAULT);
-        final Token token = new Token("testApp", "testSecret", newCreationTag(), null);
+        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),
@@ -127,7 +127,7 @@ public class SerializationTest {
         assertThat(obj.name()).isEqualTo("test");
         assertThat(obj.repos().size()).isOne();
         assertThat(obj.members().size()).isOne();
-        //assertThat(obj.members().get(0).role()).isEqualTo(ProjectRole.MEMBER);
+        assertThat(obj.members().get(userLogin).role()).isEqualTo(ProjectRole.MEMBER);
         assertThat(obj.tokens().size()).isOne();
         assertThat(obj.creation()).isNotNull();
         assertThat(obj.creation().user()).isEqualTo("editor@dogma.org");
@@ -141,7 +141,7 @@ public class SerializationTest {
                                          newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.DEFAULT);
-        final Token token = new Token("testApp", "testSecret", newCreationTag(), null);
+        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -60,34 +60,34 @@ public class TokenServiceTest {
     @Test
     public void adminToken() {
         assertThat(tokenService.createToken("forAdmin1", true, adminAuthor, admin)
-                               .toCompletableFuture().join().object().isActive()).isTrue();
+                               .join().object().isActive()).isTrue();
         assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor, guest)
-                                             .toCompletableFuture().join())
+                                             .join())
                 .isInstanceOf(IllegalArgumentException.class);
 
-        final Collection<Token> tokens = tokenService.listTokens(admin).toCompletableFuture().join();
+        final Collection<Token> tokens = tokenService.listTokens(admin).join();
         assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
                 .isEqualTo(1);
 
         assertThatThrownBy(() -> tokenService.deleteToken("forAdmin1", guestAuthor, guest)
-                                             .toCompletableFuture().join())
+                                             .join())
                 .hasCauseInstanceOf(HttpStatusException.class);
 
-        assertThat(tokenService.deleteToken("forAdmin1", adminAuthor, admin).toCompletableFuture().join());
+        assertThat(tokenService.deleteToken("forAdmin1", adminAuthor, admin).join());
     }
 
     @Test
     public void userToken() {
         assertThat(tokenService.createToken("forUser1", false, adminAuthor, admin)
-                               .toCompletableFuture().join().object().isActive()).isTrue();
+                               .join().object().isActive()).isTrue();
         assertThat(tokenService.createToken("forUser2", false, guestAuthor, guest)
-                               .toCompletableFuture().join().object().isActive()).isTrue();
+                               .join().object().isActive()).isTrue();
 
-        final Collection<Token> tokens = tokenService.listTokens(guest).toCompletableFuture().join();
+        final Collection<Token> tokens = tokenService.listTokens(guest).join();
         assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
                 .isEqualTo(0);
 
-        assertThat(tokenService.deleteToken("forUser1", adminAuthor, admin).toCompletableFuture().join());
-        assertThat(tokenService.deleteToken("forUser2", guestAuthor, guest).toCompletableFuture().join());
+        assertThat(tokenService.deleteToken("forUser1", adminAuthor, admin).join());
+        assertThat(tokenService.deleteToken("forUser2", guestAuthor, guest).join());
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collection;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.metadata.MetadataService;
+import com.linecorp.centraldogma.server.internal.metadata.MigrationUtil;
+import com.linecorp.centraldogma.server.internal.metadata.Token;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerRule;
+
+import io.netty.util.internal.StringUtil;
+
+public class TokenServiceTest {
+
+    @ClassRule
+    public static final ProjectManagerRule rule = new ProjectManagerRule() {
+        @Override
+        protected void afterExecutorStarted() {
+            MigrationUtil.migrate(projectManager(), executor());
+        }
+    };
+
+    private static final Author adminAuthor = new Author("admin@localhost.com");
+    private static final Author guestAuthor = new Author("guest@localhost.com");
+    private static final User admin = new User("admin@localhost.com", User.LEVEL_ADMIN);
+    private static final User guest = new User("guest@localhost.com");
+
+    private static TokenService tokenService;
+
+    @BeforeClass
+    public static void beforeClass() {
+        tokenService = new TokenService(rule.projectManager(), rule.executor(),
+                                        new MetadataService(rule.projectManager(), rule.executor()));
+    }
+
+    @Test
+    public void adminToken() {
+        assertThat(tokenService.createToken("forAdmin1", true, adminAuthor, admin)
+                               .toCompletableFuture().join().object().isActive()).isTrue();
+        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor, guest)
+                                             .toCompletableFuture().join())
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final Collection<Token> tokens = tokenService.listTokens(admin).toCompletableFuture().join();
+        assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
+                .isEqualTo(1);
+
+        assertThatThrownBy(() -> tokenService.deleteToken("forAdmin1", guestAuthor, guest)
+                                             .toCompletableFuture().join())
+                .hasCauseInstanceOf(HttpStatusException.class);
+
+        assertThat(tokenService.deleteToken("forAdmin1", adminAuthor, admin).toCompletableFuture().join());
+    }
+
+    @Test
+    public void userToken() {
+        assertThat(tokenService.createToken("forUser1", false, adminAuthor, admin)
+                               .toCompletableFuture().join().object().isActive()).isTrue();
+        assertThat(tokenService.createToken("forUser2", false, guestAuthor, guest)
+                               .toCompletableFuture().join().object().isActive()).isTrue();
+
+        final Collection<Token> tokens = tokenService.listTokens(guest).toCompletableFuture().join();
+        assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
+                .isEqualTo(0);
+
+        assertThat(tokenService.deleteToken("forUser1", adminAuthor, admin).toCompletableFuture().join());
+        assertThat(tokenService.deleteToken("forUser2", guestAuthor, guest).toCompletableFuture().join());
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
@@ -38,8 +38,7 @@ public class MetadataServiceTest {
     @Rule
     public final ProjectManagerRule rule = new ProjectManagerRule() {
         @Override
-        protected void initialize() {
-            super.initialize();
+        protected void afterExecutorStarted() {
             MigrationUtil.migrate(projectManager(), executor());
             // Create a project and its metadata here.
             executor().execute(Command.createProject(author, project1)).toCompletableFuture().join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
@@ -41,7 +41,7 @@ public class MetadataServiceTest {
         protected void afterExecutorStarted() {
             MigrationUtil.migrate(projectManager(), executor());
             // Create a project and its metadata here.
-            executor().execute(Command.createProject(author, project1)).toCompletableFuture().join();
+            executor().execute(Command.createProject(author, project1)).join();
         }
     };
 
@@ -63,10 +63,10 @@ public class MetadataServiceTest {
         final MetadataService mds = newMetadataService(rule);
 
         ProjectMetadata metadata;
-        metadata = mds.getProject(project1).toCompletableFuture().join();
+        metadata = mds.getProject(project1).join();
 
         assertThatThrownBy(() -> rule.executor().execute(Command.createProject(author, project1))
-                                     .toCompletableFuture().join())
+                                     .join())
                 .hasCauseInstanceOf(ProjectExistsException.class);
 
         assertThat(metadata.name()).isEqualTo(project1);
@@ -74,8 +74,8 @@ public class MetadataServiceTest {
         assertThat(metadata.removal()).isNull();
 
         // Remove a project and check whether the project is removed.
-        mds.removeProject(author, project1).toCompletableFuture().join();
-        metadata = mds.getProject(project1).toCompletableFuture().join();
+        mds.removeProject(author, project1).join();
+        metadata = mds.getProject(project1).join();
 
         assertThat(metadata.name()).isEqualTo(project1);
         assertThat(metadata.creation().user()).isEqualTo(author.email());
@@ -83,8 +83,8 @@ public class MetadataServiceTest {
         assertThat(metadata.removal().user()).isEqualTo(author.email());
 
         // Restore the removed project.
-        mds.restoreProject(author, project1).toCompletableFuture().join();
-        assertThat(mds.getProject(project1).toCompletableFuture().join().removal()).isNull();
+        mds.restoreProject(author, project1).join();
+        assertThat(mds.getProject(project1).join().removal()).isNull();
     }
 
     @Test
@@ -93,19 +93,19 @@ public class MetadataServiceTest {
 
         ProjectMetadata metadata;
         RepositoryMetadata repositoryMetadata;
-        metadata = mds.getProject(project1).toCompletableFuture().join();
+        metadata = mds.getProject(project1).join();
         assertThat(metadata).isNotNull();
 
-        mds.addRepo(author, project1, repo1, PerRolePermissions.ofPublic()).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, PerRolePermissions.ofPublic()).join();
         assertThat(getProject(mds, project1).repos().get(repo1).name()).isEqualTo(repo1);
 
         // Fail due to duplicated addition.
-        assertThatThrownBy(() -> mds.addRepo(author, project1, repo1).toCompletableFuture().join())
+        assertThatThrownBy(() -> mds.addRepo(author, project1, repo1).join())
                 .hasCauseInstanceOf(RepositoryExistsException.class);
 
         // Remove a repository.
-        mds.removeRepo(author, project1, repo1).toCompletableFuture().join();
-        assertThatThrownBy(() -> mds.removeRepo(author, project1, repo1).toCompletableFuture().join())
+        mds.removeRepo(author, project1, repo1).join();
+        assertThatThrownBy(() -> mds.removeRepo(author, project1, repo1).join())
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
         repositoryMetadata = getRepo1(mds);
@@ -115,7 +115,7 @@ public class MetadataServiceTest {
         assertThat(repositoryMetadata.removal().user()).isEqualTo(author.email());
 
         // Restore the removed repository.
-        mds.restoreRepo(author, project1, repo1).toCompletableFuture().join();
+        mds.restoreRepo(author, project1, repo1).join();
 
         repositoryMetadata = getRepo1(mds);
         assertThat(repositoryMetadata.name()).isEqualTo(repo1);
@@ -129,10 +129,10 @@ public class MetadataServiceTest {
 
         ProjectMetadata metadata;
         RepositoryMetadata repositoryMetadata;
-        metadata = mds.getProject(project1).toCompletableFuture().join();
+        metadata = mds.getProject(project1).join();
         assertThat(metadata).isNotNull();
 
-        mds.addRepo(author, project1, repo1, PerRolePermissions.ofPublic()).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, PerRolePermissions.ofPublic()).join();
 
         repositoryMetadata = getRepo1(mds);
         assertThat(repositoryMetadata.perRolePermissions().owner()).containsExactly(Permission.READ,
@@ -142,8 +142,7 @@ public class MetadataServiceTest {
         assertThat(repositoryMetadata.perRolePermissions().guest()).containsExactly(Permission.READ,
                                                                                     Permission.WRITE);
 
-        mds.updatePerRolePermissions(author, project1, repo1, PerRolePermissions.ofPrivate())
-           .toCompletableFuture().join();
+        mds.updatePerRolePermissions(author, project1, repo1, PerRolePermissions.ofPrivate()).join();
 
         repositoryMetadata = getRepo1(mds);
         assertThat(repositoryMetadata.perRolePermissions().owner()).containsExactly(Permission.READ,
@@ -153,9 +152,9 @@ public class MetadataServiceTest {
         assertThat(repositoryMetadata.perRolePermissions().guest())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
-        assertThat(mds.findPermissions(project1, repo1, owner).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, owner).join())
                 .containsExactly(Permission.READ, Permission.WRITE);
-        assertThat(mds.findPermissions(project1, repo1, guest).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, guest).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
     }
 
@@ -163,42 +162,39 @@ public class MetadataServiceTest {
     public void perUserPermissions() throws Exception {
         final MetadataService mds = newMetadataService(rule);
 
-        mds.addRepo(author, project1, repo1, ownerOnly).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, ownerOnly).join();
 
         // Not a member yet.
-        assertThatThrownBy(() -> mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY)
-                                    .toCompletableFuture().join())
+        assertThatThrownBy(() -> mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY).join())
                 .hasCauseInstanceOf(IllegalArgumentException.class);
 
         // Be a member of the project.
-        mds.addMember(author, project1, user1, ProjectRole.MEMBER).toCompletableFuture().join();
+        mds.addMember(author, project1, user1, ProjectRole.MEMBER).join();
 
         // A member of the project has no permission.
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
         // Add 'user1' to per-user permissions table.
-        mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY)
-           .toCompletableFuture().join();
+        mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY).join();
+
         // Fail due to duplicated addition.
-        assertThatThrownBy(() -> mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY)
-                                    .toCompletableFuture().join())
+        assertThatThrownBy(() -> mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY).join())
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactly(Permission.READ);
 
-        mds.updatePerUserPermission(author, project1, repo1, user1, READ_WRITE).toCompletableFuture().join();
+        mds.updatePerUserPermission(author, project1, repo1, user1, READ_WRITE).join();
 
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactly(Permission.READ, Permission.WRITE);
 
-        mds.removePerUserPermission(author, project1, repo1, user1).toCompletableFuture().join();
-        assertThatThrownBy(() -> mds.removePerUserPermission(author, project1, repo1, user1)
-                                    .toCompletableFuture().join())
+        mds.removePerUserPermission(author, project1, repo1, user1).join();
+        assertThatThrownBy(() -> mds.removePerUserPermission(author, project1, repo1, user1).join())
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
     }
 
@@ -206,44 +202,39 @@ public class MetadataServiceTest {
     public void perTokenPermissions() throws Exception {
         final MetadataService mds = newMetadataService(rule);
 
-        mds.addRepo(author, project1, repo1, ownerOnly).toCompletableFuture().join();
-        mds.createToken(author, app1).toCompletableFuture().join();
-        final Token token = mds.findTokenByAppId(app1).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, ownerOnly).join();
+        mds.createToken(author, app1).join();
+        final Token token = mds.findTokenByAppId(app1).join();
         assertThat(token).isNotNull();
 
         // Token 'app2' is not created yet.
-        assertThatThrownBy(() -> mds.addToken(author, project1, app2, ProjectRole.MEMBER)
-                                    .toCompletableFuture().join())
+        assertThatThrownBy(() -> mds.addToken(author, project1, app2, ProjectRole.MEMBER).join())
                 .hasCauseInstanceOf(IllegalArgumentException.class);
 
         // Not a member yet.
-        assertThatThrownBy(() -> mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY)
-                                    .toCompletableFuture().join())
+        assertThatThrownBy(() -> mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).join())
                 .hasCauseInstanceOf(IllegalArgumentException.class);
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
         // Be a token of the project.
-        mds.addToken(author, project1, app1, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY)
-           .toCompletableFuture().join();
+        mds.addToken(author, project1, app1, ProjectRole.MEMBER).join();
+        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).join();
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactly(Permission.READ);
 
-        mds.updatePerTokenPermission(author, project1, repo1, app1, READ_WRITE)
-           .toCompletableFuture().join();
+        mds.updatePerTokenPermission(author, project1, repo1, app1, READ_WRITE).join();
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactly(Permission.READ, Permission.WRITE);
 
-        mds.removePerTokenPermission(author, project1, repo1, app1).toCompletableFuture().join();
-        assertThatThrownBy(() -> mds.removePerTokenPermission(author, project1, repo1, app1)
-                                    .toCompletableFuture().join())
+        mds.removePerTokenPermission(author, project1, repo1, app1).join();
+        assertThatThrownBy(() -> mds.removePerTokenPermission(author, project1, repo1, app1).join())
                 .hasCauseInstanceOf(ChangeConflictException.class);
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
     }
 
@@ -251,26 +242,26 @@ public class MetadataServiceTest {
     public void removeMember() throws Exception {
         final MetadataService mds = newMetadataService(rule);
 
-        mds.addRepo(author, project1, repo1, ownerOnly).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, ownerOnly).join();
 
-        mds.addMember(author, project1, user1, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addMember(author, project1, user2, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY).toCompletableFuture().join();
-        mds.addPerUserPermission(author, project1, repo1, user2, READ_ONLY).toCompletableFuture().join();
+        mds.addMember(author, project1, user1, ProjectRole.MEMBER).join();
+        mds.addMember(author, project1, user2, ProjectRole.MEMBER).join();
+        mds.addPerUserPermission(author, project1, repo1, user1, READ_ONLY).join();
+        mds.addPerUserPermission(author, project1, repo1, user2, READ_ONLY).join();
 
-        assertThat(mds.getMember(project1, user1).toCompletableFuture().join().id()).isNotNull();
-        assertThat(mds.getMember(project1, user2).toCompletableFuture().join().id()).isNotNull();
+        assertThat(mds.getMember(project1, user1).join().id()).isNotNull();
+        assertThat(mds.getMember(project1, user2).join().id()).isNotNull();
 
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactly(Permission.READ);
 
         // Remove 'user1' from the project.
-        mds.removeMember(author, project1, user1).toCompletableFuture().join();
+        mds.removeMember(author, project1, user1).join();
         // Remove per-user permission of 'user1', too.
-        assertThat(mds.findPermissions(project1, repo1, user1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
-        assertThat(mds.findPermissions(project1, repo1, user2).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, user2).join())
                 .containsExactly(Permission.READ);
     }
 
@@ -278,25 +269,25 @@ public class MetadataServiceTest {
     public void removeToken() throws Exception {
         final MetadataService mds = newMetadataService(rule);
 
-        mds.addRepo(author, project1, repo1, ownerOnly).toCompletableFuture().join();
-        mds.createToken(author, app1).toCompletableFuture().join();
-        mds.createToken(author, app2).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, ownerOnly).join();
+        mds.createToken(author, app1).join();
+        mds.createToken(author, app2).join();
 
-        mds.addToken(author, project1, app1, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addToken(author, project1, app2, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).toCompletableFuture().join();
-        mds.addPerTokenPermission(author, project1, repo1, app2, READ_ONLY).toCompletableFuture().join();
+        mds.addToken(author, project1, app1, ProjectRole.MEMBER).join();
+        mds.addToken(author, project1, app2, ProjectRole.MEMBER).join();
+        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).join();
+        mds.addPerTokenPermission(author, project1, repo1, app2, READ_ONLY).join();
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactly(Permission.READ);
 
         // Remove 'app1' from the project.
-        mds.removeToken(author, project1, app1).toCompletableFuture().join();
+        mds.removeToken(author, project1, app1).join();
         // Remove per-token permission of 'app1', too.
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
-        assertThat(mds.findPermissions(project1, repo1, app2).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app2).join())
                 .containsExactly(Permission.READ);
     }
 
@@ -304,27 +295,27 @@ public class MetadataServiceTest {
     public void destroyToken() throws Exception {
         final MetadataService mds = newMetadataService(rule);
 
-        mds.addRepo(author, project1, repo1, ownerOnly).toCompletableFuture().join();
-        mds.createToken(author, app1).toCompletableFuture().join();
-        mds.createToken(author, app2).toCompletableFuture().join();
+        mds.addRepo(author, project1, repo1, ownerOnly).join();
+        mds.createToken(author, app1).join();
+        mds.createToken(author, app2).join();
 
-        mds.addToken(author, project1, app1, ProjectRole.MEMBER).toCompletableFuture().join();
-        mds.addToken(author, project1, app2, ProjectRole.MEMBER).toCompletableFuture().join();
+        mds.addToken(author, project1, app1, ProjectRole.MEMBER).join();
+        mds.addToken(author, project1, app2, ProjectRole.MEMBER).join();
 
-        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).toCompletableFuture().join();
-        mds.addPerTokenPermission(author, project1, repo1, app2, READ_ONLY).toCompletableFuture().join();
+        mds.addPerTokenPermission(author, project1, repo1, app1, READ_ONLY).join();
+        mds.addPerTokenPermission(author, project1, repo1, app2, READ_ONLY).join();
 
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactly(Permission.READ);
 
         // Remove 'app1' from the system completely.
-        mds.destroyToken(author, app1).toCompletableFuture().join();
+        mds.destroyToken(author, app1).join();
 
         // Remove per-token permission of 'app1', too.
-        assertThat(mds.findPermissions(project1, repo1, app1).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app1).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
-        assertThat(mds.findPermissions(project1, repo1, app2).toCompletableFuture().join())
+        assertThat(mds.findPermissions(project1, repo1, app2).join())
                 .containsExactly(Permission.READ);
     }
 
@@ -333,22 +324,22 @@ public class MetadataServiceTest {
         final MetadataService mds = newMetadataService(rule);
 
         Token token;
-        mds.createToken(author, app1).toCompletableFuture().join();
-        token = mds.getTokens().toCompletableFuture().join().get(app1);
+        mds.createToken(author, app1).join();
+        token = mds.getTokens().join().get(app1);
         assertThat(token).isNotNull();
         assertThat(token.creation().user()).isEqualTo(owner.id());
 
-        mds.deactivateToken(author, app1).toCompletableFuture().join();
-        token = mds.getTokens().toCompletableFuture().join().get(app1);
+        mds.deactivateToken(author, app1).join();
+        token = mds.getTokens().join().get(app1);
         assertThat(token.isActive()).isFalse();
         assertThat(token.deactivation().user()).isEqualTo(owner.id());
 
-        mds.activateToken(author, app1).toCompletableFuture().join();
-        assertThat(mds.getTokens().toCompletableFuture().join().get(app1).isActive()).isTrue();
+        mds.activateToken(author, app1).join();
+        assertThat(mds.getTokens().join().get(app1).isActive()).isTrue();
     }
 
     private static RepositoryMetadata getRepo1(MetadataService mds) {
-        final ProjectMetadata metadata = mds.getProject(project1).toCompletableFuture().join();
+        final ProjectMetadata metadata = mds.getProject(project1).join();
         return metadata.repo(repo1);
     }
 
@@ -357,6 +348,6 @@ public class MetadataServiceTest {
     }
 
     private ProjectMetadata getProject(MetadataService mds, String projectName) {
-        return mds.getProject(projectName).toCompletableFuture().join();
+        return mds.getProject(projectName).join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
@@ -77,7 +77,7 @@ public class MigrationUtilTest {
         // There is no legacy tokens.
         MigrationUtil.migrate(pm, executor);
 
-        final Tokens tokens1 = mds.getTokens().toCompletableFuture().join();
+        final Tokens tokens1 = mds.getTokens().join();
         assertThat(tokens1.appIds().isEmpty()).isTrue();
         assertThat(tokens1.secrets().isEmpty()).isTrue();
     }
@@ -111,15 +111,15 @@ public class MigrationUtilTest {
             // Try to migrate again at the second time. The result should be the same as before.
             MigrationUtil.migrate(pm, executor);
 
-            final Tokens tokens2 = mds.getTokens().toCompletableFuture().join();
+            final Tokens tokens2 = mds.getTokens().join();
             assertThat(tokens2.appIds().size()).isEqualTo(2);
             assertThat(tokens2.appIds().get("app1").secret()).isEqualTo(legacyToken1.secret());
             assertThat(tokens2.appIds().get("app2").secret()).isEqualTo(legacyToken2.secret());
 
             final List<ProjectMetadata> metadataList = ImmutableList.of(
-                    mds.getProject("legacyProject1").toCompletableFuture().join(),
-                    mds.getProject("legacyProject2").toCompletableFuture().join(),
-                    mds.getProject("legacyProject3").toCompletableFuture().join());
+                    mds.getProject("legacyProject1").join(),
+                    mds.getProject("legacyProject2").join(),
+                    mds.getProject("legacyProject3").join());
 
             for (final ProjectMetadata m : metadataList) {
                 assertThat(m.tokens().size()).isEqualTo(2);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
@@ -58,8 +58,8 @@ public class MigrationUtilTest {
     @Rule
     public final ProjectManagerRule rule = new ProjectManagerRule() {
         @Override
-        protected CommandExecutor configureCommandExecutor(ProjectManager projectManager,
-                                                           Executor worker) {
+        protected CommandExecutor newCommandExecutor(ProjectManager projectManager,
+                                                     Executor worker) {
             return new LegacyProjectInitializingCommandExecutor(
                     new StandaloneCommandExecutor(projectManager, null, worker));
         }

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerRule.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerRule.java
@@ -72,9 +72,9 @@ public class ProjectManagerRule extends TemporaryFolder {
     protected final void before() throws Throwable {
         super.before();
 
-        final Executor worker = configureWorker();
-        projectManager = configureProjectManager(worker);
-        executor = configureCommandExecutor(projectManager, worker);
+        final Executor worker = newWorker();
+        projectManager = newProjectManager(worker);
+        executor = newCommandExecutor(projectManager, worker);
 
         executor.start(null, null);
         ProjectInitializer.initializeInternalProject(executor);
@@ -90,14 +90,14 @@ public class ProjectManagerRule extends TemporaryFolder {
     /**
      * Override this method to customize an {@link Executor}.
      */
-    protected Executor configureWorker() {
+    protected Executor newWorker() {
         return ForkJoinPool.commonPool();
     }
 
     /**
      * Override this method to customize a {@link ProjectManager}.
      */
-    protected ProjectManager configureProjectManager(Executor worker) {
+    protected ProjectManager newProjectManager(Executor worker) {
         try {
             return new DefaultProjectManager(newFolder(), worker, null);
         } catch (Exception e) {
@@ -109,7 +109,7 @@ public class ProjectManagerRule extends TemporaryFolder {
     /**
      * Override this method to customize a {@link CommandExecutor}.
      */
-    protected CommandExecutor configureCommandExecutor(ProjectManager projectManager, Executor worker) {
+    protected CommandExecutor newCommandExecutor(ProjectManager projectManager, Executor worker) {
         return new ProjectInitializingCommandExecutor(
                 new StandaloneCommandExecutor(projectManager, null, worker));
     }

--- a/testing/src/main/java/com/linecorp/centraldogma/testing/CentralDogmaRule.java
+++ b/testing/src/main/java/com/linecorp/centraldogma/testing/CentralDogmaRule.java
@@ -37,7 +37,7 @@ import io.netty.util.NetUtil;
  * <pre>{@code
  * > public class MyTest {
  * >     @ClassRule
- * >     public final CentralDogmaRule rule = new CentralDogmaRule();
+ * >     public static final CentralDogmaRule rule = new CentralDogmaRule();
  * >
  * >     @Test
  * >     public void test() throws Exception {


### PR DESCRIPTION
Modifications:
- Add `AdministratorsOnly` decorator to `/api/v1/status` update API.
- Add `admin` property to `Token` class to specify administrator-level application token.
- (Web UI) Add a checkbox to create administrator-level application token.
- (Web UI) Add a button to show the secret of an application token for administrators.