### PR TITLE
Show configured title on the web-based administrative console

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -461,9 +461,7 @@ public class CentralDogma implements AutoCloseable {
                                           .setHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8)
                                           .build();
                 } catch (JsonProcessingException e) {
-                    return HttpFileBuilder.of(HttpData.ofUtf8("{\"hostname\":\"" + s.defaultHostname() + "\"}"))
-                                          .setHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8)
-                                          .build();
+                    throw new Error("Failed to send the hostname:", e);
                 }
             }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -32,7 +32,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.charset.StandardCharsets;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.Map;
@@ -54,9 +53,11 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.google.common.collect.ImmutableMap.Builder;
 
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -447,9 +448,23 @@ public class CentralDogma implements AutoCloseable {
             @Override
             public HttpFile get(String path, Clock clock, @Nullable String contentEncoding) {
                 requireNonNull(path, "path");
-                return HttpFileBuilder.of(HttpData.of(StandardCharsets.UTF_8, server.defaultHostname()))
-                                      .setHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8)
-                                      .build();
+                final Server s = server;
+                assert s != null;
+                final Builder<String, String> b = new Builder<>();
+                b.put("hostname", s.defaultHostname());
+                final String title = cfg.webAppTitle();
+                if (!isNullOrEmpty(title)) {
+                    b.put("title", title);
+                }
+                try {
+                    return HttpFileBuilder.of(HttpData.ofUtf8(Jackson.writeValueAsString(b.build())))
+                                          .setHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8)
+                                          .build();
+                } catch (JsonProcessingException e) {
+                    return HttpFileBuilder.of(HttpData.ofUtf8("{\"hostname\":\"" + s.defaultHostname() + "\"}"))
+                                          .setHeader(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8)
+                                          .build();
+                }
             }
 
             @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -91,6 +91,8 @@ public final class CentralDogmaBuilder {
     @Nullable
     private String repositoryCacheSpec = DEFAULT_REPOSITORY_CACHE_SPEC;
     private boolean webAppEnabled = true;
+    @Nullable
+    private String webAppTitle;
     private boolean mirroringEnabled = true;
     private int numMirroringThreads = DEFAULT_NUM_MIRRORING_THREADS;
     private int maxNumFilesPerMirror = DEFAULT_MAX_NUM_FILES_PER_MIRROR;
@@ -257,6 +259,14 @@ public final class CentralDogmaBuilder {
      */
     public CentralDogmaBuilder webAppEnabled(boolean webAppEnabled) {
         this.webAppEnabled = webAppEnabled;
+        return this;
+    }
+
+    /**
+     * Sets the title text which is displayed on the navigation bar of the administrative web application.
+     */
+    public CentralDogmaBuilder webAppTitle(String webAppTitle) {
+        this.webAppTitle = requireNonNull(webAppTitle, "webAppTitle");
         return this;
     }
 
@@ -433,7 +443,7 @@ public final class CentralDogmaBuilder {
         return new CentralDogmaConfig(dataDir, ports, tls, numWorkers, maxNumConnections,
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
                                       numRepositoryWorkers, repositoryCacheSpec, gracefulShutdownTimeout,
-                                      webAppEnabled, mirroringEnabled, numMirroringThreads,
+                                      webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
                                       null, accessLogFormat, authCfg);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -86,6 +86,9 @@ public final class CentralDogmaConfig {
     // Web dashboard
     private final boolean webAppEnabled;
 
+    @Nullable
+    private final String webAppTitle;
+
     // Mirroring
     private final boolean mirroringEnabled;
     private final int numMirroringThreads;
@@ -125,6 +128,7 @@ public final class CentralDogmaConfig {
             @JsonProperty("gracefulShutdownTimeout") @Nullable
                     GracefulShutdownTimeout gracefulShutdownTimeout,
             @JsonProperty("webAppEnabled") @Nullable Boolean webAppEnabled,
+            @JsonProperty("webAppTitle") @Nullable String webAppTitle,
             @JsonProperty("mirroringEnabled") @Nullable Boolean mirroringEnabled,
             @JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
             @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
@@ -150,6 +154,7 @@ public final class CentralDogmaConfig {
         this.repositoryCacheSpec = validateCacheSpec(
                 firstNonNull(repositoryCacheSpec, DEFAULT_REPOSITORY_CACHE_SPEC));
         this.webAppEnabled = firstNonNull(webAppEnabled, true);
+        this.webAppTitle = webAppTitle;
         this.mirroringEnabled = firstNonNull(mirroringEnabled, true);
         this.numMirroringThreads = firstNonNull(numMirroringThreads, DEFAULT_NUM_MIRRORING_THREADS);
         checkArgument(this.numMirroringThreads > 0,
@@ -245,6 +250,12 @@ public final class CentralDogmaConfig {
     @JsonProperty
     public boolean isWebAppEnabled() {
         return webAppEnabled;
+    }
+
+    @Nullable
+    @JsonProperty("webAppTitle")
+    public String webAppTitle() {
+        return webAppTitle;
     }
 
     @JsonProperty

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
@@ -8,6 +8,7 @@ angular.module('CentralDogmaAdmin')
                   $scope.isAuthenticated = Principal.isAuthenticated;
 
                   Hostname.get().then(function (data) {
-                    $scope.hostname = data;
+                    $scope.hostname = data.hostname;
+                    $scope.title = angular.isDefined(data.title) ? data.title : "";
                   });
                 });

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
@@ -11,6 +11,7 @@
         <span ng-hide="hostname" translate>window.title</span>
         <span ng-show="hostname">{{ 'window.title_with_hostname' |
                                     translate: "{ hostname: '" + hostname + "' }" }}</span>&#xA0;
+        <span ng-show="title">{{ title }}</span>
       </a>
     </div>
     <div class="collapse navbar-collapse" id="navbar-collapse" ng-switch="isAuthenticated()">

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -32,6 +32,7 @@ defaults:
       "numRepositoryWorkers": 16,
       "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
       "webAppEnabled": true,
+      "webAppTitle": null,
       "gracefulShutdownTimeout": {
         "quietPeriodMillis": 1000,
         "timeoutMillis": 10000
@@ -119,6 +120,10 @@ Core properties
 - ``webAppEnabled`` (boolean)
 
   - whether to enable the web-based administrative console. Enabled by default.
+
+- ``webAppTitle`` (string)
+
+  - the title text which is displayed on the navigation bar of the web-based administrative console.
 
 - ``gracefulShutdownTimeout``
 
@@ -337,6 +342,7 @@ in ``dogma.json`` as follows.
       "numRepositoryWorkers": 16,
       "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
       "webAppEnabled": true,
+      "webAppTitle": null,
       "gracefulShutdownTimeout": {
         "quietPeriodMillis": 1000,
         "timeoutMillis": 10000


### PR DESCRIPTION
Motivation:
Currently, there's no easy way to know if the CD instance he or she is accessing belongs to BETA or RELEASE zone. We currently show the host name of the instance, but it's not clear enough. We could add a simple text value option whose value is appended to the web page title. e.g. `Central Dogma (BETA, {hostname})`

Modifications:
- Changed to send both of hostname and title from `/hostname` API.
  - The title will be displayed on the navigation bar of the web console.
- Updated the document about the configuration.

Result:
- Make web console users less confused.