### PR TITLE
Change startup waiting time from 10s to 60s

### DIFF
--- a/dist/src/bin/startup
+++ b/dist/src/bin/startup
@@ -24,7 +24,7 @@ eecho "Starting up $APP_NAME .."
 "$JSVC_BIN" \
   -java-home "$JAVA_HOME" \
   -pidfile "$APP_PID_FILE" \
-  -wait 10 \
+  -wait 60 \
   -cwd "$APP_HOME" \
   -outfile "$APP_STDOUT_FILE" \
   -errfile "$APP_STDERR_FILE" \


### PR DESCRIPTION
Motivation:
After embedding ZooKeeper, the server requires more time to start up.

Modifications:
- Change `jsvc` `-wait` option from `-wait 10` to `-wait 60`.