### PR TITLE
Do not create the 'main' repository.

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
@@ -86,7 +86,7 @@ public class RepositoryManagementTest {
         final Map<String, RepositoryInfo> repos = rule.client().listRepositories(rule.project()).join();
 
         // Should contain 2 "rNNN"s
-        assertThat(repos.keySet()).containsExactlyInAnyOrder("meta", "main", rule.repo1(), rule.repo2());
+        assertThat(repos.keySet()).containsExactlyInAnyOrder("meta", rule.repo1(), rule.repo2());
 
         for (RepositoryInfo r : repos.values()) {
             final Commit headCommit = r.lastCommit();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -19,123 +19,19 @@ package com.linecorp.centraldogma.server.internal.command;
 import static com.linecorp.centraldogma.server.internal.command.Command.createProject;
 import static com.linecorp.centraldogma.server.internal.command.Command.createRepository;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Author;
-import com.linecorp.centraldogma.common.Change;
-import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
-import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
 // TODO(trustin): Generate more useful set of sample files.
 public final class ProjectInitializer {
 
-    private static final Logger logger = LoggerFactory.getLogger(ProjectInitializer.class);
-
-    private static final String[] SAMPLE_TEXT = {
-            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur sit" +
-            " amet mauris eu tortor fringilla tempus. Suspendisse commodo quam " +
-            "justo, finibus ultricies dui placerat in. Vestibulum vel ornare eros. " +
-            "Fusce in accumsan orci, vitae tempor mauris. Mauris eget ex sed nunc " +
-            "lacinia tincidunt sit amet eu nisl. Aenean condimentum nec enim in " +
-            "rutrum. Curabitur sed leo justo. Pellentesque urna mauris, tristique " +
-            "non ex id, sagittis imperdiet metus. Proin ac iaculis sapien.",
-
-            "Donec sollicitudin arcu nulla, quis tincidunt nibh mollis vel. Integer" +
-            " in velit iaculis, posuere sapien sed, hendrerit lorem. In non nisl " +
-            "pharetra, maximus tellus sit amet, tincidunt lectus. Etiam eleifend " +
-            "turpis sit amet ex elementum varius. Praesent ac risus vel nisl porta " +
-            "laoreet nec ac urna. Morbi non vehicula sapien, nec placerat nisi. " +
-            "Curabitur molestie laoreet vehicula. Phasellus non quam vitae arcu " +
-            "tristique tempus. Sed tincidunt, libero ut ullamcorper eleifend, purus" +
-            " dolor laoreet dolor, ut semper ante eros id diam. Ut lacinia odio eu " +
-            "urna fringilla luctus cursus non justo. Vestibulum quam tellus, " +
-            "sodales sit amet volutpat congue, semper vitae justo. Curabitur " +
-            "porttitor eros eros, vitae rhoncus tortor bibendum placerat.",
-
-            "Pellentesque feugiat, est sit amet condimentum sagittis, ligula odio " +
-            "mattis dui, placerat volutpat purus quam eu nunc. Proin ex nibh, " +
-            "euismod nec malesuada at, mattis in lacus. Nulla tempus accumsan " +
-            "imperdiet. Quisque quis gravida tellus. Quisque sollicitudin lorem sed" +
-            " egestas eleifend. Nunc tempus ac libero nec fermentum. Donec at orci " +
-            "malesuada elit egestas ultrices. In mattis ac nunc et auctor. " +
-            "Pellentesque vel dui eget metus finibus pellentesque sed vel risus. " +
-            "Suspendisse sed pellentesque nulla. Cum sociis natoque penatibus et " +
-            "magnis dis parturient montes, nascetur ridiculus mus. Ut fermentum " +
-            "interdum sem, luctus egestas velit lacinia pretium. In id convallis " +
-            "velit.",
-
-            "Aliquam id dictum dolor, vitae vestibulum eros. Aliquam malesuada " +
-            "dignissim placerat. Etiam sagittis eu lectus non pharetra. Sed sed " +
-            "fringilla diam, in faucibus elit. Quisque non fringilla augue. Donec a" +
-            " urna eu sapien ultricies laoreet a eu risus. Nunc imperdiet, enim non" +
-            " hendrerit lobortis, nisi eros varius velit, ut ultrices mi elit eget " +
-            "est. Pellentesque at suscipit nulla. Vivamus facilisis, turpis " +
-            "ultrices accumsan placerat, odio lectus bibendum elit, quis mollis " +
-            "massa neque at turpis. Proin felis felis, egestas eget velit a, " +
-            "tristique semper mauris. Etiam aliquam enim vitae tellus blandit, id " +
-            "cursus lectus ultrices. Aliquam vel risus elit. Donec pharetra ligula " +
-            "eu ipsum eleifend, eu rutrum nibh mattis. Phasellus in semper dui, id " +
-            "fermentum eros. Nulla laoreet sapien quis sollicitudin bibendum.",
-
-            "Morbi euismod ultrices erat, id efficitur turpis euismod sed. Vivamus " +
-            "hendrerit rutrum venenatis. Phasellus volutpat bibendum metus, in " +
-            "rutrum elit. Phasellus vitae venenatis velit. Fusce quis maximus lacus" +
-            ". Morbi nec maximus eros. Vestibulum est ipsum, dictum tincidunt " +
-            "viverra ut, varius id sapien. Donec dui augue, bibendum nec orci sed, " +
-            "ultricies commodo erat. Nunc tincidunt suscipit neque, vitae tincidunt" +
-            " turpis pharetra a. Nulla facilisis efficitur orci, a porttitor odio. " +
-            "Donec vulputate erat eget ultricies dignissim. Duis placerat, sapien " +
-            "et tincidunt posuere, turpis diam tempor neque, vel aliquet enim orci " +
-            "vel nunc. Donec convallis ex tellus, vel iaculis mi vestibulum at. " +
-            "Phasellus eu metus est."
-    };
-
-    private static final String SAMPLE_JSON_OBJECT =
-            "{ \"a\": \"" + SAMPLE_TEXT[0] + "\",\n" +
-            "  \"b\": \"" + SAMPLE_TEXT[1] + "\",\n" +
-            "  \"c\": \"" + SAMPLE_TEXT[2] + "\",\n" +
-            "  \"d\": \"" + SAMPLE_TEXT[3] + "\",\n" +
-            "  \"e\": \"" + SAMPLE_TEXT[4] + "\" }";
-
-    private static final String SAMPLE_JSON_ARRAY =
-            "[ \"" + SAMPLE_TEXT[0] + "\",\n" +
-            "  \"" + SAMPLE_TEXT[1] + "\",\n" +
-            "  \"" + SAMPLE_TEXT[2] + "\",\n" +
-            "  \"" + SAMPLE_TEXT[3] + "\",\n" +
-            "  \"" + SAMPLE_TEXT[4] + "\" ]";
-
     public static final String INTERNAL_PROJECT_NAME = "dogma";
-
-    static CompletableFuture<Revision> generateSampleFiles(
-            CommandExecutor executor, String projectName, String repositoryName) {
-
-        // Do not generate sample files for internal projects.
-        if (projectName.equals(INTERNAL_PROJECT_NAME)) {
-            return CompletableFuture.completedFuture(Revision.INIT);
-        }
-
-        logger.info("Generating sample files into: {}/{}", projectName, repositoryName);
-
-        final List<Change<?>> changes = Arrays.asList(
-                Change.ofTextUpsert("/samples/foo.txt", String.join("\n\n", SAMPLE_TEXT)),
-                Change.ofJsonUpsert("/samples/bar.json", SAMPLE_JSON_OBJECT),
-                Change.ofJsonUpsert("/samples/qux.json", SAMPLE_JSON_ARRAY));
-
-        return executor.execute(Command.push(
-                Author.SYSTEM, projectName, repositoryName, Revision.HEAD,
-                "Add the sample files", "", Markup.PLAINTEXT, changes));
-    }
+    public static final String INTERNAL_REPOSITORY_NAME = "main";
 
     /**
      * Creates an internal project and repositories such as a token storage.
@@ -151,7 +47,7 @@ public final class ProjectInitializer {
             }
         }
         for (final String repo : ImmutableList.of(Project.REPO_META,
-                                                  Project.REPO_MAIN)) {
+                                                  INTERNAL_REPOSITORY_NAME)) {
             try {
                 executor.execute(createRepository(Author.SYSTEM, INTERNAL_PROJECT_NAME, repo))
                         .get();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -17,9 +17,7 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.generateSampleFiles;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_JSON;
-import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_MAIN;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 
 import java.util.concurrent.CompletableFuture;
@@ -35,10 +33,8 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.internal.metadata.Member;
-import com.linecorp.centraldogma.server.internal.metadata.PerRolePermissions;
 import com.linecorp.centraldogma.server.internal.metadata.ProjectMetadata;
 import com.linecorp.centraldogma.server.internal.metadata.ProjectRole;
-import com.linecorp.centraldogma.server.internal.metadata.RepositoryMetadata;
 import com.linecorp.centraldogma.server.internal.metadata.UserAndTimestamp;
 
 public class ProjectInitializingCommandExecutor extends ForwardingCommandExecutor {
@@ -63,10 +59,7 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         final CompletableFuture<Void> f = delegate().execute(c);
         return f.thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
                                                                                    projectName, REPO_META)))
-                .thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
-                                                                                   projectName, REPO_MAIN)))
                 .thenCompose(unused -> initializeMetadata(delegate(), projectName, author))
-                .thenCompose(unused -> generateSampleFiles(delegate(), projectName, REPO_MAIN))
                 .thenApply(unused -> null);
     }
 
@@ -81,12 +74,9 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         logger.info("Initializing metadata: {}", projectName);
 
         final UserAndTimestamp userAndTimestamp = UserAndTimestamp.of(author);
-        final RepositoryMetadata mainRepositoryMetadata =
-                new RepositoryMetadata(REPO_MAIN, userAndTimestamp, PerRolePermissions.ofPublic());
         final Member member = new Member(author, ProjectRole.OWNER, userAndTimestamp);
         final ProjectMetadata metadata = new ProjectMetadata(projectName,
-                                                             ImmutableMap.of(mainRepositoryMetadata.id(),
-                                                                             mainRepositoryMetadata),
+                                                             ImmutableMap.of(),
                                                              ImmutableMap.of(member.id(), member),
                                                              ImmutableMap.of(),
                                                              userAndTimestamp, null);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.metadata;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation.asJsonArray;
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static com.linecorp.centraldogma.server.internal.metadata.RepositoryUtil.convertWithJackson;
 import static com.linecorp.centraldogma.server.internal.metadata.Tokens.SECRET_PREFIX;
 import static com.linecorp.centraldogma.server.internal.metadata.Tokens.validateSecret;
@@ -72,11 +73,6 @@ public class MetadataService extends AbstractService {
      * The name of metadata repository.
      */
     static final String METADATA_REPO = Project.REPO_META;
-
-    /**
-     * The name of token list repository.
-     */
-    static final String TOKEN_REPO = Project.REPO_MAIN;
 
     /**
      * A {@link JsonPointer} of project removal information.
@@ -690,7 +686,7 @@ public class MetadataService extends AbstractService {
      * Returns a {@link Tokens}.
      */
     public CompletableFuture<Tokens> getTokens() {
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                         .thenApply(HolderWithRevision::object);
     }
 
@@ -738,7 +734,7 @@ public class MetadataService extends AbstractService {
                                                new AddOperation(appIdPath, Jackson.valueToTree(newToken)),
                                                new AddOperation(secretPath,
                                                                 Jackson.valueToTree(newToken.id()))));
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, TOKEN_REPO, author,
+        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
                               "Add a token: '" + newToken.id(), change);
     }
 
