### PR TITLE
Add 'ID' field to credentials

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredential.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.mirror.credential;
 
 import java.net.URI;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -33,7 +34,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 })
 public interface MirrorCredential {
 
-    MirrorCredential FALLBACK = new NoneMirrorCredential(Collections.singleton(Pattern.compile("^.*$")));
+    MirrorCredential FALLBACK = new NoneMirrorCredential(null, Collections.singleton(Pattern.compile("^.*$")));
+
+    Optional<String> id();
 
     Set<Pattern> hostnamePatterns();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredential.java
@@ -18,6 +18,8 @@ package com.linecorp.centraldogma.server.internal.mirror.credential;
 
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -26,10 +28,11 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 public final class NoneMirrorCredential extends AbstractMirrorCredential {
 
     @JsonCreator
-    public NoneMirrorCredential(@JsonProperty("hostnamePatterns")
+    public NoneMirrorCredential(@JsonProperty("id") @Nullable String id,
+                                @JsonProperty("hostnamePatterns") @Nullable
                                 @JsonDeserialize(contentAs = Pattern.class)
                                 Iterable<Pattern> hostnamePatterns) {
-        super(hostnamePatterns);
+        super(id, hostnamePatterns);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredential.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -32,12 +34,13 @@ public final class PasswordMirrorCredential extends AbstractMirrorCredential {
     private final String password;
 
     @JsonCreator
-    public PasswordMirrorCredential(@JsonProperty("hostnamePatterns")
+    public PasswordMirrorCredential(@JsonProperty("id") @Nullable String id,
+                                    @JsonProperty("hostnamePatterns") @Nullable
                                     @JsonDeserialize(contentAs = Pattern.class)
                                     Iterable<Pattern> hostnamePatterns,
                                     @JsonProperty("username") String username,
                                     @JsonProperty("password") String password) {
-        super(hostnamePatterns);
+        super(id, hostnamePatterns);
 
         this.username = requireNonEmpty(username, "username");
         this.password = requireNonNull(password, "password");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredential.java
@@ -41,7 +41,8 @@ public final class PublicKeyMirrorCredential extends AbstractMirrorCredential {
     private final byte[] passphrase;
 
     @JsonCreator
-    public PublicKeyMirrorCredential(@JsonProperty("hostnamePatterns")
+    public PublicKeyMirrorCredential(@JsonProperty("id") @Nullable String id,
+                                     @JsonProperty("hostnamePatterns") @Nullable
                                      @JsonDeserialize(contentAs = Pattern.class)
                                      Iterable<Pattern> hostnamePatterns,
                                      @JsonProperty("username") String username,
@@ -49,7 +50,7 @@ public final class PublicKeyMirrorCredential extends AbstractMirrorCredential {
                                      @JsonProperty("privateKey") String privateKey,
                                      @JsonProperty("passphrase") @Nullable String passphrase) {
 
-        super(hostnamePatterns);
+        super(id, hostnamePatterns);
 
         this.username = requireNonEmpty(username, "username");
 
@@ -61,10 +62,11 @@ public final class PublicKeyMirrorCredential extends AbstractMirrorCredential {
         this.passphrase = decodeBase64OrUtf8(passphrase, "passphrase");
     }
 
-    public PublicKeyMirrorCredential(Iterable<Pattern> hostnamePatterns,
+    public PublicKeyMirrorCredential(@Nullable String id,
+                                     @Nullable Iterable<Pattern> hostnamePatterns,
                                      String username, byte[] publicKey, byte[] privateKey,
                                      @Nullable byte[] passphrase) {
-        super(hostnamePatterns);
+        super(id, hostnamePatterns);
 
         this.username = requireNonEmpty(username, "username");
         this.publicKey = requireNonEmpty(publicKey, "publicKey");

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialTest.java
@@ -23,6 +23,8 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import javax.annotation.Nullable;
+
 import org.junit.Test;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
@@ -39,27 +41,27 @@ public class MirrorCredentialTest {
 
     @Test
     public void testConstruction() {
-        // null checks
-        assertThatThrownBy(() -> new MirrorCredentialImpl(null))
+        // Without ID and hostnamePatterns, i.e. effectively disabled.
+        assertThat(new MirrorCredentialImpl(null, null).id()).isEmpty();
+        assertThat(new MirrorCredentialImpl(null, null).hostnamePatterns()).isEmpty();
+
+        // Without ID and with hostnamePatterns that contain null.
+        assertThatThrownBy(() -> new MirrorCredentialImpl(null, INVALID_PATTERNS))
                 .isInstanceOf(NullPointerException.class);
 
-        // null element checks
-        assertThatThrownBy(() -> new MirrorCredentialImpl(INVALID_PATTERNS))
-                .isInstanceOf(NullPointerException.class);
+        // Without ID and with an empty hostnamePatterns.
+        assertThat(new MirrorCredentialImpl(null, ImmutableSet.of()).hostnamePatterns()).isEmpty();
 
-        // emptiness checks
-        assertThatThrownBy(() -> new MirrorCredentialImpl(ImmutableSet.of()))
-                .isInstanceOf(IllegalArgumentException.class);
-
-        // successful construction
-        final MirrorCredential c = new MirrorCredentialImpl(HOSTNAME_PATTERNS);
+        // With ID and non-empty hostnamePatterns.
+        final MirrorCredential c = new MirrorCredentialImpl("foo", HOSTNAME_PATTERNS);
+        assertThat(c.id()).contains("foo");
         assertThat(c.hostnamePatterns().stream().map(Pattern::pattern)
                     .collect(Collectors.toSet())).containsExactly("^foo\\.com$");
     }
 
     private static final class MirrorCredentialImpl extends AbstractMirrorCredential {
-        MirrorCredentialImpl(Iterable<Pattern> hostnamePatterns) {
-            super(hostnamePatterns);
+        MirrorCredentialImpl(@Nullable String id, @Nullable Iterable<Pattern> hostnamePatterns) {
+            super(id, hostnamePatterns);
         }
 
         @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredentialTest.java
@@ -29,12 +29,19 @@ import com.linecorp.centraldogma.internal.Jackson;
 public class NoneMirrorCredentialTest {
     @Test
     public void testDeserialization() throws Exception {
+        // With hostnamePatterns
         assertThat(Jackson.readValue('{' +
                                      "  \"type\": \"none\"," +
                                      "  \"hostnamePatterns\": [" +
                                      "    \"^foo\\\\.com$\"" +
                                      "  ]" +
                                      '}', MirrorCredential.class))
-                .isEqualTo(new NoneMirrorCredential(ImmutableSet.of(Pattern.compile("^foo\\.com$"))));
+                .isEqualTo(new NoneMirrorCredential(null, ImmutableSet.of(Pattern.compile("^foo\\.com$"))));
+        // With ID
+        assertThat(Jackson.readValue('{' +
+                                     "  \"type\": \"none\"," +
+                                     "  \"id\": \"foo\"" +
+                                     '}', MirrorCredential.class))
+                .isEqualTo(new NoneMirrorCredential("foo", null));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredentialTest.java
@@ -20,11 +20,7 @@ import static com.linecorp.centraldogma.server.internal.mirror.credential.Mirror
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.regex.Pattern;
-
 import org.junit.Test;
-
-import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.centraldogma.internal.Jackson;
 
@@ -33,32 +29,28 @@ public class PasswordMirrorCredentialTest {
     @Test
     public void testConstruction() throws Exception {
         // null checks
-        assertThatThrownBy(() -> new PasswordMirrorCredential(
-                HOSTNAME_PATTERNS, null, "sesame"))
+        assertThatThrownBy(() -> new PasswordMirrorCredential(null, null, null, "sesame"))
                 .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new PasswordMirrorCredential(
-                HOSTNAME_PATTERNS, "trustin", null))
+        assertThatThrownBy(() -> new PasswordMirrorCredential(null, null, "trustin", null))
                 .isInstanceOf(NullPointerException.class);
 
         // emptiness checks
-        assertThatThrownBy(() -> new PasswordMirrorCredential(
-                HOSTNAME_PATTERNS, "", "sesame"))
+        assertThatThrownBy(() -> new PasswordMirrorCredential(null, null, "", "sesame"))
                 .isInstanceOf(IllegalArgumentException.class);
 
         // An empty password must be allowed because some servers uses password authentication
         // as token-based authentication whose username is the token and password is an empty string.
-        assertThat(new PasswordMirrorCredential(
-                HOSTNAME_PATTERNS, "trustin", "").password()).isEmpty();
+        assertThat(new PasswordMirrorCredential(null, null, "trustin", "").password()).isEmpty();
 
         // successful construction
-        final PasswordMirrorCredential c = new PasswordMirrorCredential(HOSTNAME_PATTERNS,
-                                                                        "trustin", "sesame");
+        final PasswordMirrorCredential c = new PasswordMirrorCredential(null, null, "trustin", "sesame");
         assertThat(c.username()).isEqualTo("trustin");
         assertThat(c.password()).isEqualTo("sesame");
     }
 
     @Test
     public void testDeserialization() throws Exception {
+        // With hostnamePatterns
         assertThat(Jackson.readValue('{' +
                                      "  \"type\": \"password\"," +
                                      "  \"hostnamePatterns\": [" +
@@ -67,9 +59,15 @@ public class PasswordMirrorCredentialTest {
                                      "  \"username\": \"trustin\"," +
                                      "  \"password\": \"sesame\"" +
                                      '}', MirrorCredential.class))
-                .isEqualTo(new PasswordMirrorCredential(
-                        ImmutableSet.of(Pattern.compile("^foo\\.com$")),
-                        "trustin",
-                        "sesame"));
+                .isEqualTo(new PasswordMirrorCredential(null, HOSTNAME_PATTERNS,
+                                                        "trustin", "sesame"));
+        // With ID
+        assertThat(Jackson.readValue('{' +
+                                     "  \"type\": \"password\"," +
+                                     "  \"id\": \"foo\"," +
+                                     "  \"username\": \"trustin\"," +
+                                     "  \"password\": \"sesame\"" +
+                                     '}', MirrorCredential.class))
+                .isEqualTo(new PasswordMirrorCredential("foo", null, "trustin", "sesame"));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredentialTest.java
@@ -63,39 +63,37 @@ public class PublicKeyMirrorCredentialTest {
     public void testConstruction() throws Exception {
         // null checks
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, null, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE))
+                null, null, null, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, null, PRIVATE_KEY, PASSPHRASE))
+                null, null, USERNAME, null, PRIVATE_KEY, PASSPHRASE))
                 .isInstanceOf(NullPointerException.class);
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, PUBLIC_KEY, null, PASSPHRASE))
+                null, null, USERNAME, PUBLIC_KEY, null, PASSPHRASE))
                 .isInstanceOf(NullPointerException.class);
 
         // null passphrase must be accepted.
         assertThat(new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME,
-                PUBLIC_KEY, PRIVATE_KEY, null).passphrase()).isNull();
+                null, null, USERNAME, PUBLIC_KEY, PRIVATE_KEY, null).passphrase()).isNull();
 
         // emptiness checks
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, "", PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE))
+                null, null, "", PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, "", PRIVATE_KEY, PASSPHRASE))
+                null, null, USERNAME, "", PRIVATE_KEY, PASSPHRASE))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, PUBLIC_KEY, "", PASSPHRASE))
+                null, null, USERNAME, PUBLIC_KEY, "", PASSPHRASE))
                 .isInstanceOf(IllegalArgumentException.class);
 
         // empty passphrase must be accepted, because an empty password is still a password.
         assertThat(new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME,
-                PUBLIC_KEY, PRIVATE_KEY, "").passphrase()).isEmpty();
+                null, null, USERNAME, PUBLIC_KEY, PRIVATE_KEY, "").passphrase()).isEmpty();
 
         // successful construction
         final PublicKeyMirrorCredential c = new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE);
