### PR TITLE
Make JCommander an optional dependency

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -30,7 +30,9 @@ dependencies {
     testCompile 'org.apache.curator:curator-test'
 
     // jCommander
-    compile 'com.beust:jcommander'
+    compile('com.beust:jcommander') {
+        ext.optional = true
+    }
 
     // jGit
     compile 'org.eclipse.jgit:org.eclipse.jgit'


### PR DESCRIPTION
Related: #306
Motivation:

When a user pulls `centraldogma-testing`, it also pulls JCommander
transitively, but it's actually of no use.

Modifications:

- Make JCommander optional

Result:

- Less transitive dependencies