### PR TITLE
Copy dependencies for saml and shiro modules to lib directory

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -56,7 +56,9 @@ task copyLib(group: 'Build',
     from project(':server').configurations.runtime
     from project(':server').tasks.jar
     from project.configurations.runtime
+    from project(':server-auth:saml').configurations.runtime
     from project(':server-auth:saml').tasks.jar
+    from project(':server-auth:shiro').configurations.runtime
     from project(':server-auth:shiro').tasks.jar
     into "${project.ext.distDir}/lib"
 


### PR DESCRIPTION
Motivation:
Copying dependencies for saml and shiro modules to `dist/lib` was missing.
So a user cannot start a server with authentication config.

Modifications:
- Add their dependencies to the copy target.