### PR TITLE
Allow accessing `metadata.json` to only administrators

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.centraldogma.it;
 
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 import static com.linecorp.centraldogma.testing.internal.ExpectedExceptionAppender.assertThatThrownByWithExpectedException;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,7 +88,7 @@ public class RepositoryManagementTest {
         final Map<String, RepositoryInfo> repos = rule.client().listRepositories(rule.project()).join();
 
         // Should contain 2 "rNNN"s
-        assertThat(repos.keySet()).containsExactlyInAnyOrder(INTERNAL_REPOSITORY_NAME, Project.REPO_META,
+        assertThat(repos.keySet()).containsExactlyInAnyOrder(INTERNAL_REPO, Project.REPO_META,
                                                              rule.repo1(), rule.repo2());
 
         for (RepositoryInfo r : repos.values()) {

--- a/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.it;
 
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static com.linecorp.centraldogma.testing.internal.ExpectedExceptionAppender.assertThatThrownByWithExpectedException;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,6 +33,7 @@ import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
 public class RepositoryManagementTest {
 
@@ -86,7 +88,8 @@ public class RepositoryManagementTest {
         final Map<String, RepositoryInfo> repos = rule.client().listRepositories(rule.project()).join();
 
         // Should contain 2 "rNNN"s
-        assertThat(repos.keySet()).containsExactlyInAnyOrder("meta", rule.repo1(), rule.repo2());
+        assertThat(repos.keySet()).containsExactlyInAnyOrder(INTERNAL_REPOSITORY_NAME, Project.REPO_META,
+                                                             rule.repo1(), rule.repo2());
 
         for (RepositoryInfo r : repos.values()) {
             final Commit headCommit = r.lastCommit();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LoginService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LoginService.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.server.internal.admin.authentication;
 
 import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.newHttpResponseException;
-import static com.linecorp.centraldogma.server.internal.storage.repository.cache.RepositoryCache.validateCacheSpec;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -38,7 +37,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -71,11 +69,11 @@ public class LoginService extends AbstractHttpService {
     private final Cache<String, AccessToken> cache;
 
     public LoginService(CentralDogmaSecurityManager securityManager, CommandExecutor executor,
-                        Function<String, String> loginNameNormalizer, String sessionCacheSpec) {
+                        Function<String, String> loginNameNormalizer, Cache<String, AccessToken> cache) {
         this.securityManager = requireNonNull(securityManager, "securityManager");
         this.executor = requireNonNull(executor, "executor");
         this.loginNameNormalizer = requireNonNull(loginNameNormalizer, "loginNameNormalizer");
-        cache = Caffeine.from(validateCacheSpec(sessionCacheSpec)).build();
+        this.cache = requireNonNull(cache, "cache");
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
@@ -26,6 +26,8 @@ import org.apache.shiro.util.ThreadContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.Cache;
+
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -33,6 +35,7 @@ import com.linecorp.armeria.server.AbstractHttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.auth.AuthTokenExtractors;
 import com.linecorp.armeria.server.auth.OAuth2Token;
+import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 
@@ -45,10 +48,13 @@ public class LogoutService extends AbstractHttpService {
 
     private final CentralDogmaSecurityManager securityManager;
     private final CommandExecutor executor;
+    private final Cache<String, AccessToken> cache;
 
-    public LogoutService(CentralDogmaSecurityManager securityManager, CommandExecutor executor) {
+    public LogoutService(CentralDogmaSecurityManager securityManager, CommandExecutor executor,
+                         Cache<String, AccessToken> cache) {
         this.securityManager = requireNonNull(securityManager, "securityManager");
         this.executor = requireNonNull(executor, "executor");
+        this.cache = requireNonNull(cache, "cache");
     }
 
     @Override
@@ -77,6 +83,7 @@ public class LogoutService extends AbstractHttpService {
                         // Get the principal before logging out because otherwise it will be cleared out.
                         final Object principal = currentUser.getPrincipal();
                         currentUser.logout();
+                        cache.invalidate(principal);
                         executor.execute(Command.removeSession(sessionId)).join();
                         logger.info("{} Logged out: {} ({})", ctx, principal, sessionId);
                     } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
@@ -81,11 +81,11 @@ public class LogoutService extends AbstractHttpService {
                                 .buildSubject();
 
                         // Get the principal before logging out because otherwise it will be cleared out.
-                        final Object principal = currentUser.getPrincipal();
+                        final String username = (String) currentUser.getPrincipal();
                         currentUser.logout();
-                        cache.invalidate(principal);
+                        cache.invalidate(username);
                         executor.execute(Command.removeSession(sessionId)).join();
-                        logger.info("{} Logged out: {} ({})", ctx, principal, sessionId);
+                        logger.info("{} Logged out: {} ({})", ctx, username, sessionId);
                     } else {
                         logger.debug("{} Tried to log out a non-existent session: {}", ctx, sessionId);
                     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -19,7 +19,7 @@ package com.linecorp.centraldogma.server.internal.api;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.checkUnremoveArgument;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.returnOrThrow;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -95,7 +95,7 @@ public class RepositoryServiceV1 extends AbstractService {
 
             // Do not add internal repository to the list if the user is not an administrator.
             return project.repos().list().values().stream()
-                          .filter(r -> user.isAdmin() || !INTERNAL_REPOSITORY_NAME.equals(r.name()))
+                          .filter(r -> user.isAdmin() || !INTERNAL_REPO.equals(r.name()))
                           .map(DtoConverter::convert)
                           .collect(toImmutableList());
         });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.api;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.checkUnremoveArgument;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.returnOrThrow;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -92,9 +93,9 @@ public class RepositoryServiceV1 extends AbstractService {
                 return Exceptions.throwUnsafely(HttpStatusException.of(HttpStatus.FORBIDDEN));
             }
 
-            // Do not add "meta" repository to the list if the user is not an owner of the project.
+            // Do not add internal repository to the list if the user is not an administrator.
             return project.repos().list().values().stream()
-                          .filter(r -> hasOwnerRole || !Project.REPO_META.equals(r.name()))
+                          .filter(r -> user.isAdmin() || !INTERNAL_REPOSITORY_NAME.equals(r.name()))
                           .map(DtoConverter::convert)
                           .collect(toImmutableList());
         });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.api.auth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.centraldogma.server.internal.api.auth.AbstractRoleCheckingDecorator.handleException;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
@@ -36,8 +37,6 @@ import com.linecorp.centraldogma.server.internal.admin.authentication.User;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataService;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataServiceInjector;
 import com.linecorp.centraldogma.server.internal.metadata.Permission;
-import com.linecorp.centraldogma.server.internal.metadata.ProjectRole;
-import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
 /**
  * An abstract class for checking permission of an incoming request.
@@ -58,27 +57,28 @@ abstract class AbstractPermissionCheckingDecorator
         final String repoName = ctx.pathParam("repoName");
         checkArgument(!isNullOrEmpty(repoName), "no repository name is specified");
 
-        if (Project.REPO_META.equals(repoName)) {
-            return serveMetaRepo(delegate, ctx, req, mds, user, projectName);
+        if (INTERNAL_REPOSITORY_NAME.equals(repoName)) {
+            return serveInternalRepo(delegate, ctx, req, mds, user, projectName);
         } else {
-            return serveNonMetaRepo(delegate, ctx, req, mds, user, projectName, repoName);
+            return serveUserRepo(delegate, ctx, req, mds, user, projectName, repoName);
         }
     }
 
-    private static HttpResponse serveMetaRepo(Service<HttpRequest, HttpResponse> delegate,
-                                              ServiceRequestContext ctx, HttpRequest req,
-                                              MetadataService mds, User user,
-                                              String projectName) throws Exception {
+    private static HttpResponse serveInternalRepo(Service<HttpRequest, HttpResponse> delegate,
+                                                  ServiceRequestContext ctx, HttpRequest req,
+                                                  MetadataService mds, User user,
+                                                  String projectName) throws Exception {
         if (user.isAdmin()) {
             return delegate.serve(ctx, req);
         }
-        // We do not manage permission for "meta" repository. Actually we do not have a metadata of that.
-        // So we need to check "role" here when the request is accessing to "meta" repository.
+        // We do not manage permission for the internal repository. Actually we do not have a metadata of that.
+        // So we need to check whether the current user is an 'administrator' or not when the request is
+        // accessing to the internal repository.
         return HttpResponse.from(mds.findRole(projectName, user).handle((role, cause) -> {
             if (cause != null) {
                 return handleException(cause);
             }
-            if (role != ProjectRole.OWNER) {
+            if (!user.isAdmin()) {
                 throw HttpStatusException.of(HttpStatus.FORBIDDEN);
             }
             try {
@@ -89,10 +89,10 @@ abstract class AbstractPermissionCheckingDecorator
         }));
     }
 
-    private HttpResponse serveNonMetaRepo(Service<HttpRequest, HttpResponse> delegate,
-                                          ServiceRequestContext ctx, HttpRequest req,
-                                          MetadataService mds, User user,
-                                          String projectName, String repoName) throws Exception {
+    private HttpResponse serveUserRepo(Service<HttpRequest, HttpResponse> delegate,
+                                       ServiceRequestContext ctx, HttpRequest req,
+                                       MetadataService mds, User user,
+                                       String projectName, String repoName) throws Exception {
         final CompletionStage<Collection<Permission>> f;
         try {
             f = mds.findPermissions(projectName, repoName, user);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
@@ -19,7 +19,7 @@ package com.linecorp.centraldogma.server.internal.api.auth;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.centraldogma.server.internal.api.auth.AbstractRoleCheckingDecorator.handleException;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 
 import java.util.Collection;
 import java.util.concurrent.CompletionStage;
@@ -57,7 +57,7 @@ abstract class AbstractPermissionCheckingDecorator
         final String repoName = ctx.pathParam("repoName");
         checkArgument(!isNullOrEmpty(repoName), "no repository name is specified");
 
-        if (INTERNAL_REPOSITORY_NAME.equals(repoName)) {
+        if (INTERNAL_REPO.equals(repoName)) {
             return serveInternalRepo(delegate, ctx, req, mds, user, projectName);
         } else {
             return serveUserRepo(delegate, ctx, req, mds, user, projectName, repoName);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
@@ -18,7 +18,7 @@ package com.linecorp.centraldogma.server.internal.api.converter;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -64,7 +64,7 @@ public final class HttpApiRequestConverter implements RequestConverterFunction {
             checkArgument(!isNullOrEmpty(repositoryName),
                           "repository name should not be null or empty.");
 
-            if (INTERNAL_REPOSITORY_NAME.equals(repositoryName) &&
+            if (INTERNAL_REPO.equals(repositoryName) &&
                 !AuthenticationUtil.currentUser(ctx).isAdmin()) {
                 throw HttpStatusException.of(HttpStatus.FORBIDDEN);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
@@ -18,9 +18,12 @@ package com.linecorp.centraldogma.server.internal.api.converter;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Author;
@@ -61,6 +64,10 @@ public final class HttpApiRequestConverter implements RequestConverterFunction {
             checkArgument(!isNullOrEmpty(repositoryName),
                           "repository name should not be null or empty.");
 
+            if (INTERNAL_REPOSITORY_NAME.equals(repositoryName) &&
+                !AuthenticationUtil.currentUser(ctx).isAdmin()) {
+                throw HttpStatusException.of(HttpStatus.FORBIDDEN);
+            }
             // RepositoryNotFoundException would be thrown if there is no project or no repository.
             return projectManager.get(projectName).repos().get(repositoryName);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -31,7 +31,7 @@ import com.linecorp.centraldogma.server.internal.storage.project.Project;
 public final class ProjectInitializer {
 
     public static final String INTERNAL_PROJECT_NAME = "dogma";
-    public static final String INTERNAL_REPOSITORY_NAME = "main";
+    public static final String INTERNAL_REPOSITORY_NAME = "dogma";
 
     /**
      * Creates an internal project and repositories such as a token storage.
@@ -46,6 +46,8 @@ public final class ProjectInitializer {
                 throw new Error("failed to initialize an internal project", cause);
             }
         }
+        // These repositories might be created when creating an internal project, but we try to create them
+        // again here in order to make sure them exist because sometimes their names are changed.
         for (final String repo : ImmutableList.of(Project.REPO_META,
                                                   INTERNAL_REPOSITORY_NAME)) {
             try {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializer.java
@@ -30,15 +30,15 @@ import com.linecorp.centraldogma.server.internal.storage.project.Project;
 // TODO(trustin): Generate more useful set of sample files.
 public final class ProjectInitializer {
 
-    public static final String INTERNAL_PROJECT_NAME = "dogma";
-    public static final String INTERNAL_REPOSITORY_NAME = "dogma";
+    public static final String INTERNAL_PROJ = "dogma";
+    public static final String INTERNAL_REPO = "dogma";
 
     /**
      * Creates an internal project and repositories such as a token storage.
      */
     public static void initializeInternalProject(CommandExecutor executor) {
         try {
-            executor.execute(createProject(Author.SYSTEM, INTERNAL_PROJECT_NAME))
+            executor.execute(createProject(Author.SYSTEM, INTERNAL_PROJ))
                     .get();
         } catch (Throwable cause) {
             cause = Exceptions.peel(cause);
@@ -48,10 +48,9 @@ public final class ProjectInitializer {
         }
         // These repositories might be created when creating an internal project, but we try to create them
         // again here in order to make sure them exist because sometimes their names are changed.
-        for (final String repo : ImmutableList.of(Project.REPO_META,
-                                                  INTERNAL_REPOSITORY_NAME)) {
+        for (final String repo : ImmutableList.of(Project.REPO_META, INTERNAL_REPO)) {
             try {
-                executor.execute(createRepository(Author.SYSTEM, INTERNAL_PROJECT_NAME, repo))
+                executor.execute(createRepository(Author.SYSTEM, INTERNAL_PROJ, repo))
                         .get();
             } catch (Throwable cause) {
                 cause = Exceptions.peel(cause);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.centraldogma.server.internal.command;
 
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_JSON;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_REPO;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
@@ -59,10 +59,10 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         final Author author = c.author();
 
         final CompletableFuture<Void> f = delegate().execute(c);
-        // Metadata is stored in 'INTERNAL_REPOSITORY_NAME' repository.
+        // Metadata is stored in 'INTERNAL_REPO' repository.
         return f.thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
                                                                                    projectName,
-                                                                                   INTERNAL_REPOSITORY_NAME)))
+                                                                                   INTERNAL_REPO)))
                 .thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
                                                                                    projectName, REPO_META)))
                 .thenCompose(unused -> initializeMetadata(delegate(), projectName, author))
@@ -73,7 +73,7 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
                                                                   String projectName,
                                                                   Author author) {
         // Do not generate a metadata file for internal projects.
-        if (projectName.equals(INTERNAL_PROJECT_NAME)) {
+        if (projectName.equals(INTERNAL_PROJ)) {
             return CompletableFuture.completedFuture(Revision.INIT);
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.command;
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_JSON;
+import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_REPO;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 
 import java.util.concurrent.CompletableFuture;
@@ -86,7 +87,7 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
                                                              ImmutableMap.of(),
                                                              userAndTimestamp, null);
         return executor.execute(Command.push(
-                Author.SYSTEM, projectName, REPO_META, Revision.HEAD,
+                Author.SYSTEM, projectName, METADATA_REPO, Revision.HEAD,
                 "Initialize metadata", "", Markup.PLAINTEXT,
                 Change.ofJsonUpsert(METADATA_JSON, Jackson.valueToTree(metadata))));
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.command;
 
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
 import static com.linecorp.centraldogma.server.internal.metadata.MetadataService.METADATA_JSON;
 import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 
@@ -57,7 +58,11 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         final Author author = c.author();
 
         final CompletableFuture<Void> f = delegate().execute(c);
+        // Metadata is stored in 'INTERNAL_REPOSITORY_NAME' repository.
         return f.thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
+                                                                                   projectName,
+                                                                                   INTERNAL_REPOSITORY_NAME)))
+                .thenCompose(unused -> delegate().execute(Command.createRepository(creationTimeMillis, author,
                                                                                    projectName, REPO_META)))
                 .thenCompose(unused -> initializeMetadata(delegate(), projectName, author))
                 .thenApply(unused -> null);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
@@ -60,6 +60,11 @@ import com.linecorp.centraldogma.server.internal.storage.project.SafeProjectMana
 public class MetadataService extends AbstractService {
 
     /**
+     * The name of metadata repository.
+     */
+    public static final String METADATA_REPO = INTERNAL_REPOSITORY_NAME;
+
+    /**
      * A path of metadata file.
      */
     public static final String METADATA_JSON = "/metadata.json";
@@ -68,11 +73,6 @@ public class MetadataService extends AbstractService {
      * A path of token list file.
      */
     static final String TOKEN_JSON = "/tokens.json";
-
-    /**
-     * The name of metadata repository.
-     */
-    static final String METADATA_REPO = INTERNAL_REPOSITORY_NAME;
 
     /**
      * A {@link JsonPointer} of project removal information.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
@@ -72,7 +72,7 @@ public class MetadataService extends AbstractService {
     /**
      * The name of metadata repository.
      */
-    static final String METADATA_REPO = Project.REPO_META;
+    static final String METADATA_REPO = INTERNAL_REPOSITORY_NAME;
 
     /**
      * A {@link JsonPointer} of project removal information.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/metadata/MetadataService.java
@@ -18,8 +18,8 @@ package com.linecorp.centraldogma.server.internal.metadata;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation.asJsonArray;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPOSITORY_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_REPO;
 import static com.linecorp.centraldogma.server.internal.metadata.RepositoryUtil.convertWithJackson;
 import static com.linecorp.centraldogma.server.internal.metadata.Tokens.SECRET_PREFIX;
 import static com.linecorp.centraldogma.server.internal.metadata.Tokens.validateSecret;
@@ -62,7 +62,7 @@ public class MetadataService extends AbstractService {
     /**
      * The name of metadata repository.
      */
-    public static final String METADATA_REPO = INTERNAL_REPOSITORY_NAME;
+    public static final String METADATA_REPO = INTERNAL_REPO;
 
     /**
      * A path of metadata file.
@@ -686,7 +686,7 @@ public class MetadataService extends AbstractService {
      * Returns a {@link Tokens}.
      */
     public CompletableFuture<Tokens> getTokens() {
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                         .thenApply(HolderWithRevision::object);
     }
 
@@ -734,7 +734,7 @@ public class MetadataService extends AbstractService {
                                                new AddOperation(appIdPath, Jackson.valueToTree(newToken)),
                                                new AddOperation(secretPath,
                                                                 Jackson.valueToTree(newToken.id()))));
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
+        return tokenRepo.push(INTERNAL_PROJ, INTERNAL_REPO, author,
                               "Add a token: '" + newToken.id(), change);
     }
 
@@ -753,8 +753,8 @@ public class MetadataService extends AbstractService {
             futures[i++] = removeToken(p.name(), author, appId, true).toCompletableFuture();
         }
         return CompletableFuture.allOf(futures).thenCompose(unused -> tokenRepo.push(
-                INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author, "Remove the token: '" + appId,
-                () -> tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+                INTERNAL_PROJ, INTERNAL_REPO, author, "Remove the token: '" + appId,
+                () -> tokenRepo.fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                                .thenApply(tokens -> {
                                    final Token token = tokens.object().get(appId);
                                    final JsonPointer appIdPath =
@@ -777,10 +777,10 @@ public class MetadataService extends AbstractService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
+        return tokenRepo.push(INTERNAL_PROJ, INTERNAL_REPO, author,
                               "Enable the token: '" + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -804,10 +804,10 @@ public class MetadataService extends AbstractService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, author,
+        return tokenRepo.push(INTERNAL_PROJ, INTERNAL_REPO, author,
                               "Disable the token: '" + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -829,7 +829,7 @@ public class MetadataService extends AbstractService {
      */
     public CompletableFuture<Token> findTokenByAppId(String appId) {
         requireNonNull(appId, "appId");
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().get(appId));
     }
 
@@ -839,7 +839,7 @@ public class MetadataService extends AbstractService {
     public CompletableFuture<Token> findTokenBySecret(String secret) {
         requireNonNull(secret, "secret");
         validateSecret(secret);
-        return tokenRepo.fetch(INTERNAL_PROJECT_NAME, INTERNAL_REPOSITORY_NAME, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJ, INTERNAL_REPO, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().findBySecret(secret));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.project;
 
-import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJECT_NAME;
+import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.INTERNAL_PROJ;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
@@ -112,6 +112,6 @@ public class SafeProjectManager implements ProjectManager {
 
     protected static boolean isValidProjectName(String name) {
         return name != null &&
-               !INTERNAL_PROJECT_NAME.equals(name);
+               !INTERNAL_PROJ.equals(name);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -128,6 +128,16 @@ public class RepositoryServiceV1Test {
         final String expectedJson =
                 '[' +
                 "   {" +
+                "       \"name\": \"dogma\"," +
+                "       \"creator\": {" +
+                "           \"name\": \"System\"," +
+                "           \"email\": \"system@localhost.localdomain\"" +
+                "       }," +
+                "       \"headRevision\": \"${json-unit.ignore}\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/dogma\"," +
+                "       \"createdAt\": \"${json-unit.ignore}\"" +
+                "   }," +
+                "   {" +
                 "       \"name\": \"meta\"," +
                 "       \"creator\": {" +
                 "           \"name\": \"System\"," +
@@ -194,8 +204,8 @@ public class RepositoryServiceV1Test {
         final String remains = remainedRes.content().toStringUtf8();
         final JsonNode jsonNode = Jackson.readTree(remains);
 
-        // meta and trustin repositories are left
-        assertThat(jsonNode.size()).isEqualTo(2);
+        // dogma, meta and trustin repositories are left
+        assertThat(jsonNode.size()).isEqualTo(3);
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MigrationUtilTest.java
@@ -198,6 +198,8 @@ public class MigrationUtilTest {
         // Ensure that "/project1/meta/metadata.json" has moved to "/project1/dogma/metadata.json".
         assertThat(project.repos().get(INTERNAL_REPOSITORY_NAME)
                           .getOrNull(Revision.HEAD, METADATA_JSON).join()).isNotNull();
+        assertThat(project.repos().get(Project.REPO_META)
+                          .getOrNull(Revision.HEAD, METADATA_JSON).join()).isNull();
 
         final Token token = mds.findTokenByAppId("app1").join();
         assertThat(token).isNotNull();
@@ -210,6 +212,9 @@ public class MigrationUtilTest {
         assertThat(pm.get(INTERNAL_PROJECT_NAME).repos()
                      .get(INTERNAL_REPOSITORY_NAME)
                      .getOrNull(Revision.HEAD, TOKEN_JSON).join()).isNotNull();
+        assertThat(pm.get(INTERNAL_PROJECT_NAME).repos()
+                     .get("main")
+                     .getOrNull(Revision.HEAD, TOKEN_JSON).join()).isNull();
     }
 
     private void createProject(String projectName) {


### PR DESCRIPTION
Modifications:
- Store `metadata.json` in `dogma` repository, instead of `meta` repository.
- Rename internal repository name of the internal project from `main` to `dogma` for consistency.
- Enhance `MigrationUtil` to support migration from 0.23.0.
- Miscellaneous
  - Invalidate session cache when a user is logged out.

Result:
- Closes #197