### PR TITLE
Change back the CacheableQueryCall not to call CacheableFindCall

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/CacheTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CacheTest.java
@@ -71,8 +71,7 @@ public class CacheTest {
         final Entry<?> entry = client.getFile(project, REPO_FOO, HEAD, query).join();
         final CacheStats stats3 = cacheStatsSupplier.get();
 
-        // getFile triggers three cache misses which happen twice in getOrNull() and once in find().
-        assertThat(stats3.missCount()).isEqualTo(stats2.missCount() + 3);
+        assertThat(stats3.missCount()).isEqualTo(stats2.missCount() + 1);
 
         // Subsequent getFile() should never miss.
         for (int i = 0; i < 3; i++) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableQueryCall.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CacheableQueryCall.java
@@ -16,13 +16,11 @@
 
 package com.linecorp.centraldogma.server.internal.storage.repository.cache;
 
-import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-
-import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
 
@@ -38,9 +36,6 @@ final class CacheableQueryCall extends CacheableCall<Entry<?>> {
     final Revision revision;
     final Query<?> query;
     final int hashCode;
-
-    @Nullable
-    Entry<?> computedValue;
 
     CacheableQueryCall(Repository repo, Revision revision, Query<?> query) {
         super(repo);
@@ -67,13 +62,7 @@ final class CacheableQueryCall extends CacheableCall<Entry<?>> {
 
     @Override
     CompletableFuture<Entry<?>> execute() {
-        checkState(computedValue != null, "computedValue is not set yet.");
-        return CompletableFuture.completedFuture(computedValue);
-    }
-
-    void computedValue(Entry<?> computedValue) {
-        checkState(this.computedValue == null, "computedValue is already set.");
-        this.computedValue = requireNonNull(computedValue, "computedValue");
+        return repo.getOrNull(revision, query).thenApply(e -> firstNonNull(e, EMPTY));
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -82,17 +82,16 @@ public class CachingRepositoryTest {
         doReturn(new Revision(10)).when(delegateRepo).normalizeNow(HEAD);
 
         // Uncached
-        when(delegateRepo.find(any(), any(), any())).thenReturn(
-                completedFuture(ImmutableMap.of(query.path(), queryResult)));
+        when(delegateRepo.getOrNull(any(), any(Query.class))).thenReturn(completedFuture(queryResult));
         assertThat(repo.get(HEAD, query).join()).isEqualTo(queryResult);
-        verify(delegateRepo).find(new Revision(10), query.path(), FIND_ONE_WITH_CONTENT);
+        verify(delegateRepo).getOrNull(new Revision(10), query);
         verifyNoMoreInteractions(delegateRepo);
 
         // Cached
         clearInvocations(delegateRepo);
         assertThat(repo.get(HEAD, query).join()).isEqualTo(queryResult);
         assertThat(repo.get(new Revision(10), query).join()).isEqualTo(queryResult);
-        verify(delegateRepo, never()).find(any(), any(), any());
+        verify(delegateRepo, never()).getOrNull(any(), any(Query.class));
         verifyNoMoreInteractions(delegateRepo);
     }
 
@@ -139,16 +138,16 @@ public class CachingRepositoryTest {
         doReturn(new Revision(10)).when(delegateRepo).normalizeNow(HEAD);
 
         // Uncached
-        when(delegateRepo.find(any(), any(), any())).thenReturn(completedFuture(ImmutableMap.of()));
+        when(delegateRepo.getOrNull(any(), any(Query.class))).thenReturn(completedFuture(null));
         assertThat(repo.getOrNull(HEAD, query).join()).isNull();
-        verify(delegateRepo).find(new Revision(10), query.path(), FIND_ONE_WITH_CONTENT);
+        verify(delegateRepo).getOrNull(new Revision(10), query);
         verifyNoMoreInteractions(delegateRepo);
 
         // Cached
         clearInvocations(delegateRepo);
         assertThat(repo.getOrNull(HEAD, query).join()).isNull();
         assertThat(repo.getOrNull(new Revision(10), query).join()).isNull();
-        verify(delegateRepo, never()).find(any(), any(), any());
+        verify(delegateRepo, never()).getOrNull(any(), any(Query.class));
         verifyNoMoreInteractions(delegateRepo);
     }
 


### PR DESCRIPTION
Motivation:
GC time goes up after `CachealbleQueryCall` calls `CachableFindCall`.
So revert it to find out whether it's the real cause.

Modification:
- Change back the CacheableQueryCall not to call CacheableFindCall

Result:
- Less GC time?