+                null, null, USERNAME, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE);
 
         assertThat(c.username()).isEqualTo(USERNAME);
         assertThat(c.publicKey()).isEqualTo(PUBLIC_KEY.getBytes(StandardCharsets.UTF_8));
@@ -106,7 +104,7 @@ public class PublicKeyMirrorCredentialTest {
     @Test
     public void testBase64Passphrase() throws Exception {
         final PublicKeyMirrorCredential c = new PublicKeyMirrorCredential(
-                HOSTNAME_PATTERNS, USERNAME, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE_BASE64);
+                null, null, USERNAME, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE_BASE64);
         assertThat(c.passphrase()).isEqualTo(PASSPHRASE.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -123,12 +121,8 @@ public class PublicKeyMirrorCredentialTest {
                                      "  \"privateKey\": \"" + Jackson.escapeText(PRIVATE_KEY) + "\"," +
                                      "  \"passphrase\": \"" + Jackson.escapeText(PASSPHRASE) + '"' +
                                      '}', MirrorCredential.class))
-                .isEqualTo(new PublicKeyMirrorCredential(
-                        HOSTNAME_PATTERNS,
-                        USERNAME,
-                        PUBLIC_KEY,
-                        PRIVATE_KEY,
-                        PASSPHRASE));
+                .isEqualTo(new PublicKeyMirrorCredential(null, HOSTNAME_PATTERNS, USERNAME,
+                                                         PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE));
 
         // base64 passphrase
         assertThat(Jackson.readValue('{' +
@@ -139,13 +133,21 @@ public class PublicKeyMirrorCredentialTest {
                                      "  \"username\": \"trustin\"," +
                                      "  \"publicKey\": \"" + Jackson.escapeText(PUBLIC_KEY) + "\"," +
                                      "  \"privateKey\": \"" + Jackson.escapeText(PRIVATE_KEY) + "\"," +
+                                     "  \"passphrase\": \"" + Jackson.escapeText(PASSPHRASE_BASE64) + '"' +
+                                     '}', MirrorCredential.class))
+                .isEqualTo(new PublicKeyMirrorCredential(null, HOSTNAME_PATTERNS, USERNAME,
+                                                         PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE));
+
+        // ID
+        assertThat(Jackson.readValue('{' +
+                                     "  \"type\": \"public_key\"," +
+                                     "  \"id\": \"foo\"," +
+                                     "  \"username\": \"trustin\"," +
+                                     "  \"publicKey\": \"" + Jackson.escapeText(PUBLIC_KEY) + "\"," +
+                                     "  \"privateKey\": \"" + Jackson.escapeText(PRIVATE_KEY) + "\"," +
                                      "  \"passphrase\": \"" + Jackson.escapeText(PASSPHRASE) + '"' +
                                      '}', MirrorCredential.class))
-                .isEqualTo(new PublicKeyMirrorCredential(
-                        HOSTNAME_PATTERNS,
-                        USERNAME,
-                        PUBLIC_KEY,
-                        PRIVATE_KEY,
-                        PASSPHRASE));
+                .isEqualTo(new PublicKeyMirrorCredential("foo", null, USERNAME,
+                                                         PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE));
     }
 }

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -49,7 +49,8 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
         "direction": "REMOTE_TO_LOCAL",
         "localRepo": "foo",
         "localPath": "/",
