### PR TITLE
Refactor http method string to constant in go code

### DIFF
--- a/client/go/dogma/content_service.go
+++ b/client/go/dogma/content_service.go
@@ -145,7 +145,7 @@ func (con *contentService) listFiles(ctx context.Context,
 		v.Set("revision", revision)
 		u += encodeValues(v)
 	}
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -184,7 +184,7 @@ func (con *contentService) getFile(
 
 	u += encodeValues(v)
 
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -237,7 +237,7 @@ func (con *contentService) getFiles(ctx context.Context,
 		u += encodeValues(v)
 	}
 
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,7 +266,7 @@ func (con *contentService) getHistory(ctx context.Context,
 	}
 	u += encodeValues(v)
 
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -304,7 +304,7 @@ func (con *contentService) getDiff(ctx context.Context,
 	setFromTo(v, from, to)
 	u += encodeValues(v)
 
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -340,7 +340,7 @@ func (con *contentService) getDiffs(ctx context.Context,
 	setFromTo(v, from, to)
 	u += encodeValues(v)
 
-	req, err := con.client.newRequest("GET", u, nil)
+	req, err := con.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -377,7 +377,7 @@ func (con *contentService) push(ctx context.Context, projectName, repoName, base
 
 	body := push{CommitMessage: commitMessage, Changes: changes}
 
-	req, err := con.client.newRequest("POST", u, body)
+	req, err := con.client.newRequest(http.MethodPost, u, body)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/go/dogma/content_service_test.go
+++ b/client/go/dogma/content_service_test.go
@@ -28,7 +28,7 @@ func TestListFiles(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/list/**", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `[{"path":"/a.json", "type":"JSON"},{"path":"/b.txt", "type":"TEXT"}]`)
 	})
 
@@ -44,7 +44,7 @@ func TestListFiles_WithRevision(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/list/**", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testURLQuery(t, r, "revision", "2")
 		fmt.Fprint(w, `[{"path":"/a.json", "type":"JSON"},{"path":"/b.txt", "type":"TEXT"}]`)
 	})
@@ -62,7 +62,7 @@ func TestGetFile(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/b.txt",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, `{"path":"/b.txt", "type":"TEXT", "content":"hello world~!"}`)
 		})
 
@@ -80,7 +80,7 @@ func TestGetFile_JSON(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			fmt.Fprint(w, `{"path":"/a.json", "type":"JSON", "content":{"a":"b"}}`)
 		})
 
@@ -98,7 +98,7 @@ func TestGetFile_WithJSONPath(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			testURLQuery(t, r, "jsonpath", "$.a")
 			fmt.Fprint(w, `{"path":"/a.json", "type":"JSON", "content":"b"}`)
 		})
@@ -117,7 +117,7 @@ func TestGetFile_WithJSONPathAndRevision(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			testURLQuery(t, r, "jsonpath", "$.a")
 			testURLQuery(t, r, "revision", "-1")
 			fmt.Fprint(w, `{"path":"/a.json", "type":"JSON", "content":"b"}`)
@@ -136,7 +136,7 @@ func TestGetFiles(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/**", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `[{"path":"/a.json", "type":"JSON", "content":{"a":"b"}},
 {"path":"/b.txt", "type":"TEXT", "content":"hello world~!"}]`)
 	})
@@ -154,7 +154,7 @@ func TestGetHistory(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/commits/-2", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testURLQuery(t, r, "to", "-1")
 		testURLQuery(t, r, "maxCommits", "2")
 
@@ -181,7 +181,7 @@ func TestGetDiff(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/compare",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			testURLQuery(t, r, "from", "3")
 			testURLQuery(t, r, "to", "4")
 			testURLQuery(t, r, "path", "/a.json")
@@ -216,7 +216,7 @@ func TestGetDiffs(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/compare", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testURLQuery(t, r, "from", "1")
 		testURLQuery(t, r, "to", "4")
 		testURLQuery(t, r, "pathPattern", "/**")
@@ -251,7 +251,7 @@ func TestPush(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		testURLQuery(t, r, "revision", "-1")
 
 		var reqBody push
@@ -282,7 +282,7 @@ func TestPush_TwoFiles(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		testURLQuery(t, r, "revision", "-1")
 
 		var reqBody push

--- a/client/go/dogma/dogma.go
+++ b/client/go/dogma/dogma.go
@@ -147,7 +147,7 @@ func normalizeURL(baseURL string) (*url.URL, error) {
 
 // SecurityEnabled returns whether the security of the server is enabled or not.
 func (c *Client) SecurityEnabled() (bool, error) {
-	req, err := c.newRequest("GET", pathSecurityEnabled, nil)
+	req, err := c.newRequest(http.MethodGet, pathSecurityEnabled, nil)
 	if err != nil {
 		return false, err
 	}
@@ -195,7 +195,7 @@ func (c *Client) newRequest(method, urlStr string, body interface{}) (*http.Requ
 	}
 
 	if body != nil {
-		if method == "PATCH" {
+		if method == http.MethodPatch {
 			req.Header.Set("Content-Type", "application/json-patch+json")
 		} else {
 			req.Header.Set("Content-Type", "application/json")

--- a/client/go/dogma/dogma_test.go
+++ b/client/go/dogma/dogma_test.go
@@ -80,7 +80,7 @@ func TestNewClient(t *testing.T) {
 	defer server.Close()
 
 	mux.HandleFunc("/api/v1/login", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		r.ParseForm()
 		testString(t, r.PostForm.Get("grant_type"), "password", "grant_type")
 
@@ -92,12 +92,12 @@ func TestNewClient(t *testing.T) {
 	})
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testHeader(t, r, "Authorization", "Bearer fdbe78b0-1d0c-4978-bbb1-9bc7106dad36")
 	})
 
 	c, _ := NewClient(server.URL, "foo", "bar")
-	req, _ := c.newRequest("GET", "/test", nil)
+	req, _ := c.newRequest(http.MethodGet, "/test", nil)
 
 	res, _ := c.do(context.Background(), req, nil)
 	testStatus(t, res, 200)

--- a/client/go/dogma/project_service.go
+++ b/client/go/dogma/project_service.go
@@ -37,7 +37,7 @@ type Author struct {
 func (p *projectService) create(ctx context.Context, name string) (*Project, *http.Response, error) {
 	u := defaultPathPrefix + "projects"
 
-	req, err := p.client.newRequest("POST", u, &Project{Name: name})
+	req, err := p.client.newRequest(http.MethodPost, u, &Project{Name: name})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +53,7 @@ func (p *projectService) create(ctx context.Context, name string) (*Project, *ht
 func (p *projectService) remove(ctx context.Context, name string) (*http.Response, error) {
 	u := defaultPathPrefix + "projects/" + name
 
-	req, err := p.client.newRequest("DELETE", u, nil)
+	req, err := p.client.newRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (p *projectService) remove(ctx context.Context, name string) (*http.Respons
 func (p *projectService) unremove(ctx context.Context, name string) (*Project, *http.Response, error) {
 	u := defaultPathPrefix + "projects/" + name
 
-	req, err := p.client.newRequest("PATCH", u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
+	req, err := p.client.newRequest(http.MethodPatch, u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -84,7 +84,7 @@ func (p *projectService) unremove(ctx context.Context, name string) (*Project, *
 func (p *projectService) list(ctx context.Context) ([]*Project, *http.Response, error) {
 	u := defaultPathPrefix + "projects"
 
-	req, err := p.client.newRequest("GET", u, nil)
+	req, err := p.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -101,7 +101,7 @@ func (p *projectService) list(ctx context.Context) ([]*Project, *http.Response, 
 func (p *projectService) listRemoved(ctx context.Context) ([]*Project, *http.Response, error) {
 	u := defaultPathPrefix + "projects?status=removed"
 
-	req, err := p.client.newRequest("GET", u, nil)
+	req, err := p.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client/go/dogma/project_service_test.go
+++ b/client/go/dogma/project_service_test.go
@@ -30,7 +30,7 @@ func TestCreateProject(t *testing.T) {
 	input := &Project{Name: "foo"}
 
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		testHeader(t, r, "Authorization", "Bearer anonymous")
 
 		project := new(Project)
@@ -57,7 +57,7 @@ func TestRemoveProject(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -70,7 +70,7 @@ func TestUnremoveProject(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
+		testMethod(t, r, http.MethodPatch)
 		testHeader(t, r, "Content-Type", "application/json-patch+json")
 		testBody(t, r, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 		fmt.Fprint(w,
@@ -90,7 +90,7 @@ func TestListProject(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `[
 {"name":"foo", "creator":{"name":"minux", "email":"minux@m.x"}, "url":"/api/v1/projects/foo"},
 {"name":"bar", "creator":{"name":"minux", "email":"minux@m.x"}, "url":"/api/v1/projects/bar"}]`)
@@ -110,7 +110,7 @@ func TestListRemovedProject(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testURLQuery(t, r, "status", "removed")
 		fmt.Fprint(w, `[{"name":"foo"}, {"name":"bar"}]`)
 	})

--- a/client/go/dogma/repository_service.go
+++ b/client/go/dogma/repository_service.go
@@ -35,7 +35,7 @@ func (r *repositoryService) create(ctx context.Context, projectName, repoName st
 	*http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos", defaultPathPrefix, projectName)
 
-	req, err := r.client.newRequest("POST", u, &Repository{Name: repoName})
+	req, err := r.client.newRequest(http.MethodPost, u, &Repository{Name: repoName})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,7 +52,7 @@ func (r *repositoryService) create(ctx context.Context, projectName, repoName st
 func (r *repositoryService) remove(ctx context.Context, projectName, repoName string) (*http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v", defaultPathPrefix, projectName, repoName)
 
-	req, err := r.client.newRequest("DELETE", u, nil)
+	req, err := r.client.newRequest(http.MethodDelete, u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func (r *repositoryService) unremove(ctx context.Context, projectName, repoName 
 	*http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v", defaultPathPrefix, projectName, repoName)
 
-	req, err := r.client.newRequest("PATCH", u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
+	req, err := r.client.newRequest(http.MethodPatch, u, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -85,7 +85,7 @@ func (r *repositoryService) list(ctx context.Context, projectName string) ([]*Re
 	*http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos", defaultPathPrefix, projectName)
 
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +102,7 @@ func (r *repositoryService) listRemoved(ctx context.Context, projectName string)
 	*http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos?status=removed", defaultPathPrefix, projectName)
 
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -119,7 +119,7 @@ func (r *repositoryService) normalizeRevision(
 	ctx context.Context, projectName, repoName, revision string) (int, *http.Response, error) {
 	u := fmt.Sprintf("%vprojects/%v/repos/%v/revision/%v", defaultPathPrefix, projectName, repoName, revision)
 
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return -1, nil, err
 	}

--- a/client/go/dogma/repository_service_test.go
+++ b/client/go/dogma/repository_service_test.go
@@ -30,7 +30,7 @@ func TestCreateRepository(t *testing.T) {
 	input := &Repository{Name: "bar"}
 
 	mux.HandleFunc("/api/v1/projects/foo/repos", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "POST")
+		testMethod(t, r, http.MethodPost)
 		testHeader(t, r, "Authorization", "Bearer anonymous")
 
 		repo := new(Repository)
@@ -57,7 +57,7 @@ func TestRemoveRepository(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "DELETE")
+		testMethod(t, r, http.MethodDelete)
 		w.WriteHeader(http.StatusNoContent)
 	})
 
@@ -70,7 +70,7 @@ func TestUnremoveRepository(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PATCH")
+		testMethod(t, r, http.MethodPatch)
 		testHeader(t, r, "Content-Type", "application/json-patch+json")
 		testBody(t, r, `[{"op":"replace", "path":"/status", "value":"active"}]`)
 		fmt.Fprint(w,
@@ -94,7 +94,7 @@ func TestListRepositories(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w,
 			`[{
 "name":"bar",
@@ -123,7 +123,7 @@ func TestListRemovedRepository(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testURLQuery(t, r, "status", "removed")
 		fmt.Fprint(w, `[{"name":"bar"}, {"name":"baz"}]`)
 	})
@@ -140,7 +140,7 @@ func TestNormalizeRevision(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/revision/-2", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		fmt.Fprint(w, `{"revision":3}`)
 	})
 

--- a/client/go/dogma/watch_service.go
+++ b/client/go/dogma/watch_service.go
@@ -73,7 +73,7 @@ func (ws *watchService) watchRepo(ctx context.Context,
 
 func (ws *watchService) watchRequest(ctx context.Context, watchResult chan<- *WatchResult,
 	u, lastKnownRevision string, timeout time.Duration) {
-	req, err := ws.client.newRequest("GET", u, nil)
+	req, err := ws.client.newRequest(http.MethodGet, u, nil)
 	if err != nil {
 		watchResult <- &WatchResult{Err: err}
 		return

--- a/client/go/dogma/watch_service_test.go
+++ b/client/go/dogma/watch_service_test.go
@@ -37,7 +37,7 @@ func TestWatchFile(t *testing.T) {
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json",
 		func(w http.ResponseWriter, r *http.Request) {
-			testMethod(t, r, "GET")
+			testMethod(t, r, http.MethodGet)
 			testHeader(t, r, "if-none-match", "-1")
 			testHeader(t, r, "prefer", "wait=1")
 
@@ -68,7 +68,7 @@ func TestWatcher(t *testing.T) {
 
 	expectedLastKnownRevision := 1
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
+		testMethod(t, r, http.MethodGet)
 		testHeader(t, r, "if-none-match", strconv.Itoa(expectedLastKnownRevision))
 		testHeader(t, r, "prefer", "wait=60") // watchTimeout is 60 seconds
 


### PR DESCRIPTION
Modifications:
* Change to use a constant that exists in the official library instead of string value
