### PR TITLE
Automatic client-side load balancing using DNS lookup

### DIFF
--- a/client/go/dogma/watch_service.go
+++ b/client/go/dogma/watch_service.go
@@ -139,8 +139,8 @@ func newWatcher(projectName, repoName, pathPattern string) *Watcher {
 	return &Watcher{state: initial, initialValueCh: make(chan *Latest, 1),
 		watchCTX: watchCTX, watchCancelFunc: watchCancelFunc,
 		listenersMutex: &sync.Mutex{},
-		projectName: projectName,
-		repoName: repoName, pathPattern: pathPattern}
+		projectName:    projectName,
+		repoName:       repoName, pathPattern: pathPattern}
 }
 
 // AwaitInitialValue awaits for the initial value to be available.

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.centraldogma.client.armeria.legacy;
 
+import java.net.UnknownHostException;
+
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -30,8 +32,10 @@ import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilder<LegacyCentralDogmaBuilder> {
     /**
      * Returns a newly-created {@link CentralDogma} instance.
+     *
+     * @throws UnknownHostException if failed to resolve the host names from the DNS servers
      */
-    public CentralDogma build() {
+    public CentralDogma build() throws UnknownHostException {
         final Endpoint endpoint = endpoint();
         final String scheme = "tbinary+" + (isUseTls() ? "https" : "http") + "://";
         final String uri = scheme + endpoint.authority() + "/cd/thrift/v1";

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CompositeEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CompositeEndpointGroup.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.armeria;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
+
+final class CompositeEndpointGroup extends DynamicEndpointGroup {
+
+    private final List<EndpointGroup> groups;
+
+    CompositeEndpointGroup(Iterable<EndpointGroup> groups) {
+        this.groups = ImmutableList.copyOf(requireNonNull(groups, "groups"));
+
+        // Add the listener for all groups.
+        this.groups.forEach(g -> g.addListener(this::onEndpointUpdate));
+
+        // Set the initial list of Endpoints if possible.
+        final Set<Endpoint> initialEndpoints = collectEndpoints();
+        if (!initialEndpoints.isEmpty()) {
+            setEndpoints(initialEndpoints);
+        }
+    }
+
+    @VisibleForTesting
+    List<EndpointGroup> groups() {
+        return groups;
+    }
+
+    private void onEndpointUpdate(@SuppressWarnings("unused") List<Endpoint> unused) {
+        setEndpoints(collectEndpoints());
+    }
+
+    private Set<Endpoint> collectEndpoints() {
+        final ImmutableSortedSet.Builder<Endpoint> initialEndpointsBuilder = ImmutableSortedSet.naturalOrder();
+        groups.forEach(g -> initialEndpointsBuilder.addAll(g.endpoints()));
+        return initialEndpointsBuilder.build();
+    }
+
+    @Override
+    public void close() {
+        super.close();
+        groups.forEach(EndpointGroup::close);
+    }
+}

--- a/client/java-armeria/src/test/resources/centraldogma-profile-test-xip.properties
+++ b/client/java-armeria/src/test/resources/centraldogma-profile-test-xip.properties
@@ -14,5 +14,5 @@
 # under the License.
 #
 
-centraldogma.hosts.0=alice.com
-centraldogma.hosts.1=bob.com:8080
+centraldogma.hosts.0=1.2.3.4.xip.io
+centraldogma.hosts.1=5.6.7.8.xip.io:8080

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.client.spring;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.net.UnknownHostException;
 import java.util.Optional;
 
 import javax.inject.Qualifier;
@@ -76,7 +77,7 @@ public class CentralDogmaClientAutoConfiguration {
     public CentralDogma client(
             Environment env,
             @ForCentralDogma ClientFactory clientFactory,
-            Optional<ArmeriaClientConfigurator> armeriaClientConfigurator) {
+            Optional<ArmeriaClientConfigurator> armeriaClientConfigurator) throws UnknownHostException {
 
         return new LegacyCentralDogmaBuilder()
                 .clientFactory(clientFactory)

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
@@ -35,5 +35,7 @@ public final class HttpApiV1Constants {
 
     public static final String CONTENTS = "/contents";
 
+    public static final String HEALTH_CHECK_PATH = "/monitor/l7check";
+
     private HttpApiV1Constants() {}
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.HEALTH_CHECK_PATH;
 import static com.linecorp.centraldogma.server.internal.command.ProjectInitializer.initializeInternalProject;
 import static com.linecorp.centraldogma.server.internal.storage.repository.cache.RepositoryCache.validateCacheSpec;
 import static java.util.Objects.requireNonNull;
@@ -395,7 +396,7 @@ public class CentralDogma {
             }
         });
 
-        sb.service("/monitor/l7check", new HttpHealthCheckService());
+        sb.service(HEALTH_CHECK_PATH, new HttpHealthCheckService());
 
         // TODO(hyangtack): This service is temporarily added to support redirection from '/docs' to '/docs/'.
         //                  It would be removed if this kind of redirection is handled by Armeria.

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -266,6 +266,40 @@ or her class path::
     adding: centraldogma-profile-staging.properties
     adding: centraldogma-profile-release.properties
 
+Using DNS-based lookup
+----------------------
+Central Dogma Java client always retrieves all the IP addresses of a host from the current system DNS server or
+the ``/etc/host`` file. Instead of specifying all the individual replica addresses in a client profile,
+consider specifying a single host name that's very unlikely to change in the client profile and add multiple
+``A`` or ``AAAA`` DNS records to the host name::
+
+    $ cat centraldogma-profile-release.properties
+    centraldogma.host.0=all.dogma.example.com
+
+    $ dig all.dogma.example.com
+
+    ; <<>> DiG 9.12.1-P2 <<>> all.dogma.example.com
+    ;; global options: +cmd
+    ;; Got answer:
+    ;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58779
+    ;; flags: qr rd ra; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 1
+
+    ;; OPT PSEUDOSECTION:
+    ; EDNS: version: 0, flags:; udp: 1440
+    ;; QUESTION SECTION:
+    ;all.dogma.example.com. IN A
+
+    ;; ANSWER SECTION:
+    all.dogma.example.com. 300 IN A 192.168.1.1
+    all.dogma.example.com. 300 IN A 192.168.1.2
+    all.dogma.example.com. 300 IN A 192.168.1.3
+
+    ;; Query time: 54 msec
+
+The client will periodically send DNS queries respecting the TTL values advertised by the DNS server and update
+the endpoint list dynamically, so that an administrator can add or remove a replica without distributing a new
+client profile JAR again.
+
 Spring Boot integration
 -----------------------
 If you are using `Spring Framework <https://spring.io/>`_, you can inject :api:`com.linecorp.centraldogma.client.CentralDogma`

--- a/testing/src/main/java/com/linecorp/centraldogma/testing/CentralDogmaRule.java
+++ b/testing/src/main/java/com/linecorp/centraldogma/testing/CentralDogmaRule.java
@@ -16,7 +16,9 @@
 
 package com.linecorp.centraldogma.testing;
 
+import java.io.IOError;
 import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 
 import javax.annotation.Nullable;
 
@@ -189,7 +191,12 @@ public class CentralDogmaRule extends TemporaryFolder {
 
         configureClient(clientBuilder);
 
-        client = clientBuilder.build();
+        try {
+            client = clientBuilder.build();
+        } catch (UnknownHostException e) {
+            // Should never reach here.
+            throw new IOError(e);
+        }
         httpClient = HttpClient.of("h2c://" + serverAddress.getHostString() + ':' + serverAddress.getPort());
     }
 


### PR DESCRIPTION
Motivation:

Distribution of server addresses via `.properties` file is not enough
because it's static and a user has to upgrade manually when the cluster
configuration changes. This can be disatrous when a replica in a cluster
crashes in an irrecoverable way.

Motivations:

- Use Armeria's DnsAddressEndpointGroup to dynamically query the DNS
  servers and update the endpoint list.
  - An administrator can simply update his or her DNS A/AAAA records to
    change the cluster members.
- Use HttpHealthCheckedEndpointGroup so that the requests are not sent
  to an unhealthy replica
- Extract health check service path to `HEALTH_CHECK_PATH`

Result:

- Less chance of client-side errors when a replica goes down.
- A lot more flexible addition and removal of a cluster member.