-        "remoteUri": "git+ssh://git.example.com/foo.git/settings#release"
+        "remoteUri": "git+ssh://git.example.com/foo.git/settings#release",
+        "credentialId": "my_private_key"
       }
     ]
 
@@ -57,11 +58,11 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
 
   - the type of the mirroring task. Use ``single``.
 
-- ``enabled`` (boolean)
+- ``enabled`` (boolean, optional)
 
   - whether the mirroring task is enabled. Enabled by default if unspecified.
 
-- ``schedule`` (string)
+- ``schedule`` (string, optional)
 
   - a `Quartz cron expression <http://www.quartz-scheduler.org/documentation/quartz-2.x/tutorials/crontrigger.html>`_
     that describes when the mirroring task is supposed to be triggered. If unspecified, ``0 * * * * ?``
@@ -76,7 +77,7 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
   - the Central Dogma repository name. The content under the location specified in ``remoteUri`` will be
     mirrored into this repository.
 
-- ``localPath`` (string)
+- ``localPath`` (string, optional)
 
   - the directory path in ``localRepo``. The content under the location specified in ``remoteUri`` will be
     mirrored into this directory in ``localRepo``. If unspecified, ``/`` is used.
@@ -96,6 +97,12 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
     end the URI with ``.git``. e.g. ``git+ssh://git.example.com/foo.git``
   - Fragment represents a branch name. e.g. ``#release`` will mirror the branch ``release``. If unspecified,
     the branch ``master`` is mirrored.
