### PR TITLE
Do not allow any operations when server is shutting down or a reposit…

### DIFF
--- a/server/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
+++ b/server/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
@@ -67,7 +67,7 @@ public class GitRepositoryBenchmark {
 
     @TearDown
     public void destroy() throws Exception {
-        repo.close();
+        repo.internalClose();
         Util.deleteFileTree(repoDir);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/StorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/StorageManager.java
@@ -18,10 +18,13 @@ package com.linecorp.centraldogma.server.internal.storage;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
-public interface StorageManager<T> extends AutoCloseable {
-    @Override
-    void close();
+import com.linecorp.centraldogma.common.CentralDogmaException;
+
+public interface StorageManager<T> {
+
+    void close(Supplier<CentralDogmaException> failureCauseSupplier);
 
     boolean exists(String name);
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
@@ -20,11 +20,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.util.concurrent.Executor;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.server.internal.storage.DirectoryBasedStorageManager;
@@ -48,8 +50,8 @@ public class DefaultProjectManager extends DirectoryBasedStorageManager<Project>
     }
 
     @Override
-    public void close() {
-        super.close();
+    public void close(Supplier<CentralDogmaException> failureCauseSupplier) {
+        super.close(failureCauseSupplier);
         if (cache != null) {
             cache.clear();
         }
@@ -66,18 +68,19 @@ public class DefaultProjectManager extends DirectoryBasedStorageManager<Project>
     }
 
     @Override
-    protected void closeChild(File childDir, Project child) {
+    protected void closeChild(File childDir, Project child,
+                              Supplier<CentralDogmaException> failureCauseSupplier) {
         final DefaultProject c = (DefaultProject) child;
-        c.repos.close();
+        c.repos.close(failureCauseSupplier);
     }
 
     @Override
-    protected RuntimeException newStorageExistsException(String name) {
+    protected CentralDogmaException newStorageExistsException(String name) {
         return new ProjectExistsException(name);
     }
 
     @Override
-    protected RuntimeException newStorageNotFoundException(String name) {
+    protected CentralDogmaException newStorageNotFoundException(String name) {
         return new ProjectNotFoundException(name);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -23,8 +23,11 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+
+import com.linecorp.centraldogma.common.CentralDogmaException;
 
 /**
  * A wrapper class of {@link ProjectManager} which prevents accessing internal projects
@@ -44,8 +47,8 @@ public class SafeProjectManager implements ProjectManager {
     }
 
     @Override
-    public void close() {
-        delegate().close();
+    public void close(Supplier<CentralDogmaException> failureCauseSupplier) {
+        delegate().close(failureCauseSupplier);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -27,7 +27,9 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.internal.Util;
 
@@ -47,8 +49,8 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     }
 
     @Override
-    public void close() {
-        delegate.close();
+    public void close(Supplier<CentralDogmaException> failureCauseSupplier) {
+        delegate.close(failureCauseSupplier);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitUtil.java
@@ -68,7 +68,7 @@ final class CommitUtil {
         requireNonNull(author, "author");
         when = when / 1000L * 1000L; // Drop the milliseconds
         try {
-            JsonNode jsonNode = Jackson.readTree(jsonString);
+            final JsonNode jsonNode = Jackson.readTree(jsonString);
 
             final String summary = Jackson.textValue(jsonNode.get(FIELD_NAME_SUMMARY), "");
             final String detail = Jackson.textValue(jsonNode.get(FIELD_NAME_DETAIL), "");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
@@ -34,6 +34,7 @@ import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.thrift.Author;
 import com.linecorp.centraldogma.internal.thrift.AuthorConverter;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaException;
@@ -193,6 +194,8 @@ final class Converter {
             code = ErrorCode.REPOSITORY_NOT_FOUND;
         } else if (t instanceof RepositoryExistsException) {
             code = ErrorCode.REPOSITORY_EXISTS;
+        } else if (t instanceof ShuttingDownException) {
+            code = ErrorCode.SHUTTING_DOWN;
         }
 
         final CentralDogmaException cde = new CentralDogmaException(code);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/plugin/PluginTest.java
@@ -43,6 +43,7 @@ import org.junit.rules.TestName;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.server.internal.storage.project.DefaultProjectManager;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
@@ -68,7 +69,7 @@ public class PluginTest {
     @AfterClass
     public static void afterClass() throws Exception {
         if (pm != null) {
-            pm.close();
+            pm.close(ShuttingDownException::new);
             pm = null;
         }
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
@@ -43,6 +43,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.server.internal.mirror.Mirror;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.internal.mirror.credential.NoneMirrorCredential;
@@ -88,7 +89,7 @@ public class DefaultMetaRepositoryTest {
 
     @AfterClass
     public static void destroy() {
-        pm.close();
+        pm.close(ShuttingDownException::new);
     }
 
     @Before

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -37,6 +37,7 @@ import org.junit.rules.TestName;
 
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepositoryManager;
 
@@ -120,13 +121,13 @@ public class RepositoryManagerWrapperTest {
         final String name = testName.getMethodName();
         m.create(name);
         assertTrue(m.exists(name));
-        m.close();
+        m.close(ShuttingDownException::new);
 
-        assertThatThrownBy(() -> m.get(name)).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.exists(name)).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.remove(name)).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.unremove(name)).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.list()).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> m.listRemoved()).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(() -> m.get(name)).isInstanceOf(ShuttingDownException.class);
+        assertThatThrownBy(() -> m.exists(name)).isInstanceOf(ShuttingDownException.class);
+        assertThatThrownBy(() -> m.remove(name)).isInstanceOf(ShuttingDownException.class);
+        assertThatThrownBy(() -> m.unremove(name)).isInstanceOf(ShuttingDownException.class);
+        assertThatThrownBy(() -> m.list()).isInstanceOf(ShuttingDownException.class);
+        assertThatThrownBy(() -> m.listRemoved()).isInstanceOf(ShuttingDownException.class);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
@@ -148,7 +148,7 @@ public class CommitIdDatabaseTest {
                                            Change.ofTextUpsert("/" + i + ".txt", "")).join();
             }
         } finally {
-            repo.close();
+            repo.internalClose();
         }
 
         // Wipe out the commit ID database.
@@ -165,7 +165,7 @@ public class CommitIdDatabaseTest {
                 assertThat(repo.find(new Revision(i + 1), "/" + i + ".txt").join()).hasSize(1);
             }
         } finally {
-            repo.close();
+            repo.internalClose();
         }
 
         assertThat(Files.size(commitIdDatabaseFile.toPath())).isEqualTo((numCommits + 1) * 24L);

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerRule.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerRule.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ForkJoinPool;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
 
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.command.ProjectInitializer;
 import com.linecorp.centraldogma.server.internal.command.ProjectInitializingCommandExecutor;
@@ -121,6 +122,6 @@ public class ProjectManagerRule extends TemporaryFolder {
     protected void after() {
         super.after();
         executor.stop();
-        projectManager.close();
+        projectManager.close(ShuttingDownException::new);
     }
 }


### PR DESCRIPTION
…ory is removed

Motivation:

When a Repository is closed, then pending operations for the Repository
may fail with an unexpected exception because CommitIdDatabase or jGit
Repository will be closed.

Modifications:

- Make sure a Repository is open before performing any operations.
- Change the signature of the close() methods in the following classes
  so that we can tell why a Repository or a Project has been closed, 1)
  server is shutting down or 2) the Repository or the Project has been
  removed from its RepositoryManager or ProjectManager.
  - GitRepository
  - StorageManager and all its subtypes
- Move the shutdown handling code in WatchService to GitRepository for
  consistency
- Change the shutdown sequence of the server components so that an RPC
  server does not close the connection before sending the SHUTTING_DOWN
  responses.
  - Also replace the nested try-finally blocks with catch(Throwable) for
    simplicity

Result:

- A user is never able to perform an operation on:
  - removed repositories
  - removed projects
  - server that's shutting down