### PR TITLE
Add the path to Central Dogma bin directory to PATH environment variable

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -7,6 +7,7 @@ FROM openjdk:8
 ENV CENTRALDOGMA_HOME "/opt/centraldogma"
 ENV CENTRALDOGMA_OPTS "-nodetach"
 ENV JAVA_OPTS "$CENTRALDOGMA_OPTS"
+ENV PATH "$CENTRALDOGMA_HOME/bin:$PATH"
 
 # Install CentralDogma binaries and configurations.
 RUN mkdir -p                      \


### PR DESCRIPTION
I think it's more helpful for the bin directory to be added to the PATH environment variable, when trying the official documentation's Command-line client examples with Docker.

# As-Is

```
root@59898138fb3a:/# dogma -v
bash: dogma: command not found
```

# To-Be

```
root@66eda13670d0:/# dogma -v
Central Dogma version 0.32.2-SNAPSHOT (d0f922e)
```