@@ -757,8 +753,8 @@ public class MetadataService extends AbstractService {
             futures[i++] = removeToken(p.name(), author, appId, true).toCompletableFuture();
         }
         return CompletableFuture.allOf(futures).thenCompose(unused -> tokenRepo.push(
-                INTERNAL_PROJECT_NAME, TOKEN_REPO, author, "Remove the token: '" + appId,
-                () -> tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+                INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author, "Remove the token: '" + appId,
+                () -> tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                                .thenApply(tokens -> {
                                    final Token token = tokens.object().get(appId);
                                    final JsonPointer appIdPath =
@@ -781,10 +777,10 @@ public class MetadataService extends AbstractService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, TOKEN_REPO, author,
+        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
                               "Enable the token: '" + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -808,10 +804,10 @@ public class MetadataService extends AbstractService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, TOKEN_REPO, author,
+        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
                               "Disable the token: '" + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -833,7 +829,7 @@ public class MetadataService extends AbstractService {
      */
     public CompletableFuture<Token> findTokenByAppId(String appId) {
         requireNonNull(appId, "appId");
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().get(appId));
     }
 
@@ -843,7 +839,7 @@ public class MetadataService extends AbstractService {
     public CompletableFuture<Token> findTokenBySecret(String secret) {
         requireNonNull(secret, "secret");
         validateSecret(secret);
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, TOKEN_REPO, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().findBySecret(secret));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtil.java
@@ -17,9 +17,9 @@
 package com.linecorp.centraldogma.server.internal.metadata;
 
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_JSON;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.TOKEN_JSON;
-import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.TOKEN_REPO;
 import static com.linecorp.centraldogma.server.internal.metadata.RepositoryUtil.convertWithJackson;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
@@ -97,7 +97,8 @@ public final class MigrationUtil {
 
         final UserAndTimestamp userAndTimestamp = UserAndTimestamp.of(author);
 
-        final Entry<?> tokenEntry = projectManager.get(INTERNAL_PROJECT_NAME).repos().get(TOKEN_REPO)
+        final Entry<?> tokenEntry = projectManager.get(INTERNAL_PROJECT_NAME).repos()
+                                                  .get(INTERNAL_REPOSITORY_NAME)
                                                   .getOrElse(Revision.HEAD, TOKEN_JSON, null).join();
         final Collection<Token> migratedTokens =
                 tokenEntry == null || force ? migrateTokens(projectManager, executor) : ImmutableSet.of();
@@ -179,7 +180,7 @@ public final class MigrationUtil {
                 Change.ofJsonUpsert(TOKEN_JSON, Jackson.valueToTree(new Tokens(tokenMap, secretMap)));
 
         try {
-            tokensRepo.push(INTERNAL_PROJECT_NAME, TOKEN_REPO, author, "Add the token list file",
+            tokensRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author, "Add the token list file",
                             change).toCompletableFuture().join();
         } catch (Throwable cause) {
             cause = Exceptions.peel(cause);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -30,7 +30,6 @@ import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.internal.plugin.PluginManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository;
 import com.linecorp.centraldogma.server.internal.storage.repository.MetaRepository;
-import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.cache.CachingRepositoryManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.cache.RepositoryCache;
@@ -82,11 +81,6 @@ class DefaultProject implements Project {
         } else {
             return this.metaRepo.get();
         }
-    }
-
-    @Override
-    public Repository mainRepo() {
-        return repos.get(REPO_MAIN);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
@@ -19,12 +19,10 @@ package com.linecorp.centraldogma.server.internal.storage.project;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.server.internal.plugin.PluginManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.MetaRepository;
-import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryManager;
 
 public interface Project {
     String REPO_META = "meta";
-    String REPO_MAIN = "main";
 
     String name();
 
@@ -37,8 +35,6 @@ public interface Project {
     }
 
     MetaRepository metaRepo();
-
-    Repository mainRepo();
 
     RepositoryManager repos();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -128,16 +128,6 @@ public class RepositoryServiceV1Test {
         final String expectedJson =
                 '[' +
                 "   {" +
-                "       \"name\": \"main\"," +
-                "       \"creator\": {" +
-                "           \"name\": \"System\"," +
-                "           \"email\": \"system@localhost.localdomain\"" +
-                "       }," +
-                "       \"headRevision\": \"${json-unit.ignore}\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/main\"," +
-                "       \"createdAt\": \"${json-unit.ignore}\"" +
-                "   }," +
-                "   {" +
                 "       \"name\": \"meta\"," +
                 "       \"creator\": {" +
                 "           \"name\": \"System\"," +
@@ -204,8 +194,8 @@ public class RepositoryServiceV1Test {
         final String remains = remainedRes.content().toStringUtf8();
         final JsonNode jsonNode = Jackson.readTree(remains);
 
-        // main, meta and trustin repositories are left
-        assertThat(jsonNode.size()).isEqualTo(3);
+        // meta and trustin repositories are left
+        assertThat(jsonNode.size()).isEqualTo(2);
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
@@ -20,7 +20,6 @@ import static com.linecorp.centraldogma.server.internal.command.ProjectInitializ
 import static com.linecorp.centraldogma.server.internal.metadata.MigrationUtil.LEGACY_TOKEN_JSON;
 import static com.linecorp.centraldogma.server.internal.metadata.MigrationUtil.LEGACY_TOKEN_REPO;
 import static com.linecorp.centraldogma.server.internal.metadata.Tokens.SECRET_PREFIX;
-import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_MAIN;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -66,6 +65,7 @@ public class MigrationUtilTest {
     };
 
     private static final Author author = Author.SYSTEM;
+    private static final String REPO_FOO = "foo";
 
     @Test
     public void migrationWithoutLegacyTokens() throws Exception {
@@ -129,17 +129,17 @@ public class MigrationUtilTest {
                 assertThat(m.tokens().get("app2").role()).isEqualTo(ProjectRole.MEMBER);
 
                 // Every repository is "public", so everyone has read/write permission to the repository.
-                assertThat(m.repo(REPO_MAIN).perRolePermissions().owner())
+                assertThat(m.repo(REPO_FOO).perRolePermissions().owner())
                         .containsExactly(Permission.READ, Permission.WRITE);
                 assertThat(m.repo("oneMoreThing").perRolePermissions().owner())
                         .containsExactly(Permission.READ, Permission.WRITE);
 
-                assertThat(m.repo(REPO_MAIN).perRolePermissions().member())
+                assertThat(m.repo(REPO_FOO).perRolePermissions().member())
                         .containsExactly(Permission.READ, Permission.WRITE);
                 assertThat(m.repo("oneMoreThing").perRolePermissions().member())
                         .containsExactly(Permission.READ, Permission.WRITE);
 
-                assertThat(m.repo(REPO_MAIN).perRolePermissions().guest())
+                assertThat(m.repo(REPO_FOO).perRolePermissions().guest())
                         .containsExactly(Permission.READ, Permission.WRITE);
                 assertThat(m.repo("oneMoreThing").perRolePermissions().guest())
                         .containsExactly(Permission.READ, Permission.WRITE);
@@ -154,7 +154,7 @@ public class MigrationUtilTest {
     private void createProject(String projectName) {
         final RepositoryManager manager = rule.projectManager().create(projectName).repos();
         manager.create(REPO_META);
-        manager.create(REPO_MAIN);
+        manager.create(REPO_FOO);
         manager.create("oneMoreThing");
     }
 
@@ -180,7 +180,7 @@ public class MigrationUtilTest {
             return f.thenCompose(unused -> delegate().execute(
                     Command.createRepository(creationTimeMillis, author, projectName, REPO_META)))
                     .thenCompose(unused -> delegate().execute(
-                            Command.createRepository(creationTimeMillis, author, projectName, REPO_MAIN)))
+                            Command.createRepository(creationTimeMillis, author, projectName, REPO_FOO)))
                     .thenApply(unused -> null);
         }
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.centraldogma.server.internal.plugin;
 
-import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_MAIN;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 import static java.util.Objects.requireNonNull;
 import static org.hamcrest.Matchers.is;
@@ -53,6 +52,8 @@ public class PluginTest {
 
     @ClassRule
     public static final TemporaryFolder rootDir = new TemporaryFolder();
+
+    private static final String REPO_FOO = "foo";
 
     private static ProjectManager pm;
 
@@ -112,7 +113,7 @@ public class PluginTest {
     private Project newProject() {
         final Project p = pm.create(testName.getMethodName());
         p.repos().create(REPO_META);
-        p.repos().create(REPO_MAIN);
+        p.repos().create(REPO_FOO);
         p.metaRepo().commit(Revision.HEAD, 0L, Author.SYSTEM, "", loadChanges("meta"));
         p.plugins().reload();
         return p;

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -90,7 +90,7 @@ of ``Owner`` and ``Member`` role in the UI. More information about the role is a
     brings you to the ``Application Token`` management page.
 
 You can see the configuration UI for a repository when you click the name of repository in the
-``Repository Permission`` list. The following image shows the configuration of the ``main`` repository.
+``Repository Permission`` list. The following image shows the configuration of the repository called ``main``.
 In this page, you can do the followings.
 
 - Changing the role of a member or a token in a project

--- a/site/src/sphinx/client-cli.rst
+++ b/site/src/sphinx/client-cli.rst
@@ -58,14 +58,14 @@ To list repositories, specify a project name::
     $ dogma ls projFoo
     [
         {
-            "name": "main",
+            "name": "repoA",
             "head": {
                 "revision": {
-                    "major": 2,
+                    "major": 1,
                     "minor": 0,
                 },
                 "timestamp": "2017-09-23T00:48:13Z",
-                "summary": "Add the sample files",
+                "summary": "Create a new repository",
                 "detail": {
                     "content": "",
                     "markup": "PLAINTEXT"

--- a/site/src/sphinx/concepts.rst
+++ b/site/src/sphinx/concepts.rst
@@ -7,20 +7,18 @@ Concepts
     @startuml
     object Central_Dogma
     object Project
-    object Main_repo
     object Meta_repo
-    object Other_repos
+    object User_repos
 
     Central_Dogma *-- "*" Project
-    Project *-- "1" Main_repo
     Project *-- "1" Meta_repo
-    Project *-- "*" Other_repos
+    Project *-- "*" User_repos
     @enduml
 
 - Project
 
-  - A *project* is a top-level element in Central Dogma storage model. Each project contains at least two
-    repositories: ``main`` and ``meta``. A project can have more than two repositories.
+  - A *project* is a top-level element in Central Dogma storage model. Each project contains at least one
+    repository called ``meta``. A project can have more than one repository.
 
     .. note::
 
@@ -30,12 +28,16 @@ Concepts
 
   - A *repository* is where the configuration files of your application are stored actually. It keeps the
     history of each change (commit), such as who added what change when.
-  - Main repository
 
-    - A *main repository* is a repository whose name is ``main`` in a project. It is often a primary place
-      to store the configuration files of your application, although a user can create another repository in
-      a project. When a project is created, its main repository will contain some sample files that are OK to
-      delete.
+    .. note::
+
+        You may find it easier to understand a repository as a 'repository' under an organization in GitHub.
+
+  - User repository
+
+    - A *user repository* is a repository where a user (i.e. you) store the application configuration files.
+      A user can create more than one repository under a project, just like a user creates multiple
+      repositories under an organization.
 
   - Meta repository
 


### PR DESCRIPTION
Related: #174

Motivation:

Now that we are moving to more Github-like structure, it's probably better removing the notion of 'main' repository. That is:

Do not create the main repository when a project is created
Allow creating/removing/unremoving all repositories except 'meta'

Modifications:

- Remove Project.REPO_MAIN
- Remove Project.mainRepo()
- Replace MetadataService.TOKEN_REPO with ProjectInitializer.INTERNAL_REPOSITORY_NAME

Result:

- Closes #178
- A user has more choices on the name of primary repository