### PR TITLE
Do not use framed version of Javadoc

### DIFF
--- a/site/src/sphinx/_extensions/api.py
+++ b/site/src/sphinx/_extensions/api.py
@@ -73,8 +73,8 @@ def api_visit_literal(self, node, next_visitor):
         uri = javadoc_mappings[text]
         text = text.replace('$', '.')
 
-    # Prepend the frame index.html path.
-    uri = os.path.relpath(javadoc_dir, env.app.outdir).replace(os.sep, '/') + '/index.html?' + uri
+    # Prepend the path to the Javadoc directory.
+    uri = os.path.relpath(javadoc_dir, env.app.outdir).replace(os.sep, '/') + '/' + uri
     # Prepend the '@' back again if necessary
     if is_annotation:
         text = '@' + text

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -379,6 +379,6 @@ Once configured correctly, you would be able to run an application like the foll
 
 Read the Javadoc
 ----------------
-Refer to `the API documentation of 'CentralDogma' interface <apidocs/index.html?com/linecorp/centraldogma/client/CentralDogma.html>`_
+Refer to `the API documentation of 'CentralDogma' interface <apidocs/com/linecorp/centraldogma/client/CentralDogma.html>`_
 for the complete list of operations you can perform with a Central Dogma server, which should be definitely
 much more than what this tutorial covers, such as fetching and watching multiple files.

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -1,5 +1,5 @@
 .. _`Apache Shiro`: https://shiro.apache.org/
-.. _`the Caffeine API documentation`: https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.5.5/index.html?com/github/benmanes/caffeine/cache/CaffeineSpec.html
+.. _`the Caffeine API documentation`: https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.6.2/com/github/benmanes/caffeine/cache/CaffeineSpec.html
 
 
 .. _setup-configuration:


### PR DESCRIPTION
Motivation:

Since Java 9, Javadoc defaults to non-framed version. We should be
consistent across our web site for hyperlinks to Javadoc.

Modifications:

- Use hyperlinks to non-framed versions of Javadoc

Result:

Consistency