### PR TITLE
Redirect to the first requested URL after SAML SSO performed

### DIFF
--- a/server/src/main/resources/webapp/scripts/app/app.js
+++ b/server/src/main/resources/webapp/scripts/app/app.js
@@ -33,7 +33,7 @@ angular.module(
              Security.resolve().then(function () {
                Principal.refresh().then(function () {
                  if (!Principal.isAuthenticated()) {
-                   $window.location.href= "/link/auth/login";
+                   $window.location.href= "/link/auth/login?ref=" + $location.path();
                  }
                });
              });


### PR DESCRIPTION
Motivation:
Currently the web browser is redirected to the root(`/`). It'd be better if we can redirect it to the first requested URL.

Modifications:
- Add `ref` parameter when redirecting an unauthenticated request to `/link/auth/login`.
  - The parameter will be sent to an identity provider and get back via `relayState` parameter.