### PR TITLE
Add Caffeine cache for session information

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
@@ -57,7 +57,7 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
     /**
      * Adds the {@link URI} of the Central Dogma server.
      *
-     * @deprecated Use {@link #host(String)} or {@link #profile(String...)} instead.
+     * @deprecated Use {@link #host(String)} or {@link #profile(String...)}.
      *
      * @param uri the URI of the Central Dogma server. e.g.
      *            {@code tbinary+http://example.com:36462/cd/thrift/v1}

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/AccessToken.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/AccessToken.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 
 public class AccessToken {
 
@@ -32,6 +33,8 @@ public class AccessToken {
     private final long expiresIn;
 
     private final String refreshToken;
+
+    private final long deadline;
 
     //TODO(minwoox) Add scope if needed.
 
@@ -46,6 +49,7 @@ public class AccessToken {
         this.accessToken = requireNonNull(accessToken, "accessToken");
         this.expiresIn = expiresIn;
         this.refreshToken = requireNonNull(refreshToken, "refreshToken");
+        this.deadline = System.currentTimeMillis() + expiresIn;
     }
 
     @JsonProperty("access_token")
@@ -66,5 +70,19 @@ public class AccessToken {
     @JsonProperty("refresh_token")
     public String refreshToken() {
         return refreshToken;
+    }
+
+    public long deadline() {
+        return deadline;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("accessToken", accessToken)
+                          .add("expiresIn", expiresIn)
+                          .add("tokenType", tokenType)
+                          .add("deadline", deadline)
+                          .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -231,7 +231,7 @@ public class CentralDogma {
 
             logger.info("Starting the project manager: {}", cfg.dataDir());
 
-            pm = new DefaultProjectManager(cfg.dataDir(), repositoryWorker, cfg.cacheSpec());
+            pm = new DefaultProjectManager(cfg.dataDir(), repositoryWorker, cfg.repositoryCacheSpec());
             logger.info("Started the project manager: {}", pm);
 
             logger.info("Current settings:\n{}", cfg);
@@ -244,7 +244,8 @@ public class CentralDogma {
 
             if (cfg.isSecurityEnabled()) {
                 securityManager = new CentralDogmaSecurityManager(cfg.dataDir(), securityConfig,
-                                                                  cfg.webAppSessionTimeoutMillis());
+                                                                  cfg.webAppSessionTimeoutMillis(),
+                                                                  cfg.sessionCacheSpec());
             }
 
             logger.info("Starting the command executor ..");
@@ -534,7 +535,8 @@ public class CentralDogma {
         if (cfg.isSecurityEnabled()) {
             requireNonNull(securityManager, "securityManager");
 
-            loginService = new LoginService(securityManager, executor, loginNameNormalizer);
+            loginService = new LoginService(securityManager, executor,
+                                            loginNameNormalizer, cfg.sessionCacheSpec());
             logoutService = new LogoutService(securityManager, executor);
 
             sb.service("/security_enabled", new AbstractHttpService() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -18,12 +18,14 @@ package com.linecorp.centraldogma.server;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_CACHE_SPEC;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_NUM_FILES_PER_MIRROR;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_MIRRORING_THREADS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_REPOSITORY_WORKERS;
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_REPOSITORY_CACHE_SPEC;
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_SESSION_CACHE_SPEC;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS;
+import static com.linecorp.centraldogma.server.internal.storage.repository.cache.RepositoryCache.validateCacheSpec;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -56,7 +58,6 @@ import com.google.common.collect.ImmutableSet;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.server.internal.storage.repository.cache.RepositoryCache;
 
 import io.netty.util.NetUtil;
 
@@ -77,7 +78,8 @@ final class CentralDogmaConfig {
     private final Integer numRepositoryWorkers;
 
     // Cache
-    private final String cacheSpec;
+    private final String repositoryCacheSpec;
+    private final String sessionCacheSpec;
 
     // Web dashboard
     private final boolean webAppEnabled;
@@ -119,7 +121,9 @@ final class CentralDogmaConfig {
                        @JsonProperty("idleTimeoutMillis") Long idleTimeoutMillis,
                        @JsonProperty("maxFrameLength") Integer maxFrameLength,
                        @JsonProperty("numRepositoryWorkers") Integer numRepositoryWorkers,
-                       @JsonProperty("cacheSpec") String cacheSpec,
+                       @JsonProperty("cacheSpec") String cacheSpec, // for backward compatibility
+                       @JsonProperty("repositoryCacheSpec") String repositoryCacheSpec,
+                       @JsonProperty("sessionCacheSpec") String sessionCacheSpec,
                        @JsonProperty("gracefulShutdownTimeout")
                                GracefulShutdownTimeout gracefulShutdownTimeout,
                        @JsonProperty("webAppEnabled") Boolean webAppEnabled,
@@ -148,7 +152,15 @@ final class CentralDogmaConfig {
         this.numRepositoryWorkers = firstNonNull(numRepositoryWorkers, DEFAULT_NUM_REPOSITORY_WORKERS);
         checkArgument(this.numRepositoryWorkers > 0,
                       "numRepositoryWorkers: %s (expected: > 0)", this.numRepositoryWorkers);
-        this.cacheSpec = RepositoryCache.validateCacheSpec(firstNonNull(cacheSpec, DEFAULT_CACHE_SPEC));
+
+        if (repositoryCacheSpec != null) {
+            this.repositoryCacheSpec = validateCacheSpec(repositoryCacheSpec);
+        } else {
+            this.repositoryCacheSpec = validateCacheSpec(
+                    firstNonNull(cacheSpec, DEFAULT_REPOSITORY_CACHE_SPEC));
+        }
+
+        this.sessionCacheSpec = validateCacheSpec(firstNonNull(sessionCacheSpec, DEFAULT_SESSION_CACHE_SPEC));
         this.webAppEnabled = firstNonNull(webAppEnabled, true);
         this.webAppSessionTimeoutMillis = firstNonNull(webAppSessionTimeoutMillis,
                                                        DEFAULT_WEB_APP_SESSION_TIMEOUT_MILLIS);
@@ -226,9 +238,25 @@ final class CentralDogmaConfig {
         return numRepositoryWorkers;
     }
 
+    /**
+     * Returns the {@code repositoryCacheSpec}.
+     *
+     * @deprecated Use {@link #repositoryCacheSpec()}.
+     */
     @JsonProperty
