### PR TITLE
Run TestNG tests with shaded classes

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -26,24 +26,25 @@ dependencies {
     testCompile 'org.testng:testng'
 }
 
-// Run the test cases based on reactive-streams-tck
+// Run the JSON patch test cases.
 task testNg(type: Test,
-        group: 'Verification',
-        description: 'Runs the TestNG unit tests.') {
-    useTestNG()
-    testClassesDirs = tasks.test.testClassesDirs
-    classpath = tasks.test.classpath
-    scanForTestClasses = false
-}
-tasks.test.finalizedBy tasks.testNg
-tasks.check.dependsOn tasks.testNg
+            group: 'Verification',
+            description: 'Runs the TestNG unit tests.',
+            dependsOn: tasks.shadedTestClasses) {
 
-if (hasFlags('coverage')) {
-    jacocoTestReport {
-        // Include the coverage data from the TestNG test cases.
-        executionData file("${project.buildDir}/jacoco/testNg.exec")
+    useTestNG()
+    include '/com/linecorp/centraldogma/internal/jsonpatch/**'
+
+    scanForTestClasses = false
+    testClassesDirs = tasks.shadedTest.testClassesDirs
+
+    // Set the class path as late as possible so that the 'shadedTest' task has the correct classpath.
+    afterProjectsWithFlag('java') {
+        classpath = tasks.shadedTest.classpath
     }
 }
+tasks.shadedTest.finalizedBy tasks.testNg
+tasks.check.dependsOn tasks.testNg
 
 tasks.trimShadedJar.configure {
     keep "class !com.linecorp.centraldogma.internal.shaded.**,com.linecorp.centraldogma.** { *; }"


### PR DESCRIPTION
Motivation:

Our test coverage has decreased since 5c4c5ad772ce0d37044fe6d65522ef5636d15d68
because `:common:testNg` task did not run with shaded classes and thus
JaCoCo ignored the data collected from it due to mismatching byte code
offsets.

Modifications:

- Run TestNG tests with shaded classes

Result:

Test coverage is up again.