### PR TITLE
Cache in find() when getFile() is called with the query whose type is…

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryUtil.java
@@ -55,12 +55,12 @@ import com.linecorp.centraldogma.internal.Jackson;
 /**
  * Utility methods that are useful when implementing a {@link Repository} implementation.
  */
-public final class RepositoryUtil {
+final class RepositoryUtil {
 
     private static final CancellationException CANCELLATION_EXCEPTION =
             Exceptions.clearTrace(new CancellationException("parent complete"));
 
-    public static CompletableFuture<MergedEntry<?>> mergeEntries(
+    static CompletableFuture<MergedEntry<?>> mergeEntries(
             List<CompletableFuture<Entry<?>>> entryFutures, Revision revision,
             MergeQuery<?> query) {
         requireNonNull(entryFutures, "entryFutures");
@@ -125,7 +125,7 @@ public final class RepositoryUtil {
      * @throws QueryExecutionException if an {@link Exception} is raised while applying the specified
      *                                 {@link Query} to the {@link Entry#content()}
      */
-    public static <T> Entry<T> applyQuery(Entry<T> entry, Query<T> query) {
+    static <T> Entry<T> applyQuery(Entry<T> entry, Query<T> query) {
         requireNonNull(query, "query");
         entry.content(); // Ensure that content is not null.
         final EntryType entryType = entry.type();


### PR DESCRIPTION
… the IDENTITY

Motivation:
Currently, getFile() is cached using `CacheableQueryCall`.
`mergeFiles()` calls CachingRespository.find() internally to cache the entries.
So if we change to cache the result in the one place using `CachableFindCall`, the chances of cache hit will be increased.

Modifications:
- Change to call `find()` in `CachingRepository.getOrNull()` when the query type is `IDENTITY`

Result:
- Better cache hit ratio