### PR TITLE
Load client profiles from all resources

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/ClientProfile.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/ClientProfile.java
@@ -35,19 +35,27 @@ import com.linecorp.centraldogma.internal.Jackson;
 final class ClientProfile {
 
     private final String name;
+    private final int priority;
     private final Set<Entry> hosts;
 
     @JsonCreator
     ClientProfile(@JsonProperty(value = "name", required = true) String name,
+                  @JsonProperty("priority") @Nullable Integer priority,
                   @JsonProperty("hosts") @JsonDeserialize(contentAs = Entry.class) @Nullable Set<Entry> hosts) {
         this.name = requireNonNull(name, "name");
         checkArgument(!name.isEmpty(), "name is empty.");
+        this.priority = firstNonNull(priority, 0);
         this.hosts = ImmutableSet.copyOf(firstNonNull(hosts, ImmutableSet.of()));
     }
 
     @JsonProperty
     String name() {
         return name;
+    }
+
+    @JsonProperty
+    int priority() {
+        return priority;
     }
 
     @JsonProperty

--- a/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
@@ -42,7 +42,6 @@ public class CentralDogmaBuilderTest {
     @Test
     public void emptyProfile() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
-
         assertThatThrownBy(() -> b.profile("bar"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("no profile matches");
@@ -62,7 +61,7 @@ public class CentralDogmaBuilderTest {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("foo");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
-                InetSocketAddress.createUnresolved("foo.com", 36462));
+                InetSocketAddress.createUnresolved("foo.test.com", 36462));
     }
 
     @Test
@@ -71,8 +70,41 @@ public class CentralDogmaBuilderTest {
         b.useTls();
         b.profile("foo");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
-                InetSocketAddress.createUnresolved("foo.com", 8443),
-                InetSocketAddress.createUnresolved("bar.com", 443));
+                InetSocketAddress.createUnresolved("foo.test.com", 443));
+    }
+
+    @Test
+    public void profileLoadedFromAllResources() {
+        final CentralDogmaBuilder b = new CentralDogmaBuilder();
+        b.profile("production");
+        assertThat(b.hosts()).containsExactlyInAnyOrder(
+                InetSocketAddress.createUnresolved("prod1.com", 36462),
+                InetSocketAddress.createUnresolved("prod2.com", 36462));
+    }
+
+    @Test
+    public void ipHosts() {
+        final CentralDogmaBuilder b = new CentralDogmaBuilder();
+        b.profile("ip_hosts");
+        assertThat(b.hosts()).containsExactlyInAnyOrder(
+                new InetSocketAddress("192.168.0.1", 8081),
+                new InetSocketAddress("192.168.0.2", 8082));
+    }
+
+    @Test
+    public void profileWithHighPriorityWins() {
+        final CentralDogmaBuilder b = new CentralDogmaBuilder();
+        b.profile("high_priority_wins");
+        assertThat(b.hosts()).containsExactlyInAnyOrder(
+                InetSocketAddress.createUnresolved("high-priority.com", 36462));
+    }
+
+    @Test
+    public void profileWithLowPriorityLoses() {
+        final CentralDogmaBuilder b = new CentralDogmaBuilder();
+        b.profile("low_priority_loses");
+        assertThat(b.hosts()).containsExactlyInAnyOrder(
+                InetSocketAddress.createUnresolved("high-priority.com", 36462));
     }
 
     @Test
@@ -80,9 +112,10 @@ public class CentralDogmaBuilderTest {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         // The last valid profile should win, to be consistent with Spring Boot profiles.
         b.profile("foo", "qux");
+        assertThat(b.selectedProfile()).isEqualTo("qux");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
-                InetSocketAddress.createUnresolved("alice.com", 36462),
-                InetSocketAddress.createUnresolved("bob.com", 36462));
+                InetSocketAddress.createUnresolved("qux1.test.com", 36462),
+                InetSocketAddress.createUnresolved("qux2.test.com", 36462));
     }
 
     @Test

--- a/client/java/src/test/resources/centraldogma-profiles-test.json
+++ b/client/java/src/test/resources/centraldogma-profiles-test.json
@@ -3,17 +3,12 @@
     "name": "foo",
     "hosts": [
       {
-        "host": "foo.com",
+        "host": "foo.test.com",
         "protocol": "http",
         "port": 36462
       },
       {
-        "host": "foo.com",
-        "protocol": "https",
-        "port": 8443
-      },
-      {
-        "host": "bar.com",
+        "host": "foo.test.com",
         "protocol": "https",
         "port": 443
       }
@@ -27,14 +22,51 @@
     "name": "qux",
     "hosts": [
       {
-        "host": "alice.com",
+        "host": "qux1.test.com",
         "protocol": "http",
         "port": 36462
       },
       {
-        "host": "bob.com",
+        "host": "qux2.test.com",
         "protocol": "http",
         "port": 36462
+      }
+    ]
+  },
+  {
+    "name": "high_priority_wins",
+    "priority": 100,
+    "hosts": [
+      {
+        "host": "low-priority.com",
+        "protocol": "http",
+        "port": 36462
+      }
+    ]
+  },
+  {
+    "name": "low_priority_loses",
+    "priority": 200,
+    "hosts": [
+      {
+        "host": "high-priority.com",
+        "protocol": "http",
+        "port": 36462
+      }
+    ]
+  },
+  {
+    "name": "ip_hosts",
+    "hosts": [
+      {
+        "host": "192.168.0.1",
+        "protocol": "http",
+        "port": 8081
+      },
+      {
+        "host": "192.168.0.2",
+        "protocol": "http",
+        "port": 8082
       }
     ]
   }

