### PR TITLE
Exclude slf4j-log4j12 from dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -182,6 +182,7 @@ org.apache.zookeeper:
     - commons-cli:commons-cli
     - org.apache.yetus:audience-annotations
     - io.netty:netty
+    - org.slf4j:slf4j-log4j12
 
 org.assertj:
   assertj-core: { version: '3.11.1' }


### PR DESCRIPTION
Motivation:
The following exception is raised when executing test cases.
```
Caused by: java.lang.IllegalStateException: Detected both log4j-over-slf4j.jar AND bound slf4j-log4j12.jar on the class path, preempting StackOverflowError. See also http://www.slf4j.org/codes.html#log4jDelegationLoop for more details.
```

Modifications:
- Exclude slf4j-log4j12 from dependencies.