### PR TITLE
Adjust timeout for HTTP `watch` requests according to `wait` parameter

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/CentralDogmaClientTimeoutScheduler.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/CentralDogmaClientTimeoutScheduler.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.SimpleDecoratingClient;
 import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
 /**
  * Decorates a {@link Client} to enlarge responseTimeout when requesting watchFile or watchRepository.
@@ -44,11 +45,8 @@ class CentralDogmaClientTimeoutScheduler extends SimpleDecoratingClient<RpcReque
                 final List<Object> params = req.params();
                 final long timeout = (Long) params.get(params.size() - 1);
                 if (timeout > 0) {
-                    if (timeout > Long.MAX_VALUE - ctx.responseTimeoutMillis()) {
-                        ctx.setResponseTimeoutMillis(0);
-                    } else {
-                        ctx.setResponseTimeoutMillis(ctx.responseTimeoutMillis() + timeout);
-                    }
+                    ctx.setResponseTimeoutMillis(
+                            WatchTimeout.makeReasonable(timeout, ctx.responseTimeoutMillis()));
                 }
             }
         }

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/CentralDogmaTimeoutSchedulerTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/CentralDogmaTimeoutSchedulerTest.java
@@ -42,6 +42,7 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
 import io.netty.channel.DefaultEventLoop;
@@ -77,7 +78,7 @@ public class CentralDogmaTimeoutSchedulerTest {
 
     @Test
     public void execute_watch_timeoutOverflow() throws Exception {
-        check("watchRepository", Long.MAX_VALUE - 10, 100L, 0);
+        check("watchRepository", Long.MAX_VALUE - 10, 100L, WatchTimeout.MAX_MILLIS);
     }
 
     @Test

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.internal.api.v1;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A utility class which provides constants and methods related to watch timeout.
+ */
+public final class WatchTimeout {
+    /**
+     * The maximum timeout duration, in milliseconds.
+     */
+    public static final long MAX_MILLIS = TimeUnit.DAYS.toMillis(365);
+
+    /**
+     * Returns a reasonable timeout duration for a watch request.
+     *
+     * @param expectedTimeoutMillis timeout duration that a user wants to use, in milliseconds
+     * @param bufferMillis buffer duration which needs to be added, in milliseconds
+     * @return timeout duration in milliseconds, between the specified {@code bufferMillis} and
+     *         the {@link #MAX_MILLIS}.
+     */
+    public static long makeReasonable(long expectedTimeoutMillis, long bufferMillis) {
+        checkArgument(expectedTimeoutMillis > 0,
+                      "expectedTimeoutMillis: %s (expected: > 0)", expectedTimeoutMillis);
+        checkArgument(bufferMillis >= 0,
+                      "bufferMillis: %s (expected: > 0)", bufferMillis);
+
+        final long timeout = Math.min(expectedTimeoutMillis, MAX_MILLIS);
+        if (bufferMillis == 0) {
+            return timeout;
+        }
+
+        if (timeout > MAX_MILLIS - bufferMillis) {
+            return MAX_MILLIS;
+        } else {
+            return bufferMillis + timeout;
+        }
+    }
+
+    private WatchTimeout() {}
+}

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
@@ -26,7 +26,7 @@ public final class WatchTimeout {
     /**
      * The maximum timeout duration, in milliseconds.
      */
-    public static final long MAX_MILLIS = TimeUnit.DAYS.toMillis(365);
+    public static final long MAX_MILLIS = TimeUnit.DAYS.toMillis(1);
 
     /**
      * Returns a reasonable timeout duration for a watch request.

--- a/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.internal.api.v1;
+
+import static com.linecorp.centraldogma.internal.api.v1.WatchTimeout.MAX_MILLIS;
+import static com.linecorp.centraldogma.internal.api.v1.WatchTimeout.makeReasonable;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
+
+public class WatchTimeoutTest {
+
+    @Test
+    public void testMakeReasonable() {
+        assertThat(makeReasonable(1_000, 1_000)).isEqualTo(2_000);
+        assertThat(makeReasonable(MAX_MILLIS, 1_000)).isEqualTo(MAX_MILLIS);
+        assertThat(makeReasonable(MAX_MILLIS + 1_000, 0)).isEqualTo(MAX_MILLIS);
+        assertThat(makeReasonable(MAX_MILLIS - 1_000, 500)).isEqualTo(MAX_MILLIS - 500);
+
+        assertThatThrownBy(() -> makeReasonable(0, 1_000))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> makeReasonable(-1, 1_000))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> makeReasonable(1_000, -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -55,6 +55,8 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             } else {
                 timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
             }
+            // Update timeout according to the watch API specifications.
+            ctx.setRequestTimeoutMillis(timeoutMillis);
             return Optional.of(new WatchRequest(lastKnownRevision, timeoutMillis));
         }
         return Optional.empty();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -29,6 +29,7 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
 /**
  * A request converter that converts to {@link WatchRequest} when the request contains
@@ -56,7 +57,8 @@ public final class WatchRequestConverter implements RequestConverterFunction {
                 timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
             }
             // Update timeout according to the watch API specifications.
-            ctx.setRequestTimeoutMillis(timeoutMillis);
+            ctx.setRequestTimeoutMillis(
+                    WatchTimeout.makeReasonable(timeoutMillis, ctx.requestTimeoutMillis()));
             return Optional.of(new WatchRequest(lastKnownRevision, timeoutMillis));
         }
         return Optional.empty();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaTimeoutScheduler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaTimeoutScheduler.java
@@ -23,6 +23,7 @@ import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.SimpleDecoratingService;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
 public final class CentralDogmaTimeoutScheduler extends SimpleDecoratingService<RpcRequest, RpcResponse> {
 
@@ -38,11 +39,8 @@ public final class CentralDogmaTimeoutScheduler extends SimpleDecoratingService<
                 final List<Object> params = req.params();
                 final long timeout = (Long) params.get(params.size() - 1);
                 if (timeout > 0) {
-                    if (timeout > Long.MAX_VALUE - ctx.requestTimeoutMillis()) {
-                        ctx.setRequestTimeoutMillis(0);
-                    } else {
-                        ctx.setRequestTimeoutMillis(ctx.requestTimeoutMillis() + timeout);
-                    }
+                    ctx.setRequestTimeoutMillis(
+                            WatchTimeout.makeReasonable(timeout, ctx.requestTimeoutMillis()));
                 }
             }
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -565,9 +565,9 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     public void watchRepositoryTimeout() {
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, CONTENTS_PREFIX)
                                                .add(HttpHeaderNames.IF_NONE_MATCH, "-1")
-                                               .add(HttpHeaderNames.PREFER, "wait=1"); // 1 second
+                                               .add(HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
         final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
-        await().atMost(3, TimeUnit.SECONDS).untilAsserted(future::isDone);
+        await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(future.join().headers().status()).isSameAs(HttpStatus.NOT_MODIFIED);
     }
 
@@ -575,9 +575,9 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     public void watchFileTimeout() {
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, CONTENTS_PREFIX + "/foo.json")
                                                .add(HttpHeaderNames.IF_NONE_MATCH, "-1")
-                                               .add(HttpHeaderNames.PREFER, "wait=1"); // 1 second
+                                               .add(HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
         final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
-        await().atMost(3, TimeUnit.SECONDS).untilAsserted(future::isDone);
+        await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(future.join().headers().status()).isSameAs(HttpStatus.NOT_MODIFIED);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
@@ -35,8 +35,10 @@ public class ContentServiceV1TestBase {
     public final CentralDogmaRule dogma = new CentralDogmaRule() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            // Shorten the default request timeout here, in order to do a test that a watch request overrides
-            // the default request timeout.
+            // Shorten the default request timeout here, in order to do the following tests
+            // that a watch request overrides the default request timeout.
+            // - ContentServiceV1Test#watchRepositoryTimeout
+            // - ContentServiceV1Test#watchFileTimeout
             builder.requestTimeoutMillis(3_000);
         }
     };

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
@@ -26,12 +26,20 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.testing.CentralDogmaRule;
 
 public class ContentServiceV1TestBase {
 
     @Rule
-    public final CentralDogmaRule dogma = new CentralDogmaRule();
+    public final CentralDogmaRule dogma = new CentralDogmaRule() {
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            // Shorten the default request timeout here, in order to do a test that a watch request overrides
+            // the default request timeout.
+            builder.requestTimeoutMillis(3_000);
+        }
+    };
 
     static final String CONTENTS_PREFIX = "/api/v1/projects/myPro/repos/myRepo/contents";
 


### PR DESCRIPTION
Motivation:
Currently Central Dogma server does not adjust timeout for `watch` requests.
So every `watch` request would be timed out after the default timeout in the server even if the request contains `wait` value which is greater than the default timeout. It causes that the server responds `503 Service Unavailable` to the client.

Modifications:
- Adjust timeout for `watch` requests in `WatchRequestConverter`.
- Change the max timeout from `Long.MAX_VALUE` to `TimeUnit.DAYS.toMillis(1)` (1 day).
- Fix test cases.

Result:
- A user can adjust the timeout of a `watch` request.