### PR TITLE
Do not exclude net.minidev:json-smart from dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -59,8 +59,6 @@ com.googlecode.java-diff-utils:
 com.jayway.jsonpath:
   json-path: 
     version: '2.2.0'
-    exclusions:
-    - net.minidev:json-smart
     relocations:
     - from: com.jayway.jsonpath
       to:   com.linecorp.centraldogma.internal.shaded.jsonpath


### PR DESCRIPTION
Motivation:

Spring's JsonProjectingMethodInterceptorFactory triggers jsonpath's
JsonSmartMappingProvider and JsonSmartJsonProvider to be loaded by JVM.

Because we excluded json-smart from our dependencies, a user will
encounter a NoClassDefFoundError.

A user could load our class 'Jackson', which practically prevents the
smart-json classes from being loaded, but it has the following problems:

- A user may not like what our class 'Jackson' does, which changes the
  default configuration of jsonpath.
- A user has to trigger our class 'Jackson' is loaded explicitly, which
  is not user-friendly.

Modifications:

- Remove the exclusion of smart-json
- Override the default configuration of jsonpath only when jsonpath is
  shaded

Result:

- centraldogma-common works well with other software, shaded or not shaded