### PR TITLE
Add RepositoryMetadata of `meta` repository when initializing metadata

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ProjectInitializingCommandExecutor.java
@@ -35,8 +35,10 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.internal.metadata.Member;
+import com.linecorp.centraldogma.server.internal.metadata.PerRolePermissions;
 import com.linecorp.centraldogma.server.internal.metadata.ProjectMetadata;
 import com.linecorp.centraldogma.server.internal.metadata.ProjectRole;
+import com.linecorp.centraldogma.server.internal.metadata.RepositoryMetadata;
 import com.linecorp.centraldogma.server.internal.metadata.UserAndTimestamp;
 
 public class ProjectInitializingCommandExecutor extends ForwardingCommandExecutor {
@@ -80,9 +82,11 @@ public class ProjectInitializingCommandExecutor extends ForwardingCommandExecuto
         logger.info("Initializing metadata: {}", projectName);
 
         final UserAndTimestamp userAndTimestamp = UserAndTimestamp.of(author);
+        final RepositoryMetadata repo = new RepositoryMetadata(REPO_META, userAndTimestamp,
+                                                               PerRolePermissions.DEFAULT);
         final Member member = new Member(author, ProjectRole.OWNER, userAndTimestamp);
         final ProjectMetadata metadata = new ProjectMetadata(projectName,
-                                                             ImmutableMap.of(),
+                                                             ImmutableMap.of(repo.id(), repo),
                                                              ImmutableMap.of(member.id(), member),
                                                              ImmutableMap.of(),
                                                              userAndTimestamp, null);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/MetadataServiceTest.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.metadata;
 import static com.linecorp.centraldogma.server.internal.metadata.PerRolePermissions.NO_PERMISSION;
 import static com.linecorp.centraldogma.server.internal.metadata.PerRolePermissions.READ_ONLY;
 import static com.linecorp.centraldogma.server.internal.metadata.PerRolePermissions.READ_WRITE;
+import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -72,6 +73,8 @@ public class MetadataServiceTest {
         assertThat(metadata.name()).isEqualTo(project1);
         assertThat(metadata.creation().user()).isEqualTo(author.email());
         assertThat(metadata.removal()).isNull();
+        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repos().get(REPO_META)).isNotNull();
 
         // Remove a project and check whether the project is removed.
         mds.removeProject(author, project1).join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.metadata;
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static com.linecorp.centraldogma.server.internal.storage.project.Project.REPO_META;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.InetSocketAddress;
@@ -94,24 +95,30 @@ public class ThriftBackwardCompatibilityTest {
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();
+        assertThat(metadata.repo(REPO_META)).isNotNull();
+        assertThat(metadata.repo(REPO_META).removal()).isNull();
 
         client.removeRepository(projectName, repo1);
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNotNull();
+        assertThat(metadata.repo(REPO_META)).isNotNull();
+        assertThat(metadata.repo(REPO_META).removal()).isNull();
 
         client.unremoveRepository(projectName, repo1);
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isOne();
+        assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();
+        assertThat(metadata.repo(REPO_META)).isNotNull();
+        assertThat(metadata.repo(REPO_META).removal()).isNull();
     }
 }


### PR DESCRIPTION
Motivation:
`meta` repository is automatically created when creating a new project, but its metadata wasn't created.

Modifications:
- Add `RepositoryMetadata` of `meta` repository to the `ProjectMetadata` when initializing metadata.

Result:
- A user can see his or her `meta` repository.