### PR TITLE
Consistent HTTP API error response

### DIFF
--- a/client/go/dogma/watch_service.go
+++ b/client/go/dogma/watch_service.go
@@ -40,7 +40,7 @@ type WatchResult struct {
 
 type commitWithEntry struct {
 	*Commit
-	Entry  *Entry `json:"entry,omitempty"`
+	Entry *Entry `json:"entry,omitempty"`
 }
 
 func (ws *watchService) watchFile(ctx context.Context, projectName, repoName, lastKnownRevision string,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/authentication/LogoutService.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.auth.AuthTokenExtractors;
 import com.linecorp.armeria.server.auth.OAuth2Token;
 import com.linecorp.centraldogma.internal.api.v1.AccessToken;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 
@@ -92,14 +93,14 @@ public class LogoutService extends AbstractHttpService {
                     future.complete(HttpResponse.of(HttpStatus.OK));
                 } catch (Throwable t) {
                     logger.warn("{} Failed to log out: {}", ctx, sessionId, t);
-                    future.complete(HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
+                    future.complete(HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, t));
                 } finally {
                     ThreadContext.unbindSecurityManager();
                 }
             });
         }).exceptionally(voidFunction(cause -> {
             logger.warn("{} Unexpected exception:", ctx, cause);
-            future.complete(HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR));
+            future.complete(HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, cause));
         }));
         return HttpResponse.from(future);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -57,6 +57,7 @@ import com.linecorp.centraldogma.server.internal.admin.dto.CommitMessageDto;
 import com.linecorp.centraldogma.server.internal.admin.dto.EntryDto;
 import com.linecorp.centraldogma.server.internal.admin.dto.RevisionDto;
 import com.linecorp.centraldogma.server.internal.api.AbstractService;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.internal.api.auth.HasReadPermission;
 import com.linecorp.centraldogma.server.internal.api.auth.HasWritePermission;
 import com.linecorp.centraldogma.server.internal.command.Command;
