### PR TITLE
Add /api/v1/login and /api/v1/logout

### DIFF
--- a/client/go/dogma/dogma.go
+++ b/client/go/dogma/dogma.go
@@ -56,10 +56,9 @@ const (
 	defaultBaseURL  = defaultScheme + "://" + defaultHostName + ":36462/"
 
 	defaultPathPrefix = "api/v1/"
-	v0PathPrefix      = "api/v0/"
 
 	pathSecurityEnabled = "security_enabled"
-	pathAuthenticate    = v0PathPrefix + "authenticate"
+	pathLogin           = defaultPathPrefix + "login"
 )
 
 // A Client communicates with the Central Dogma server API.
@@ -85,7 +84,7 @@ func NewClient(baseURL, username, password string) (*Client, error) {
 		return nil, err
 	}
 
-	config := oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: normalizedURL.String() + pathAuthenticate}}
+	config := oauth2.Config{Endpoint: oauth2.Endpoint{TokenURL: normalizedURL.String() + pathLogin}}
 	token, err := config.PasswordCredentialsToken(context.Background(), username, password)
 	if err != nil {
 		return nil, err

--- a/client/go/dogma/dogma_test.go
+++ b/client/go/dogma/dogma_test.go
@@ -79,7 +79,7 @@ func TestNewClient(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	mux.HandleFunc("/api/v0/authenticate", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/login", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 		r.ParseForm()
 		testString(t, r.PostForm.Get("grant_type"), "password", "grant_type")

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/authentication/LoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/authentication/LoginAndLogoutTest.java
@@ -54,7 +54,7 @@ public class LoginAndLogoutTest {
     static AggregatedHttpMessage login(CentralDogmaRule rule, String username, String password) {
         return rule.httpClient().execute(
                 HttpHeaders.of(HttpHeaderNames.METHOD, "POST",
-                               HttpHeaderNames.PATH, "/api/v0/authenticate",
+                               HttpHeaderNames.PATH, "/api/v1/login",
                                HttpHeaderNames.CONTENT_TYPE, MediaType.FORM_DATA.toString()),
                 "grant_type=password&username=" + username + "&password=" + password,
                 StandardCharsets.US_ASCII).aggregate().join();
@@ -64,7 +64,7 @@ public class LoginAndLogoutTest {
             CentralDogmaRule rule, String username, String password) {
         return rule.httpClient().execute(
                 HttpHeaders.of(HttpHeaderNames.METHOD, "POST",
-                               HttpHeaderNames.PATH, "/api/v0/authenticate",
+                               HttpHeaderNames.PATH, "/api/v1/login",
                                HttpHeaderNames.AUTHORIZATION, "basic " + encoder.encodeToString(
                                        (USERNAME + ':' + PASSWORD).getBytes(StandardCharsets.US_ASCII))))
                    .aggregate().join();
@@ -73,7 +73,7 @@ public class LoginAndLogoutTest {
     static AggregatedHttpMessage logout(CentralDogmaRule rule, String sessionId) {
         return rule.httpClient().execute(
                 HttpHeaders.of(HttpHeaderNames.METHOD, "POST",
-                               HttpHeaderNames.PATH, "/api/v0/logout",
+                               HttpHeaderNames.PATH, "/api/v1/logout",
                                HttpHeaderNames.AUTHORIZATION,
                                "bearer " + sessionId)).aggregate().join();
     }


### PR DESCRIPTION
Motivation:

The login/logout API is currently only under /api/v0. We should provide
same service under /api/v1, so we can remove /api/v0 later.

Modifiations:

Bind login/logout service at /api/v1/login and /api/v1/logout as well.

Result:

Easier to drop the old HTTP API