### PR TITLE
Add 500ms delay when refreshing web UI after metadata modification

### DIFF
--- a/server/src/main/resources/webapp/scripts/app/app.js
+++ b/server/src/main/resources/webapp/scripts/app/app.js
@@ -21,7 +21,8 @@ angular.module(
       API_V1_PREFIX: 'api/v1/',
       PROJECT_ROLE_OWNER: "OWNER",
       PROJECT_ROLE_MEMBER: "MEMBER",
-      PROJECT_ROLE_GUEST: "GUEST"
+      PROJECT_ROLE_GUEST: "GUEST",
+      REFRESH_DELAY_MSEC: 500
     })
     .run(function ($rootScope, $location, $window, $http, $state, $translate, $uibModal,
                    Principal, Language, NotificationUtil, Security) {

--- a/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.project.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.project.controller.js
@@ -5,7 +5,7 @@ angular.module('CentralDogmaAdmin')
                 function ($scope, $state, $stateParams, ApiService, ApiV1Service, $location, $window, $uibModal,
                           SettingsService, ConfirmationDialog, IdentifierWithRole, EntitiesUtil,
                           ProjectService, RepositoryService, Principal, CentralDogmaConstant,
-                          NotificationUtil, StringUtil, Security) {
+                          NotificationUtil, StringUtil, Security, $timeout) {
                   $scope.project = {
                     name: $stateParams.projectName,
                     roles: [
@@ -140,7 +140,7 @@ angular.module('CentralDogmaAdmin')
                     });
                   };
 
-                  $scope.refresh = function() {
+                  $scope.refreshNow = function() {
                     function refresh0(tokens) {
                       ApiV1Service.get(StringUtil.encodeUri(['projects', $scope.project.name])).then(function (metadata) {
                         var addedAppIds, allAppIds;
@@ -204,5 +204,11 @@ angular.module('CentralDogmaAdmin')
                     });
                   };
 
-                  $scope.refresh();
+                  $scope.refresh = function() {
+                    $timeout(function () {
+                      $scope.refreshNow();
+                    }, CentralDogmaConstant.REFRESH_DELAY_MSEC);
+                  };
+
+                  $scope.refreshNow();
                 });

--- a/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.repository.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.repository.controller.js
@@ -3,7 +3,7 @@
 angular.module('CentralDogmaAdmin')
     .controller('MetadataRepositoryController',
                 function ($scope, $state, $stateParams, ApiV1Service, $uibModal, Permission, ConfirmationDialog,
-                          Principal, CentralDogmaConstant, StringUtil, NotificationUtil, EntitiesUtil) {
+                          Principal, CentralDogmaConstant, StringUtil, NotificationUtil, EntitiesUtil, $timeout) {
                   $scope.project = {
                     name: $stateParams.projectName
                   };
@@ -125,7 +125,7 @@ angular.module('CentralDogmaAdmin')
                     removePermTable('tokens', appId, 'entities.title_remove_token');
                   };
 
-                  $scope.refresh = function() {
+                  $scope.refreshNow = function() {
                     ApiV1Service.get("projects/" + $scope.project.name).then(function (metadata) {
                       var registeredAppIdList, registeredMemberList;
 
@@ -167,6 +167,12 @@ angular.module('CentralDogmaAdmin')
                     });
                   };
 
-                  $scope.refresh();
+                  $scope.refresh = function() {
+                    $timeout(function () {
+                      $scope.refreshNow();
+                    }, CentralDogmaConstant.REFRESH_DELAY_MSEC);
+                  };
+
+                  $scope.refreshNow();
                 });
 

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.controller.js
@@ -1,16 +1,23 @@
 'use strict';
 
 angular.module('CentralDogmaAdmin').controller('TokensController',
-  function ($scope, $uibModal, SettingsService, ConfirmationDialog, NotificationUtil, EntitiesUtil) {
+  function ($scope, $uibModal, SettingsService, ConfirmationDialog, NotificationUtil, EntitiesUtil,
+            $timeout, CentralDogmaConstant) {
     $scope.sanitizeEmail = EntitiesUtil.sanitizeEmail;
 
-    var refresh = function () {
+    var refreshNow = function () {
       $scope.selectedToken = null;
       SettingsService.listTokens().then(
         function (tokens) {
           $scope.tokens = tokens;
         }
       );
+    };
+
+    var refresh = function () {
+      $timeout(function () {
+        refreshNow();
+      }, CentralDogmaConstant.REFRESH_DELAY_MSEC);
     };
 
     $scope.selectToken = function (token) {
@@ -90,5 +97,5 @@ angular.module('CentralDogmaAdmin').controller('TokensController',
       });
     };
 
-    refresh();
+    refreshNow();
   });


### PR DESCRIPTION
Motivation:
A user may get a dirty result after modifying metadata due to replication lag. Adding some delay before refreshing may help to make the situation less often.

Modifications:
- Add 500ms delay before refreshing web UI.