### PR TITLE
Remove Guice from the build dependencies / Update Go

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,9 +7,6 @@ buildscript {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.0'
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.7'
-        // For gogradle. It seems gogradle doesn't support buildscript so just leave this here until
-        // gogradle supports it.
-        classpath 'com.google.inject:guice:4.2.1'
     }
 }
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -27,7 +27,7 @@ ext {
     def defaultClientRepoUrl = 'https://github.com/line/centraldogma-go.git'
     def defaultClientTag = '6d0497f9bc410438c34833c4a0ea9e5a8de4173a'
 
-    goVersion = '1.11.1'
+    goVersion = '1.11.2'
 
     clientRepoUrl = project.findProperty('goClientRepoUrl')?: defaultClientRepoUrl
     clientTag = project.findProperty('goClientTag')?: defaultClientTag

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath "com.boazj.gradle:gradle-log-plugin:${managedVersions['com.boazj.gradle:gradle-log-plugin']}"
         classpath "com.bmuschko:gradle-docker-plugin:${managedVersions['com.bmuschko:gradle-docker-plugin']}"
+        classpath "com.google.guava:guava:${managedVersions['com.google.guava:guava']}"
     }
 }
 


### PR DESCRIPTION
Motivation:

Build seems to run fine without Guice.

Modifications:

- Removed Guice from the build dependencies.
- Added Guava to the build dependencies for `:dist`
- Updates Go from 1.11.1 to 1.11.2

Result:

Less build-time dependencies