### PR TITLE
Update dependencies

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -20,10 +20,6 @@ import java.net.UnknownHostException;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
-import com.linecorp.armeria.common.RpcRequest;
-import com.linecorp.armeria.common.RpcResponse;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.internal.CsrfToken;
@@ -41,19 +37,16 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
         final String uri = scheme + endpoint.authority() + "/cd/thrift/v1";
         final ClientBuilder builder = new ClientBuilder(uri)
                 .factory(clientFactory())
-                .decorator(RpcRequest.class, RpcResponse.class,
-                           CentralDogmaClientTimeoutScheduler::new);
+                .rpcDecorator(CentralDogmaClientTimeoutScheduler::new);
         clientConfigurator().configure(builder);
 
-        builder.decorator(HttpRequest.class, HttpResponse.class,
-                          (delegate, ctx, req) -> {
-                              if (!req.headers().contains(HttpHeaderNames.AUTHORIZATION)) {
-                                  // To prevent CSRF attack, we add 'Authorization' header to every request.
-                                  req.headers().set(HttpHeaderNames.AUTHORIZATION,
-                                                    "bearer " + CsrfToken.ANONYMOUS);
-                              }
-                              return delegate.execute(ctx, req);
-                          });
+        builder.decorator((delegate, ctx, req) -> {
+            if (!req.headers().contains(HttpHeaderNames.AUTHORIZATION)) {
+                // To prevent CSRF attack, we add 'Authorization' header to every request.
+                req.headers().set(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS);
+            }
+            return delegate.execute(ctx, req);
+        });
         return new LegacyCentralDogma(clientFactory(), builder.build(CentralDogmaService.AsyncIface.class));
     }
 }

--- a/client/java-spring-boot1-autoconfigure/build.gradle
+++ b/client/java-spring-boot1-autoconfigure/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(':client:java-armeria-legacy')
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.17.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.18.RELEASE'
 
     testCompile project(':client:java-armeria')
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.17.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.18.RELEASE'
     testRuntime 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.linecorp.armeria:armeria-bom:0.76.2
+- com.linecorp.armeria:armeria-bom:0.77.0
 
 ch.qos.logback:
   logback-classic:
@@ -18,7 +18,7 @@ com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
 
 com.bmuschko:
-  gradle-docker-plugin: { version: '4.0.5' }
+  gradle-docker-plugin: { version: '4.2.0' }
 
 com.craigburke.gradle:
   client-dependencies: { version: '1.4.1' }
@@ -32,7 +32,7 @@ com.cronutils:
 
 com.fasterxml.jackson.core:
   jackson-annotations:
-    version: &JACKSON_VERSION '2.9.7'
+    version: &JACKSON_VERSION '2.9.8'
     javadocs:
     - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
   jackson-core:
@@ -110,7 +110,7 @@ com.linecorp.armeria:
     - https://line.github.io/armeria/apidocs/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.14' }
+  checkstyle: { version: '8.15' }
 
 com.spotify:
   completable-futures:
@@ -150,7 +150,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.7' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.1.1' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.2.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -188,7 +188,7 @@ org.assertj:
   assertj-core: { version: '3.11.1' }
 
 org.awaitility:
-  awaitility: { version: '3.1.3' }
+  awaitility: { version: '3.1.5' }
 
 org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
@@ -200,7 +200,7 @@ org.hibernate.validator:
   hibernate-validator: { version: '6.0.13.Final' }
 
 org.javassist:
-  javassist: { version: '3.24.0-GA' }
+  javassist: { version: '3.24.1-GA' }
 
 org.mockito:
   mockito-core: { version: '2.23.4' }
@@ -223,7 +223,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.0.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.1.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
@@ -42,8 +42,6 @@ import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.common.AggregatedHttpMessage;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpRequest;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
@@ -98,7 +96,7 @@ public class ContentCompressionTest {
         final Iface clientWithDecompressor = Clients.newDerivedClient(
                 clientWithoutDecompressor,
                 options -> new ClientOptionsBuilder(options)
-                        .decorator(HttpRequest.class, HttpResponse.class, HttpDecodingClient.newDecorator())
+                        .decorator(HttpDecodingClient.newDecorator())
                         .build());
 
         final GetFileResult result = clientWithDecompressor.getFile(PROJ, REPO, head, query);


### PR DESCRIPTION
- Armeria 0.76.2 -> 0.77.0
  - Removed the usage of deprecated `decorator()` method.
- Jackson 2.9.7 -> 2.9.8
- Javassist 3.24.0 -> 3.24.1
- Spring Boot 2.1.0 -> 2.1.1, 1.5.17 -> 1.5.18
- Build time only:
  - Awaitility 3.1.3 -> 3.1.5
  - Checkstyle 8.14 -> 8.15
  - gradle-docker-plugin 4.0.5 -> 4.2.0
  - JSON-unit 2.1.1 -> 2.2.0