### PR TITLE
Update ZooKeeper autopurge settings

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -328,8 +328,8 @@ public final class ZooKeeperCommandExecutor
             copyZkProperty(zkProps, "syncLimit", "10");
             copyZkProperty(zkProps, "tickTime", "3000");
             copyZkProperty(zkProps, "syncEnabled", "true");
-            copyZkProperty(zkProps, "autopurge.snapRetainCount", "7");
-            copyZkProperty(zkProps, "autopurge.purgeInterval", "24");
+            copyZkProperty(zkProps, "autopurge.snapRetainCount", "3");
+            copyZkProperty(zkProps, "autopurge.purgeInterval", "1");
 
             // Set the data directories.
             zkProps.setProperty("dataDir", zkDataDir.getPath());


### PR DESCRIPTION
Motivation:

There's not much point in keeping many ZooKeeper snapshots in Central
Dogma because it uses ZooKeeper as a message queue. Losing the most
up-to-date ZooKeeper data tree means all replicas must be checked for
consistency and replication state (including `last_revision` and
ZooKeeper data tree) must be started from scratch anyway.

Modifications:

- Reduce `autopurge.snapCount` (the number of snapshots to keep when
  autopurging) to 3, which is an allowed minimum.
- Shorten the autopurge interval from 24 hours to 1 hour.
  - We have to shorten this as much as possible, because ZooKeeper will
    create a new snapshot for every 100,000 changes, leaving more than 3
    snapshots between autopurge tasks on a busy server.

Result:

- Less disk usage.