### PR TITLE
Fix IndexOutOfBoundsException when watching via HTTP API

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchResultDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/WatchResultDto.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.centraldogma.internal.api.v1;
 
+import static java.util.Objects.requireNonNull;
+
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -23,18 +25,22 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Revision;
 
 @JsonInclude(Include.NON_EMPTY)
-public class WatchResultDto extends CommitDto {
+public class WatchResultDto {
 
+    private final Revision revision;
     private final EntryDto<?> entry;
 
-    public WatchResultDto(Revision revision, Author author, CommitMessageDto commitMessage,
-                          long commitTimeMillis, @Nullable EntryDto<?> entry) {
-        super(revision, author, commitMessage, commitTimeMillis);
+    public WatchResultDto(Revision revision, @Nullable EntryDto<?> entry) {
+        this.revision = requireNonNull(revision, "revision");
         this.entry = entry;
+    }
+
+    @JsonProperty("revision")
+    public Revision revision() {
+        return revision;
     }
 
     @JsonProperty("entry")
@@ -47,9 +53,6 @@ public class WatchResultDto extends CommitDto {
         return MoreObjects.toStringHelper(this)
                           .omitNullValues()
                           .add("revision", revision())
-                          .add("author", author())
-                          .add("commitMessage", commitMessage())
-                          .add("pushedAt", pushedAt())
                           .add("entry", entry())
                           .toString();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -35,7 +35,6 @@ import com.linecorp.centraldogma.internal.api.v1.MergedEntryDto;
 import com.linecorp.centraldogma.internal.api.v1.ProjectDto;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.internal.api.v1.RepositoryDto;
-import com.linecorp.centraldogma.internal.api.v1.WatchResultDto;
 import com.linecorp.centraldogma.server.internal.storage.project.Project;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 
@@ -93,14 +92,6 @@ final class DtoConverter {
     public static CommitDto convert(Revision revision, Author author, CommitMessageDto commitMessage,
                                     long commitTimeMillis) {
         return new CommitDto(revision, author, commitMessage, commitTimeMillis);
-    }
-
-    public static WatchResultDto convert(Commit commit, @Nullable EntryDto<?> entry) {
-        requireNonNull(commit, "commit");
-
-        return new WatchResultDto(commit.revision(), commit.author(),
-                                  new CommitMessageDto(commit.summary(), commit.detail(), commit.markup()),
-                                  commit.when(), entry);
     }
 
     public static <T> ChangeDto<T> convert(Change<T> change) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -545,17 +545,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
         final String expectedJson =
                 '{' +
-                "   \"revision\" : 3," +
-                "   \"author\" : {" +
-                "       \"name\" : \"${json-unit.ignore}\"," +
-                "       \"email\" : \"${json-unit.ignore}\"" +
-                "   }," +
-                "   \"pushedAt\" : \"${json-unit.ignore}\"," +
-                "   \"commitMessage\" : {" +
-                "       \"summary\" : \"Edit foo.json\"," +
-                "       \"detail\" : \"Edit because we need it.\"," +
-                "       \"markup\" : \"PLAINTEXT\"" +
-                "   }" +
+                "   \"revision\" : 3" +
                 '}';
         final String actualJson = res.content().toStringUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
@@ -601,16 +591,6 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson =
                 '{' +
                 "   \"revision\" : 4," +
-                "   \"author\" : {" +
-                "       \"name\" : \"${json-unit.ignore}\"," +
-                "       \"email\" : \"${json-unit.ignore}\"" +
-                "   }," +
-                "   \"pushedAt\" : \"${json-unit.ignore}\"," +
-                "   \"commitMessage\" : {" +
-                "       \"summary\" : \"Edit foo.json\"," +
-                "       \"detail\" : \"Edit because we need it.\"," +
-                "       \"markup\" : \"PLAINTEXT\"" +
-                "   }," +
                 "   \"entry\": {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
@@ -644,16 +624,6 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson =
                 '{' +
                 "   \"revision\" : 4," +
-                "   \"author\" : {" +
-                "       \"name\" : \"${json-unit.ignore}\"," +
-                "       \"email\" : \"${json-unit.ignore}\"" +
-                "   }," +
-                "   \"pushedAt\" : \"${json-unit.ignore}\"," +
-                "   \"commitMessage\" : {" +
-                "       \"summary\" : \"Edit foo.json\"," +
-                "       \"detail\" : \"Edit because we need it.\"," +
-                "       \"markup\" : \"PLAINTEXT\"" +
-                "   }," +
                 "   \"entry\": {" +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +


### PR DESCRIPTION
Motivation:

When a user tries to watch a file with `lastKnownRevision = 1` and the
file was unchanged in the latest commit, the server fails with an
`IndexOutOfBoundsException`, because the `repository.history()` call
yields an empty list.

Modifications:

- Removed all fields other than `revision` and `entry` from
  `WatchResultDto` so that we do not need to fetch a commit.

Result:

- No more IIOBE on `watchFile` and `watchRepository`.
