### PR TITLE
Rename centraldogma-client-java-spring-boot1-* to centraldogma-client-spring-boot1-*

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,9 @@ ext {
         ':client:java-armeria': "${rootProject.name}-client-armeria",
         ':client:java-armeria-legacy': "${rootProject.name}-client-armeria-legacy",
         ':client:java-spring-boot-autoconfigure': "${rootProject.name}-client-spring-boot-autoconfigure",
-        ':client:java-spring-boot-starter': "${rootProject.name}-client-spring-boot-starter"
+        ':client:java-spring-boot-starter': "${rootProject.name}-client-spring-boot-starter",
+        ':client:java-spring-boot1-autoconfigure': "${rootProject.name}-client-spring-boot1-autoconfigure",
+        ':client:java-spring-boot1-starter': "${rootProject.name}-client-spring-boot1-starter"
     ]
 }
 


### PR DESCRIPTION
We forgot to add the renaming rule for Spring Boot 1 integration JARs.