### PR TITLE
Fix a condition to do not create duplicated armeriaClient

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/client/java-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,1 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.linecorp.centraldogma.client.spring.CentralDogmaConfiguration
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfiguration

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaAutoConfigurationTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaAutoConfigurationTest.java
@@ -31,7 +31,7 @@ import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.spring.CentralDogmaAutoConfigurationTest.TestConfiguration;
-import com.linecorp.centraldogma.client.spring.CentralDogmaConfiguration.ForCentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfiguration.ForCentralDogma;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationTest.java
@@ -28,14 +28,14 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaConfigurationTest.TestConfiguration;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationTest.TestConfiguration;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "confTest" })
-public class CentralDogmaConfigurationTest {
+public class CentralDogmaClientAutoConfigurationTest {
     @Configuration
-    @Import(CentralDogmaConfiguration.class)
+    @Import(CentralDogmaClientAutoConfiguration.class)
     public static class TestConfiguration {
     }
 

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
@@ -31,13 +31,13 @@ import org.springframework.test.context.junit4.SpringRunner;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.ClientFactoryBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaConfiguration.ForCentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaConfigurationWithClientFactoryTest.TestConfiguration;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfiguration.ForCentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithClientFactoryTest.TestConfiguration;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "confTest" })
-public class CentralDogmaConfigurationWithClientFactoryTest {
+public class CentralDogmaClientAutoConfigurationWithClientFactoryTest {
     @SpringBootApplication
     public static class TestConfiguration {
         private static final ClientFactory dogmaClientFactory = new ClientFactoryBuilder().build();


### PR DESCRIPTION
Motivations:

`CentralDogmaConfiguration` always creates `clientFactory` bean due to
the missing condition checking when retrieved `methodMetadata` is not a type of `StandardMethodMetadata `

Modifications:

- Rename to `CentralDogmaClientAutoConfiguration`
- Move the configuration condition
- Rename `armeriaClientFactory` to avoid bean overriding due to the
common name

Result:

- Do not duplicate `@ForCentralDogma` annotated armeria client factory
- Easy to understand the role of the configuration class
- Enable to load the configuration context when it is necessary only