### PR TITLE
Fix a bug where serverId autodetection fails when more than one NIC h…

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
@@ -164,12 +164,13 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
             }
 
             if (zkAddr.equals(ip)) {
+                final int serverId = entry.getKey().intValue();
                 if (currentServerId < 0) {
-                    currentServerId = entry.getKey().intValue();
-                } else {
+                    currentServerId = serverId;
+                } else if (currentServerId != serverId) {
                     throw new IllegalStateException(
                             "cannot auto-detect server ID because there are more than one IP address match. " +
-                            "Both server ID " + currentServerId + " and " + entry.getKey() +
+                            "Both server ID " + currentServerId + " and " + serverId +
                             " have a matching IP address. Consider specifying server ID explicitly.");
                 }
             }


### PR DESCRIPTION
…ave the same IP address

Motivation:

`serverId` autodetection in `ZooKeeperReplicationConfig` fails when a
machine has more than one NIC and they have the same IP address
assigned. For example:

    $ ip addr
    1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1
        link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
        inet 127.0.0.1/8 scope host lo
           valid_lft forever preferred_lft forever
        inet 10.20.30.40/32 brd 10.20.30.40 scope global lo:private
           valid_lft forever preferred_lft forever
    ...
    3: private: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue state UNKNOWN qlen 1000
        link/ether aa:aa:aa:aa:aa:aa brd ff:ff:ff:ff:ff:ff
        inet 10.20.30.40/32 scope global private
           valid_lft forever preferred_lft forever

Modifications:

- Do not complain when there are more than one match as long as their
  server IDs are identical.

Result:

- Server does not fail to start up with a silly exception message such
  as:

      Both server ID 1 and 1 have a matching IP address.