### PR TITLE
Interrupt Central Dogma server startup process if stop is requested.

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/NoneReplicationConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/NoneReplicationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2018 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,15 +14,13 @@
  * under the License.
  */
 
-package com.linecorp.centraldogma.server.internal.replication;
+package com.linecorp.centraldogma.server;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 
 import org.junit.Test;
 
-import com.linecorp.centraldogma.server.ReplicationConfig;
-
-public class ReplicationConfigTest {
+public class NoneReplicationConfigTest {
     @Test
     public void testJsonConversion() {
         assertJsonConversion(ReplicationConfig.NONE,

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.replication;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.curator.test.InstanceSpec;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.DisableOnDebug;
+import org.junit.rules.TestRule;
+import org.junit.rules.Timeout;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.ZooKeeperAddress;
+import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+/**
+ * Makes sure that we can stop a replica that's waiting for the initial quorum.
+ */
+public class StartStopWithoutInitialQuorumTest {
+
+    @Rule
+    public final TestRule timeoutRule = new DisableOnDebug(new Timeout(1, TimeUnit.MINUTES));
+
+    @Rule
+    public final CentralDogmaRule dogma = new CentralDogmaRule() {
+        @Override
+        protected void before() {
+            // Do not start yet.
+        }
+
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            // Set up a cluster of two replicas where the second replica is always unavailable,
+            final int quorumPort = InstanceSpec.getRandomPort();
+            final int electionPort = InstanceSpec.getRandomPort();
+            final int clientPort = InstanceSpec.getRandomPort();
+
+            builder.replication(new ZooKeeperReplicationConfig(
+                    1, ImmutableMap.of(1, new ZooKeeperAddress("127.0.0.1",
+                                                               quorumPort, electionPort, clientPort),
+                                       2, new ZooKeeperAddress("127.0.0.1", 1, 1, 1))));
+        }
+    };
+
+    @Test
+    public void test() {
+        final CompletableFuture<Void> startFuture = dogma.startAsync();
+        dogma.stopAsync().join();
+        startFuture.join();
+    }
+}


### PR DESCRIPTION
Motivation:

In a replicated setup, the startup process of Central Dogma server can
take an extended period of time if the cluster does not contain the
initial quorum. In this situation, any attempt to stop the server will
block until the cluster contains the initial quorum and thus a user had
to terminate the process manually to stop the server.

Modifications:

- Stop waiting for the quorum if there is a pending stop request.
  - Made the following changes to `CentralDogmaRule` to test this scenario:
    - Made `CentralDogmaRule.before()` and `after()` non-final.
    - Added `CentralDogmaRule.startAsync()` and `stopAsync()`.
    - Made sure the temporary folder is deleted after the server stops.
- Miscellaneous:
  - Fixed intermittent `FileNotFoundException` in `ZooKeeperCommandExecutorTest`.
  - Renamed `ReplicationConfigTest` to `NoneReconfigurationConfigTest`.

Result:

- A user can stop a server even if it is stuck in the startup process.
- Less flakiness