### PR TITLE
Add maxCommits url query to the REST API

### DIFF
--- a/client/go/dogma/cmd/cli_cmds.go
+++ b/client/go/dogma/cmd/cli_cmds.go
@@ -45,6 +45,11 @@ var toRevisionFlag = cli.StringFlag{
 	Usage: "Specifies the revision to apply until",
 }
 
+var maxCommitsFlag = cli.IntFlag{
+	Name:  "max-commits",
+	Usage: "Specifies the number of maximum commits to fetch",
+}
+
 var printFormatFlags = []cli.Flag{
 	cli.BoolFlag{
 		Name:   "pretty",
@@ -254,7 +259,7 @@ func CLICommands() []cli.Command {
 			Name:      "log",
 			Usage:     "Shows commit logs of the path",
 			ArgsUsage: "<project_name>/<repository_name>[/<path>]",
-			Flags:     append(printFormatFlags, fromRevisionFlag, toRevisionFlag),
+			Flags:     append(printFormatFlags, fromRevisionFlag, toRevisionFlag, maxCommitsFlag),
 			Action: func(c *cli.Context) error {
 				style, err := getPrintStyle(c)
 				if err != nil {

--- a/client/go/dogma/cmd/log_cmd.go
+++ b/client/go/dogma/cmd/log_cmd.go
@@ -23,8 +23,9 @@ import (
 )
 
 type logCommand struct {
-	repo  repositoryRequestInfoWithFromTo
-	style PrintStyle
+	repo       repositoryRequestInfoWithFromTo
+	maxCommits int
+	style      PrintStyle
 }
 
 func (l *logCommand) execute(c *cli.Context) error {
@@ -35,7 +36,7 @@ func (l *logCommand) execute(c *cli.Context) error {
 	}
 
 	commits, res, err := client.GetHistory(
-		context.Background(), repo.projName, repo.repoName, repo.from, repo.to, repo.path)
+		context.Background(), repo.projName, repo.repoName, repo.from, repo.to, repo.path, l.maxCommits)
 	if err != nil {
 		return err
 	}
@@ -69,5 +70,10 @@ func newLogCommand(c *cli.Context, style PrintStyle) (Command, error) {
 	repoWithFromTo.from = from
 	repoWithFromTo.to = to
 
-	return &logCommand{repo: repoWithFromTo, style: style}, nil
+	log := &logCommand{repo: repoWithFromTo, style: style}
+	maxCommits := c.Int("max-commits")
+	if maxCommits != 0 {
+		log.maxCommits = maxCommits
+	}
+	return log, nil
 }

--- a/client/go/dogma/content_service.go
+++ b/client/go/dogma/content_service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
@@ -236,7 +237,7 @@ func (con *contentService) getFiles(ctx context.Context,
 }
 
 func (con *contentService) getHistory(ctx context.Context,
-	projectName, repoName, from, to, pathPattern string) ([]*Commit, *http.Response, error) {
+	projectName, repoName, from, to, pathPattern string, maxCommits int) ([]*Commit, *http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v/commits/%v", defaultPathPrefix, projectName, repoName, from)
 
 	v := &url.Values{}
@@ -245,6 +246,9 @@ func (con *contentService) getHistory(ctx context.Context,
 	}
 	if len(to) != 0 {
 		v.Set("to", to)
+	}
+	if maxCommits != 0 {
+		v.Set("maxCommits", strconv.Itoa(maxCommits))
 	}
 	u += encodeValues(v)
 

--- a/client/go/dogma/content_service_test.go
+++ b/client/go/dogma/content_service_test.go
@@ -156,11 +156,13 @@ func TestGetHistory(t *testing.T) {
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/commits/-2", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testURLQuery(t, r, "to", "-1")
+		testURLQuery(t, r, "maxCommits", "2")
+
 		fmt.Fprint(w, `[{"revision":1, "author":{"name":"minux", "email":"minux@m.x"}, "commitMessage":{"Summary":"Add a.json"}},
 {"revision":2, "author":{"name":"minux", "email":"minux@m.x"}, "commitMessage":{"Summary":"Edit a.json"}}]`)
 	})
 
-	history, _, _ := c.GetHistory(context.Background(), "foo", "bar", "-2", "-1", "/**")
+	history, _, _ := c.GetHistory(context.Background(), "foo", "bar", "-2", "-1", "/**", 2)
 	want := []*Commit{
 		{Revision: 1, Author: &Author{Name: "minux", Email: "minux@m.x"},
 			CommitMessage: &CommitMessage{Summary: "Add a.json"}},

--- a/client/go/dogma/dogma.go
+++ b/client/go/dogma/dogma.go
@@ -342,8 +342,8 @@ func (c *Client) GetFiles(ctx context.Context,
 //
 // If the from and to are not specified, this will return the history from the init to the latest revision.
 func (c *Client) GetHistory(ctx context.Context,
-	projectName, repoName, from, to, pathPattern string) ([]*Commit, *http.Response, error) {
-	return c.content.getHistory(ctx, projectName, repoName, from, to, pathPattern)
+	projectName, repoName, from, to, pathPattern string, maxCommits int) ([]*Commit, *http.Response, error) {
+	return c.content.getHistory(ctx, projectName, repoName, from, to, pathPattern, maxCommits)
 }
 
 // GetDiff returns the diff of a file between two revisions. If the from and to are not specified, this will

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -133,6 +133,44 @@ public class ListCommitsAndDiffTest {
     }
 
     @Test
+    public void listCommitsWithmaxCommits() {
+        final AggregatedHttpMessage aRes =
+                httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/-1?to=1&maxCommits=2")
+                          .aggregate().join();
+        final String expectedJson =
+                '[' +
+                "   {" +
+                "       \"revision\": 3," +
+                "       \"author\": {" +
+                "           \"name\": \"${json-unit.ignore}\"," +
+                "           \"email\": \"${json-unit.ignore}\"" +
+                "       }," +
+                "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                "       \"commitMessage\" : {" +
+                "           \"summary\" : \"Add foo1.json\"," +
+                "           \"detail\": \"Add because we need it.\"," +
+                "           \"markup\": \"PLAINTEXT\"" +
+                "       }" +
+                "   }," +
+                "   {" +
+                "       \"revision\": 2," +
+                "       \"author\": {" +
+                "           \"name\": \"${json-unit.ignore}\"," +
+                "           \"email\": \"${json-unit.ignore}\"" +
+                "       }," +
+                "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                "       \"commitMessage\" : {" +
+                "           \"summary\" : \"Add foo0.json\"," +
+                "           \"detail\": \"Add because we need it.\"," +
+                "           \"markup\": \"PLAINTEXT\"" +
+                "       }" +
+                "   }" +
+                ']';
+        final String actualJson = aRes.content().toStringUtf8();
+        assertThatJson(actualJson).isEqualTo(expectedJson);
+    }
+
+    @Test
     public void getOneCommit() {
         final AggregatedHttpMessage aRes = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/2")
                                                      .aggregate().join();


### PR DESCRIPTION
Motivation:
A user may not know how many history is in the repository and may have get an error
to get history using relative revision number (e.g, from `-1` to `-10` when there're
only three history).
If the user uses the `maxCommits` url query parameter (e.g `maxCommits=10`  with from `-1` to `1`),
there's no likely chance to fail and he or she is able to get the history no matter how many history
is is.

Modifications:
- Add `maxCommits` url query to the REST API
- Modify Go library to use it

Result:
- Better user experience