### PR TITLE
Fix a bug where jumping to a revision in file list view did not work

### DIFF
--- a/server/src/main/resources/webapp/scripts/components/entities/repository.service.js
+++ b/server/src/main/resources/webapp/scripts/components/entities/repository.service.js
@@ -66,7 +66,8 @@ angular.module('CentralDogmaAdmin')
 
                    return ApiV1Service.get(StringUtil.encodeUri(['projects', projectName,
                                                                  'repos', repositoryName,
-                                                                 'list', path]));
+                                                                 'list', path]) +
+                                           "?revision=" + revision);
                  },
 
                  getFile: function (projectName, repositoryName, revision, query) {


### PR DESCRIPTION
Modifications:

- Ensure `?revision=<target_revision>` is passed to the GET request sent
  by `getTree()`