### PR TITLE
Adjust timeout for WatchService

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeout.java
@@ -32,6 +32,16 @@ public final class WatchTimeout {
      * Returns a reasonable timeout duration for a watch request.
      *
      * @param expectedTimeoutMillis timeout duration that a user wants to use, in milliseconds
+     * @return timeout duration in milliseconds, between 1 and the {@link #MAX_MILLIS}.
+     */
+    public static long makeReasonable(long expectedTimeoutMillis) {
+        return makeReasonable(expectedTimeoutMillis, 0);
+    }
+
+    /**
+     * Returns a reasonable timeout duration for a watch request.
+     *
+     * @param expectedTimeoutMillis timeout duration that a user wants to use, in milliseconds
      * @param bufferMillis buffer duration which needs to be added, in milliseconds
      * @return timeout duration in milliseconds, between the specified {@code bufferMillis} and
      *         the {@link #MAX_MILLIS}.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/WatchService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/WatchService.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 
 import io.netty.channel.EventLoop;
@@ -86,6 +87,7 @@ public final class WatchService {
 
         final ScheduledFuture<?> timeoutFuture;
         if (timeoutMillis > 0) {
+            timeoutMillis = WatchTimeout.makeReasonable(timeoutMillis);
             timeoutMillis = applyJitter(timeoutMillis);
             final EventLoop eventLoop = RequestContext.current().eventLoop();
             timeoutFuture = eventLoop.schedule(() -> result.completeExceptionally(CANCELLATION_EXCEPTION),


### PR DESCRIPTION
Motivation:
When I worked on #325, I missed adjusting timeout for `WatchService`.

Modifications:
- Adjust timeout when scheduling a timeout job.