--- a/client/java/src/test/resources/centraldogma-profiles.json
+++ b/client/java/src/test/resources/centraldogma-profiles.json
@@ -1,1 +1,84 @@
-"This file should never be accessed because 'centraldogma-profiles-test.json' must be tried first."
+[
+  {
+    "name": "foo",
+    "hosts": [
+      {
+        "host": "error.com",
+        "protocol": "http",
+        "port": 36462
+      },
+      {
+        "host": "error.com",
+        "protocol": "https",
+        "port": 443
+      }
+    ]
+  },
+  {
+    "name": "bar",
+    "hosts": [
+      {
+        "host": "error.com",
+        "protocol": "http",
+        "port": 36462
+      },
+      {
+        "host": "error.com",
+        "protocol": "https",
+        "port": 443
+      }
+    ]
+  },
+  {
+    "name": "qux",
+    "hosts": [
+      {
+        "host": "error.com",
+        "protocol": "http",
+        "port": 36462
+      },
+      {
+        "host": "error.com",
+        "protocol": "https",
+        "port": 443
+      }
+    ]
+  },
+  {
+    "name": "high_priority_wins",
+    "priority": 200,
+    "hosts": [
+      {
+        "host": "high-priority.com",
+        "protocol": "http",
+        "port": 36462
+      }
+    ]
+  },
+  {
+    "name": "low_priority_loses",
+    "priority": 100,
+    "hosts": [
+      {
+        "host": "low-priority.com",
+        "protocol": "http",
+        "port": 36462
+      }
+    ]
+  },
+  {
+    "name": "production",
+    "hosts": [
+      {
+        "host": "prod1.com",
+        "protocol": "http",
+        "port": 36462
+      },
+      {
+        "host": "prod2.com",
+        "protocol": "http",
+        "port": 36462
+      }
+    ]
+  }
+]

--- a/site/src/sphinx/_static/schema-centraldogma-profiles.json
+++ b/site/src/sphinx/_static/schema-centraldogma-profiles.json
@@ -15,6 +15,14 @@
           "local", "beta", "release"
         ]
       },
+      "priority": {
+        "$id": "https://line.github.io/centraldogma/schema/client-profiles/items/properties/priority",
+        "type": "integer",
+        "title": "The priority of the client profile",
+        "examples": [
+          "0", "-100", "100"
+        ]
+      },
       "hosts": {
         "$id": "https://line.github.io/centraldogma/schema/client-profiles/items/properties/hosts",
         "type": "array",

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -250,6 +250,7 @@ the replicas in the ``beta`` profile support ``http`` only:
 
     [ {
       "name": "beta",
+      "priority": 0,
       "hosts": [ {
         "host": "replica1.beta.example.com",
         "protocol": "http",
@@ -261,6 +262,7 @@ the replicas in the ``beta`` profile support ``http`` only:
       } ]
     }, {
       "name": "release",
+      "priority": 0,
       "hosts": [ {
         "host": "replica1.release.example.com",
         "protocol": "http",
@@ -285,16 +287,57 @@ the replicas in the ``beta`` profile support ``http`` only:
     Use `the JSON schema <_static/schema-centraldogma-profiles.json>`_ to validate your
     ``centraldogma-profiles.json`` file.
 
-You may want to archive this file into a JAR file and distribute it via a Maven repository, so that your users
-get the up-to-date host list easily. For example, a user could put ``centraldogma-profiles-1.0.jar`` into his
-or her class path::
+You may want to archive this file into a JAR file and distribute it as the *official* client profiles via
+a Maven repository, so that your users get the up-to-date host list easily. For example, a user could put
+``centraldogma-profiles-1.0.jar`` into his or her class path::
 
     $ cat centraldogma-profiles.json
-    [ { "name": "release", "hosts": [ ... ] } ]
+    [ { "name": "beta",    "priority": 0, "hosts": [ ... ] },
+      { "name": "release", "priority": 0, "hosts": [ ... ] } ]
 
     $ jar cvf centraldogma-profiles-1.0.jar centraldogma-profiles.json
     added manifest
     adding: centraldogma-profiles.json
+
+Custom client profiles
+^^^^^^^^^^^^^^^^^^^^^^
+A user can add his or her own custom client profiles other than the official ones by adding more
+``centraldogma-profiles.json`` files to the class path. The following example adds a custom profile called
+``localtest``:
+
+.. code-block:: json
+
+    [ {
+      "name": "localtest",
+      "hosts": [ {
+        "host": "127.0.0.1",
+        "protocol": "http",
+        "port": 36462
+      } ]
+    } ]
+
+A user can also override the official profile provided by an administrator by specifying a higher priority.
+For example, you can override the ``beta`` profile using priority ``100`` which is higher than the default
+priority of ``0``:
+
+.. code-block:: json
+
+    [ {
+      "name": "beta",
+      "priority": 100,
+      "hosts": [ {
+        "host": "replica1.alternative-beta.example.com",
+        "protocol": "http",
+        "port": 36462
+      }, {
+        "host": "replica2.alternative-beta.example.com",
+        "protocol": "http",
+        "port": 36462
+      } ]
+    } ]
+
+Note that other profiles such as ``release`` are still loaded from the ``centraldogma-profiles.json`` distributed by
+the administrator.
 
 Using DNS-based lookup
 ----------------------


### PR DESCRIPTION
Motivation:

Currently, Central Dogma client uses only the first found
`centraldogma-profiles.json` file to load client profiles. It would be
useful to load all `centraldogma-profiles.json` files in the class path
so that it is possible for a user to add custom profiles on top of the
official profiles provided by administrators.

Modifications:

- Add `priority' property to a client profile
- Load all profile JSONs so that all profiles are considered.
- Make sure the profile that has higher priority or appeared first in
  the classpath wins when there are more than one profile with the same
  name.

Result:

- Fixes #292
