### PR TITLE
Use OpenJDK 10 instead of Oracle JDK 10 for build stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk10
+- openjdk10
 sudo: false
 os:
 - linux
@@ -13,6 +13,7 @@ notifications:
     secure: rOFBG229e+VtmUzV0o3GDiLhGueDPYp5CX26vJCL1MvS+zocVKvebxmoGbXau9D7HaaPX1sAy9u/oZQquKwiv2cpBRNuNuqDzK26u3LGYRFjPqu2aO7gF+g4XZyXjPi4t2bqrgA+FIFUwD3SVN41bNCCGECiFpARw7io8V8qPkJpokOQMS/GPSt8SrAUUCUxUoxecqZTGWI0qEMXaXcUMovBEpIym1zn/IFTml4ugOhgOyZl90u7dwX3kMN7QrFwicarCFbI5EYbUb+Nj1Ih6jqSSfBhttyVaBdWJdoOLZIy4Es/3IbG70Y4hpc24TIY5VXVkxWPrD5tB1M3yvrjGP017ZDIOTE1SuZeaWnGYml7SVPWFHTbuKeNvw+yyyTSXv1zOK7LqOI15RpnDFmcocPgfeyebh1+SD3jQZ8NrmL24NDjQdP92zpqoKH9Oy6AUReMJ+G3TZAGma2uzLwKmaiclZ6SxBdtBfMwuQjwb1B+OcoH2i54LAfjTny/s2RKQ8VUPV5DBOaIAbAX0ID1IbkzwUyXfJBfp3mBqjYMIfa4JDR/fA2q2JisZqL5UfKTnxigMub6LBPAt67aCQmaaqJNtS7rxhnSbvlOdQIu5pYxV2B+r6eMO2S8SFRsoA5YqkfOQT7ZB3hVlaw1DqJy9sFrRDBR2sc66Tc78Z4T9og=
 cache:
   directories:
+  - "$HOME/.cache/install-jdk"
   - "$HOME/.gradle/wrapper/dists"
   - "$HOME/.gradle/caches/jars-3"
   - "$HOME/.gradle/caches/modules-2"
@@ -20,14 +21,14 @@ cache:
   - "$HOME/.gradle/caches/sphinx-binary"
 env:
   global:
-  - _JAVA_OPTIONS=
-  - GRADLE_OPTS=-Xmx1280m
+  - "_JAVA_OPTIONS=-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts"
+  - "GRADLE_OPTS=-Xmx1280m"
 before_install:
 - "./gradlew --version"
 install:
 - true
 script:
-- "./gradlew --no-daemon --stacktrace -Pcoverage checkstyle test build"
+- "./gradlew --no-daemon --stacktrace -Pcoverage checkstyle check build"
 before_cache:
 - find $HOME/.gradle/caches -name '*.lock' -delete
 after_success:


### PR DESCRIPTION
Motivation:

Oracle keeps removing the old JDK download URLs whenever they release a
new version.

Modifications:

- Use `openjdk10` instead of `oraclejdk10`
- Pass `-Djavax.net.ssl.trustStore` to use the system certificates
- Add `~/.cache/install-jdk` to the build cache

Result:

Build stability