### PR TITLE
Add jitters to mirroring jobs

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
@@ -55,13 +55,17 @@ public class DefaultMirroringServiceTest {
         final AtomicInteger taskCounter = new AtomicInteger();
         final ProjectManager pm = mock(ProjectManager.class);
         final Project p = mock(Project.class);
-        final MetaRepository r = mock(MetaRepository.class);
+        final MetaRepository mr = mock(MetaRepository.class);
+        final Repository r = mock(Repository.class);
         when(pm.list()).thenReturn(ImmutableMap.of("foo", p));
-        when(p.metaRepo()).thenReturn(r);
-        when(r.mirrors()).thenReturn(ImmutableSet.of(new Mirror(
-                EVERY_SECOND, MirrorDirection.REMOTE_TO_LOCAL, MirrorCredential.FALLBACK,
-                mock(Repository.class), "/", URI.create("unused://uri"), "/", null) {
+        when(p.name()).thenReturn("foo");
+        when(p.metaRepo()).thenReturn(mr);
+        when(r.parent()).thenReturn(p);
+        when(r.name()).thenReturn("bar");
 
+        final Mirror mirror = new Mirror(EVERY_SECOND, MirrorDirection.REMOTE_TO_LOCAL,
+                                         MirrorCredential.FALLBACK, r, "/",
+                                         URI.create("unused://uri"), "/", null) {
             @Override
             protected void mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes) {}
 
@@ -72,7 +76,9 @@ public class DefaultMirroringServiceTest {
                 taskCounter.incrementAndGet();
                 Thread.sleep(2000);
             }
-        }));
+        };
+
+        when(mr.mirrors()).thenReturn(ImmutableSet.of(mirror));
 
         final DefaultMirroringService service =
                 new DefaultMirroringService(temporaryFolder.getRoot(), pm, 1, 1, 1);


### PR DESCRIPTION
Motivation:

Most users schedule their mirroring jobs to run every minute.
MirroringService runs those jobs when 'second' is 0, we see a spike in
system activity every minute.

Modifications:

- Calculate a jitter beteen -1 and 1 minute for each Mirror so that the
  system load is spread.
  - Add Mirror.nextExecutionTime()
  - Make Mirror.schedule() visible only for testing
- Miscellaneous:
  - Rename lastRunTime to lastExecutionTime
  - Increase the keep-alive time of mirroring threads from 60 to 90
    seconds, so that they do not die too often even if there is only one
    mirroring job that runs every minute.

Result:

- Less number of load spikes
- Fixes #215