### PR TITLE
Fix frontend-side route conflicts

### DIFF
--- a/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.project.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.project.html
@@ -1,6 +1,6 @@
 <div ng-cloak>
   <h2>
-    <a ng-href="#">Projects</a> / {{project.name}}
+    <a ng-href="#/projects">Projects</a> / {{project.name}}
     <div class="pull-right" has-role="LEVEL_USER" ng-if="isOwner()">
       <a type="button" class="btn btn-xs" ng-click="removeProject()">
         <span class="glyphicon glyphicon-trash"></span>
@@ -23,7 +23,7 @@
     <tbody>
     <tr ng-repeat="repo in metadata.repos" ng-switch="repo.isActive">
       <td ng-switch-when="true">
-        <a ng-href="#/{{project.name}}/{{repo.name}}">
+        <a ng-href="#/projects/{{project.name}}/repos/{{repo.name}}">
           <span class="glyphicon">{{repo.name}}</span>
         </a>
       </td>
@@ -52,7 +52,7 @@
   <hr />
   <div class="row">
     <div class="pull-right" has-role="LEVEL_USER" ng-if="isOwner()">
-      <a type="button" class="btn btn-primary" ng-href="#/{{project.name}}/new">
+      <a type="button" class="btn btn-primary" ng-href="#/projects/{{project.name}}/new_repo">
         <span class="glyphicon glyphicon-plus"></span> {{ 'entities.button_create_repository' | translate }}
       </a>
     </div>

--- a/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.repository.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/metadata/metadata.repository.html
@@ -1,5 +1,5 @@
 <div ng-cloak>
-  <h2><a ng-href="#">Projects</a> / <a ng-href="#/metadata/{{project.name}}">{{project.name}}</a> /
+  <h2><a ng-href="#/projects">Projects</a> / <a ng-href="#/metadata/{{project.name}}">{{project.name}}</a> /
     {{repository.name}}</h2>
   <hr />
 

--- a/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
@@ -6,7 +6,7 @@
   <table class="table table-hover table-responsive">
     <tbody>
     <tr ng-repeat="repository in repositories">
-      <td><a ng-href="#/{{project.name}}/{{repository.name}}">{{repository.name}}</a></td>
+      <td><a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}">{{repository.name}}</a></td>
     </tr>
     </tbody>
   </table>
@@ -15,7 +15,7 @@
 
   <div class="row">
     <div class="pull-right" has-role="LEVEL_USER">
-      <a type="button" class="btn btn-primary" ng-href="#/{{project.name}}/new">
+      <a type="button" class="btn btn-primary" ng-href="#/projects/{{project.name}}/new_repo">
         <span class="glyphicon glyphicon-plus"></span> {{ 'entities.button_create_repository' | translate }}
       </a>
     </div>

--- a/server/src/main/resources/webapp/scripts/app/entities/projects/projects.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/projects/projects.html
@@ -6,7 +6,7 @@
   <table class="table table-hover table-responsive">
     <tbody>
     <tr ng-repeat="project in projects">
-      <td><a ng-href="#/{{project.name}}">{{project.name}}</a></td>
+      <td><a ng-href="#/projects/{{project.name}}">{{project.name}}</a></td>
       <div has-role="LEVEL_USER">
         <td align="right">
           <a ng-click="movePageIfAccessible(project.name)">
@@ -22,7 +22,7 @@
 
   <div class="row">
     <div class="pull-right" has-role="LEVEL_USER">
-      <a ng-href="#/project/new" type="button" class="btn btn-primary">
+      <a ng-href="#/new_project" type="button" class="btn btn-primary">
         <span class="glyphicon glyphicon-plus"></span> {{ 'entities.button_create_project' | translate }}
       </a>
     </div>

