### PR TITLE
Change Go client library corrsponding to the changes in HTTP API

### DIFF
--- a/client/go/dogma/content_service.go
+++ b/client/go/dogma/content_service.go
@@ -81,13 +81,18 @@ func (c *Entry) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// PushResult represents a result of push in the repository.
+type PushResult struct {
+	Revision int    `json:"revision"`
+	PushedAt string `json:"pushedAt"`
+}
+
 // Commit represents a commit in the repository.
 type Commit struct {
 	Revision      int            `json:"revision"`
 	Author        *Author        `json:"author"`
 	CommitMessage *CommitMessage `json:"commitMessage,omitempty"`
 	PushedAt      string         `json:"pushedAt,omitempty"`
-	Entries       []*Entry       `json:"entries,omitempty"`
 }
 
 // CommitMessages represents a commit message in the repository.
@@ -359,7 +364,7 @@ type push struct {
 }
 
 func (con *contentService) push(ctx context.Context, projectName, repoName, baseRevision string,
-	commitMessage *CommitMessage, changes []*Change) (*Commit, *http.Response, error) {
+	commitMessage *CommitMessage, changes []*Change) (*PushResult, *http.Response, error) {
 	if len(commitMessage.Summary) == 0 {
 		return nil, nil, fmt.Errorf(
 			"summary of commitMessage cannot be empty. commitMessage: %+v", commitMessage)
@@ -382,10 +387,10 @@ func (con *contentService) push(ctx context.Context, projectName, repoName, base
 		return nil, nil, err
 	}
 
-	commit := new(Commit)
-	res, err := con.client.do(ctx, req, commit)
+	pushResult := new(PushResult)
+	res, err := con.client.do(ctx, req, pushResult)
 	if err != nil {
 		return nil, res, err
 	}
-	return commit, res, nil
+	return pushResult, res, nil
 }

--- a/client/go/dogma/content_service_test.go
+++ b/client/go/dogma/content_service_test.go
@@ -262,18 +262,16 @@ func TestPush(t *testing.T) {
 			t.Errorf("Push request body %+v, want %+v", changes, want)
 		}
 
-		fmt.Fprint(w, `{"revision":2, "author":{"name":"minux", "email":"minux@m.x"},
-"entries":[{"path":"/a.json", "type":"JSON"}]}`)
+		fmt.Fprint(w, `{"revision":2, "pushedAt":"2017-05-22T00:00:00Z"}`)
 	})
 
 	commitMessage := &CommitMessage{Summary: "Add a.json"}
 	change := []*Change{{Path: "/a.json", Type: UpsertJSON, Content: map[string]interface{}{"a": "b"}}}
-	commit, _, _ := c.Push(context.Background(), "foo", "bar", "-1", commitMessage, change)
+	pushResult, _, _ := c.Push(context.Background(), "foo", "bar", "-1", commitMessage, change)
 
-	entries := []*Entry{{Path: "/a.json", Type: JSON}}
-	want := &Commit{Revision: 2, Author: &Author{Name: "minux", Email: "minux@m.x"}, Entries: entries}
-	if !reflect.DeepEqual(commit, want) {
-		t.Errorf("Push returned %+v, want %+v", commit, want)
+	want := &PushResult{Revision: 2, PushedAt: "2017-05-22T00:00:00Z"}
+	if !reflect.DeepEqual(pushResult, want) {
+		t.Errorf("Push returned %+v, want %+v", pushResult, want)
 	}
 }
 
@@ -294,22 +292,17 @@ func TestPush_TwoFiles(t *testing.T) {
 			t.Errorf("Push request body %+v, want %+v", changes, want)
 		}
 
-		fmt.Fprint(w, `{"revision":3,
-"author":{"name":"minux", "email":"minux@m.x"},
-"entries":
-[{"path":"/a.json", "type":"JSON"},
-{"path":"/b.txt", "type":"TEXT"}]}`)
+		fmt.Fprint(w, `{"revision":3, "pushedAT":"2017-05-22T00:00:00Z"}`)
 	})
 
 	commitMessage := &CommitMessage{Summary: "Add a.json and b.txt"}
 	changes := []*Change{{Path: "/a.json", Type: UpsertJSON, Content: map[string]interface{}{"a": "b"}},
 		{Path: "/b.txt", Type: UpsertText, Content: "myContent"}}
 
-	commit, _, _ := c.Push(context.Background(), "foo", "bar", "-1", commitMessage, changes)
+	pushResult, _, _ := c.Push(context.Background(), "foo", "bar", "-1", commitMessage, changes)
 
-	entries := []*Entry{{Path: "/a.json", Type: JSON}, {Path: "/b.txt", Type: Text}}
-	want := &Commit{Revision: 3, Author: &Author{Name: "minux", Email: "minux@m.x"}, Entries: entries}
-	if !reflect.DeepEqual(commit, want) {
-		t.Errorf("Push returned %+v, want %+v", commit, want)
+	want := &PushResult{Revision: 3, PushedAt: "2017-05-22T00:00:00Z"}
+	if !reflect.DeepEqual(pushResult, want) {
+		t.Errorf("Push returned %+v, want %+v", pushResult, want)
 	}
 }

