### PR TITLE
Fix `IllegalArgumentException` when a user sent an invalid auth token

### DIFF
--- a/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
+++ b/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.auth.shiro;
 
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.MALFORMED_SESSION_ID;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.WRONG_PASSWORD;
@@ -95,6 +96,7 @@ public class ShiroLoginAndLogoutTest {
     @Test
     public void incorrectLogout() throws Exception {
         assertThat(logout(client, WRONG_SESSION_ID).status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(logout(client, MALFORMED_SESSION_ID).status()).isEqualTo(HttpStatus.UNAUTHORIZED);
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.auth;
 
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.MALFORMED_SESSION_ID;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.WRONG_PASSWORD;
@@ -187,6 +188,7 @@ public class ReplicatedLoginAndLogoutTest {
     public void incorrectLogout() throws Exception {
         final int baselineReplicationLogCount = replicationLogCount();
         assertThat(logout(client1, WRONG_SESSION_ID).status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(logout(client1, MALFORMED_SESSION_ID).status()).isEqualTo(HttpStatus.UNAUTHORIZED);
 
         // Ensure that a failed logout attempt does not produce any replication logs.
         assertThat(replicationLogCount()).isEqualTo(baselineReplicationLogCount);

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
@@ -34,6 +34,7 @@ public final class TestAuthMessageUtil {
     public static final String PASSWORD = "bar";
     public static final String WRONG_PASSWORD = "baz";
     public static final String WRONG_SESSION_ID = "00000000-0000-0000-0000-000000000000";
+    public static final String MALFORMED_SESSION_ID = "not_a_session_id";
 
     private static final Encoder encoder = Base64.getEncoder();
 


### PR DESCRIPTION
Motivation:

Server produces 'Unexpected exception during authorization' error caused
by `IllegalArgumentException: sessionId: ... (expected: UUID)` when a
user sent an invalid or unexpected `authorization` header.

Modifications:

- Make sure `SessionManager.get()` and `exists()` does not raise an
  exception for malformed session ID but just return `null` and `false`.
- Added a way to use `FileBasedSessionManager` without an expiration
  task, which is useful for testing.

Result:

- Less unexpected exceptions.