--- a/server/src/main/resources/webapp/scripts/app/entities/projects/projects.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/projects/projects.js
@@ -16,7 +16,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('projectNew', {
                     parent: 'entity',
-                    url: '/project/new',
+                    url: '/new_project',
                     data: {
                       roles: [CentralDogmaConstant.LEVEL_USER]
                     },
@@ -29,7 +29,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('project', {
                     parent: 'entity',
-                    url: '/:projectName',
+                    url: '/projects/:projectName',
                     data: {},
                     views: {
                       'content@': {

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repositories.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repositories.js
@@ -5,7 +5,7 @@ angular.module('CentralDogmaAdmin')
               $stateProvider
                   .state('repositoryNew', {
                     parent: 'entity',
-                    url: '/:projectName/new',
+                    url: '/projects/:projectName/new_repo',
                     data: {},
                     views: {
                       'content@': {
@@ -16,7 +16,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repository', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName',
+                    url: '/projects/:projectName/repos/:repositoryName',
                     data: {},
                     views: {
                       'content@': {
@@ -27,7 +27,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryTree', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/list/:revision/{path:repositoryPath}',
+                    url: '/projects/:projectName/repos/:repositoryName/list/:revision/{path:repositoryPath}',
                     data: {},
                     views: {
                       'content@': {
@@ -38,7 +38,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryFile', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/files/:revision/{path:repositoryPath}',
+                    url: '/projects/:projectName/repos/:repositoryName/files/:revision/{path:repositoryPath}',
                     data: {},
                     views: {
                       'content@': {
@@ -49,7 +49,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryFileNew', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/new/:revision/{path:repositoryPath}',
+                    url: '/projects/:projectName/repos/:repositoryName/new_file/:revision/{path:repositoryPath}',
                     data: {
                       roles: [CentralDogmaConstant.LEVEL_USER]
                     },
@@ -63,7 +63,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryFileEdit', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/edit/:revision/{path:repositoryPath}',
+                    url: '/projects/:projectName/repos/:repositoryName/edit/:revision/{path:repositoryPath}',
                     data: {
                       roles: [CentralDogmaConstant.LEVEL_USER]
                     },
@@ -77,7 +77,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryHistory', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/history/:revision/{path:repositoryPath}',
+                    url: '/projects/:projectName/repos/:repositoryName/history/:revision/{path:repositoryPath}',
                     data: {},
                     views: {
                       'content@': {
@@ -88,7 +88,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositorySearch', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/search/:revision?term',
+                    url: '/projects/:projectName/repos/:repositoryName/search/:revision?term',
                     data: {},
                     views: {
                       'content@': {
@@ -99,7 +99,7 @@ angular.module('CentralDogmaAdmin')
                   })
                   .state('repositoryQuery', {
                     parent: 'entity',
-                    url: '/:projectName/:repositoryName/query/:revision/{path:repositoryPath}?expression',
+                    url: '/projects/:projectName/repos/:repositoryName/query/:revision/{path:repositoryPath}?expression',
                     data: {},
                     views: {
                       'content@': {

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.controller.js
@@ -23,7 +23,7 @@ angular.module('CentralDogmaAdmin')
                   };
 
                   $scope.setRevision = function (revision) {
-                    $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
+                    $location.path('/projects/' + $scope.project.name + '/repos/' + $scope.repository.name +
                                    '/files/' + revision + $scope.path);
                   };
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.edit.html
@@ -11,15 +11,15 @@
 
       <p class="form-control-static">
       <span>
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
       </span>
       <span>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
           <strong>{{repository.name}}</strong>
         </a>
       </span>
       <span>
-        @ <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
+        @ <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
       </span>
       </p>
     </div>
@@ -30,12 +30,12 @@
 
       <div class="input-group">
         <span>
-          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+          <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
             <strong>{{repository.name}}</strong>
           </a>
         </span>
         <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last"> /
-          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+          <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
             {{parsedPath.name}}
           </a>
         </span>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.html
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-xs-6">
       <p style="font-size: large;">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
-        <a ng-href="#/{{project.name}}/{{repository.name}}"><b>{{repository.name}}</b></a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}"><b>{{repository.name}}</b></a>
       </p>
     </div>
     <div class="col-xs-6">
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>
@@ -45,11 +45,11 @@
   <div class="row">
     <div class="col-xs-12 col-sm-6">
       <a type="button" class="btn btn-default"
-         ng-href="#/{{project.name}}/{{repository.name}}/history/{{revision}}{{path}}">
+         ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/history/{{revision}}{{path}}">
         <span class="glyphicon glyphicon-option-vertical"></span> {{ 'entities.button_history' | translate }}
       </a>
       <a type="button" class="btn btn-default" ng-if="file.type === 'JSON'"
-         ng-href="#/{{project.name}}/{{repository.name}}/query/{{revision}}{{path}}">
+         ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/query/{{revision}}{{path}}">
         <span class="glyphicon glyphicon-glass"></span> {{ 'entities.button_query' | translate }}
       </a>
     </div>
@@ -57,7 +57,7 @@
     <div class="col-xs-12 col-sm-6">
       <div class="pull-right" has-role="LEVEL_USER">
         <a type="button" class="btn btn-primary"
-           ng-href="#/{{project.name}}/{{repository.name}}/edit/{{revision}}{{path}}">
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/edit/{{revision}}{{path}}">
           <span class="glyphicon glyphicon-edit"></span> {{ 'entities.button_edit' | translate }}
         </a>
         <button class="btn btn-danger"

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.new.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.file.new.html
@@ -11,15 +11,15 @@
 
       <p class="form-control-static">
         <span>
-          <a ng-href="#/{{project.name}}">{{project.name}}</a> /
+          <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
         </span>
         <span>
-          <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+          <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
             <strong>{{repository.name}}</strong>
           </a>
         </span>
         <span>
-          @ <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
+          @ <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">{{revision}}</a>
         </span>
       </p>
     </div>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.controller.js
@@ -20,7 +20,7 @@ angular.module('CentralDogmaAdmin')
                   $scope.commits = [];
 
                   $scope.setRevision = function (revision) {
-                    $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
+                    $location.path('/projects/' + $scope.project.name + '/repos/' + $scope.repository.name +
                                    '/history/' + revision + $scope.path);
                   };
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.history.html
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-xs-6">
       <p style="font-size: large;">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
-        <a ng-href="#/{{project.name}}/{{repository.name}}"><strong>{{repository.name}}</strong></a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}"><strong>{{repository.name}}</strong></a>
       </p>
     </div>
     <div class="col-xs-6">
@@ -24,21 +24,21 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first">
       /
-      <a ng-if="!$last" ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+      <a ng-if="!$last" ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
       <a ng-if="$last && file.type !== 'DIRECTORY'"
-         ng-href="#/{{project.name}}/{{repository.name}}/files/{{revision}}{{parsedPath.path}}">
+         ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/files/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
       <a ng-if="$last && file.type === 'DIRECTORY'"
-         ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+         ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>
@@ -56,7 +56,7 @@
     <tbody>
     <tr ng-repeat="commit in commits">
       <td>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{commit.revision.revisionNumber}}{{path}}">
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{commit.revision.revisionNumber}}{{path}}">
           {{commit.revision.revisionNumber}}
         </a>
       </td>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.new.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.new.html
@@ -8,7 +8,7 @@
       <label class="control-label" translate>entities.project_name</label>
 
       <p class="form-control-static">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a>
       </p>
     </div>
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.controller.js
@@ -70,7 +70,7 @@ angular.module('CentralDogmaAdmin')
                   }
 
                   $scope.setRevision = function (revision) {
-                    $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
+                    $location.path('/projects/' + $scope.project.name + '/repos/' + $scope.repository.name +
                                    '/query/' + revision + $scope.path);
                   };
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.query.html
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-xs-6">
       <p style="font-size: large;">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
-        <a ng-href="#/{{project.name}}/{{repository.name}}"><b>{{repository.name}}</b></a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}"><b>{{repository.name}}</b></a>
       </p>
     </div>
     <div class="col-xs-6">
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first && !$last">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.controller.js
@@ -22,7 +22,7 @@ angular.module('CentralDogmaAdmin')
 
                   $scope.setRevision = function (revision) {
                     console.log($scope.term);
-                    $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
+                    $location.path('/projects/' + $scope.project.name + '/repos/' + $scope.repository.name +
                                    '/search/' + revision);
                   };
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.search.html
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-xs-6">
       <p style="font-size: large;">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
-        <a ng-href="#/{{project.name}}/{{repository.name}}"><b>{{repository.name}}</b></a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}"><b>{{repository.name}}</b></a>
       </p>
     </div>
     <div class="col-xs-6">
@@ -35,11 +35,11 @@
       </td>
       <td>
         <a ng-if="file.type === 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{file.path}}">
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{file.path}}">
           {{file.path}}
         </a>
         <a ng-if="file.type !== 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/files/{{revision}}{{file.path}}">
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/files/{{revision}}{{file.path}}">
           {{file.path}}
         </a>
       </td>

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.controller.js
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.controller.js
@@ -19,7 +19,7 @@ angular.module('CentralDogmaAdmin')
                   $scope.selectedFile = null;
 
                   $scope.setRevision = function (revision) {
-                    $location.path('/' + $scope.project.name + '/' + $scope.repository.name +
+                    $location.path('/projects/' + $scope.project.name + '/repos/' + $scope.repository.name +
                                    '/list/' + revision + $scope.path);
                   };
 

--- a/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/repositories/repository.tree.html
@@ -8,8 +8,8 @@
   <div class="row">
     <div class="col-xs-6">
       <p style="font-size: large;">
-        <a ng-href="#/{{project.name}}">{{project.name}}</a> /
-        <a ng-href="#/{{project.name}}/{{repository.name}}"><strong>{{repository.name}}</strong></a>
+        <a ng-href="#/projects/{{project.name}}">{{project.name}}</a> /
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}"><strong>{{repository.name}}</strong></a>
       </p>
     </div>
     <div class="col-xs-6">
@@ -24,13 +24,13 @@
 
   <p>
     <span>
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}/">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}/">
         <strong>{{repository.name}}</strong>
       </a>
     </span>
     <span ng-repeat="parsedPath in parsedPaths" ng-if="!$first">
       /
-      <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
+      <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPath.path}}">
         {{parsedPath.name}}
       </a>
     </span>
@@ -41,7 +41,7 @@
     <tr ng-if="parsedPaths.length > 1">
       <td style="width: 20px;"><span class="glyphicon glyphicon-level-up"></span></td>
       <td>
-        <a ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{parsedPaths[parsedPaths.length-2].path}}">..</a>
+        <a ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{parsedPaths[parsedPaths.length-2].path}}">..</a>
       </td>
     </tr>
     <tr ng-if="files.length == 0">
@@ -55,9 +55,9 @@
       </td>
       <td>
         <a ng-if="file.type === 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/list/{{revision}}{{file.path}}">{{file.name}}</a>
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/list/{{revision}}{{file.path}}">{{file.name}}</a>
         <a ng-if="file.type !== 'DIRECTORY'"
-           ng-href="#/{{project.name}}/{{repository.name}}/files/{{revision}}{{file.path}}">{{file.name}}</a>
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/files/{{revision}}{{file.path}}">{{file.name}}</a>
       </td>
     </tr>
     </tbody>
@@ -68,7 +68,7 @@
   <div class="row">
     <div class="col-xs-12 col-sm-6">
       <a type="button" class="btn btn-default"
-         ng-href="#/{{project.name}}/{{repository.name}}/history/{{revision}}{{path}}">
+         ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/history/{{revision}}{{path}}">
         <span class="glyphicon glyphicon-option-vertical"></span> {{ 'entities.button_history' | translate }}
       </a>
     </div>
@@ -76,7 +76,7 @@
     <div class="col-xs-12 col-sm-6">
       <div class="pull-right" has-role="LEVEL_USER">
         <a type="button" class="btn btn-primary"
-           ng-href="#/{{project.name}}/{{repository.name}}/new/{{revision}}{{path}}">
+           ng-href="#/projects/{{project.name}}/repos/{{repository.name}}/new_file/{{revision}}{{path}}">
           <span class="glyphicon glyphicon-plus"></span> {{ 'entities.button_create' | translate }}
         </a>
         <button class="btn btn-danger"


### PR DESCRIPTION
Motivation:

Our frontend-side router has conflicts like:

- `/:projectName/new` vs. `/:projectName/:repoName` when `repoName` is `new`
- `/projects` vs. `/:projectName` when `projectName` is `projects`

Modifications:

- Make sure all entity paths have the form of
  `/projects/:projectName/repos/:repoName`
- Clarify the type of the entity being created
  - `new` -> `new_project`, `new_repo` or `new_file`

Result:

- Fixes #270
- A user can create and access a repository whose name is `new`, `list`,
  `files`, etc, from the web UI.
- A user can create and access a project whose name is `projects`,
  `metadata`, etc, from the web UI.
- URLs of the entities in the web UI have been changes in an incompatible way.
  - Note: The server-side HTTP API remains unaffected.

/cc @occho