### PR TITLE
Update metadata when creating/removing a project/repository by Thrift…

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
@@ -124,6 +124,7 @@ public class ProjectServiceV1 extends AbstractService {
     @Decorator(ProjectOwnersOnly.class)
     public CompletableFuture<Void> removeProject(@RequestObject Project project,
                                                  @RequestObject Author author) {
+        // Metadata must be updated first because it cannot be updated if the project is removed.
         return mds.removeProject(author, project.name())
                   .thenCompose(unused -> execute(Command.removeProject(author, project.name())))
                   .handle(HttpApiUtil::throwUnsafelyIfNonNull);
@@ -141,6 +142,7 @@ public class ProjectServiceV1 extends AbstractService {
                                                       @RequestObject JsonNode node,
                                                       @RequestObject Author author) {
         checkUnremoveArgument(node);
+        // Restore the project first then update its metadata as 'active'.
         return execute(Command.unremoveProject(author, projectName))
                 .thenCompose(unused -> mds.restoreProject(author, projectName))
                 .handle(returnOrThrow(() -> DtoConverter.convert(projectManager().get(projectName))));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -140,7 +140,7 @@ public class RepositoryServiceV1 extends AbstractService {
     public CompletableFuture<Void> removeRepository(@Param("repoName") String repoName,
                                                     @RequestObject Repository repository,
                                                     @RequestObject Author author) {
-        if (Project.REPO_META.equals(repoName)) {
+        if (Project.isMetaRepo(repoName)) {
             throw HttpStatusException.of(HttpStatus.FORBIDDEN);
         }
         return execute(Command.removeRepository(author, repository.parent().name(), repository.name()))

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/Project.java
@@ -39,4 +39,8 @@ public interface Project {
     RepositoryManager repos();
 
     PluginManager plugins();
+
+    static boolean isMetaRepo(String repoName) {
+        return REPO_META.equals(repoName);
+    }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -46,7 +46,7 @@ public class AdministrativeServiceTest {
     @Before
     public void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -59,7 +59,7 @@ public class ContentServiceV1Test {
     @Before
     public void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -45,7 +45,7 @@ public class ListCommitsAndDiffTest {
     @Before
     public void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -53,7 +53,7 @@ public class ProjectServiceV1Test {
     @Before
     public void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -101,7 +101,7 @@ public class RepositoryServiceV1Test {
         assertThat(aRes.headers().status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
-                "   \"message\": \"myRepo already exists.\"" +
+                "   \"message\": \"repository: myRepo already exists.\"" +
                 '}';
         assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -57,7 +57,7 @@ public class RepositoryServiceV1Test {
     @Before
     public void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.metadata;
+
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.HttpClientBuilder;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+public class ThriftBackwardCompatibilityTest {
+
+    @ClassRule
+    public static final CentralDogmaRule dogma = new CentralDogmaRule();
+
+    private static HttpClient httpClient;
+
+    private static final String projectName = "foo";
+
+    @BeforeClass
+    public static void init() {
+        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
+        final String serverUri = "http://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+        httpClient = new HttpClientBuilder(serverUri)
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+    }
+
+    @Test
+    public void shouldBackwardCompatible() throws Exception {
+        final String repo1 = "repo1";
+
+        dogma.client().createProject(projectName).join();
+        dogma.client().createRepository(projectName, repo1).join();
+        dogma.client().push(projectName, repo1, Revision.HEAD, "",
+                            Change.ofTextUpsert("/sample.txt", "test")).join();
+
+        AggregatedHttpMessage res;
+        res = httpClient.get(PROJECTS_PREFIX + '/' + projectName + REPOS).aggregate().join();
+        final List<JsonNode> nodes = new ArrayList<>();
+        Jackson.readTree(res.content().toStringUtf8()).elements().forEachRemaining(nodes::add);
+
+        assertThat(nodes.stream().map(n -> n.get("name").textValue()).collect(Collectors.toList()))
+                .containsAnyOf("dogma", "meta", repo1);
+
+        ProjectMetadata metadata;
+
+        res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
+        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repo(repo1)).isNotNull();
+        assertThat(metadata.repo(repo1).removal()).isNull();
+
+        dogma.client().removeRepository(projectName, repo1).join();
+
+        res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
+        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repo(repo1)).isNotNull();
+        assertThat(metadata.repo(repo1).removal()).isNotNull();
+
+        dogma.client().unremoveRepository(projectName, repo1).join();
+
+        res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
+        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repo(repo1)).isNotNull();
+        assertThat(metadata.repo(repo1).removal()).isNull();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -64,13 +64,11 @@ public class ThriftBackwardCompatibilityTest {
     @BeforeClass
     public static void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        httpClient = new HttpClientBuilder("http://" + serverAddress.getHostString() +
-                                           ':' + serverAddress.getPort())
+        httpClient = new HttpClientBuilder("http://127.0.0.1:" + serverAddress.getPort())
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
                 .build();
 
-        client = new ClientBuilder("ttext+http://" + serverAddress.getHostString() +
-                                   ':' + serverAddress.getPort() + "/cd/thrift/v1")
+        client = new ClientBuilder("ttext+http://127.0.0.1:" + serverAddress.getPort() + "/cd/thrift/v1")
                 .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
                 .build(Iface.class);
     }


### PR DESCRIPTION
… API

Motivation:
There's a bug in Central Dogma's Thrift-side code where permission-related metadata is not populated when a Thrift client creates a repository/project.

Modifications:
- Update metadata for the following RPC methods:
  - removeProject
  - unremoveProject
  - createRepository
  - removeRepository
  - unremoveRepository

Result:
- Closes #210