### PR TITLE
Normalize the path parameter in HTTP API v1

### DIFF
--- a/client/go/dogma/content_service.go
+++ b/client/go/dogma/content_service.go
@@ -131,7 +131,7 @@ func (c *Change) UnmarshalJSON(b []byte) error {
 
 func (con *contentService) listFiles(ctx context.Context,
 	projectName, repoName, revision, pathPattern string) ([]*Entry, *http.Response, error) {
-	u := fmt.Sprintf("%vprojects/%v/repos/%v/tree%v", defaultPathPrefix, projectName, repoName, pathPattern)
+	u := fmt.Sprintf("%vprojects/%v/repos/%v/list%v", defaultPathPrefix, projectName, repoName, pathPattern)
 
 	if len(revision) != 0 {
 		v := &url.Values{}

--- a/client/go/dogma/content_service_test.go
+++ b/client/go/dogma/content_service_test.go
@@ -27,7 +27,7 @@ func TestListFiles(t *testing.T) {
 	c, mux, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/api/v1/projects/foo/repos/bar/tree/**", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/projects/foo/repos/bar/list/**", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"path":"/a.json", "type":"JSON"},{"path":"/b.txt", "type":"TEXT"}]`)
 	})
@@ -43,7 +43,7 @@ func TestListFiles_WithRevision(t *testing.T) {
 	c, mux, teardown := setup()
 	defer teardown()
 
-	mux.HandleFunc("/api/v1/projects/foo/repos/bar/tree/**", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/api/v1/projects/foo/repos/bar/list/**", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testURLQuery(t, r, "revision", "2")
 		fmt.Fprint(w, `[{"path":"/a.json", "type":"JSON"},{"path":"/b.txt", "type":"TEXT"}]`)

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.internal.api.v1;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.CONTENTS;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
 import static java.util.Objects.requireNonNull;
@@ -51,7 +52,7 @@ public class EntryDto<T> {
         } else {
             this.content = content;
         }
-        url = PROJECTS_PREFIX + '/' + projectName + REPOS + '/' + repoName + path;
+        url = PROJECTS_PREFIX + '/' + projectName + REPOS + '/' + repoName + CONTENTS + path;
     }
 
     @JsonProperty("path")

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -18,6 +18,10 @@ package com.linecorp.centraldogma.server.internal.api;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.armeria.common.util.Functions.voidFunction;
+import static com.linecorp.centraldogma.common.EntryType.DIRECTORY;
+import static com.linecorp.centraldogma.internal.Util.isValidDirPath;
+import static com.linecorp.centraldogma.internal.Util.isValidFilePath;
 import static com.linecorp.centraldogma.server.internal.api.DtoConverter.convert;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.returnOrThrow;
 import static java.util.Objects.requireNonNull;
@@ -28,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import com.google.common.base.Throwables;
@@ -53,7 +56,6 @@ import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.ChangeType;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
-import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RedundantChangeException;
@@ -90,40 +92,66 @@ public class ContentServiceV1 extends AbstractService {
     }
 
     /**
-     * GET /projects/{projectName}/repos/{repoName}/tree{path}?revision={revision}
+     * GET /projects/{projectName}/repos/{repoName}/list{path}?revision={revision}
      *
      * <p>Returns the list of files in the path.
      */
-    @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/tree(?<path>(|/.*))$")
+    @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/list(?<path>(|/.*))$")
     @Decorator(HasReadPermission.class)
-    public CompletionStage<List<EntryDto<?>>> listFiles(@Param("path") String path,
-                                                        @Param("revision") @Default("-1") String revision,
-                                                        @RequestObject Repository repository) {
-        final String path0 = rootDirIfEmpty(path);
-        return listFiles(repository, path0, new Revision(revision),
-                         ImmutableMap.of(FindOption.FETCH_CONTENT, false));
+    public CompletableFuture<List<EntryDto<?>>> listFiles(@Param("path") String path,
+                                                          @Param("revision") @Default("-1") String revision,
+                                                          @RequestObject Repository repository) {
+        final String normalizedPath = normalizePath(path);
+        final CompletableFuture<List<EntryDto<?>>> future = new CompletableFuture<>();
+        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)),
+                  ImmutableMap.of(FindOption.FETCH_CONTENT, false), future);
+        return future;
     }
 
-    private static CompletionStage<List<EntryDto<?>>> listFiles(Repository repository, String path,
-                                                                Revision revision,
-                                                                Map<FindOption<?>, ?> options) {
-        final String pathPattern = appendWildCardIfDirectory(path);
-        return repository.find(revision, pathPattern, options)
-                         .thenApply(entries -> entries.values().stream()
-                                                      .filter(entry -> entry.type() != EntryType.DIRECTORY)
-                                                      .map(entry -> convert(repository, entry))
-                                                      .collect(toImmutableList()));
-    }
-
-    private static String appendWildCardIfDirectory(String path) {
-        return path.endsWith("/") ? path + '*' : path;
+    private static void listFiles(Repository repository, String pathPattern, Revision normalizedRevision,
+                                  Map<FindOption<?>, ?> options, CompletableFuture<List<EntryDto<?>>> result) {
+        repository.find(normalizedRevision, pathPattern, options).handle(voidFunction((entries, thrown) -> {
+            if (thrown != null) {
+                result.completeExceptionally(thrown);
+                return;
+            }
+            // If the pathPattern is a valid file path and the result is a directory, the client forgets to add
+            // "/*" to the end of the path. So, let's do it and invoke once more.
+            // This is called once at most, because the pathPattern is not a valid file path anymore.
+            if (isValidFilePath(pathPattern) && entries.size() == 1 &&
+                entries.values().iterator().next().type() == DIRECTORY) {
+                listFiles(repository, pathPattern + "/*", normalizedRevision, options, result);
+            } else {
+                result.complete(entries.values().stream()
+                                       .map(entry -> convert(repository, entry))
+                                       .collect(toImmutableList()));
+            }
+        }));
     }
 
     /**
-     * Returns "/" if the specified path is null or empty.
+     * Normalizes the path according to the following order.
+     * <ul>
+     *   <li>if the path is {@code null}, empty string or "/", normalize to {@code "/*"}</li>
+     *   <li>if the path is a valid file path, return the path as it is</li>
+     *   <li>if the path is a valid directory path, append "*" at the end</li>
+     * </ul>
      */
-    private static String rootDirIfEmpty(String path) {
-        return isNullOrEmpty(path) ? "/" : path;
+    private static String normalizePath(String path) {
+        if (path == null || "".equals(path) || "/".equals(path)) {
+            return "/*";
+        }
+        if (isValidFilePath(path)) {
+            return path;
+        }
+        if (isValidDirPath(path)) {
+            if (path.endsWith("/")) {
+                return path + "*";
+            } else {
+                return path + "/*";
+            }
+        }
+        return path;
     }
 
     /**
@@ -133,12 +161,12 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Post("/projects/{projectName}/repos/{repoName}/contents")
     @Decorator(HasWritePermission.class)
-    public CompletionStage<?> commit(@Param("revision") @Default("-1") String revision,
-                                     @RequestObject Repository repository,
-                                     @RequestObject Author author,
-                                     @RequestObject CommitMessageDto commitMessage,
-                                     @RequestObject(ChangesRequestConverter.class)
-                                             Iterable<Change<?>> changes) {
+    public CompletableFuture<?> commit(@Param("revision") @Default("-1") String revision,
+                                       @RequestObject Repository repository,
+                                       @RequestObject Author author,
+                                       @RequestObject CommitMessageDto commitMessage,
+                                       @RequestObject(ChangesRequestConverter.class)
+                                               Iterable<Change<?>> changes) {
         final Revision normalizedRevision = repository.normalizeNow(new Revision(revision));
 
         final CompletableFuture<Map<String, Change<?>>> changesFuture =
@@ -164,9 +192,9 @@ public class ContentServiceV1 extends AbstractService {
         });
     }
 
-    private CompletionStage<Revision> push(long commitTimeMills, Author author, Repository repository,
-                                           Revision revision, CommitMessageDto commitMessage,
-                                           Iterable<Change<?>> changes) {
+    private CompletableFuture<Revision> push(long commitTimeMills, Author author, Repository repository,
+                                             Revision revision, CommitMessageDto commitMessage,
+                                             Iterable<Change<?>> changes) {
         final String summary = commitMessage.summary();
         final String detail = commitMessage.detail();
         final Markup markup = commitMessage.markup();
@@ -210,13 +238,13 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/contents(?<path>(|/.*))$")
     @Decorator(HasReadPermission.class)
-    public CompletionStage<?> getFiles(@Param("path") String path,
-                                       @Param("revision") @Default("-1") String revision,
-                                       @RequestObject Repository repository,
-                                       @RequestObject(WatchRequestConverter.class)
-                                               Optional<WatchRequest> watchRequest,
-                                       @RequestObject(QueryRequestConverter.class) Optional<Query<?>> query) {
-        final String path0 = rootDirIfEmpty(path);
+    public CompletableFuture<?> getFiles(@Param("path") String path,
+                                         @Param("revision") @Default("-1") String revision,
+                                         @RequestObject Repository repository,
+                                         @RequestObject(WatchRequestConverter.class)
+                                                 Optional<WatchRequest> watchRequest,
+                                         @RequestObject(QueryRequestConverter.class) Optional<Query<?>> query) {
+        final String normalizedPath = normalizePath(path);
 
         // watch repository or a file
         if (watchRequest.isPresent()) {
@@ -226,7 +254,7 @@ public class ContentServiceV1 extends AbstractService {
                 return watchFile(repository, lastKnownRevision, query.get(), timeOutMillis);
             }
 
-            return watchRepository(repository, lastKnownRevision, path0, timeOutMillis);
+            return watchRepository(repository, lastKnownRevision, normalizedPath, timeOutMillis);
         }
 
         if (query.isPresent()) {
@@ -236,11 +264,14 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         // get files
-        return listFiles(repository, path0, new Revision(revision), ImmutableMap.of());
+        final CompletableFuture<List<EntryDto<?>>> future = new CompletableFuture<>();
+        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)),
+                  ImmutableMap.of(), future);
+        return future;
     }
 
-    private CompletionStage<?> watchFile(Repository repository, Revision lastKnownRevision,
-                                         Query<?> query, long timeOutMillis) {
+    private CompletableFuture<?> watchFile(Repository repository, Revision lastKnownRevision,
+                                           Query<?> query, long timeOutMillis) {
         final CompletableFuture<? extends Entry<?>> future = watchService.watchFile(
                 repository, lastKnownRevision, query, timeOutMillis);
 
@@ -248,8 +279,8 @@ public class ContentServiceV1 extends AbstractService {
                      .exceptionally(this::handleWatchFailure);
     }
 
-    private static CompletionStage<Object> handleWatchSuccess(Repository repository,
-                                                              Revision revision, String pathPattern) {
+    private static CompletableFuture<Object> handleWatchSuccess(Repository repository,
+                                                                Revision revision, String pathPattern) {
         final CompletableFuture<List<Commit>> historyFuture =
                 repository.history(revision, revision, pathPattern);
         return repository.find(revision, pathPattern, ImmutableMap.of(FindOption.FETCH_CONTENT, false))
@@ -270,9 +301,8 @@ public class ContentServiceV1 extends AbstractService {
         return Exceptions.throwUnsafely(thrown);
     }
 
-    private CompletionStage<?> watchRepository(Repository repository, Revision lastKnownRevision,
-                                               String path, long timeOutMillis) {
-        final String pathPattern = appendWildCardIfDirectory(path);
+    private CompletableFuture<?> watchRepository(Repository repository, Revision lastKnownRevision,
+                                                 String pathPattern, long timeOutMillis) {
         final CompletableFuture<Revision> future =
                 watchService.watchRepository(repository, lastKnownRevision, pathPattern, timeOutMillis);
 
@@ -289,10 +319,10 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/commits(?<revision>(|/.*))$")
     @Decorator(HasReadPermission.class)
-    public CompletionStage<?> listCommits(@Param("revision") String revision,
-                                          @Param("path") @Default("/**") String path,
-                                          @Param("to") Optional<String> to,
-                                          @RequestObject Repository repository) {
+    public CompletableFuture<?> listCommits(@Param("revision") String revision,
+                                            @Param("path") @Default("/**") String path,
+                                            @Param("to") Optional<String> to,
+                                            @RequestObject Repository repository) {
         final Revision fromRevision;
         final Revision toRevision;
 
@@ -330,11 +360,11 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Get("/projects/{projectName}/repos/{repoName}/compare")
     @Decorator(HasReadPermission.class)
-    public CompletionStage<?> getDiff(@Param("path") @Default("/**") String pathPattern,
-                                      @Param("from") @Default("1") String from,
-                                      @Param("to") @Default("head") String to,
-                                      @RequestObject Repository repository,
-                                      @RequestObject(QueryRequestConverter.class) Optional<Query<?>> query) {
+    public CompletableFuture<?> getDiff(@Param("path") @Default("/**") String pathPattern,
+                                        @Param("from") @Default("1") String from,
+                                        @Param("to") @Default("head") String to,
+                                        @RequestObject Repository repository,
+                                        @RequestObject(QueryRequestConverter.class) Optional<Query<?>> query) {
         if (query.isPresent()) {
             return repository.diff(new Revision(from), new Revision(to), query.get())
                              .thenApply(DtoConverter::convert);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -59,7 +59,10 @@ final class DtoConverter {
 
     public static <T> EntryDto<T> convert(Repository repository, Entry<T> entry) {
         requireNonNull(entry, "entry");
-        return convert(repository, entry.path(), entry.type(), entry.content());
+        if (entry.hasContent()) {
+            return convert(repository, entry.path(), entry.type(), entry.content());
+        }
+        return convert(repository, entry.path(), entry.type());
     }
 
     public static <T> EntryDto<T> convert(Repository repository, String path, EntryType type) {

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repositories.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repositories.js
@@ -27,7 +27,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryTree', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/tree/:revision/{path:repositoryPath}',
+                    url: '/:projectName/:repositoryName/list/:revision/{path:repositoryPath}',
                     data: {},
                     views: {
                       'content@': {

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.html
@@ -14,12 +14,12 @@
         <a ng-href="#/{{project.name}}">{{project.name}}</a> /
       </span>
       <span>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
           <strong>{{repository.name}}</strong>
         </a>
       </span>
       <span>
-        @ <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">{{revision}}</a>
+        @ <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
       </span>
       </p>
     </div>
@@ -30,12 +30,12 @@
 
       <div class="input-group">
         <span>
-          <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
             <strong>{{repository.name}}</strong>
           </a>
         </span>
         <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last"> /
-          <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
             {{parsedPath.name}}
           </a>
         </span>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.html
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.new.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.new.html
@@ -14,12 +14,12 @@
           <a ng-href="#/{{project.name}}">{{project.name}}</a> /
         </span>
         <span>
-          <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
             <strong>{{repository.name}}</strong>
           </a>
         </span>
         <span>
-          @ <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">{{revision}}</a>
+          @ <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
         </span>
       </p>
     </div>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.html
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first">
       /
-      <a ng-if="!$last" ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+      <a ng-if="!$last" ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
       <a ng-if="$last && file.type !== 'DIRECTORY'"
@@ -38,7 +38,7 @@
         {{parsedPath.name}}
       </a>
       <a ng-if="$last && file.type === 'DIRECTORY'"
-         ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+         ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>
@@ -56,7 +56,7 @@
     <tbody>
     <tr ng-repeat="commit in commits">
       <td>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{commit.revision.revisionNumber}}{{path}}">
+        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{commit.revision.revisionNumber}}{{path}}">
           {{commit.revision.revisionNumber}}
         </a>
       </td>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.html
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.html
@@ -35,7 +35,7 @@
       </td>
       <td>
         <a ng-if="file.type === 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{file.path}}">
+           ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{file.path}}">
           {{file.path}}
         </a>
         <a ng-if="file.type !== 'DIRECTORY'"

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.controller.js
@@ -20,7 +20,7 @@ angular.module('CentralDogmaAdmin')
 
                   $scope.setRevision = function (revision) {
                     $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
-                                   '/tree/' + revision + $scope.path);
+                                   '/list/' + revision + $scope.path);
                   };
 
                   $scope.selectFile = function (file) {

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.html
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}/">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>
@@ -41,7 +41,7 @@
     <tr ng-if="parsedPaths.length > 1">
       <td style="width: 20px;"><span class="glyphicon glyphicon-level-up"></span></td>
       <td>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{parsedPaths[parsedPaths.length-2].path}}">..</a>
+        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPaths[parsedPaths.length-2].path}}">..</a>
       </td>
     </tr>
     <tr ng-if="files.length == 0">
@@ -55,7 +55,7 @@
       </td>
       <td>
         <a ng-if="file.type === 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/tree/{{revision}}{{file.path}}">{{file.name}}</a>
+           ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{file.path}}">{{file.name}}</a>
         <a ng-if="file.type !== 'DIRECTORY'"
            ng-href="#/{{project.name}}/{{repository.name}}/files/{{revision}}{{file.path}}">{{file.name}}</a>
       </td>

--- a/server/src/main/resources/webapp/scripts/components/entities/repository.service.js
+++ b/server/src/main/resources/webapp/scripts/components/entities/repository.service.js
@@ -66,7 +66,7 @@ angular.module('CentralDogmaAdmin')
 
                    return ApiV1Service.get(StringUtil.encodeUri(['projects', projectName,
                                                                  'repos', repositoryName,
-                                                                 'tree', path]));
+                                                                 'list', path]));
                  },
 
                  getFile: function (projectName, repositoryName, revision, query) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -87,7 +87,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }]" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
@@ -120,7 +120,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/bar.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/bar.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/bar.json\"" +
                 "   }]" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
@@ -157,7 +157,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/b\"," +
                 "       \"type\": \"DIRECTORY\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/b\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/b\"" +
                 "   }]" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
@@ -198,11 +198,11 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/foo0.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo0.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo0.json\"" +
                 "   },{" +
                 "       \"path\": \"/foo1.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo1.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo1.json\"" +
                 "   }]" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
@@ -328,7 +328,7 @@ public class ContentServiceV1Test {
                 "   \"path\": \"/foo.json\"," +
                 "   \"type\": \"JSON\"," +
                 "   \"content\" : {\"a\":\"bar\"}," +
-                "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
@@ -346,7 +346,7 @@ public class ContentServiceV1Test {
                 "   \"path\": \"/foo.json\"," +
                 "   \"type\": \"JSON\"," +
                 "   \"content\" : \"bar\"," +
-                "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 '}';
         final String actualJson = aRes.content().toStringUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
@@ -364,17 +364,17 @@ public class ContentServiceV1Test {
                 "   {" +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a/bar.txt\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a/bar.txt\"" +
                 "   }," +
                 "   {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
         final String actualJson1 = res1.content().toStringUtf8();
@@ -388,12 +388,12 @@ public class ContentServiceV1Test {
                 "   {" +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
         final String actualJson2 = res2.content().toStringUtf8();
@@ -407,7 +407,7 @@ public class ContentServiceV1Test {
                 "   {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
         assertThatJson(expectedJson3).isEqualTo(res3.content().toStringUtf8());
@@ -430,19 +430,19 @@ public class ContentServiceV1Test {
                 "   {" +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
                 "       \"content\" : \"text in the file.\\n\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a/bar.txt\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a/bar.txt\"" +
                 "   }," +
                 "   {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\" : {\"a\":\"bar\"}," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
         final String actualJson1 = res1.content().toStringUtf8();
@@ -456,7 +456,7 @@ public class ContentServiceV1Test {
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\" : {\"a\":\"bar\"}," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
         final String actualJson2 = res2.content().toStringUtf8();
@@ -517,7 +517,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }]" +
                 '}';
         final String actualJson = res1.content().toStringUtf8();
@@ -559,7 +559,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a/bar.txt\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a/bar.txt\"" +
                 "   }]" +
                 '}';
         final String actualJson = res1.content().toStringUtf8();
@@ -610,7 +610,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }]" +
                 '}';
         final String actualJson = res.content().toStringUtf8();
@@ -670,7 +670,7 @@ public class ContentServiceV1Test {
                 "   \"entries\": [{" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }]" +
                 '}';
         final AggregatedHttpMessage res = future.join();
@@ -697,7 +697,7 @@ public class ContentServiceV1Test {
                 "   {" +
                 "       \"path\": \"/a.json/b.json\"," +
                 "       \"type\": \"DIRECTORY\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a.json/b.json\"" +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a.json/b.json\"" +
                 "   }" +
                 ']';
         // List directory without slash.

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -358,9 +358,14 @@ public class ContentServiceV1Test {
         addBarTxt();
         // get the list of all files
         final AggregatedHttpMessage res1 = httpClient
-                .get("/api/v1/projects/myPro/repos/myRepo/tree/**").aggregate().join();
+                .get("/api/v1/projects/myPro/repos/myRepo/list/**").aggregate().join();
         final String expectedJson1 =
                 '[' +
+                "   {" +
+                "       \"path\": \"/a\"," +
+                "       \"type\": \"DIRECTORY\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "   }," +
                 "   {" +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
@@ -377,9 +382,14 @@ public class ContentServiceV1Test {
 
         // get the list of files only under root
         final AggregatedHttpMessage res2 = httpClient
-                .get("/api/v1/projects/myPro/repos/myRepo/tree/").aggregate().join();
+                .get("/api/v1/projects/myPro/repos/myRepo/list/").aggregate().join();
         final String expectedJson2 =
                 '[' +
+                "   {" +
+                "       \"path\": \"/a\"," +
+                "       \"type\": \"DIRECTORY\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "   }," +
                 "   {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
@@ -391,13 +401,21 @@ public class ContentServiceV1Test {
 
         // get the list of all files with revision 2, so only foo.json will be fetched
         final AggregatedHttpMessage res3 = httpClient
-                .get("/api/v1/projects/myPro/repos/myRepo/tree/**?revision=2").aggregate().join();
-        assertThatJson(expectedJson2).isEqualTo(res3.content().toStringUtf8());
+                .get("/api/v1/projects/myPro/repos/myRepo/list/**?revision=2").aggregate().join();
+        final String expectedJson3 =
+                '[' +
+                "   {" +
+                "       \"path\": \"/foo.json\"," +
+                "       \"type\": \"JSON\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/foo.json\"" +
+                "   }" +
+                ']';
+        assertThatJson(expectedJson3).isEqualTo(res3.content().toStringUtf8());
 
         // get the list with a file path
         final AggregatedHttpMessage res4 = httpClient
-                .get("/api/v1/projects/myPro/repos/myRepo/tree/foo.json").aggregate().join();
-        assertThatJson(expectedJson2).isEqualTo(res4.content().toStringUtf8());
+                .get("/api/v1/projects/myPro/repos/myRepo/list/foo.json").aggregate().join();
+        assertThatJson(expectedJson3).isEqualTo(res4.content().toStringUtf8());
     }
 
     @Test
@@ -409,6 +427,11 @@ public class ContentServiceV1Test {
         final AggregatedHttpMessage res1 = httpClient.get(CONTENTS_PREFIX + "/**").aggregate().join();
         final String expectedJson1 =
                 '[' +
+                "   {" +
+                "       \"path\": \"/a\"," +
+                "       \"type\": \"DIRECTORY\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a\"" +
+                "   }," +
                 "   {" +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
@@ -459,8 +482,8 @@ public class ContentServiceV1Test {
         assertThat(res1.headers().status()).isEqualTo(HttpStatus.OK);
 
         final AggregatedHttpMessage res2 = httpClient.get(CONTENTS_PREFIX + "/**").aggregate().join();
-        // only /a/bar.txt file is left
-        assertThat(Jackson.readTree(res2.content().toStringUtf8()).size()).isOne();
+        // /a directory and /a/bar.txt file are left
+        assertThat(Jackson.readTree(res2.content().toStringUtf8()).size()).isEqualTo(2);
     }
 
     @Test
@@ -653,6 +676,39 @@ public class ContentServiceV1Test {
         final AggregatedHttpMessage res = future.join();
         final String actualJson = res.content().toStringUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
+    }
+
+    @Test
+    public void listADirectoryWithoutSlash() {
+        final String body =
+                '{' +
+                "   \"path\" : \"/a.json/b.json/c.json/d.json\"," +
+                "   \"type\" : \"UPSERT_JSON\"," +
+                "   \"content\" : {\"a\": \"bar\"}," +
+                "   \"commitMessage\" : {" +
+                "       \"summary\" : \"Add d.json in weird directory structure\"" +
+                "   }" +
+                '}';
+        final HttpHeaders headers = HttpHeaders.of(HttpMethod.POST, CONTENTS_PREFIX)
+                                               .contentType(MediaType.JSON);
+        httpClient.execute(headers, body).aggregate().join();
+        final String expectedJson =
+                '[' +
+                "   {" +
+                "       \"path\": \"/a.json/b.json\"," +
+                "       \"type\": \"DIRECTORY\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/a.json/b.json\"" +
+                "   }" +
+                ']';
+        // List directory without slash.
+        final AggregatedHttpMessage res1 = httpClient
+                .get("/api/v1/projects/myPro/repos/myRepo/list/a.json").aggregate().join();
+        assertThatJson(res1.content().toStringUtf8()).isEqualTo(expectedJson);
+
+        // Listing directory with a slash is same with the listing director without slash which is res1.
+        final AggregatedHttpMessage res2 = httpClient
+                .get("/api/v1/projects/myPro/repos/myRepo/list/a.json/").aggregate().join();
+        assertThatJson(res2.content().toStringUtf8()).isEqualTo(expectedJson);
     }
 
     private static AggregatedHttpMessage addFooJson() {


### PR DESCRIPTION
Motivations:
Currently, it does not return direcotries when calling `listFiles` or `getFiles`.
And there are a lot of chances that a user requests with a `path` that is not following
the pattern completely  such as a direcotry without ending slash.

Modifications:
- Normalizes the path so that it can handle most of cases
- Changes to return `CompletebleFuture` in HTTP API V1 for consistency

Result:
- Can use HTTP API v1