--- a/client/go/dogma/dogma.go
+++ b/client/go/dogma/dogma.go
@@ -365,7 +365,7 @@ func (c *Client) GetDiffs(ctx context.Context,
 
 // Push pushes the specified changes to the repository.
 func (c *Client) Push(ctx context.Context, projectName, repoName, baseRevision string,
-	commitMessage *CommitMessage, changes []*Change) (*Commit, *http.Response, error) {
+	commitMessage *CommitMessage, changes []*Change) (*PushResult, *http.Response, error) {
 	return c.content.push(ctx, projectName, repoName, baseRevision, commitMessage, changes)
 }
 

--- a/client/go/dogma/watch_service_test.go
+++ b/client/go/dogma/watch_service_test.go
@@ -28,8 +28,8 @@ import (
 var response = `{"revision":3,
 "author":{"name":"minux", "email":"minux@m.x"},
 "commitMessage":{"summary":"Add a.json"},
-"entries":
-[{"path":"/a.json", "type":"JSON", "content": {"a":"b"} }]}`
+"entry":{"path":"/a.json", "type":"JSON", "content": {"a":"b"}}
+}`
 
 func TestWatchFile(t *testing.T) {
 	c, mux, teardown := setup()
@@ -49,16 +49,19 @@ func TestWatchFile(t *testing.T) {
 	query := &Query{Path: "/a.json", Type: Identity}
 	watchResult := c.WatchFile(context.Background(), "foo", "bar", "-1", query, 1*time.Second)
 
-	entries := []*Entry{{Path: "/a.json", Type: JSON, Content: map[string]interface{}{"a": "b"}}}
-	want := &Commit{Revision: 3, Author: &Author{Name: "minux", Email: "minux@m.x"},
-		CommitMessage: &CommitMessage{Summary: "Add a.json"}, Entries: entries}
+	entryWant := &Entry{Path: "/a.json", Type: JSON, Content: map[string]interface{}{"a": "b"}}
+	commitWant := &Commit{Revision: 3, Author: &Author{Name: "minux", Email: "minux@m.x"},
+		CommitMessage: &CommitMessage{Summary: "Add a.json"}}
 	select {
 	case result := <-watchResult:
-		if !reflect.DeepEqual(result.Commit, want) {
-			t.Errorf("WatchFile returned %+v, want %+v", result.Commit, want)
+		if !reflect.DeepEqual(result.Commit, commitWant) {
+			t.Errorf("WatchFile returned %+v, want %+v", result.Commit, commitWant)
+		}
+		if !reflect.DeepEqual(result.Entry, entryWant) {
+			t.Errorf("WatchFile returned %+v, want %+v", result.Entry, entryWant)
 		}
 	case <-time.After(3 * time.Second):
-		t.Errorf("WatchFile returned nothing, want %+v", want)
+		t.Errorf("WatchFile returned nothing, want %+v, %+v", commitWant, entryWant)
 	}
 }
 
@@ -79,8 +82,8 @@ func TestWatcher(t *testing.T) {
 		fmt.Fprint(w, `{"revision":`+strconv.Itoa(expectedLastKnownRevision)+`,
 "author":{"name":"minux", "email":"minux@m.x"},
 "commitMessage":{"summary":"Add a.json"},
-"entries":
-[{"path":"/a.json", "type":"JSON", "content": {"a":`+strconv.Itoa(expectedLastKnownRevision)+`} }]}`)
+"entry":{"path":"/a.json", "type":"JSON", "content": {"a":`+strconv.Itoa(expectedLastKnownRevision)+`}}
+}`)
 	}
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json", handler)
@@ -135,8 +138,8 @@ func TestWatcher_convertingValueFunc(t *testing.T) {
 		fmt.Fprint(w, `{"revision":`+strconv.Itoa(expectedLastKnownRevision)+`,
 "author":{"name":"minux", "email":"minux@m.x"},
 "commitMessage":{"summary":"Add a.json"},
-"entries":
-[{"path":"/a.json", "type":"JSON", "content": {"a":`+strconv.Itoa(expectedLastKnownRevision)+`} }]}`)
+"entry":{"path":"/a.json", "type":"JSON", "content": {"a":`+strconv.Itoa(expectedLastKnownRevision)+`}}
+}`)
 	}
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/a.json", handler)
@@ -238,9 +241,8 @@ func TestRepoWatcher(t *testing.T) {
 
 		fmt.Fprint(w, `{"revision":`+strconv.Itoa(expectedLastKnownRevision)+`,
 "author":{"name":"minux", "email":"minux@m.x"},
-"commitMessage":{"summary":"Add a.json"},
-"entries":
-[{"path":"/a.json", "type":"JSON", "content": {"a":`+strconv.Itoa(expectedLastKnownRevision)+`} }]}`)
+"commitMessage":{"summary":"Add a.json"}
+}`)
 	}
 
 	mux.HandleFunc("/api/v1/projects/foo/repos/bar/contents/**", handler)


### PR DESCRIPTION
Motivation:
This is related to #242.

Modification:
- Add `PushResult` struct
- Remove `entries` in `Commit` struct
- Add `entry` into `WatchResult` struct

Result:
- Compatible with #242