+
+- ``credentialId`` (string, optional)
+
+  - the ID of the credential to use for authentication, as defined in ``/credentials.json``. If unspecified,
+    the credential whose ``hostnamePattern`` is matched by the host name part of the ``remoteUri`` value will
+    be selected automatically.
 
 ``/credentials.json`` contains the authentication credentials which are required when accessing the Git
 repositories defined in ``/mirrors.json``:
@@ -118,6 +125,7 @@ repositories defined in ``/mirrors.json``:
         "password": "secret!"
       },
       {
+        "id": "my_private_key",
         "type": "public_key",
         "hostnamePatterns": [
           "^.*\.secure\.com$"
@@ -129,14 +137,20 @@ repositories defined in ``/mirrors.json``:
       }
     ]
 
+- ``id`` (string, optional)
+
+  - the ID of the credential. You can specify the value of this field in the ``credentialId`` field of the
+    mirror definitions in ``/mirrors.json``.
+
 - ``type`` (string)
 
   - the type of authentication mechanism: ``none``, ``password`` or ``public_key``.
 
-- ``hostnamePatterns`` (array of strings)
+- ``hostnamePatterns`` (array of strings, optional)
 
   - the regular repressions that matches a host name. The credential whose hostname pattern matches first will
-    be used when accessing a host.
+    be used when accessing a host. You may want to omit this field if you do not want the credential to be
+    selected automatically, i.e. a mirror has to specify the ``credentialId`` field.
 
 - ``username`` (string)
 


### PR DESCRIPTION
Motivations:

Sometimes, a user has to specify different credentials for different
repositories that reside in the same host. In this case, we cannot
select the credentials based on hostname patterns, because their
hostnames are same.

Modifications:

- Add `id` field to `credentials.json`
- Add `credentialId` and `defaultCredentialId` field to `mirrors.json`
- Update the documentation

Result:

Can specify different credentials for different repositories that reside
in the same host