+    @Deprecated
     String cacheSpec() {
-        return cacheSpec;
+        return repositoryCacheSpec;
+    }
+
+    @JsonProperty
+    String repositoryCacheSpec() {
+        return repositoryCacheSpec;
+    }
+
+    @JsonProperty
+    String sessionCacheSpec() {
+        return sessionCacheSpec;
     }
 
     @JsonProperty

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LegacyToken.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LegacyToken.java
@@ -33,7 +33,7 @@ import com.linecorp.centraldogma.server.internal.metadata.Token;
 /**
  * Specifies details of an application token.
  *
- * @deprecated Use {@link Token} instead.
+ * @deprecated Use {@link Token}.
  */
 @Deprecated
 @JsonInclude(Include.NON_NULL)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/Repository.java
@@ -103,7 +103,7 @@ public interface Repository {
      * Returns the {@link CompletableFuture} whose value is the absolute {@link Revision} of the
      * specified {@link Revision}.
      *
-     * @deprecated Use {@link #normalizeNow(Revision)} instead.
+     * @deprecated Use {@link #normalizeNow(Revision)}.
      */
     @Deprecated
     default CompletableFuture<Revision> normalize(Revision revision) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/RepositoryCache.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/RepositoryCache.java
@@ -51,7 +51,7 @@ public final class RepositoryCache {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public RepositoryCache(String cacheSpec) {
-        this.cacheSpec = requireNonNull(cacheSpec, "cacheSpec");
+        this.cacheSpec = requireNonNull(validateCacheSpec(cacheSpec), "cacheSpec");
 
         final Caffeine<Object, Object> builder = Caffeine.from(cacheSpec);
         if (cacheSpec.contains("maximumWeight=")) {

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -1,4 +1,6 @@
 .. _`Apache Shiro`: https://shiro.apache.org/
+.. _`the Caffeine API documentation`: https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.5.5/index.html?com/github/benmanes/caffeine/cache/CaffeineSpec.html
+
 
 .. _setup-configuration:
 
@@ -27,7 +29,8 @@ defaults:
       "idleTimeoutMillis": null,
       "maxFrameLength": null,
       "numRepositoryWorkers": 16,
-      "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
       "webAppEnabled": true,
       "webAppSessionTimeoutMillis": 604800000,
       "gracefulShutdownTimeout": {
@@ -110,13 +113,16 @@ Core properties
   - the number of worker threads dedicated to handling repository reads and writes.
     If ``null``, the default value of '16 threads' is used.
 
-- ``cacheSpec`` (string)
+- ``repositoryCacheSpec`` (string)
 
   - the cache specification string which determines the capacity and behavior of the repository
-    access cache. Refer to `the Caffeine API documentation
-    <https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.5.5/index.html?com/github/benmanes/caffeine/cache/CaffeineSpec.html>`_
-    for more information. Note that the weight of the cache has been tuned to be roughly proportional to its
-    memory usage.
+    access cache. Refer to `the Caffeine API documentation`_ for more information.
+    Note that the weight of the cache has been tuned to be roughly proportional to its memory usage.
+
+- ``sessionCacheSpec`` (string)
+
+  - the cache specification string which determines the capacity and behavior of the cache for the session
+    information of the server. Refer to `the Caffeine API documentation`_ for more information.
 
 - ``webAppEnabled`` (boolean)
 
@@ -236,7 +242,8 @@ Once you have an access to a ZooKeeper cluster, update the ``replication`` secti
       "idleTimeoutMillis": null,
       "maxFrameLength": null,
       "numRepositoryWorkers": 16,
-      "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
       "webAppEnabled": true,
       "webAppSessionTimeoutMillis": 604800000,
       "gracefulShutdownTimeout": {
@@ -323,7 +330,8 @@ in ``dogma.json`` as follows.
       "idleTimeoutMillis": null,
       "maxFrameLength": null,
       "numRepositoryWorkers": 16,
-      "cacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
+      "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
       "webAppEnabled": true,
       "gracefulShutdownTimeout": {
         "quietPeriodMillis": 1000,


### PR DESCRIPTION
Motivation:
Currently, if a user logins with his or her `username` and `password` consecutively,
`LoginService` creates sessions for each login and responses with different tokens.
If the token is not expired, we do not have to issue a new token again because the
previous token is still valid. Also, it can be a burden because the server has to
send `CreateToken` Command to all the replicas to create a token.

Modifications:
- Add `sessionCacheSpec`
- Rename `cacheSpec` to `repositoryCacheSpec` to distinguish
- Add `Caffeine` cache to `LoginService`
- Change the cache inside `SecurityManager` to `Caffeine` as well

Result:
- Close #177