### PR TITLE
Fix watcher leaks

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -253,6 +253,18 @@ public class CachingRepositoryTest {
     }
 
     @Test
+    public void finaLatestRevisionHead() {
+        final Repository repo = newCachingRepo();
+        final Revision actualHeadRev = new Revision(2);
+        doReturn(new RevisionRange(actualHeadRev, actualHeadRev))
+                .when(delegateRepo).normalizeNow(HEAD, HEAD);
+
+        assertThat(repo.findLatestRevision(HEAD, "/**").join()).isNull();
+        verify(delegateRepo, never()).findLatestRevision(any(), any());
+        verifyNoMoreInteractions(delegateRepo);
+    }
+
+    @Test
     public void watchFastPath() {
         final Repository repo = setMockNames(newCachingRepo());
         doReturn(new RevisionRange(INIT, new Revision(2))).when(delegateRepo).normalizeNow(INIT, HEAD);


### PR DESCRIPTION
Related: e0fcb62507679ce85f9b2eb7f71e6911407d9e15

Motivation:

CachingRepository.watch(lastKnownRevision, pathPattern) leaks watchers
because it does not cancel the watcher when a user cancels the future
returned by CachingRepository.

Modification:

- Propagate the state between the two involved futures so that its
  cancellation request does not leak the futures.
- Reuse the future returned by findLatestRevision() if possible.

Result:

Leak is gone