@@ -169,7 +170,7 @@ public class RepositoryService extends AbstractService {
                             if (cause == null) {
                                 return HttpResponse.of(HttpStatus.OK);
                             } else {
-                                return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+                                return HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, cause);
                             }
                         }));
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/util/RestfulJsonResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/util/RestfulJsonResponseConverter.java
@@ -28,6 +28,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 
 /**
  * A default response converter of CentralDogma admin service.
@@ -48,7 +49,7 @@ public class RestfulJsonResponseConverter implements ResponseConverterFunction {
                                    MediaType.JSON_UTF_8,
                                    httpData);
         } catch (JsonProcessingException e) {
-            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+            return HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AdministrativeService.java
@@ -86,7 +86,8 @@ public final class AdministrativeService extends AbstractService {
         if (writableNode.asBoolean()) {
             if (!oldStatus.writable) {
                 // TODO(trustin): Implement exiting read-only mode.
-                throw HttpStatusException.of(HttpStatus.NOT_IMPLEMENTED);
+                return HttpApiUtil.throwResponse(HttpStatus.NOT_IMPLEMENTED,
+                                                 "Please consider sending a pull request. ;-)");
             }
         } else {
             if (oldStatus.writable) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -30,8 +30,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.annotation.ConsumeType;
 import com.linecorp.armeria.server.annotation.Delete;
 import com.linecorp.armeria.server.annotation.ExceptionHandler;
@@ -158,7 +156,8 @@ public class TokenService extends AbstractService {
             // Give permission to the administrators.
             if (!loginUser.isAdmin() &&
                 !token.creation().user().equals(loginUser.id())) {
-                return Exceptions.throwUnsafely(HttpStatusException.of(HttpStatus.FORBIDDEN));
+                return HttpApiUtil.throwResponse(HttpStatus.FORBIDDEN,
+                                                 "Unauthorized token: %s", token);
             }
             return token;
         });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AbstractPermissionCheckingDecorator.java
@@ -28,11 +28,11 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.DecoratingServiceFunction;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
 import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataService;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataServiceInjector;
 import com.linecorp.centraldogma.server.internal.metadata.Permission;
@@ -79,7 +79,10 @@ abstract class AbstractPermissionCheckingDecorator
                 return handleException(cause);
             }
             if (!user.isAdmin()) {
-                throw HttpStatusException.of(HttpStatus.FORBIDDEN);
+                return HttpApiUtil.throwResponse(
+                        HttpStatus.FORBIDDEN,
+                        "Repository '%s/%s' can be accessed only by an administrator.",
+                        projectName, Project.REPO_DOGMA);
             }
             try {
                 return delegate.serve(ctx, req);
@@ -105,7 +108,10 @@ abstract class AbstractPermissionCheckingDecorator
                 return handleException(cause);
             }
             if (!hasPermission(permission)) {
-                throw HttpStatusException.of(HttpStatus.FORBIDDEN);
+                return HttpApiUtil.throwResponse(
+                        HttpStatus.FORBIDDEN,
+                        "You must have %s permission for repository '%s/%s'.",
+                        permission, projectName, repoName);
             }
             try {
                 return delegate.serve(ctx, req);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AdministratorsOnly.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/AdministratorsOnly.java
@@ -20,11 +20,11 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.DecoratingServiceFunction;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
 import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 
 /**
  * A decorator only to allow a request from administrator.
@@ -39,6 +39,8 @@ public class AdministratorsOnly implements DecoratingServiceFunction<HttpRequest
         if (user.isAdmin()) {
             return delegate.serve(ctx, req);
         }
-        throw HttpStatusException.of(HttpStatus.FORBIDDEN);
+        return HttpApiUtil.throwResponse(
+                HttpStatus.FORBIDDEN,
+                "You must be an administrator to perform this operation.");
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CreateApiResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CreateApiResponseConverter.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.internal.metadata.HolderWithLocation;
 
 /**
@@ -61,7 +62,7 @@ public final class CreateApiResponseConverter implements ResponseConverterFuncti
             return HttpResponse.of(headers, HttpData.of(Jackson.writeValueAsBytes(jsonNode)));
         } catch (JsonProcessingException e) {
             logger.debug("Failed to convert a response:", e);
-            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+            return HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
@@ -22,12 +22,12 @@ import static java.util.Objects.requireNonNull;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.server.internal.admin.authentication.AuthenticationUtil;
 import com.linecorp.centraldogma.server.internal.admin.authentication.User;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
@@ -65,7 +65,10 @@ public final class HttpApiRequestConverter implements RequestConverterFunction {
 
             if (Project.REPO_DOGMA.equals(repositoryName) &&
                 !AuthenticationUtil.currentUser(ctx).isAdmin()) {
-                throw HttpStatusException.of(HttpStatus.FORBIDDEN);
+                return HttpApiUtil.throwResponse(
+                        HttpStatus.FORBIDDEN,
+                        "Repository '%s/%s' can be accessed only by an administrator.",
+                        projectName, Project.REPO_DOGMA);
             }
             // RepositoryNotFoundException would be thrown if there is no project or no repository.
             return projectManager.get(projectName).repos().get(repositoryName);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiResponseConverter.java
@@ -32,6 +32,7 @@ import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.ResponseConverterFunction;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 
 /**
  * A default {@link ResponseConverterFunction} of HTTP API.
@@ -53,7 +54,7 @@ public final class HttpApiResponseConverter implements ResponseConverterFunction
             return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8, httpData);
         } catch (JsonProcessingException e) {
             logger.debug("Failed to convert a response:", e);
-            return HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR);
+            return HttpApiUtil.newResponse(HttpStatus.INTERNAL_SERVER_ERROR, e);
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
@@ -149,10 +149,6 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
 
     protected abstract CentralDogmaException newStorageNotFoundException(String name);
 
-    private CentralDogmaException newStorageNotFoundException0(String name) {
-        return newStorageNotFoundException(childTypeName + ": " + name);
-    }
-
     @Override
     public void close(Supplier<CentralDogmaException> failureCauseSupplier) {
         requireNonNull(failureCauseSupplier, "failureCauseSupplier");
@@ -199,13 +195,13 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
         if (created.get()) {
             return child;
         } else {
-            throw newStorageExistsException(childTypeName + ": " + name);
+            throw newStorageExistsException(name);
         }
     }
 
     private T create0(Author author, String name, long creationTimeMillis) {
         if (new File(rootDir, name + SUFFIX_REMOVED).exists()) {
-            throw newStorageExistsException(childTypeName + ": " + name + " (removed)");
+            throw newStorageExistsException(name + " (removed)");
         }
 
         final File f = new File(rootDir, name);
@@ -286,10 +282,10 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
         ensureOpen();
         final T child = children.remove(validateChildName(name));
         if (child == null) {
-            throw newStorageNotFoundException0(name);
+            throw newStorageNotFoundException(name);
         }
 
-        closeChild(name, child, () -> newStorageNotFoundException0(name));
+        closeChild(name, child, () -> newStorageNotFoundException(name));
 
         if (!new File(rootDir, name).renameTo(new File(rootDir, name + SUFFIX_REMOVED))) {
             throw new StorageException("failed to mark " + childTypeName + " as removed: " + name);
@@ -303,7 +299,7 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
 
         final File removed = new File(rootDir, name + SUFFIX_REMOVED);
         if (!removed.isDirectory()) {
-            throw newStorageNotFoundException0(name);
+            throw newStorageNotFoundException(name);
         }
 
         final File unremoved = new File(rootDir, name);
@@ -314,7 +310,7 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
 
         final T unremovedChild = loadChild(unremoved);
         if (unremovedChild == null) {
-            throw newStorageNotFoundException0(name);
+            throw newStorageNotFoundException(name);
         }
         return unremovedChild;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -99,7 +99,7 @@ class DefaultProject implements Project {
         requireNonNull(repositoryWorker, "repositoryWorker");
 
         if (rootDir.exists()) {
-            throw new ProjectExistsException(rootDir.toString());
+            throw new ProjectExistsException(rootDir.getName());
         }
 
         name = rootDir.getName();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManager.java
@@ -17,6 +17,8 @@
 package com.linecorp.centraldogma.server.internal.storage.repository;
 
 import com.linecorp.centraldogma.server.internal.storage.StorageManager;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
 public interface RepositoryManager extends StorageManager<Repository> {
+    Project parent();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -33,6 +33,7 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.internal.Util;
+import com.linecorp.centraldogma.server.internal.storage.project.Project;
 
 public class RepositoryManagerWrapper implements RepositoryManager {
     private final RepositoryManager delegate;
@@ -47,6 +48,11 @@ public class RepositoryManagerWrapper implements RepositoryManager {
         for (Map.Entry<String, Repository> entry : delegate.list().entrySet()) {
             repos.computeIfAbsent(entry.getKey(), n -> repoWrapper.apply(entry.getValue()));
         }
+    }
+
+    @Override
+    public Project parent() {
+        return delegate.parent();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
@@ -58,6 +58,11 @@ public class GitRepositoryManager extends DirectoryBasedStorageManager<Repositor
     }
 
     @Override
+    public Project parent() {
+        return (Project) childArg(0);
+    }
+
+    @Override
     protected Repository openChild(File childDir, Object[] childArgs) throws Exception {
         final Project project = (Project) childArgs[0];
         final GitRepositoryFormat preferredFormat = (GitRepositoryFormat) childArgs[1];
@@ -133,12 +138,12 @@ public class GitRepositoryManager extends DirectoryBasedStorageManager<Repositor
 
     @Override
     protected CentralDogmaException newStorageExistsException(String name) {
-        return new RepositoryExistsException(name);
+        return new RepositoryExistsException(parent().name() + '/' + name);
     }
 
     @Override
     protected CentralDogmaException newStorageNotFoundException(String name) {
-        return new RepositoryNotFoundException(name);
+        return new RepositoryNotFoundException(parent().name() + '/' + name);
     }
 
     /**

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -37,6 +37,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.testing.CentralDogmaRule;
 
@@ -87,7 +88,8 @@ public class ProjectServiceV1Test {
         assertThat(res.headers().status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
-                "   \"message\": \"project: myPro already exists.\"" +
+                "   \"exception\": \"" + ProjectExistsException.class.getName() + "\"," +
+                "   \"message\": \"Project 'myPro' exists already.\"" +
                 '}';
         assertThatJson(res.content().toStringUtf8()).isEqualTo(expectedJson);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -38,6 +38,8 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.centraldogma.common.ProjectNotFoundException;
+import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.testing.CentralDogmaRule;
@@ -101,7 +103,8 @@ public class RepositoryServiceV1Test {
         assertThat(aRes.headers().status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
-                "   \"message\": \"repository: myRepo already exists.\"" +
+                "  \"exception\": \"" + RepositoryExistsException.class.getName() + "\"," +
+                "  \"message\": \"Repository 'myPro/myRepo' exists already.\"" +
                 '}';
         assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
     }
@@ -115,7 +118,8 @@ public class RepositoryServiceV1Test {
         assertThat(aRes.headers().status()).isEqualTo(HttpStatus.NOT_FOUND);
         final String expectedJson =
                 '{' +
-                "   \"message\": \"absentProject does not exist.\"" +
+                "  \"exception\": \"" + ProjectNotFoundException.class.getName() + "\"," +
+                "  \"message\": \"Project 'absentProject' does not exist.\"" +
                 '}';
         assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -24,7 +24,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.server.HttpStatusException;
+import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.server.internal.admin.authentication.User;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataService;
@@ -70,7 +70,7 @@ public class TokenServiceTest {
 
         assertThatThrownBy(() -> tokenService.deleteToken("forAdmin1", guestAuthor, guest)
                                              .join())
-                .hasCauseInstanceOf(HttpStatusException.class);
+                .hasCauseInstanceOf(HttpResponseException.class);
 
         assertThat(tokenService.deleteToken("forAdmin1", adminAuthor, admin).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(token.appId());


### PR DESCRIPTION
Motivation:

The current HTTP API error response:

- has fewer information than our Java client requires, such as:
  - whether a commit has failed because the changeset is redundant or
    the changeset really has a conflict
- sometimes returns a JSON document with different fields, e.g.
  TokenService

Modifications:

- Revamp the error response factory methods in `HttpApiUtil`
  - Include the exception type if possible
  - Always set 'message' field.
- Use the error response factory methods in `HttpApiUtil` wherever
  possible

Result:

- Consistency
- Clients have more information about why the operation has failed,
  which is sometimes not enough with an HTTP status code.