### PR TITLE
Refactor the enums stringer

### DIFF
--- a/client/go/dogma/content_service.go
+++ b/client/go/dogma/content_service.go
@@ -60,7 +60,7 @@ func (c *Entry) MarshalJSON() ([]byte, error) {
 		Type string `json:"type"`
 		*Alias
 	}{
-		Type:  entryTypeValues[c.Type],
+		Type:  c.Type.String(),
 		Alias: (*Alias)(c),
 	})
 }
@@ -110,7 +110,7 @@ func (c *Change) MarshalJSON() ([]byte, error) {
 		Type string `json:"type"`
 		*Alias
 	}{
-		Type:  changeTypeValues[c.Type],
+		Type:  c.Type.String(),
 		Alias: (*Alias)(c),
 	})
 }

--- a/client/go/dogma/enums.go
+++ b/client/go/dogma/enums.go
@@ -34,14 +34,14 @@ var changeTypeMap = map[string]ChangeType{
 	"APPLY_TEXT_PATCH": ApplyTextPatch,
 }
 
-var changeTypeValues = [...]string{
-	"UNKNOWN",
-	"UPSERT_JSON",
-	"UPSERT_TEXT",
-	"REMOVE",
-	"RENAME",
-	"APPLY_JSON_PATCH",
-	"APPLY_TEXT_PATCH",
+// String returns the string value of ChangeType
+func (c ChangeType) String() string {
+	for k, v := range changeTypeMap {
+		if v == c {
+			return k
+		}
+	}
+	return "UNKNOWN"
 }
 
 type EntryType int
@@ -58,9 +58,12 @@ var entryTypeMap = map[string]EntryType{
 	"DIRECTORY": Directory,
 }
 
-var entryTypeValues = [...]string{
-	"UNKNOWN",
-	"JSON",
-	"TEXT",
-	"DIRECTORY",
+// String returns the string value of EntryType
+func (c EntryType) String() string {
+	for k, v := range entryTypeMap {
+		if v == c {
+			return k
+		}
+	}
+	return "UNKNOWN"
 }


### PR DESCRIPTION
Motivation:
This doesn't look good.
```
type ChangeType int

const (
	UpsertJSON ChangeType = iota + 1
	UpsertText
	Remove
	Rename
	ApplyJSONPatch
	ApplyTextPatch
)

var changeTypeMap = map[string]ChangeType{
	"UPSERT_JSON":      UpsertJSON,
	"UPSERT_TEXT":      UpsertText,
	"REMOVE":           Remove,
	"RENAME":           Rename,
	"APPLY_JSON_PATCH": ApplyJSONPatch,
	"APPLY_TEXT_PATCH": ApplyTextPatch,
}

var changeTypeValues = [...]string{
	"UNKNOWN",
	"UPSERT_JSON",
	"UPSERT_TEXT",
	"REMOVE",
	"RENAME",
	"APPLY_JSON_PATCH",
	"APPLY_TEXT_PATCH",
}
```
- We have to maintain 2 ChangeType lookup data structures that were being coupled together. If we add one more value for `changeTypeMap`, `changeTypeValues` must be update, as follows.
- Similar to EntryType

Modifications:
- Add method `String()` for enums `ChangeType` and `EntryType`. 
- Simply call `type.String()` instead looking up from `changeTypeValues[type]`.

Result:

- Better look
- Easier to extend