### PR TITLE
Use HttpApiExceptionHandler for v0 RepositoryService

### DIFF
--- a/server/src/main/resources/webapp/i18n/en.main.json
+++ b/server/src/main/resources/webapp/i18n/en.main.json
@@ -71,6 +71,7 @@
     "path": "Path",
     "project_name": "Project name",
     "recent_commits": "Recent commits",
+    "redundant_changes": "You did not change anything.",
     "repository": "Repository",
     "repository_name": "Repository name",
     "resolved_conflicts": "Latest content is fetched and merged with your previous changes. Please check the content again.",

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.controller.js
@@ -104,7 +104,11 @@ angular.module('CentralDogmaAdmin')
                         }, function (error) {
                           switch (error.status) {
                           case 409:
-                            NotificationUtil.error('entities.conflict_occurred');
+                            if (error.exception === 'com.linecorp.centraldogma.common.RedundantChangeException') {
+                              NotificationUtil.error('entities.redundant_changes');
+                            } else {
+                              NotificationUtil.error('entities.conflict_occurred');
+                            }
                             break;
                           default:
                             NotificationUtil.error(error);

--- a/server/src/main/resources/webapp/scripts/components/util/api.service.js
+++ b/server/src/main/resources/webapp/scripts/components/util/api.service.js
@@ -36,7 +36,8 @@ angular.module('CentralDogmaAdmin')
                      var rejected = {
                        status: error.status,
                        statusText: error.statusText,
-                       message: error.data.message
+                       message: angular.isDefined(error.data.message) ? error.data.message : '',
+                       exception: angular.isDefined(error.data.exception) ? error.data.exception : ''
                      };
 
                      var callback = defer.promise.$$state.pending;


### PR DESCRIPTION
Motivation:

HTTP API v0 RepositoryService does not have an exception handler
defined, as a result, an administrator will see a warning message
about exception handlers in the log file and a user will see a 500
Internal Server Error response produced by Armeria's default
exception handler.

Modifications:

- Use HttpApiExceptionHandler for v0 RepositoryService
- Distinguish whether it was really a conflict or just an empty
  changeset

Result:

- Less WARN logs
- Better user experience when using the web UI