### PR TITLE
Specify maxparallel in chmod

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -42,7 +42,7 @@ tasks.clean.doFirst {
     // We need to grant write permission before attempting to delete them.
     def modulesDir = project.file("${goPath}/pkg/mod")
     if (modulesDir.exists()) {
-        ant.chmod(dir: modulesDir, perm: 'u+w', type: 'both', includes: '**')
+        ant.chmod(dir: modulesDir, perm: 'u+w', type: 'both', includes: '**', maxparallel: '500')
     }
 }
 


### PR DESCRIPTION
Motivation:

Some OS limit the number of files which a `chmod` can change in once.
So we have to limit the number not to raise an error.