### PR TITLE
Make it possible to keep replicating in read-only mode

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/CommandExecutor.java
@@ -28,6 +28,10 @@ public interface CommandExecutor {
 
     CompletableFuture<Void> stop();
 
+    boolean isWritable();
+
+    void setWritable(boolean writable);
+
     <T> CompletableFuture<T> execute(Command<T> command);
 
     <T> CompletableFuture<T> execute(int replicaId, Command<T> command);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ForwardingCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/command/ForwardingCommandExecutor.java
@@ -55,6 +55,16 @@ public class ForwardingCommandExecutor implements CommandExecutor {
     }
 
     @Override
+    public boolean isWritable() {
+        return delegate().isWritable();
+    }
+
+    @Override
+    public void setWritable(boolean writable) {
+        delegate().setWritable(writable);
+    }
+
+    @Override
     public <T> CompletableFuture<T> execute(Command<T> command) {
         return delegate().execute(command);
     }


### PR DESCRIPTION
Motivation:

A user may want to keep the replication turned on while prohibiting any
direct writes to a replica. This behavior is useful when a user needs to
make sure that all replicas caught up all replication logs, which is
unachievable if entered read-only mode with replication turned off
because the read-only replica will not be able to catch up the replication
logs created by other replicas after it went read-only.

Modifications:

- Add `CommandExecutor.writable` property so that it is possible to
  enter read-only mode without stopping replication.
- Update `AdministrativeService` to expose `replicating` property as well
  as `writable` in the server status.
- `AdministrativeService` now allows leaving read-only mode.

Result:

- It is much easier for a user to ensure that all replicas contain the
  same data during maintenance.
- A user can leave read-only mode without restarting a replica.