### PR TITLE
HTTP-based Java client

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -15,10 +15,12 @@
  */
 package com.linecorp.centraldogma.client.armeria.legacy;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.centraldogma.internal.Util.unsafeCast;
+import static com.linecorp.centraldogma.internal.Util.validateProjectName;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
@@ -40,12 +43,10 @@ import org.apache.thrift.TException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.spotify.futures.CompletableFutures;
 
-import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.common.thrift.ThriftCompletableFuture;
 import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.RepositoryInfo;
-import com.linecorp.centraldogma.client.Watcher;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Change;
@@ -69,8 +70,7 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.internal.client.FileWatcher;
-import com.linecorp.centraldogma.internal.client.RepositoryWatcher;
+import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.internal.thrift.AuthorConverter;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 import com.linecorp.centraldogma.internal.thrift.ChangeConverter;
@@ -89,29 +89,37 @@ import com.linecorp.centraldogma.internal.thrift.RevisionConverter;
 import com.linecorp.centraldogma.internal.thrift.WatchFileResult;
 import com.linecorp.centraldogma.internal.thrift.WatchRepositoryResult;
 
-final class LegacyCentralDogma implements CentralDogma {
+final class LegacyCentralDogma extends AbstractCentralDogma {
 
-    private final ClientFactory clientFactory;
     private final CentralDogmaService.AsyncIface client;
 
-    LegacyCentralDogma(ClientFactory clientFactory, CentralDogmaService.AsyncIface client) {
-        this.clientFactory = requireNonNull(clientFactory, "clientFactory");
+    LegacyCentralDogma(ScheduledExecutorService executor, CentralDogmaService.AsyncIface client) {
+        super(executor);
         this.client = requireNonNull(client, "client");
     }
 
     @Override
-    public CompletableFuture<Void> createProject(String name) {
-        return run(callback -> client.createProject(name, callback));
+    public CompletableFuture<Void> createProject(String projectName) {
+        return run(callback -> {
+            validateProjectName(projectName);
+            client.createProject(projectName, callback);
+        });
     }
 
     @Override
-    public CompletableFuture<Void> removeProject(String name) {
-        return run(callback -> client.removeProject(name, callback));
+    public CompletableFuture<Void> removeProject(String projectName) {
+        return run(callback -> {
+            validateProjectName(projectName);
+            client.removeProject(projectName, callback);
+        });
     }
 
     @Override
-    public CompletableFuture<Void> unremoveProject(String name) {
-        return run(callback -> client.unremoveProject(name, callback));
+    public CompletableFuture<Void> unremoveProject(String projectName) {
+        return run(callback -> {
+            validateProjectName(projectName);
+            client.unremoveProject(projectName, callback);
+        });
     }
 
     @Override
@@ -127,42 +135,59 @@ final class LegacyCentralDogma implements CentralDogma {
 
     @Override
     public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
-        return run(callback -> client.createRepository(projectName, repositoryName, callback));
+        return run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            client.createRepository(projectName, repositoryName, callback);
+        });
     }
 
     @Override
     public CompletableFuture<Void> removeRepository(String projectName, String repositoryName) {
-        return run(callback -> client.removeRepository(projectName, repositoryName, callback));
+        return run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            client.removeRepository(projectName, repositoryName, callback);
+        });
     }
 
     @Override
     public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
-        return run(callback -> client.unremoveRepository(projectName, repositoryName, callback));
+        return run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            client.unremoveRepository(projectName, repositoryName, callback);
+        });
     }
 
     @Override
     public CompletableFuture<Map<String, RepositoryInfo>> listRepositories(String projectName) {
-        final CompletableFuture<List<Repository>> future = run(
-                callback -> client.listRepositories(projectName, callback));
+        final CompletableFuture<List<Repository>> future = run(callback -> {
+            validateProjectName(projectName);
+            client.listRepositories(projectName, callback);
+        });
         return future.thenApply(list -> convertToMap(
                 list,
                 Function.identity(),
                 Repository::getName,
-                r -> new RepositoryInfo(r.getName(), CommitConverter.TO_MODEL.convert(r.getHead()))));
+                r -> new RepositoryInfo(
+                        r.getName(), RevisionConverter.TO_MODEL.convert(r.getHead().getRevision()))));
     }
 
     @Override
     public CompletableFuture<Set<String>> listRemovedRepositories(String projectName) {
-        return run(callback -> client.listRemovedRepositories(projectName, callback));
+        return run(callback -> {
+            validateProjectName(projectName);
+            client.listRemovedRepositories(projectName, callback);
+        });
     }
 
     @Override
     public CompletableFuture<Revision> normalizeRevision(String projectName, String repositoryName,
                                                          Revision revision) {
-        final CompletableFuture<com.linecorp.centraldogma.internal.thrift.Revision> future =
-                run(callback -> client.normalizeRevision(projectName, repositoryName,
-                                                         RevisionConverter.TO_DATA.convert(revision),
-                                                         callback));
+        final CompletableFuture<com.linecorp.centraldogma.internal.thrift.Revision> future = run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+            client.normalizeRevision(projectName, repositoryName,
+                                     RevisionConverter.TO_DATA.convert(revision), callback);
+        });
         return future.thenApply(RevisionConverter.TO_MODEL::convert);
     }
 
@@ -170,9 +195,16 @@ final class LegacyCentralDogma implements CentralDogma {
     public CompletableFuture<Map<String, EntryType>> listFiles(String projectName, String repositoryName,
                                                                Revision revision, String pathPattern) {
         final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Entry>> future =
-                run(callback -> client.listFiles(projectName, repositoryName,
-                                                 RevisionConverter.TO_DATA.convert(revision),
-                                                 pathPattern, callback));
+                run(callback -> {
+                    validateProjectAndRepositoryName(projectName, repositoryName);
+                    requireNonNull(revision, "revision");
+                    requireNonNull(pathPattern, "pathPattern");
+                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+                    client.listFiles(projectName, repositoryName,
+                                     RevisionConverter.TO_DATA.convert(revision),
+                                     pathPattern, callback);
+                });
         return future.thenApply(list -> list.stream().collect(toImmutableMap(
                 com.linecorp.centraldogma.internal.thrift.Entry::getPath,
                 e -> EntryConverter.convertEntryType(e.getType()))));
@@ -183,11 +215,12 @@ final class LegacyCentralDogma implements CentralDogma {
                                                    Revision revision, Query<T> query) {
 
         return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
-
-            final CompletableFuture<GetFileResult> future =
-                    run(callback -> client.getFile(projectName, repositoryName,
-                                                   RevisionConverter.TO_DATA.convert(normRev),
-                                                   QueryConverter.TO_DATA.convert(query), callback));
+            final CompletableFuture<GetFileResult> future = run(callback -> {
+                requireNonNull(query, "query");
+                client.getFile(projectName, repositoryName,
+                               RevisionConverter.TO_DATA.convert(normRev),
+                               QueryConverter.TO_DATA.convert(query), callback);
+            });
             return future.thenApply(r -> {
                 if (r == null) {
                     return null;
@@ -225,9 +258,13 @@ final class LegacyCentralDogma implements CentralDogma {
 
         return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
             final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Entry>> future =
-                    run(callback -> client.getFiles(projectName, repositoryName,
-                                                    RevisionConverter.TO_DATA.convert(normRev),
-                                                    pathPattern, callback));
+                    run(callback -> {
+                        requireNonNull(pathPattern, "pathPattern");
+                        checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                        client.getFiles(projectName, repositoryName,
+                                        RevisionConverter.TO_DATA.convert(normRev),
+                                        pathPattern, callback);
+                    });
             return future.thenApply(list -> convertToMap(list, e -> EntryConverter.convert(normRev, e),
                                                          Entry::path, Function.identity()));
         });
@@ -238,6 +275,9 @@ final class LegacyCentralDogma implements CentralDogma {
                                                             Revision revision, MergeQuery<T> mergeQuery) {
         final CompletableFuture<com.linecorp.centraldogma.internal.thrift.MergedEntry> future =
                 run(callback -> {
+                    validateProjectAndRepositoryName(projectName, repositoryName);
+                    requireNonNull(revision, "revision");
+                    requireNonNull(mergeQuery, "mergeQuery");
                     client.mergeFiles(projectName, repositoryName,
                                       RevisionConverter.TO_DATA.convert(revision),
                                       MergeQueryConverter.TO_DATA.convert(mergeQuery),
@@ -271,21 +311,34 @@ final class LegacyCentralDogma implements CentralDogma {
                                                       Revision to,
                                                       String pathPattern) {
         final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Commit>> future =
-                run(callback -> client.getHistory(projectName, repositoryName,
-                                                  RevisionConverter.TO_DATA.convert(from),
-                                                  RevisionConverter.TO_DATA.convert(to), pathPattern,
-                                                  callback));
+                run(callback -> {
+                    validateProjectAndRepositoryName(projectName, repositoryName);
+                    requireNonNull(from, "from");
+                    requireNonNull(to, "to");
+                    requireNonNull(pathPattern, "pathPattern");
+                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+                    client.getHistory(projectName, repositoryName,
+                                      RevisionConverter.TO_DATA.convert(from),
+                                      RevisionConverter.TO_DATA.convert(to),
+                                      pathPattern, callback);
+                });
         return future.thenApply(list -> convertToList(list, CommitConverter.TO_MODEL::convert));
     }
 
     @Override
     public <T> CompletableFuture<Change<T>> getDiff(String projectName, String repositoryName,
                                                     Revision from, Revision to, Query<T> query) {
-        final CompletableFuture<DiffFileResult> future =
-                run(callback -> client.diffFile(projectName, repositoryName,
-                                                RevisionConverter.TO_DATA.convert(from),
-                                                RevisionConverter.TO_DATA.convert(to),
-                                                QueryConverter.TO_DATA.convert(query), callback));
+        final CompletableFuture<DiffFileResult> future = run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(from, "from");
+            requireNonNull(to, "to");
+            requireNonNull(query, "query");
+            client.diffFile(projectName, repositoryName,
+                            RevisionConverter.TO_DATA.convert(from),
+                            RevisionConverter.TO_DATA.convert(to),
+                            QueryConverter.TO_DATA.convert(query), callback);
+        });
         return future.thenApply(r -> {
             if (r == null) {
                 return null;
@@ -323,9 +376,16 @@ final class LegacyCentralDogma implements CentralDogma {
     public CompletableFuture<List<Change<?>>> getDiffs(String projectName, String repositoryName,
                                                        Revision from, Revision to, String pathPattern) {
         final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Change>> future =
-                run(callback -> client.getDiffs(projectName, repositoryName,
-                                                RevisionConverter.TO_DATA.convert(from),
-                                                RevisionConverter.TO_DATA.convert(to), pathPattern, callback));
+                run(callback -> {
+                    validateProjectAndRepositoryName(projectName, repositoryName);
+                    requireNonNull(from, "from");
+                    requireNonNull(to, "to");
+                    requireNonNull(pathPattern, "pathPattern");
+                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                    client.getDiffs(projectName, repositoryName,
+                                    RevisionConverter.TO_DATA.convert(from),
+                                    RevisionConverter.TO_DATA.convert(to), pathPattern, callback);
+                });
         return future.thenApply(list -> convertToList(list, ChangeConverter.TO_MODEL::convert));
     }
 
@@ -334,10 +394,15 @@ final class LegacyCentralDogma implements CentralDogma {
                                                               Revision baseRevision,
                                                               Iterable<? extends Change<?>> changes) {
         final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Change>> future =
-                run(callback -> client.getPreviewDiffs(
-                        projectName, repositoryName,
-                        RevisionConverter.TO_DATA.convert(baseRevision),
-                        convertToList(changes, ChangeConverter.TO_DATA::convert), callback));
+                run(callback -> {
+                    validateProjectAndRepositoryName(projectName, repositoryName);
+                    requireNonNull(baseRevision, "baseRevision");
+                    requireNonNull(changes, "changes");
+                    client.getPreviewDiffs(
+                            projectName, repositoryName,
+                            RevisionConverter.TO_DATA.convert(baseRevision),
+                            convertToList(changes, ChangeConverter.TO_DATA::convert), callback);
+                });
         return future.thenApply(LegacyCentralDogma::convertToChangesModel);
     }
 
@@ -353,14 +418,21 @@ final class LegacyCentralDogma implements CentralDogma {
     public CompletableFuture<PushResult> push(String projectName, String repositoryName, Revision baseRevision,
                                               Author author, String summary, String detail, Markup markup,
                                               Iterable<? extends Change<?>> changes) {
-        final CompletableFuture<com.linecorp.centraldogma.internal.thrift.Commit> future =
-                run(callback -> client.push(projectName, repositoryName,
-                                            RevisionConverter.TO_DATA.convert(baseRevision),
-                                            AuthorConverter.TO_DATA.convert(author), summary,
-                                            new Comment(detail).setMarkup(
-                                                    MarkupConverter.TO_DATA.convert(markup)),
-                                            convertToList(changes, ChangeConverter.TO_DATA::convert),
-                                            callback));
+        final CompletableFuture<com.linecorp.centraldogma.internal.thrift.Commit> future = run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(baseRevision, "baseRevision");
+            requireNonNull(author, "author");
+            requireNonNull(summary, "summary");
+            requireNonNull(detail, "detail");
+            requireNonNull(markup, "markup");
+            requireNonNull(changes, "changes");
+            client.push(projectName, repositoryName,
+                        RevisionConverter.TO_DATA.convert(baseRevision),
+                        AuthorConverter.TO_DATA.convert(author), summary,
+                        new Comment(detail).setMarkup(MarkupConverter.TO_DATA.convert(markup)),
+                        convertToList(changes, ChangeConverter.TO_DATA::convert),
+                        callback);
+        });
         return future.thenApply(PushResultConverter.TO_MODEL::convert);
     }
 
@@ -369,11 +441,16 @@ final class LegacyCentralDogma implements CentralDogma {
                                                        Revision lastKnownRevision,
                                                        String pathPattern,
                                                        long timeoutMillis) {
-        final CompletableFuture<WatchRepositoryResult> future =
-                run(callback -> client.watchRepository(projectName, repositoryName,
-                                                       RevisionConverter.TO_DATA.convert(lastKnownRevision),
-                                                       pathPattern, timeoutMillis,
-                                                       callback));
+        final CompletableFuture<WatchRepositoryResult> future = run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(lastKnownRevision, "lastKnownRevision");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+            client.watchRepository(projectName, repositoryName,
+                                   RevisionConverter.TO_DATA.convert(lastKnownRevision),
+                                   pathPattern, timeoutMillis,
+                                   callback);
+        });
         return future.thenApply(r -> {
             if (r == null) {
                 return null;
@@ -388,11 +465,15 @@ final class LegacyCentralDogma implements CentralDogma {
                                                      Revision lastKnownRevision, Query<T> query,
                                                      long timeoutMillis) {
 
-        final CompletableFuture<WatchFileResult> future =
-                run(callback -> client.watchFile(projectName, repositoryName,
-                                                 RevisionConverter.TO_DATA.convert(lastKnownRevision),
-                                                 QueryConverter.TO_DATA.convert(query),
-                                                 timeoutMillis, callback));
+        final CompletableFuture<WatchFileResult> future = run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(lastKnownRevision, "lastKnownRevision");
+            requireNonNull(query, "query");
+            client.watchFile(projectName, repositoryName,
+                             RevisionConverter.TO_DATA.convert(lastKnownRevision),
+                             QueryConverter.TO_DATA.convert(query),
+                             timeoutMillis, callback);
+        });
         return future.thenApply(r -> {
             if (r == null) {
                 return null;
@@ -426,24 +507,13 @@ final class LegacyCentralDogma implements CentralDogma {
         });
     }
 
-    @Override
-    public <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
-                                         Query<T> query, Function<? super T, ? extends U> function) {
-        final FileWatcher<U> watcher =
-                new FileWatcher<>(this, clientFactory.eventLoopGroup(),
-                                  projectName, repositoryName, query, function);
-        watcher.start();
-        return watcher;
+    private static void validateProjectName(String projectName) {
+        Util.validateProjectName(projectName, "projectName");
     }
 
-    @Override
-    public <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName,
-                                            String pathPattern, Function<Revision, ? extends T> function) {
-        final RepositoryWatcher<T> watcher =
-                new RepositoryWatcher<>(this, clientFactory.eventLoopGroup(),
-                                        projectName, repositoryName, pathPattern, function);
-        watcher.start();
-        return watcher;
+    private static void validateProjectAndRepositoryName(String projectName, String repositoryName) {
+        validateProjectName(projectName);
+        Util.validateRepositoryName(repositoryName, "repositoryName");
     }
 
     @Nullable

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -20,7 +20,8 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.centraldogma.internal.Util.unsafeCast;
-import static com.linecorp.centraldogma.internal.Util.validateProjectName;
+import static com.linecorp.centraldogma.internal.Util.validatePathPattern;
+import static com.linecorp.centraldogma.internal.Util.validateRepositoryName;
 import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
@@ -41,6 +42,7 @@ import javax.annotation.Nullable;
 import org.apache.thrift.TException;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.google.common.collect.Iterables;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.thrift.ThriftCompletableFuture;
@@ -198,8 +200,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                 run(callback -> {
                     validateProjectAndRepositoryName(projectName, repositoryName);
                     requireNonNull(revision, "revision");
-                    requireNonNull(pathPattern, "pathPattern");
-                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                    validatePathPattern(pathPattern, "pathPattern");
 
                     client.listFiles(projectName, repositoryName,
                                      RevisionConverter.TO_DATA.convert(revision),
@@ -259,8 +260,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
         return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
             final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Entry>> future =
                     run(callback -> {
-                        requireNonNull(pathPattern, "pathPattern");
-                        checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                        validatePathPattern(pathPattern, "pathPattern");
                         client.getFiles(projectName, repositoryName,
                                         RevisionConverter.TO_DATA.convert(normRev),
                                         pathPattern, callback);
@@ -315,8 +315,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                     validateProjectAndRepositoryName(projectName, repositoryName);
                     requireNonNull(from, "from");
                     requireNonNull(to, "to");
-                    requireNonNull(pathPattern, "pathPattern");
-                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                    validatePathPattern(pathPattern, "pathPattern");
 
                     client.getHistory(projectName, repositoryName,
                                       RevisionConverter.TO_DATA.convert(from),
@@ -380,8 +379,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                     validateProjectAndRepositoryName(projectName, repositoryName);
                     requireNonNull(from, "from");
                     requireNonNull(to, "to");
-                    requireNonNull(pathPattern, "pathPattern");
-                    checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+                    validatePathPattern(pathPattern, "pathPattern");
                     client.getDiffs(projectName, repositoryName,
                                     RevisionConverter.TO_DATA.convert(from),
                                     RevisionConverter.TO_DATA.convert(to), pathPattern, callback);
@@ -426,6 +424,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
             requireNonNull(detail, "detail");
             requireNonNull(markup, "markup");
             requireNonNull(changes, "changes");
+            checkArgument(!Iterables.isEmpty(changes), "changes is empty.");
             client.push(projectName, repositoryName,
                         RevisionConverter.TO_DATA.convert(baseRevision),
                         AuthorConverter.TO_DATA.convert(author), summary,
@@ -444,8 +443,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
         final CompletableFuture<WatchRepositoryResult> future = run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);
             requireNonNull(lastKnownRevision, "lastKnownRevision");
-            requireNonNull(pathPattern, "pathPattern");
-            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+            validatePathPattern(pathPattern, "pathPattern");
             client.watchRepository(projectName, repositoryName,
                                    RevisionConverter.TO_DATA.convert(lastKnownRevision),
                                    pathPattern, timeoutMillis,
@@ -513,7 +511,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
 
     private static void validateProjectAndRepositoryName(String projectName, String repositoryName) {
         validateProjectName(projectName);
-        Util.validateRepositoryName(repositoryName, "repositoryName");
+        validateRepositoryName(repositoryName, "repositoryName");
     }
 
     @Nullable

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -52,7 +52,7 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
         builder.decorator((delegate, ctx, req) -> {
             if (!req.headers().contains(HttpHeaderNames.AUTHORIZATION)) {
                 // To prevent CSRF attack, we add 'Authorization' header to every request.
-                req.headers().set(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS);
+                req.headers().set(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS);
             }
             return delegate.execute(ctx, req);
         });

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -19,12 +19,20 @@ import java.net.UnknownHostException;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.internal.CsrfToken;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
+/**
+ * Builds a legacy {@link CentralDogma} client based on Thrift.
+ *
+ * @deprecated Use {@link ArmeriaCentralDogmaBuilder}.
+ */
+@Deprecated
 public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilder<LegacyCentralDogmaBuilder> {
     /**
      * Returns a newly-created {@link CentralDogma} instance.
@@ -35,10 +43,11 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
         final Endpoint endpoint = endpoint();
         final String scheme = "tbinary+" + (isUseTls() ? "https" : "http") + "://";
         final String uri = scheme + endpoint.authority() + "/cd/thrift/v1";
-        final ClientBuilder builder = new ClientBuilder(uri)
-                .factory(clientFactory())
-                .rpcDecorator(CentralDogmaClientTimeoutScheduler::new);
+        final ClientBuilder builder = new ClientBuilder(uri);
         clientConfigurator().configure(builder);
+        builder.factory(clientFactory())
+               .decorator(HttpDecodingClient.newDecorator())
+               .rpcDecorator(LegacyCentralDogmaTimeoutScheduler::new);
 
         builder.decorator((delegate, ctx, req) -> {
             if (!req.headers().contains(HttpHeaderNames.AUTHORIZATION)) {
@@ -47,6 +56,7 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
             }
             return delegate.execute(ctx, req);
         });
-        return new LegacyCentralDogma(clientFactory(), builder.build(CentralDogmaService.AsyncIface.class));
+        return new LegacyCentralDogma(clientFactory().eventLoopGroup(),
+                                      builder.build(CentralDogmaService.AsyncIface.class));
     }
 }

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutScheduler.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutScheduler.java
@@ -28,12 +28,12 @@ import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 /**
  * Decorates a {@link Client} to enlarge responseTimeout when requesting watchFile or watchRepository.
  */
-class CentralDogmaClientTimeoutScheduler extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
+class LegacyCentralDogmaTimeoutScheduler extends SimpleDecoratingClient<RpcRequest, RpcResponse> {
 
     /**
      * Creates a new instance that decorates the specified {@link Client}.
      */
-    CentralDogmaClientTimeoutScheduler(Client<RpcRequest, RpcResponse> delegate) {
+    LegacyCentralDogmaTimeoutScheduler(Client<RpcRequest, RpcResponse> delegate) {
         super(delegate);
     }
 

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -39,7 +39,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
-import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.RepositoryInfo;
 import com.linecorp.centraldogma.client.armeria.legacy.ThriftTypes.TAuthor;
@@ -85,7 +85,7 @@ public class LegacyCentralDogmaTest {
 
     @Before
     public void setup() {
-        client = new LegacyCentralDogma(ClientFactory.DEFAULT, iface);
+        client = new LegacyCentralDogma(CommonPools.workerGroup(), iface);
     }
 
     @Test
@@ -189,13 +189,7 @@ public class LegacyCentralDogmaTest {
             return null;
         }).when(iface).listRepositories(any(), any());
         assertThat(client.listRepositories("project").get()).isEqualTo(ImmutableMap.of(
-                "repo",
-                new RepositoryInfo(
-                        "repo",
-                        new Commit(new Revision(42),
-                                   new Author("hitchhiker", "arthur@dent.com"),
-                                   Instant.parse("1978-03-08T00:00:00Z").toEpochMilli(),
-                                   "The primary phrase", "", Markup.PLAINTEXT))));
+                "repo", new RepositoryInfo("repo", new Revision(42))));
         verify(iface).listRepositories(eq("project"), any());
     }
 

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
@@ -47,18 +47,18 @@ import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
 import io.netty.channel.DefaultEventLoop;
 
-public class CentralDogmaTimeoutSchedulerTest {
+public class LegacyCentralDogmaTimeoutSchedulerTest {
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
 
     @Mock
     private Client<RpcRequest, RpcResponse> client;
 
-    private CentralDogmaClientTimeoutScheduler decorator;
+    private LegacyCentralDogmaTimeoutScheduler decorator;
 
     @Before
     public void setup() {
-        decorator = new CentralDogmaClientTimeoutScheduler(client);
+        decorator = new LegacyCentralDogmaTimeoutScheduler(client);
     }
 
     @Test

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -51,14 +51,12 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Ascii;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import com.google.common.math.IntMath;
 import com.google.common.math.LongMath;
-import com.google.common.net.UrlEscapers;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -1,0 +1,1037 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.armeria;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.linecorp.centraldogma.internal.Util.unsafeCast;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
+import static java.util.Objects.requireNonNull;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Streams;
+import com.google.common.math.LongMath;
+
+import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.HttpStatusClass;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.centraldogma.client.AbstractCentralDogma;
+import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.AuthorizationException;
+import com.linecorp.centraldogma.common.CentralDogmaException;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.ChangeType;
+import com.linecorp.centraldogma.common.Commit;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.MergeQuery;
+import com.linecorp.centraldogma.common.MergedEntry;
+import com.linecorp.centraldogma.common.ProjectExistsException;
+import com.linecorp.centraldogma.common.ProjectNotFoundException;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.QueryExecutionException;
+import com.linecorp.centraldogma.common.QueryType;
+import com.linecorp.centraldogma.common.RedundantChangeException;
+import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryNotFoundException;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.RevisionNotFoundException;
+import com.linecorp.centraldogma.common.ShuttingDownException;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.Util;
+import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
+
+final class ArmeriaCentralDogma extends AbstractCentralDogma {
+
+    private static final MediaType JSON_PATCH_UTF8 = MediaType.JSON_PATCH.withCharset(StandardCharsets.UTF_8);
+
+    private static final byte[] UNREMOVE_PATCH = toBytes(JsonNodeFactory.instance.arrayNode(1).add(
+            JsonNodeFactory.instance.objectNode().put("op", "replace")
+                                    .put("path", "/status")
+                                    .put("value", "active")));
+    private static final String REMOVED_PARAM = "?status=removed";
+
+    private static final Map<String, Function<String, CentralDogmaException>> EXCEPTION_FACTORIES =
+            ImmutableMap.<String, Function<String, CentralDogmaException>>builder()
+                    .put(ProjectExistsException.class.getName(), ProjectExistsException::new)
+                    .put(ProjectNotFoundException.class.getName(), ProjectNotFoundException::new)
+                    .put(QueryExecutionException.class.getName(), QueryExecutionException::new)
+                    .put(RedundantChangeException.class.getName(), RedundantChangeException::new)
+                    .put(RevisionNotFoundException.class.getName(), RevisionNotFoundException::new)
+                    .put(EntryNotFoundException.class.getName(), EntryNotFoundException::new)
+                    .put(ChangeConflictException.class.getName(), ChangeConflictException::new)
+                    .put(RepositoryNotFoundException.class.getName(), RepositoryNotFoundException::new)
+                    .put(AuthorizationException.class.getName(), AuthorizationException::new)
+                    .put(ShuttingDownException.class.getName(), ShuttingDownException::new)
+                    .put(RepositoryExistsException.class.getName(), RepositoryExistsException::new)
+                    .build();
+
+    private final HttpClient client;
+    private final String authorization;
+
+    ArmeriaCentralDogma(ScheduledExecutorService executor, HttpClient client, String accessToken) {
+        super(executor);
+        this.client = requireNonNull(client, "client");
+        authorization = "bearer " + requireNonNull(accessToken, "accessToken");
+    }
+
+    @Override
+    public CompletableFuture<Void> createProject(String projectName) {
+        try {
+            validateProjectName(projectName);
+
+            final ObjectNode root = JsonNodeFactory.instance.objectNode();
+            root.put("name", projectName);
+
+            return client.execute(headers(HttpMethod.POST, PROJECTS_PREFIX), toBytes(root))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::createProject);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void createProject(AggregatedHttpMessage res) {
+        if (res.status().code() == 201) { // Created
+            return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeProject(String projectName) {
+        try {
+            validateProjectName(projectName);
+            return client.execute(headers(HttpMethod.DELETE, pathBuilder(projectName).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::removeProject);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void removeProject(AggregatedHttpMessage res) {
+        if (res.status().code() == 204) { // No Content
+            return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Void> unremoveProject(String projectName) {
+        try {
+            validateProjectName(projectName);
+            return client.execute(headers(HttpMethod.PATCH, pathBuilder(projectName).toString()),
+                                  UNREMOVE_PATCH)
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::unremoveProject);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void unremoveProject(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) { // OK
+            return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listProjects() {
+        return client.execute(headers(HttpMethod.GET, PROJECTS_PREFIX))
+                     .aggregate()
+                     .thenApply(ArmeriaCentralDogma::handleNameList);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listRemovedProjects() {
+        return client.execute(headers(HttpMethod.GET, PROJECTS_PREFIX + REMOVED_PARAM))
+                     .aggregate()
+                     .thenApply(ArmeriaCentralDogma::handleNameList);
+    }
+
+    @Override
+    public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+
+            final String path = pathBuilder(projectName).append(REPOS).toString();
+            final ObjectNode root = JsonNodeFactory.instance.objectNode();
+            root.put("name", repositoryName);
+
+            return client.execute(headers(HttpMethod.POST, path), toBytes(root))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::createRepository);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void createRepository(AggregatedHttpMessage res) {
+        if (res.status().code() == 201) { // Created
+            return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeRepository(String projectName, String repositoryName) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            return client.execute(headers(HttpMethod.DELETE,
+                                          pathBuilder(projectName, repositoryName).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::removeRepository);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void removeRepository(AggregatedHttpMessage res) {
+        if (res.status().code() == 204) { // No Content
+            return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            return client.execute(headers(HttpMethod.PATCH,
+                                          pathBuilder(projectName, repositoryName).toString()),
+                                  UNREMOVE_PATCH)
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::handleSimpleResponse);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Map<String, RepositoryInfo>> listRepositories(String projectName) {
+        try {
+            validateProjectName(projectName);
+            return client.execute(headers(HttpMethod.GET, pathBuilder(projectName).append(REPOS).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::listRepositories);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Map<String, RepositoryInfo> listRepositories(AggregatedHttpMessage res) {
+        final int code = res.status().code();
+        if (code == 200) { // OK
+            return Streams.stream(toJson(res, JsonNodeType.ARRAY))
+                          .map(node -> {
+                              final String name = getField(node, "name").asText();
+                              final Revision headRevision =
+                                      new Revision(getField(node, "headRevision").asInt());
+                              return new RepositoryInfo(name, headRevision);
+                          })
+                          .collect(toImmutableMap(RepositoryInfo::name, Function.identity()));
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listRemovedRepositories(String projectName) {
+        try {
+            validateProjectName(projectName);
+            return client.execute(headers(HttpMethod.GET,
+                                          pathBuilder(projectName).append(REPOS)
+                                                                  .append(REMOVED_PARAM).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::handleNameList);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<Revision> normalizeRevision(String projectName, String repositoryName,
+                                                         Revision revision) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+
+            final String path = pathBuilder(projectName, repositoryName)
+                    .append("/revision/")
+                    .append(revision.text())
+                    .toString();
+
+            return client.execute(headers(HttpMethod.GET, path))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::normalizeRevision);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Revision normalizeRevision(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            return new Revision(getField(toJson(res, JsonNodeType.OBJECT), "revision").asInt());
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, EntryType>> listFiles(String projectName, String repositoryName,
+                                                               Revision revision, String pathPattern) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/list");
+            if (pathPattern.charAt(0) != '/') {
+                path.append("/**/");
+            }
+            path.append(pathPattern);
+            path.append("?revision=").append(revision.major());
+
+            return client.execute(headers(HttpMethod.GET, path.toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::listFiles);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Map<String, EntryType> listFiles(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final ImmutableMap.Builder<String, EntryType> builder = ImmutableMap.builder();
+            final JsonNode node = toJson(res, JsonNodeType.ARRAY);
+            node.forEach(e -> builder.put(
+                    getField(e, "path").asText(),
+                    EntryType.valueOf(getField(e, "type").asText())));
+            return builder.build();
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public <T> CompletableFuture<Entry<T>> getFile(String projectName, String repositoryName, Revision revision,
+                                                   Query<T> query) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+            requireNonNull(query, "query");
+
+            return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+                final StringBuilder path = pathBuilder(projectName, repositoryName);
+                path.append("/contents").append(query.path());
+                path.append("?revision=").append(normRev.text());
+                appendJsonPaths(path, query.type(), query.expressions());
+
+                return client.execute(headers(HttpMethod.GET, path.toString()))
+                             .aggregate()
+                             .thenApply(res -> getFile(normRev, res));
+            });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static <T> Entry<T> getFile(Revision normRev, AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+            return toEntry(normRev, node);
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Entry<?>>> getFiles(String projectName, String repositoryName,
+                                                             Revision revision, String pathPattern) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+            return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+                final StringBuilder path = pathBuilder(projectName, repositoryName);
+                path.append("/contents");
+                if (pathPattern.charAt(0) != '/') {
+                    path.append("/**/");
+                }
+                path.append(pathPattern);
+                path.append("?revision=").append(normRev.major());
+
+                return client.execute(headers(HttpMethod.GET, path.toString()))
+                             .aggregate()
+                             .thenApply(res -> getFiles(normRev, res));
+            });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Map<String, Entry<?>> getFiles(Revision normRev, AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final JsonNode node = toJson(res, null);
+            final ImmutableMap.Builder<String, Entry<?>> builder = ImmutableMap.builder();
+            if (node.isObject()) { // Single entry
+                final Entry<?> entry = toEntry(normRev, node);
+                builder.put(entry.path(), entry);
+            } else if (node.isArray()) { // Multiple entries
+                node.forEach(e -> {
+                    final Entry<?> entry = toEntry(normRev, e);
+                    builder.put(entry.path(), entry);
+                });
+            } else {
+                return rejectNeitherArrayNorObject(res);
+            }
+            return builder.build();
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public <T> CompletableFuture<MergedEntry<T>> mergeFiles(String projectName, String repositoryName,
+                                                            Revision revision, MergeQuery<T> mergeQuery) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(revision, "revision");
+            requireNonNull(mergeQuery, "mergeQuery");
+
+            return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+                final StringBuilder path = pathBuilder(projectName, repositoryName);
+                path.append("/merge?revision=").append(normRev.major());
+                mergeQuery.mergeSources().forEach(
+                        src -> path.append(src.isOptional() ? "&optional_path=" : "&path=").append(src.path()));
+                appendJsonPaths(path, mergeQuery.type(), mergeQuery.expressions());
+                return client.execute(headers(HttpMethod.GET, path.toString()))
+                             .aggregate()
+                             .thenApply(ArmeriaCentralDogma::mergeFiles);
+            });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static <T> MergedEntry<T> mergeFiles(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+
+            // Build path list.
+            final ImmutableList.Builder<String> pathsBuilder = ImmutableList.builder();
+            for (JsonNode path : getField(node, "paths")) {
+                if (path.getNodeType() != JsonNodeType.STRING) {
+                    throw new CentralDogmaException("Received a merged entry with a non-string path: " + node);
+                }
+                pathsBuilder.add(path.asText());
+            }
+            final List<String> paths = pathsBuilder.build();
+            if (paths.isEmpty()) {
+                throw new CentralDogmaException("Received a merged entry with empty paths: " + node);
+            }
+
+            // Build the merged entry.
+            final Revision revision = new Revision(getField(node, "revision").asInt());
+            final EntryType type = EntryType.valueOf(getField(node, "type").asText());
+            final JsonNode content = getField(node, "content");
+            switch (type) {
+                case JSON: {
+                    @SuppressWarnings("unchecked")
+                    final MergedEntry<T> cast =
+                            (MergedEntry<T>) MergedEntry.of(revision, type, content, paths);
+                    return cast;
+                }
+                case TEXT: {
+                    if (content.getNodeType() != JsonNodeType.STRING) {
+                        throw new CentralDogmaException(
+                                "Received a TEXT merged entry whose content is not a string: " + node);
+                    }
+                    @SuppressWarnings("unchecked")
+                    final MergedEntry<T> cast =
+                            (MergedEntry<T>) MergedEntry.of(revision, type, content.asText(), paths);
+                    return cast;
+                }
+                default:
+                    throw new CentralDogmaException(
+                            "Received a merged entry whose type is neither JSON nor TEXT: " + node);
+            }
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<List<Commit>> getHistory(String projectName, String repositoryName,
+                                                      Revision from, Revision to,
+                                                      String pathPattern) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(from, "from");
+            requireNonNull(to, "to");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/commits/").append(from.text());
+            path.append("?to=").append(to.text());
+            path.append("&path=").append(encodeParam(pathPattern));
+
+            return client.execute(headers(HttpMethod.GET, path.toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::getHistory);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static List<Commit> getHistory(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final JsonNode node = toJson(res, null);
+            if (node.isObject()) {
+                return ImmutableList.of(toCommit(node));
+            } else if (node.isArray()) {
+                return Streams.stream(node)
+                              .map(ArmeriaCentralDogma::toCommit)
+                              .collect(toImmutableList());
+            } else {
+                return rejectNeitherArrayNorObject(res);
+            }
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public <T> CompletableFuture<Change<T>> getDiff(String projectName, String repositoryName, Revision from,
+                                                    Revision to, Query<T> query) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(from, "from");
+            requireNonNull(to, "to");
+            requireNonNull(query, "query");
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/compare");
+            path.append("?path=").append(encodeParam(query.path()));
+            path.append("&from=").append(from.text());
+            path.append("&to=").append(to.text());
+            appendJsonPaths(path, query.type(), query.expressions());
+
+            return client.execute(headers(HttpMethod.GET, path.toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::getDiff);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static <T> Change<T> getDiff(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            return toChange(toJson(res, JsonNodeType.OBJECT));
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<List<Change<?>>> getDiffs(String projectName, String repositoryName, Revision from,
+                                                       Revision to, String pathPattern) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(from, "from");
+            requireNonNull(to, "to");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/compare");
+            path.append("?pathPattern=").append(encodeParam(pathPattern));
+            path.append("&from=").append(from.text());
+            path.append("&to=").append(to.text());
+
+            return client.execute(headers(HttpMethod.GET, path.toString()))
+                         .aggregate()
+                         .thenApply(res -> {
+                             if (res.status().code() == 200) {
+                                 final JsonNode node = toJson(res, null);
+                                 if (node.isObject()) {
+                                     return ImmutableList.of(toChange(node));
+                                 } else if (node.isArray()) {
+                                     return Streams.stream(node)
+                                                   .map(ArmeriaCentralDogma::toChange)
+                                                   .collect(toImmutableList());
+                                 } else {
+                                     return rejectNeitherArrayNorObject(res);
+                                 }
+                             }
+
+                             return handleErrorResponse(res);
+                         });
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Override
+    public CompletableFuture<List<Change<?>>> getPreviewDiffs(String projectName, String repositoryName,
+                                                              Revision baseRevision,
+                                                              Iterable<? extends Change<?>> changes) {
+        try {
+            try {
+                validateProjectAndRepositoryName(projectName, repositoryName);
+                requireNonNull(baseRevision, "baseRevision");
+                requireNonNull(changes, "changes");
+
+                final String path = pathBuilder(projectName, repositoryName)
+                        .append("/preview?revision=")
+                        .append(baseRevision.text())
+                        .toString();
+
+                final ArrayNode changesNode = toJson(changes);
+                return client.execute(headers(HttpMethod.POST, path), toBytes(changesNode))
+                             .aggregate()
+                             .thenApply(ArmeriaCentralDogma::getPreviewDiffs);
+            } catch (Exception e) {
+                return exceptionallyCompletedFuture(e);
+            }
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static List<Change<?>> getPreviewDiffs(AggregatedHttpMessage res) {
+        switch (res.status().code()) {
+            case 200:
+                final JsonNode node = toJson(res, JsonNodeType.ARRAY);
+                final ImmutableList.Builder<Change<?>> builder = ImmutableList.builder();
+                node.forEach(e -> builder.add(toChange(e)));
+                return builder.build();
+            case 204:
+                return ImmutableList.of();
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<PushResult> push(String projectName, String repositoryName, Revision baseRevision,
+                                              String summary, String detail, Markup markup,
+                                              Iterable<? extends Change<?>> changes) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(baseRevision, "baseRevision");
+            requireNonNull(summary, "summary");
+            checkArgument(!summary.isEmpty(), "empty summary");
+            requireNonNull(markup, "markup");
+            requireNonNull(changes, "changes");
+
+            final String path = pathBuilder(projectName, repositoryName)
+                    .append("/contents?revision=")
+                    .append(baseRevision.text())
+                    .toString();
+
+            final ObjectNode commitNode = JsonNodeFactory.instance.objectNode();
+            commitNode.set("commitMessage",
+                           JsonNodeFactory.instance.objectNode()
+                                                   .put("summary", summary)
+                                                   .put("detail", detail)
+                                                   .put("markup", markup.name()));
+            commitNode.set("changes", toJson(changes));
+
+            return client.execute(headers(HttpMethod.POST, path), toBytes(commitNode))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::push);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static PushResult push(AggregatedHttpMessage res) {
+        if (res.status().code() == 200) {
+            final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+            return new PushResult(
+                    new Revision(getField(node, "revision").asInt()),
+                    Instant.parse(getField(node, "pushedAt").asText()).toEpochMilli());
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<PushResult> push(String projectName, String repositoryName, Revision baseRevision,
+                                              Author author, String summary, String detail, Markup markup,
+                                              Iterable<? extends Change<?>> changes) {
+        // The author specified by the client will be ignored.
+        // The server will determine the author.
+        return push(projectName, repositoryName, baseRevision, summary, detail, markup, changes);
+    }
+
+    @Override
+    public CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
+                                                       Revision lastKnownRevision, String pathPattern,
+                                                       long timeoutMillis) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(lastKnownRevision, "lastKnownRevision");
+            requireNonNull(pathPattern, "pathPattern");
+            checkArgument(!pathPattern.isEmpty(), "empty pathPattern");
+            checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/contents");
+            if (pathPattern.charAt(0) != '/') {
+                path.append("/**/");
+            }
+            path.append(pathPattern);
+
+            return watch(lastKnownRevision, timeoutMillis, path.toString(),
+                         ArmeriaCentralDogma::watchRepository);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Nullable
+    private static Revision watchRepository(AggregatedHttpMessage res) {
+        switch (res.status().code()) {
+            case 200: // OK
+                final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+                return new Revision(getField(node, "revision").asInt());
+            case 304: // Not Modified
+                return null;
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
+                                                     Revision lastKnownRevision, Query<T> query,
+                                                     long timeoutMillis) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            requireNonNull(lastKnownRevision, "lastKnownRevision");
+            requireNonNull(query, "query");
+            checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
+
+            final StringBuilder path = pathBuilder(projectName, repositoryName);
+            path.append("/contents").append(query.path());
+            if (query.type() == QueryType.JSON_PATH) {
+                path.append('?');
+                query.expressions().forEach(expr -> path.append("jsonpath=").append(encodeParam(expr))
+                                                        .append('&'));
+
+                // Remove the trailing '?' or '&'.
+                path.setLength(path.length() - 1);
+            }
+
+            return watch(lastKnownRevision, timeoutMillis, path.toString(), ArmeriaCentralDogma::watchFile);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    @Nullable
+    private static <T> Entry<T> watchFile(AggregatedHttpMessage res) {
+        switch (res.status().code()) {
+            case 200: // OK
+                final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+                final Revision revision = new Revision(getField(node, "revision").asInt());
+                return toEntry(revision, getField(node, "entry"));
+            case 304: // Not Modified
+                return null;
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    private <T> CompletableFuture<T> watch(Revision lastKnownRevision, long timeoutMillis,
+                                           String path, Function<AggregatedHttpMessage, T> func) {
+        final HttpHeaders headers = headers(HttpMethod.GET, path)
+                .set(HttpHeaderNames.IF_NONE_MATCH, lastKnownRevision.text())
+                .set(HttpHeaderNames.PREFER, "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L);
+
+        try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
+            ctx.setResponseTimeoutMillis(
+                    WatchTimeout.makeReasonable(timeoutMillis, ctx.responseTimeoutMillis()));
+        })) {
+            return client.execute(headers).aggregate().thenApply(func);
+        }
+    }
+
+    private static void validateProjectName(String projectName) {
+        Util.validateProjectName(projectName, "projectName");
+    }
+
+    private static void validateProjectAndRepositoryName(String projectName, String repositoryName) {
+        validateProjectName(projectName);
+        Util.validateRepositoryName(repositoryName, "repositoryName");
+    }
+
+    private HttpHeaders headers(HttpMethod method, String path) {
+        final HttpHeaders headers = HttpHeaders.of(method, path);
+        headers.set(HttpHeaderNames.AUTHORIZATION, authorization);
+        headers.setObject(HttpHeaderNames.ACCEPT, MediaType.JSON);
+
+        switch (method) {
+            case POST:
+            case PUT:
+                headers.setObject(HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_UTF_8);
+                break;
+            case PATCH:
+                headers.setObject(HttpHeaderNames.CONTENT_TYPE, JSON_PATCH_UTF8);
+                break;
+        }
+
+        return headers;
+    }
+
+    private static StringBuilder pathBuilder(String projectName) {
+        return new StringBuilder().append(PROJECTS_PREFIX).append('/').append(projectName);
+    }
+
+    private static StringBuilder pathBuilder(String projectName, String repositoryName) {
+        return pathBuilder(projectName).append(REPOS).append('/').append(repositoryName);
+    }
+
+    private static void appendJsonPaths(StringBuilder path, QueryType queryType, Iterable<String> expressions) {
+        if (queryType == QueryType.JSON_PATH) {
+            expressions.forEach(expr -> path.append("&jsonpath=").append(encodeParam(expr)));
+        }
+    }
+
+    @SuppressWarnings("CharsetObjectCanBeUsed") // We target Java 8.
+    private static String encodeParam(String pathPattern) {
+        try {
+            return URLEncoder.encode(pathPattern, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new Error(); // Never reaches here.
+        }
+    }
+
+    /**
+     * Encodes the specified {@link JsonNode} into a byte array.
+     */
+    private static byte[] toBytes(JsonNode content) {
+        try {
+            return Jackson.writeValueAsBytes(content);
+        } catch (JsonProcessingException e) {
+            // Should never reach here.
+            throw new Error(e);
+        }
+    }
+
+    /**
+     * Encodes a list of {@link Change}s into a JSON array.
+     */
+    private static ArrayNode toJson(Iterable<? extends Change<?>> changes) {
+        final ArrayNode changesNode = JsonNodeFactory.instance.arrayNode();
+        changes.forEach(c -> {
+            final ObjectNode changeNode = JsonNodeFactory.instance.objectNode();
+            changeNode.put("path", c.path());
+            changeNode.put("type", c.type().name());
+            final Class<?> contentType = c.type().contentType();
+            if (contentType == JsonNode.class) {
+                changeNode.set("content", (JsonNode) c.content());
+            } else if (contentType == String.class) {
+                changeNode.put("content", (String) c.content());
+            }
+            changesNode.add(changeNode);
+        });
+        return changesNode;
+    }
+
+    /**
+     * Parses the content of the specified {@link AggregatedHttpMessage} into a {@link JsonNode}.
+     */
+    private static JsonNode toJson(AggregatedHttpMessage res, @Nullable JsonNodeType expectedNodeType) {
+        final String content = toString(res);
+        final JsonNode node;
+        try {
+            node = Jackson.readTree(content);
+        } catch (JsonParseException e) {
+            throw new CentralDogmaException("failed to parse the response JSON", e);
+        }
+
+        if (expectedNodeType != null && node.getNodeType() != expectedNodeType) {
+            throw new CentralDogmaException(
+                    "invalid server response; expected: " + expectedNodeType +
+                    ", actual: " + node.getNodeType() + ", content: " + content);
+        }
+        return node;
+    }
+
+    private static <T> T rejectNeitherArrayNorObject(AggregatedHttpMessage res) {
+        throw new CentralDogmaException(
+                "invalid server response; expected: " + JsonNodeType.OBJECT + " or " + JsonNodeType.ARRAY +
+                ", content: " + toString(res));
+    }
+
+    private static String toString(AggregatedHttpMessage res) {
+        final MediaType contentType = firstNonNull(res.headers().contentType(), MediaType.JSON_UTF_8);
+        final Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
+        return res.content(charset);
+    }
+
+    private static <T> Entry<T> toEntry(Revision revision, JsonNode node) {
+        final String entryPath = getField(node, "path").asText();
+        final EntryType entryType = EntryType.valueOf(getField(node, "type").asText());
+        switch (entryType) {
+            case JSON:
+                return unsafeCast(Entry.ofJson(revision, entryPath, getField(node, "content")));
+            case TEXT:
+                return unsafeCast(Entry.ofText(revision, entryPath,
+                                               getField(node, "content").asText()));
+            case DIRECTORY:
+                return unsafeCast(Entry.ofDirectory(revision, entryPath));
+        }
+        throw new Error(); // Never reaches here.
+    }
+
+    private static Commit toCommit(JsonNode node) {
+        final Revision revision = new Revision(getField(node, "revision").asInt());
+        final JsonNode authorNode = getField(node, "author");
+        final Author author = new Author(getField(authorNode, "name").asText(),
+                                         getField(authorNode, "email").asText());
+        final long pushedAt = Instant.from(DateTimeFormatter.ISO_INSTANT.parse(
+                getField(node, "pushedAt").asText())).toEpochMilli();
+        final JsonNode commitMessageNode = getField(node, "commitMessage");
+        final String summary = getField(commitMessageNode, "summary").asText();
+        final String detail = getField(commitMessageNode, "detail").asText();
+        final Markup marksup = Markup.valueOf(getField(commitMessageNode, "markup").asText());
+        return new Commit(revision, author, pushedAt, summary, detail, marksup);
+    }
+
+    private static <T> Change<T> toChange(JsonNode node) {
+        final String actualPath = getField(node, "path").asText();
+        final ChangeType type = ChangeType.valueOf(getField(node, "type").asText());
+        switch (type) {
+            case UPSERT_JSON:
+                return unsafeCast(Change.ofJsonUpsert(actualPath, getField(node, "content")));
+            case UPSERT_TEXT:
+                return unsafeCast(Change.ofTextUpsert(actualPath, getField(node, "content").asText()));
+            case REMOVE:
+                return unsafeCast(Change.ofRemoval(actualPath));
+            case RENAME:
+                return unsafeCast(Change.ofRename(actualPath, getField(node, "content").asText()));
+            case APPLY_JSON_PATCH:
+                return unsafeCast(Change.ofJsonPatch(actualPath, getField(node, "content")));
+            case APPLY_TEXT_PATCH:
+                return unsafeCast(Change.ofTextPatch(actualPath, getField(node, "content").asText()));
+        }
+
+        throw new Error(); // Never reaches here.
+    }
+
+    private static Set<String> handleNameList(AggregatedHttpMessage res) {
+        final int code = res.status().code();
+        if (code == 200) { // OK
+            return Streams.stream(toJson(res, JsonNodeType.ARRAY))
+                          .map(node -> getField(node, "name").asText())
+                          .collect(toImmutableSet());
+        }
+        return handleErrorResponse(res);
+    }
+
+    private static JsonNode getField(JsonNode node, String fieldName) {
+        final JsonNode field = node.get(fieldName);
+        if (field == null) {
+            throw new CentralDogmaException(
+                    "invalid server response; field '" + fieldName + "' does not exist: " + node);
+        }
+        return field;
+    }
+
+    @Nullable
+    private static <T> T handleSimpleResponse(AggregatedHttpMessage res) {
+        final HttpStatus status = res.status();
+        assert status != null : res;
+        if (status.code() == 200) {
+            return null;
+        }
+
+        return handleErrorResponse(res);
+    }
+
+    private static <T> T handleErrorResponse(AggregatedHttpMessage res) {
+        final HttpStatus status = res.status();
+        assert status != null : res;
+        if (status.codeClass() != HttpStatusClass.SUCCESS) {
+            final JsonNode node = toJson(res, JsonNodeType.OBJECT);
+            final JsonNode exceptionNode = node.get("exception");
+            final JsonNode messageNode = node.get("message");
+
+            if (exceptionNode != null) {
+                final String typeName = exceptionNode.textValue();
+                if (typeName != null) {
+                    final Function<String, CentralDogmaException> exceptionFactory =
+                            EXCEPTION_FACTORIES.get(typeName);
+                    if (exceptionFactory != null) {
+                        throw exceptionFactory.apply(messageNode.textValue());
+                    }
+                }
+            }
+        }
+
+        throw new CentralDogmaException("unexpected response: " + res.headers() + ", " + res.contentUtf8());
+    }
+}

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.armeria;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.net.UnknownHostException;
+
+import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.HttpClient;
+import com.linecorp.armeria.client.encoding.HttpDecodingClient;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.internal.CsrfToken;
+
+public final class ArmeriaCentralDogmaBuilder
+        extends AbstractArmeriaCentralDogmaBuilder<ArmeriaCentralDogmaBuilder> {
+
+    private String accessToken = CsrfToken.ANONYMOUS;
+
+    /**
+     * Sets the access token to use when authenticating a client.
+     */
+    public ArmeriaCentralDogmaBuilder accessToken(String accessToken) {
+        requireNonNull(accessToken, "accessToken");
+        checkArgument(!accessToken.isEmpty(), "accessToken is empty.");
+        this.accessToken = accessToken;
+        return this;
+    }
+
+    /**
+     * Returns a newly-created {@link CentralDogma} instance.
+     *
+     * @throws UnknownHostException if failed to resolve the host names from the DNS servers
+     */
+    public CentralDogma build() throws UnknownHostException {
+        final Endpoint endpoint = endpoint();
+        final String scheme = "none+" + (isUseTls() ? "https" : "http") + "://";
+        final String uri = scheme + endpoint.authority();
+        final ClientBuilder builder = new ClientBuilder(uri);
+        clientConfigurator().configure(builder);
+        builder.factory(clientFactory());
+        builder.decorator(HttpDecodingClient.newDecorator());
+        return new ArmeriaCentralDogma(clientFactory().eventLoopGroup(),
+                                       builder.build(HttpClient.class), accessToken);
+    }
+}

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.armeria;
+
+import static com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogma.encodePathPattern;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ArmeriaCentralDogmaTest {
+    @Test
+    public void testEncodePathPattern() {
+        assertThat(encodePathPattern("/")).isEqualTo("/");
+        assertThat(encodePathPattern(" ")).isEqualTo("%20");
+        assertThat(encodePathPattern("  ")).isEqualTo("%20%20");
+        assertThat(encodePathPattern("a b")).isEqualTo("a%20b");
+        assertThat(encodePathPattern(" a ")).isEqualTo("%20a%20");
+
+        // No new string has to be created when escaping is not necessary.
+        final String pathPatternThatDoesNotNeedEscaping = "/*.zip,/**/*.jar";
+        assertThat(encodePathPattern(pathPatternThatDoesNotNeedEscaping))
+                .isSameAs(pathPatternThatDoesNotNeedEscaping);
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.client.FileWatcher;
+import com.linecorp.centraldogma.internal.client.RepositoryWatcher;
+
+/**
+ * A skeletal {@link CentralDogma} implementation.
+ */
+public abstract class AbstractCentralDogma implements CentralDogma {
+
+    private final ScheduledExecutorService executor;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param executor the {@link ScheduledExecutorService} which will be used for watching a file or
+     *                 a repository
+     */
+    protected AbstractCentralDogma(ScheduledExecutorService executor) {
+        this.executor = requireNonNull(executor, "executor");
+    }
+
+    @Override
+    public final <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
+                                               Function<? super T, ? extends U> function) {
+        final FileWatcher<U> watcher =
+                new FileWatcher<>(this, executor, projectName, repositoryName, query, function);
+        watcher.start();
+        return watcher;
+    }
+
+    @Override
+    public final <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
+                                                  Function<Revision, ? extends T> function) {
+        final RepositoryWatcher<T> watcher =
+                new RepositoryWatcher<>(this, executor,
+                                        projectName, repositoryName, pathPattern, function);
+        watcher.start();
+        return watcher;
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -48,17 +48,17 @@ public interface CentralDogma {
     /**
      * Creates a project.
      */
-    CompletableFuture<Void> createProject(String name);
+    CompletableFuture<Void> createProject(String projectName);
 
     /**
      * Removes a project. A removed project can be unremoved using {@link #unremoveProject(String)}.
      */
-    CompletableFuture<Void> removeProject(String name);
+    CompletableFuture<Void> removeProject(String projectName);
 
     /**
      * Unremoves a project.
      */
-    CompletableFuture<Void> unremoveProject(String name);
+    CompletableFuture<Void> unremoveProject(String projectName);
 
     /**
      * Retrieves the list of the projects.

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/RepositoryInfo.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/RepositoryInfo.java
@@ -20,22 +20,25 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.centraldogma.common.Commit;
+import com.linecorp.centraldogma.common.Revision;
 
 /**
  * An immutable holder of repository information.
  */
 public final class RepositoryInfo {
 
+    // TODO(trustin): Add createdAt and creator property once we remove the Thrift API.
+
     private final String name;
-    private final Commit lastCommit;
+    private final Revision headRevision;
 
     /**
-     * Creates a new instance with the specified repository name and the last {@link Commit} of the repository.
+     * Creates a new instance with the specified repository name and the latest {@link Revision} of the
+     * repository.
      */
-    public RepositoryInfo(String name, Commit lastCommit) {
+    public RepositoryInfo(String name, Revision headRevision) {
         this.name = requireNonNull(name, "name");
-        this.lastCommit = requireNonNull(lastCommit, "lastCommit");
+        this.headRevision = requireNonNull(headRevision, "headRevision");
     }
 
     /**
@@ -46,10 +49,10 @@ public final class RepositoryInfo {
     }
 
     /**
-     * Returns the last {@link Commit} of the repository.
+     * Returns the latest {@link Revision} of the repository.
      */
-    public Commit lastCommit() {
-        return lastCommit;
+    public Revision headRevision() {
+        return headRevision;
     }
 
     @Override
@@ -63,19 +66,19 @@ public final class RepositoryInfo {
         }
 
         final RepositoryInfo that = (RepositoryInfo) o;
-        return name.equals(that.name) && lastCommit.equals(that.lastCommit);
+        return name.equals(that.name) && headRevision.equals(that.headRevision);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode() * 31 + lastCommit.hashCode();
+        return name.hashCode() * 31 + headRevision.hashCode();
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("name", name)
-                          .add("lastCommit", lastCommit)
+                          .add("headRevision", headRevision)
                           .toString();
     }
 }

--- a/common/src/main/java/com/linecorp/centraldogma/common/AuthorizationException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/AuthorizationException.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.common;
+
+/**
+ * A {@link CentralDogmaException} that is raised when a client failed to authenticate or attempted to
+ * perform an unauthorized operation.
+ */
+public class AuthorizationException extends CentralDogmaException {
+
+    private static final long serialVersionUID = 1690947864320539031L;
+
+    /**
+     * Creates a new instance.
+     */
+    public AuthorizationException() {}
+
+    /**
+     * Creates a new instance.
+     */
+    public AuthorizationException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public AuthorizationException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public AuthorizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     * @param writableStackTrace whether or not the stack trace should be writable
+     */
+    public AuthorizationException(String message, boolean writableStackTrace) {
+        super(message, writableStackTrace);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected AuthorizationException(String message, Throwable cause, boolean enableSuppression,
+                                     boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/common/src/main/java/com/linecorp/centraldogma/common/Entry.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Entry.java
@@ -219,7 +219,7 @@ public final class Entry<T> implements ContentHolder<T> {
                           .add("revision", revision.text())
                           .add("path", path)
                           .add("type", type)
-                          .add("content", contentAsText())
+                          .add("content", hasContent() ? contentAsText() : null)
                           .toString();
     }
 }

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -165,7 +165,7 @@ public final class Util {
     }
 
     public static boolean isValidRepositoryName(String repoName) {
-        requireNonNull(repoName, "projectName");
+        requireNonNull(repoName, "repoName");
         return PROJECT_AND_REPO_NAME_PATTERN.matcher(repoName).matches();
     }
 

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.internal;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
@@ -44,6 +45,7 @@ public final class Util {
             "^(?:/[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)+\\.(?i)json$");
     private static final Pattern DIR_PATH_PATTERN = Pattern.compile(
             "^(?:/[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)*/?$");
+    private static final Pattern PATH_PATTERN_PATTERN = Pattern.compile("^[- /*_.,0-9a-zA-Z]+$");
     private static final Pattern EMAIL_PATTERN = Pattern.compile(
             "^[_A-Za-z0-9-+]+(?:\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(?:\\.[A-Za-z0-9]+)*(?:\\.[A-Za-z]{2,})$");
     private static final Pattern GENERAL_EMAIL_PATTERN = Pattern.compile(
@@ -59,12 +61,9 @@ public final class Util {
 
     public static String validateFileName(String name, String paramName) {
         requireNonNull(name, paramName);
-        if (isValidFileName(name)) {
-            return name;
-        }
-
-        throw new IllegalArgumentException(
-                paramName + ": " + name + " (expected: " + FILE_NAME_PATTERN.pattern() + ')');
+        checkArgument(isValidFileName(name),
+                      "%s: %s (expected: %s)", paramName, name, FILE_NAME_PATTERN);
+        return name;
     }
 
     public static boolean isValidFileName(String name) {
@@ -74,12 +73,9 @@ public final class Util {
 
     public static String validateFilePath(String path, String paramName) {
         requireNonNull(path, paramName);
-        if (isValidFilePath(path)) {
-            return path;
-        }
-
-        throw new IllegalArgumentException(
-                paramName + ": " + path + " (expected: " + FILE_PATH_PATTERN.pattern() + ')');
+        checkArgument(isValidFilePath(path),
+                      "%s: %s (expected: %s)", paramName, path, FILE_PATH_PATTERN);
+        return path;
     }
 
     public static boolean isValidFilePath(String path) {
@@ -90,12 +86,9 @@ public final class Util {
 
     public static String validateJsonFilePath(String path, String paramName) {
         requireNonNull(path, paramName);
-        if (isValidJsonFilePath(path)) {
-            return path;
-        }
-
-        throw new IllegalArgumentException(
-                paramName + ": " + path + " (expected: " + JSON_FILE_PATH_PATTERN.pattern() + ')');
+        checkArgument(isValidJsonFilePath(path),
+                      "%s: %s (expected: %s)", paramName, path, JSON_FILE_PATH_PATTERN);
+        return path;
     }
 
     public static boolean isValidJsonFilePath(String path) {
@@ -106,10 +99,8 @@ public final class Util {
 
     public static String validateJsonPath(String jsonPath, String paramName) {
         requireNonNull(jsonPath, paramName);
-        if (!isValidJsonPath(jsonPath)) {
-            throw new IllegalArgumentException(paramName + " is invalid JSON path: " + jsonPath);
-        }
-
+        checkArgument(isValidJsonPath(jsonPath),
+                      "%s: %s (expected: a valid JSON path)", paramName, jsonPath);
         return jsonPath;
     }
 
@@ -124,38 +115,9 @@ public final class Util {
 
     public static String validateDirPath(String path, String paramName) {
         requireNonNull(path, paramName);
-        if (isValidDirPath(path)) {
-            return path;
-        }
-
-        throw new IllegalArgumentException(
-                paramName + ": " + path + " (expected: " + DIR_PATH_PATTERN.pattern() + ')');
-    }
-
-    public static boolean isValidProjectName(String projectName) {
-        requireNonNull(projectName, "projectName");
-        return PROJECT_AND_REPO_NAME_PATTERN.matcher(projectName).matches();
-    }
-
-    public static String validateProjectName(String projectName, String paramName) {
-        if (isValidProjectName(projectName)) {
-            return projectName;
-        }
-        throw new IllegalArgumentException(paramName + ": " + projectName +
-                                           " (expected: " + PROJECT_AND_REPO_NAME_PATTERN.pattern() + ')');
-    }
-
-    public static boolean isValidRepositoryName(String repoName) {
-        requireNonNull(repoName, "projectName");
-        return PROJECT_AND_REPO_NAME_PATTERN.matcher(repoName).matches();
-    }
-
-    public static String validateRepositoryName(String repoName, String paramName) {
-        if (isValidRepositoryName(repoName)) {
-            return repoName;
-        }
-        throw new IllegalArgumentException(paramName + ": " + repoName +
-                                           " (expected: " + PROJECT_AND_REPO_NAME_PATTERN.pattern() + ')');
+        checkArgument(isValidDirPath(path),
+                      "%s: %s (expected: %s)", paramName, path, DIR_PATH_PATTERN);
+        return path;
     }
 
     public static boolean isValidDirPath(String path) {
@@ -171,8 +133,51 @@ public final class Util {
                DIR_PATH_PATTERN.matcher(path).matches();
     }
 
+    public static String validatePathPattern(String pathPattern, String paramName) {
+        requireNonNull(pathPattern, paramName);
+        checkArgument(isValidPathPattern(pathPattern),
+                      "%s: %s (expected: %s)", paramName, pathPattern, PATH_PATTERN_PATTERN);
+        return pathPattern;
+    }
+
+    public static boolean isValidPathPattern(String pathPattern) {
+        requireNonNull(pathPattern, "pathPattern");
+        return PATH_PATTERN_PATTERN.matcher(pathPattern).matches();
+    }
+
+    public static String validateProjectName(String projectName, String paramName) {
+        requireNonNull(projectName, paramName);
+        checkArgument(isValidProjectName(projectName),
+                      "%s: %s (expected: %s)", paramName, projectName, PROJECT_AND_REPO_NAME_PATTERN);
+        return projectName;
+    }
+
+    public static boolean isValidProjectName(String projectName) {
+        requireNonNull(projectName, "projectName");
+        return PROJECT_AND_REPO_NAME_PATTERN.matcher(projectName).matches();
+    }
+
+    public static String validateRepositoryName(String repoName, String paramName) {
+        requireNonNull(repoName, paramName);
+        checkArgument(isValidRepositoryName(repoName),
+                      "%s: %s (expected: %s)", paramName, repoName, PROJECT_AND_REPO_NAME_PATTERN);
+        return repoName;
+    }
+
+    public static boolean isValidRepositoryName(String repoName) {
+        requireNonNull(repoName, "projectName");
+        return PROJECT_AND_REPO_NAME_PATTERN.matcher(repoName).matches();
+    }
+
+    public static String validateEmailAddress(String emailAddr, String paramName) {
+        requireNonNull(emailAddr, paramName);
+        checkArgument(isValidEmailAddress(emailAddr),
+                      "%s: %s (expected: a valid e-mail address)", paramName, emailAddr);
+        return emailAddr;
+    }
+
     public static boolean isValidEmailAddress(String emailAddr) {
-        requireNonNull(emailAddr);
+        requireNonNull(emailAddr, "emailAddr");
         if (EMAIL_PATTERN.matcher(emailAddr).matches()) {
             return true;
         }
@@ -184,17 +189,6 @@ public final class Util {
                    isValidIpV6Address(domainPart);
         }
         return false;
-    }
-
-    public static String validateEmailAddress(String emailAddr, String paramName) {
-        requireNonNull(emailAddr, paramName);
-        if (isValidEmailAddress(emailAddr)) {
-            return emailAddr;
-        }
-
-        throw new IllegalArgumentException(
-                paramName + ": " + emailAddr +
-                " (expected: " + EMAIL_PATTERN.pattern() + " or IP address domain)");
     }
 
     public static String toEmailAddress(String emailAddr, String paramName) {

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.centraldogma.internal.api.v1;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.CONTENTS;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
@@ -27,7 +26,6 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.node.NullNode;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.centraldogma.common.EntryType;
@@ -46,11 +44,7 @@ public class EntryDto<T> {
     public EntryDto(String path, EntryType type, String projectName, String repoName, @Nullable T content) {
         this.path = requireNonNull(path, "path");
         this.type = requireNonNull(type, "type");
-        if (content instanceof NullNode || (content instanceof String && isNullOrEmpty((String) content))) {
-            this.content = null;
-        } else {
-            this.content = content;
-        }
+        this.content = content;
         url = PROJECTS_PREFIX + '/' + projectName + REPOS + '/' + repoName + CONTENTS + path;
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/AbstractMultiClientTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/AbstractMultiClientTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.it;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Collection;
+import java.util.EnumSet;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+@RunWith(Parameterized.class)
+public abstract class AbstractMultiClientTest {
+
+    @Parameters(name = "{index}: {0}")
+    public static Collection<ClientType> clientTypes() {
+        return EnumSet.allOf(ClientType.class);
+    }
+
+    private final ClientType clientType;
+
+    AbstractMultiClientTest(ClientType clientType) {
+        this.clientType = clientType;
+    }
+
+    final CentralDogma client() {
+        CentralDogmaRule rule = null;
+        for (Field f : getClass().getDeclaredFields()) {
+            if (CentralDogmaRule.class.isAssignableFrom(f.getType())) {
+                f.setAccessible(true);
+                try {
+                    rule = (CentralDogmaRule) ((f.getModifiers() & Modifier.STATIC) != 0 ? f.get(null)
+                                                                                         : f.get(this));
+                } catch (Exception ignored) {
+                    // Failed to get the field.
+                }
+                break;
+            }
+        }
+
+        checkState(rule != null, "could not find a CentralDogmaRule field");
+        return clientType.client(rule);
+    }
+
+    final ClientType clientType() {
+        return clientType;
+    }
+}

--- a/it/src/test/java/com/linecorp/centraldogma/it/ClientType.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/ClientType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it;
+
+import java.util.function.Function;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+enum ClientType {
+    DEFAULT(CentralDogmaRule::client),
+    LEGACY(CentralDogmaRule::legacyClient);
+
+    private final Function<CentralDogmaRule, CentralDogma> clientFactory;
+
+    ClientType(Function<CentralDogmaRule, CentralDogma> clientFactory) {
+        this.clientFactory = clientFactory;
+    }
+
+    CentralDogma client(CentralDogmaRule rule) {
+        return clientFactory.apply(rule);
+    }
+}

--- a/it/src/test/java/com/linecorp/centraldogma/it/FileHistoryAndDiffTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/FileHistoryAndDiffTest.java
@@ -21,10 +21,14 @@ import org.junit.Test;
 
 import com.linecorp.centraldogma.common.Revision;
 
-public class FileHistoryAndDiffTest {
+public class FileHistoryAndDiffTest extends AbstractMultiClientTest {
 
     @ClassRule
     public static final CentralDogmaRuleWithScaffolding rule = new CentralDogmaRuleWithScaffolding();
+
+    public FileHistoryAndDiffTest(ClientType clientType) {
+        super(clientType);
+    }
 
     // getHistory
     // getDiff
@@ -33,7 +37,7 @@ public class FileHistoryAndDiffTest {
     public void testGetHistory() throws Exception {
         // TODO(trustin): Implement me.
         System.err.println(
-                rule.client().getHistory(rule.project(), rule.repo1(),
-                                         new Revision(1), Revision.HEAD, "/**").join());
+                client().getHistory(rule.project(), rule.repo1(),
+                                    new Revision(1), Revision.HEAD, "/**").join());
     }
 }

--- a/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
@@ -31,7 +31,7 @@ import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Revision;
 
-public class FileManagementTest {
+public class FileManagementTest extends AbstractMultiClientTest {
 
     private static final String TEST_ROOT = '/' + TestConstants.randomText() + '/';
 
@@ -50,11 +50,15 @@ public class FileManagementTest {
         }
     };
 
+    public FileManagementTest(ClientType clientType) {
+        super(clientType);
+    }
+
     @Test
     public void testGetFiles() throws Exception {
-        final Revision headRev = rule.client().normalizeRevision(
+        final Revision headRev = client().normalizeRevision(
                 rule.project(), rule.repo1(), Revision.HEAD).join();
-        final Map<String, Entry<?>> files = rule.client().getFiles(
+        final Map<String, Entry<?>> files = client().getFiles(
                 rule.project(), rule.repo1(), Revision.HEAD, TEST_ROOT + "*.json").join();
         assertThat(files).hasSize(NUM_FILES);
         files.values().forEach(f -> {
@@ -66,7 +70,7 @@ public class FileManagementTest {
     @Test
     public void testGetFilesWithDirectory() throws Exception {
         final String testRootWithoutSlash = TEST_ROOT.substring(0, TEST_ROOT.length() - 1);
-        final Map<String, Entry<?>> files = rule.client().getFiles(
+        final Map<String, Entry<?>> files = client().getFiles(
                 rule.project(), rule.repo1(), Revision.HEAD,
                 testRootWithoutSlash + ", " + TEST_ROOT + '*').join();
 
@@ -87,7 +91,7 @@ public class FileManagementTest {
 
     @Test
     public void testListFiles() throws Exception {
-        final Map<String, EntryType> files = rule.client().listFiles(
+        final Map<String, EntryType> files = client().listFiles(
                 rule.project(), rule.repo1(), Revision.HEAD, TEST_ROOT + "*.json").join();
         assertThat(files).hasSize(NUM_FILES);
         files.values().forEach(t -> assertThat(t).isEqualTo(EntryType.JSON));

--- a/it/src/test/java/com/linecorp/centraldogma/it/GetFileTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/GetFileTest.java
@@ -31,14 +31,18 @@ import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
 
-public class GetFileTest {
+public class GetFileTest extends AbstractMultiClientTest {
 
     @ClassRule
     public static final CentralDogmaRuleWithScaffolding rule = new CentralDogmaRuleWithScaffolding();
 
+    public GetFileTest(ClientType clientType) {
+        super(clientType);
+    }
+
     @Test
     public void testInvalidJsonPath() {
-        assertThatThrownBy(() -> rule.client().getFile(
+        assertThatThrownBy(() -> client().getFile(
                 rule.project(), rule.repo1(), Revision.HEAD,
                 Query.ofJsonPath("/test/test2.json", "$.non_exist_path")).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(QueryExecutionException.class);
@@ -47,7 +51,7 @@ public class GetFileTest {
     @Test
     public void testInvalidFile() throws Exception {
         assertThatThrownByWithExpectedException(EntryNotFoundException.class, "non_existing_file", () ->
-                rule.client().getFile(rule.project(), rule.repo1(), Revision.HEAD,
+                client().getFile(rule.project(), rule.repo1(), Revision.HEAD,
                                       Query.ofJsonPath("/test/non_existing_file.json", "$.a")).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(EntryNotFoundException.class);
     }
@@ -55,7 +59,7 @@ public class GetFileTest {
     @Test
     public void testInvalidRepo() throws Exception {
         assertThatThrownByWithExpectedException(RepositoryNotFoundException.class, "non_exist_repo", () ->
-                rule.client().getFile(rule.project(), "non_exist_repo", Revision.HEAD,
+                client().getFile(rule.project(), "non_exist_repo", Revision.HEAD,
                                       Query.ofJsonPath("/test/test2.json", "$.a")).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(RepositoryNotFoundException.class);
     }
@@ -63,7 +67,7 @@ public class GetFileTest {
     @Test
     public void testInvalidProject() throws Exception {
         assertThatThrownByWithExpectedException(ProjectNotFoundException.class, "non_exist_proj", () ->
-                rule.client().getFile("non_exist_proj", rule.repo1(), Revision.HEAD,
+                client().getFile("non_exist_proj", rule.repo1(), Revision.HEAD,
                                       Query.ofJsonPath("/test/test2.json", "$.non_exist_path")).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(ProjectNotFoundException.class);
     }

--- a/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.it;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.MergeQuery;
+import com.linecorp.centraldogma.common.MergeSource;
+import com.linecorp.centraldogma.common.MergedEntry;
+import com.linecorp.centraldogma.common.QueryExecutionException;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.testing.CentralDogmaRule;
+
+public class MergeFileTest extends AbstractMultiClientTest {
+
+    @Rule
+    public final CentralDogmaRule rule = new CentralDogmaRule() {
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("myPro").join();
+            client.createRepository("myPro", "myRepo").join();
+            client.push("myPro", "myRepo", Revision.HEAD, "Initial files",
+                        Change.ofJsonUpsert("/foo.json", "{ \"a\": \"bar\" }"),
+                        Change.ofJsonUpsert("/foo1.json", "{ \"b\": \"baz\" }"),
+                        Change.ofJsonUpsert("/foo2.json", "{ \"a\": \"new_bar\" }")).join();
+        }
+    };
+
+    public MergeFileTest(ClientType clientType) {
+        super(clientType);
+    }
+
+    @Test
+    public void mergeJsonFiles() {
+        final MergedEntry<?> merged = client().mergeFiles("myPro", "myRepo", Revision.HEAD,
+                                                          MergeSource.ofRequired("/foo.json"),
+                                                          MergeSource.ofRequired("/foo1.json"),
+                                                          MergeSource.ofRequired("/foo2.json"),
+                                                          MergeSource.ofOptional("/foo3.json")).join();
+
+        assertThat(merged.paths()).containsExactly("/foo.json", "/foo1.json","/foo2.json");
+        assertThat(merged.revision()).isEqualTo(new Revision(2));
+        assertThatJson(merged.content()).isEqualTo("{ \"a\": \"new_bar\", \"b\": \"baz\" }");
+
+        assertThatThrownBy(() -> client().mergeFiles("myPro", "myRepo", Revision.HEAD,
+                                                     MergeSource.ofRequired("/foo.json"),
+                                                     MergeSource.ofRequired("/foo1.json"),
+                                                     MergeSource.ofRequired("/foo2.json"),
+                                                     MergeSource.ofRequired("/foo3.json")).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(EntryNotFoundException.class);
+    }
+
+    @Test
+    public void exceptionWhenOnlyOptionalFilesAndDoNotExist() {
+        assertThatThrownBy(() -> client().mergeFiles("myPro", "myRepo", Revision.HEAD,
+                                                     MergeSource.ofOptional("/non_existent1.json"),
+                                                     MergeSource.ofRequired("/non_existent2.json")).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(EntryNotFoundException.class);
+    }
+
+    @Test
+    public void mismatchedValueWhileMerging() {
+        client().push("myPro", "myRepo", Revision.HEAD, "Add /foo10.json",
+                      Change.ofJsonUpsert("/foo10.json", "{ \"a\": 1 }")).join();
+
+        final String queryString = "path=/foo.json" + '&' +
+                                   "path=/foo1.json" + '&' +
+                                   "path=/foo2.json" + '&' +
+                                   "path=/foo10.json";
+
+        assertThatThrownBy(() -> client().mergeFiles("myPro", "myRepo", Revision.HEAD,
+                                                     MergeSource.ofRequired("/foo.json"),
+                                                     MergeSource.ofRequired("/foo1.json"),
+                                                     MergeSource.ofRequired("/foo2.json"),
+                                                     MergeSource.ofRequired("/foo10.json")).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(QueryExecutionException.class);
+    }
+
+    @Test
+    public void mergeJsonPaths() {
+        final MergeQuery<JsonNode> query = MergeQuery.ofJsonPath(
+                ImmutableList.of(MergeSource.ofRequired("/foo.json"),
+                                 MergeSource.ofRequired("/foo1.json"),
+                                 MergeSource.ofRequired("/foo2.json")),
+                "$[?(@.b == \"baz\")]",
+                "$[0].b");
+
+        final MergedEntry<?> merged = client().mergeFiles("myPro", "myRepo", Revision.HEAD, query).join();
+
+        assertThat(merged.paths()).containsExactly("/foo.json", "/foo1.json","/foo2.json");
+        assertThat(merged.revision()).isEqualTo(new Revision(2));
+        assertThatJson(merged.content()).isStringEqualTo("baz");
+
+        final MergeQuery<JsonNode> badQuery = MergeQuery.ofJsonPath(
+                ImmutableList.of(MergeSource.ofRequired("/foo.json"),
+                                 MergeSource.ofRequired("/foo1.json"),
+                                 MergeSource.ofRequired("/foo2.json")),
+                "$.c");
+
+        assertThatThrownBy(() -> client().mergeFiles("myPro", "myRepo", Revision.HEAD, badQuery).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(QueryExecutionException.class);
+    }
+}

--- a/it/src/test/java/com/linecorp/centraldogma/it/RevisionNormalizationTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RevisionNormalizationTest.java
@@ -27,10 +27,14 @@ import org.junit.Test;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 
-public class RevisionNormalizationTest {
+public class RevisionNormalizationTest extends AbstractMultiClientTest {
 
     @ClassRule
     public static final CentralDogmaRuleWithScaffolding rule = new CentralDogmaRuleWithScaffolding();
+
+    public RevisionNormalizationTest(ClientType clientType) {
+        super(clientType);
+    }
 
     /**
      * Ensure that the absolute major revision numbers are returned as-is.
@@ -38,7 +42,7 @@ public class RevisionNormalizationTest {
     @Test
     public void testAbsoluteMajor() throws Exception {
         final Revision expected = new Revision(1);
-        final Revision actual = rule.client().normalizeRevision(rule.project(), rule.repo1(), expected).join();
+        final Revision actual = client().normalizeRevision(rule.project(), rule.repo1(), expected).join();
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -49,13 +53,13 @@ public class RevisionNormalizationTest {
     public void testAbsoluteMajorOutOfRange() throws Exception {
         final Revision outOfRange = new Revision(Integer.MAX_VALUE);
         assertThatThrownByWithExpectedException(RevisionNotFoundException.class, "2147483647", () ->
-                rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
+                client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(RevisionNotFoundException.class);
     }
 
     @Test
     public void testRelativeMajor() throws Exception {
-        final Revision actual = rule.client().normalizeRevision(
+        final Revision actual = client().normalizeRevision(
                 rule.project(), rule.repo1(), Revision.HEAD).join();
         assertThat(actual.isRelative()).isFalse();
     }
@@ -67,7 +71,7 @@ public class RevisionNormalizationTest {
     public void testRelativeMajorOutOfRange() throws Exception {
         final Revision outOfRange = new Revision(Integer.MIN_VALUE);
         assertThatThrownByWithExpectedException(RevisionNotFoundException.class, "-2147483648", () ->
-                rule.client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
+                client().normalizeRevision(rule.project(), rule.repo1(), outOfRange).join())
                 .isInstanceOf(CompletionException.class).hasCauseInstanceOf(RevisionNotFoundException.class);
     }
 }

--- a/server-auth/webapp/src/react-app-env.d.ts
+++ b/server-auth/webapp/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -413,6 +413,7 @@ public class CentralDogma implements AutoCloseable {
     private Server startServer(ProjectManager pm, CommandExecutor executor,
                                @Nullable SessionManager sessionManager) {
         final ServerBuilder sb = new ServerBuilder();
+        sb.verboseResponses(true);
         cfg.ports().forEach(sb::port);
 
         if (cfg.ports().stream().anyMatch(ServerPort::hasTls)) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -511,7 +511,7 @@ public class CentralDogma implements AutoCloseable {
                         new DocServiceBuilder().exampleHttpHeaders(
                                 CentralDogmaService.class,
                                 HttpHeaders.of(HttpHeaderNames.AUTHORIZATION,
-                                               "bearer " + CsrfToken.ANONYMOUS))
+                                               "Bearer " + CsrfToken.ANONYMOUS))
                                                .build());
 
         configureHttpApi(sb, pm, executor, watchService, mds, authProvider, sessionManager);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -207,7 +207,6 @@ public class ContentServiceV1 extends AbstractService {
      * <p>Previews the actual changes which will be resulted by the given changes.
      */
     @Post("/projects/{projectName}/repos/{repoName}/preview")
-    @RequiresReadPermission
     public CompletableFuture<Iterable<ChangeDto<?>>> preview(
             @Param("revision") @Default("-1") String revision,
             Repository repository,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -23,8 +23,6 @@ import static com.linecorp.centraldogma.internal.Util.isValidDirPath;
 import static com.linecorp.centraldogma.internal.Util.isValidFilePath;
 import static com.linecorp.centraldogma.server.internal.api.DtoConverter.convert;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.returnOrThrow;
-import static com.linecorp.centraldogma.server.internal.storage.repository.FindOptions.FIND_ALL_WITHOUT_CONTENT;
-import static com.linecorp.centraldogma.server.internal.storage.repository.Repository.DEFAULT_MAX_COMMITS;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
@@ -37,7 +35,6 @@ import java.util.function.Function;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -59,6 +56,7 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionRange;
+import com.linecorp.centraldogma.internal.api.v1.ChangeDto;
 import com.linecorp.centraldogma.internal.api.v1.CommitMessageDto;
 import com.linecorp.centraldogma.internal.api.v1.EntryDto;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
@@ -75,6 +73,7 @@ import com.linecorp.centraldogma.server.internal.command.Command;
 import com.linecorp.centraldogma.server.internal.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.internal.storage.repository.FindOption;
+import com.linecorp.centraldogma.server.internal.storage.repository.FindOptions;
 import com.linecorp.centraldogma.server.internal.storage.repository.Repository;
 
 /**
@@ -104,13 +103,15 @@ public class ContentServiceV1 extends AbstractService {
                                                           Repository repository) {
         final String normalizedPath = normalizePath(path);
         final CompletableFuture<List<EntryDto<?>>> future = new CompletableFuture<>();
-        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)),
-                  FIND_ALL_WITHOUT_CONTENT, future);
+        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)), false, future);
         return future;
     }
 
     private static void listFiles(Repository repository, String pathPattern, Revision normalizedRevision,
-                                  Map<FindOption<?>, ?> options, CompletableFuture<List<EntryDto<?>>> result) {
+                                  boolean withContent, CompletableFuture<List<EntryDto<?>>> result) {
+        final Map<FindOption<?>, ?> options = withContent ? FindOptions.FIND_ALL_WITH_CONTENT
+                                                          : FindOptions.FIND_ALL_WITHOUT_CONTENT;
+
         repository.find(normalizedRevision, pathPattern, options).handle((entries, thrown) -> {
             if (thrown != null) {
                 result.completeExceptionally(thrown);
@@ -121,10 +122,10 @@ public class ContentServiceV1 extends AbstractService {
             // This is called once at most, because the pathPattern is not a valid file path anymore.
             if (isValidFilePath(pathPattern) && entries.size() == 1 &&
                 entries.values().iterator().next().type() == DIRECTORY) {
-                listFiles(repository, pathPattern + "/*", normalizedRevision, options, result);
+                listFiles(repository, pathPattern + "/*", normalizedRevision, withContent, result);
             } else {
                 result.complete(entries.values().stream()
-                                       .map(entry -> convert(repository, entry))
+                                       .map(entry -> convert(repository, entry, withContent))
                                        .collect(toImmutableList()));
             }
             return null;
@@ -159,11 +160,11 @@ public class ContentServiceV1 extends AbstractService {
     /**
      * POST /projects/{projectName}/repos/{repoName}/contents?revision={revision}
      *
-     * <p>Adds or edits a file.
+     * <p>Pushes a commit.
      */
     @Post("/projects/{projectName}/repos/{repoName}/contents")
     @RequiresWritePermission
-    public CompletableFuture<PushResultDto> commit(
+    public CompletableFuture<PushResultDto> push(
             @Param("revision") @Default("-1") String revision,
             Repository repository,
             Author author,
@@ -176,11 +177,11 @@ public class ContentServiceV1 extends AbstractService {
                 repository.previewDiff(normalizedRevision, changes);
 
         return changesFuture.thenCompose(previewDiffs -> {
-            final long commitTimeMillis = System.currentTimeMillis();
             if (previewDiffs.isEmpty()) {
                 throw new RedundantChangeException();
             }
 
+            final long commitTimeMillis = System.currentTimeMillis();
             return push(commitTimeMillis, author, repository, normalizedRevision,
                         commitMessage, previewDiffs.values())
                     .toCompletableFuture()
@@ -198,6 +199,28 @@ public class ContentServiceV1 extends AbstractService {
         return execute(Command.push(
                 commitTimeMills, author, repository.parent().name(), repository.name(),
                 revision, summary, detail, markup, changes));
+    }
+
+    /**
+     * POST /projects/{projectName}/repos/{repoName}/preview?revision={revision}
+     *
+     * <p>Previews the actual changes which will be resulted by the given changes.
+     */
+    @Post("/projects/{projectName}/repos/{repoName}/preview")
+    @RequiresReadPermission
+    public CompletableFuture<Iterable<ChangeDto<?>>> preview(
+            @Param("revision") @Default("-1") String revision,
+            Repository repository,
+            @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
+
+        final Revision normalizedRevision = repository.normalizeNow(new Revision(revision));
+
+        final CompletableFuture<Map<String, Change<?>>> changesFuture =
+                repository.previewDiff(normalizedRevision, changes);
+
+        return changesFuture.thenApply(previewDiffs -> previewDiffs.values().stream()
+                                                                   .map(DtoConverter::convert)
+                                                                   .collect(toImmutableList()));
     }
 
     /**
@@ -234,13 +257,12 @@ public class ContentServiceV1 extends AbstractService {
         if (query.isPresent()) {
             // get a file
             return repository.get(new Revision(revision), query.get())
-                             .handle(returnOrThrow((Entry<?> result) -> convert(repository, result)));
+                             .handle(returnOrThrow((Entry<?> result) -> convert(repository, result, true)));
         }
 
         // get files
         final CompletableFuture<List<EntryDto<?>>> future = new CompletableFuture<>();
-        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)),
-                  ImmutableMap.of(), future);
+        listFiles(repository, normalizedPath, repository.normalizeNow(new Revision(revision)), true, future);
         return future;
     }
 
@@ -251,7 +273,7 @@ public class ContentServiceV1 extends AbstractService {
 
         return future.thenApply(entry -> {
             final Revision revision = entry.revision();
-            final EntryDto<?> entryDto = convert(repository, entry);
+            final EntryDto<?> entryDto = convert(repository, entry, true);
             return (Object) new WatchResultDto(revision, entryDto);
         }).exceptionally(ContentServiceV1::handleWatchFailure);
     }
@@ -303,8 +325,8 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         final RevisionRange range = repository.normalizeNow(fromRevision, toRevision).toDescending();
-        final int maxCommits0 = maxCommits.map(integer -> Math.min(integer, DEFAULT_MAX_COMMITS))
-                                          .orElse(DEFAULT_MAX_COMMITS);
+        final int maxCommits0 = maxCommits.map(integer -> Math.min(integer, Repository.DEFAULT_MAX_COMMITS))
+                                          .orElse(Repository.DEFAULT_MAX_COMMITS);
         return repository
                 .history(range.from(), range.to(), normalizePath(path), maxCommits0)
                 .thenApply(commits -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -58,9 +58,9 @@ final class DtoConverter {
                                  repository.creationTimeMillis());
     }
 
-    public static <T> EntryDto<T> convert(Repository repository, Entry<T> entry) {
+    public static <T> EntryDto<T> convert(Repository repository, Entry<T> entry, boolean withContent) {
         requireNonNull(entry, "entry");
-        if (entry.hasContent()) {
+        if (withContent && entry.hasContent()) {
             return convert(repository, entry.path(), entry.type(), entry.content());
         }
         return convert(repository, entry.path(), entry.type());

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -41,10 +41,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
+import com.linecorp.armeria.common.stream.AbortedStreamException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.Jackson;
 
 /**
@@ -172,7 +174,10 @@ public final class HttpApiUtil {
         //                 the stack trace of the cause to the trusted client.
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
             if (cause != null) {
-                logger.warn("{} Returning an internal server error: {}", ctx, m, cause);
+                if (!(cause instanceof ShuttingDownException ||
+                      cause instanceof AbortedStreamException)) {
+                    logger.warn("{} Returning an internal server error: {}", ctx, m, cause);
+                }
             } else {
                 logger.warn("{} Returning an internal server error: {}", ctx, m);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/PathPatternFilter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/PathPatternFilter.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
-import static java.util.Objects.requireNonNull;
+import static com.linecorp.centraldogma.internal.Util.validatePathPattern;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,7 @@ final class PathPatternFilter extends TreeFilter {
     private final String pathPattern;
 
     private PathPatternFilter(String pathPattern) {
-        requireNonNull(pathPattern, "pathPattern");
+        validatePathPattern(pathPattern, "pathPattern");
 
         final String[] pathPatterns = SPLIT.split(pathPattern);
         final StringBuilder pathPatternBuf = new StringBuilder(pathPattern.length());

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -45,6 +45,7 @@ import com.linecorp.centraldogma.internal.thrift.Entry;
 import com.linecorp.centraldogma.internal.thrift.ErrorCode;
 import com.linecorp.centraldogma.internal.thrift.GetFileResult;
 import com.linecorp.centraldogma.internal.thrift.MergeQuery;
+import com.linecorp.centraldogma.internal.thrift.MergedEntry;
 import com.linecorp.centraldogma.internal.thrift.NamedQuery;
 import com.linecorp.centraldogma.internal.thrift.Plugin;
 import com.linecorp.centraldogma.internal.thrift.Project;
@@ -307,7 +308,11 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     public void mergeFiles(String projectName, String repositoryName, Revision revision,
                            MergeQuery mergeQuery, AsyncMethodCallback resultHandler) {
         handle(projectManager.get(projectName).repos().get(repositoryName)
-                             .mergeFiles(convert(revision), convert(mergeQuery)),
+                             .mergeFiles(convert(revision), convert(mergeQuery))
+                             .thenApply(merged -> new MergedEntry(convert(merged.revision()),
+                                                                  convert(merged.type()),
+                                                                  merged.contentAsText(),
+                                                                  merged.paths())),
                resultHandler);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
@@ -84,7 +84,7 @@ public class ContentCompressionTest {
         // Should fail to decode without the decompressor.
         final Iface clientWithoutDecompressor = new ClientBuilder(
                 "ttext+http://127.0.0.1:" + rule.serverAddress().getPort() + "/cd/thrift/v1")
-                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
+                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS)
                 .setHttpHeader(HttpHeaderNames.ACCEPT_ENCODING, "deflate")
                 .build(Iface.class);
 
@@ -107,7 +107,7 @@ public class ContentCompressionTest {
     public void http() throws Exception {
         final HttpClient client = new HttpClientBuilder(
                 "http://127.0.0.1:" + rule.serverAddress().getPort())
-                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
+                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS)
                 .setHttpHeader(HttpHeaderNames.ACCEPT_ENCODING, "deflate")
                 .build();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -48,7 +48,7 @@ public class AdministrativeServiceTest {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous").build();
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1TestBase.java
@@ -52,7 +52,7 @@ public class ContentServiceV1TestBase {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous").build();
 
         // the default project used for unit tests
         HttpHeaders headers = HttpHeaders.of(HttpMethod.POST, "/api/v1/projects").contentType(MediaType.JSON);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -47,7 +47,7 @@ public class ListCommitsAndDiffTest {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous").build();
 
         // the default project used for unit tests
         HttpHeaders headers = HttpHeaders.of(HttpMethod.POST, "/api/v1/projects").contentType(MediaType.JSON);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -56,7 +56,7 @@ public class ProjectServiceV1Test {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous").build();
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -61,7 +61,7 @@ public class RepositoryServiceV1Test {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
         httpClient = new HttpClientBuilder(serverUri)
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer anonymous").build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous").build();
 
         // the default project used for unit tests
         final String body = "{\"name\": \"myPro\"}";

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -209,7 +209,7 @@ public class PermissionTest {
     @Test
     public void test() {
         final HttpClient client = new HttpClientBuilder(rule.uri("/"))
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + secret).build();
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + secret).build();
 
         AggregatedHttpMessage response;
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -67,11 +67,11 @@ public class ThriftBackwardCompatibilityTest {
     public static void init() {
         final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
         httpClient = new HttpClientBuilder("http://127.0.0.1:" + serverAddress.getPort())
-                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
+                .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS)
                 .build();
 
         client = new ClientBuilder("ttext+http://127.0.0.1:" + serverAddress.getPort() + "/cd/thrift/v1")
-                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "bearer " + CsrfToken.ANONYMOUS)
+                .setHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS)
                 .build(Iface.class);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
@@ -143,7 +143,7 @@ public class TokenlessClientLoggerTest {
 
     private static HttpRequest newRequestWithToken() {
         return HttpRequest.of(HttpHeaders.of(HttpMethod.GET, "/")
-                                         .set(HttpHeaderNames.AUTHORIZATION, "bearer anonymous"));
+                                         .set(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous"));
     }
 
     private static HttpRequest newRequestWithoutToken() {

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -22,7 +22,7 @@ Gradle:
     ...
     dependencies {
         ...
-        compile 'com.linecorp.centraldogma:centraldogma-client-armeria-legacy:\ |release|\ '
+        compile 'com.linecorp.centraldogma:centraldogma-client-armeria:\ |release|\ '
         ...
     }
     ...
@@ -37,7 +37,7 @@ Maven:
       ...
       <dependency>
         <groupId>com.linecorp.centraldogma</groupId>
-        <artifactId>centraldogma-client-armeria-legacy</artifactId>
+        <artifactId>centraldogma-client-armeria</artifactId>
         <version>\ |release|\ </version>
       </dependency>
       ...
@@ -51,14 +51,14 @@ First, we should create a new instance of :api:`com.linecorp.centraldogma.client
 .. code-block:: java
 
     import com.linecorp.centraldogma.client.CentralDogma;
-    import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
+    import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 
     // The default port 36462 is used if unspecified.
-    CentralDogma dogma = new LegacyCentralDogmaBuilder()
+    CentralDogma dogma = new ArmeriaCentralDogmaBuilder()
             .host("127.0.0.1")
             .build();
     // You can specify an alternative port or enable TLS as well:
-    CentralDogma dogma2 = new LegacyCentralDogmaBuilder()
+    CentralDogma dogma2 = new ArmeriaCentralDogmaBuilder()
             .useTls()                   // Enable TLS.
             .host("example.com", 8443); // Use port 8443.
             .build();
@@ -67,6 +67,22 @@ First, we should create a new instance of :api:`com.linecorp.centraldogma.client
 
     Internally, the client uses `Armeria`_ as its networking layer. You may want to customize the client
     settings, such as specifying alternative Armeria ``ClientFactory`` or configuring Armeria ``ClientBuilder``.
+
+Specifying an access token
+--------------------------
+You must specify an access token if your Central Dogma server has enabled authorization.
+
+.. code-block:: java
+
+    CentralDogma dogma = new ArmeriaCentralDogmaBuilder()
+            .host("127.0.0.1")
+            .accessToken("appToken-cffed349-d573-457f-8f74-4727ad9341ce")
+            .build();
+
+.. note::
+
+    See :ref:`auth` for more information about securing a Central Dogma server and managing permissions and
+    access tokens.
 
 .. _getting-a-file:
 
@@ -331,9 +347,9 @@ You can also specify more than one host using the ``host()`` method:
 
 .. code-block:: java
 
-    import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
+    import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 
-    LegacyCentralDogmaBuilder builder = new LegacyCentralDogmaBuilder();
+    ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
     // The default port 36462 is used if unspecified.
     builder.host("replica1.example.com");
     // You can specify an alternative port number.
@@ -345,14 +361,14 @@ You can also specify more than one host using the ``host()`` method:
 Using client profiles
 ---------------------
 You can load the list of the Central Dogma servers from one of the following JSON files in the class path using
-``LegacyCentralDogmaBuilder.profile(String...)``:
+``ArmeriaCentralDogmaBuilder.profile(String...)``:
 
 - ``centraldogma-profiles-test.json``
 - ``centraldogma-profiles.json`` (if ``centraldogma-profiles-test.json`` is missing)
 
 .. code-block:: java
 
-    LegacyCentralDogmaBuilder builder = new LegacyCentralDogmaBuilder();
+    ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
     // Loads the profile 'beta' from /centraldogma-profiles-test.json or /centraldogma-profiles.json
     builder.profile("beta");
     CentralDogma dogma = builder.build();

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
@@ -62,7 +62,7 @@ public final class TestAuthMessageUtil {
                 HttpHeaders.of(HttpHeaderNames.METHOD, "POST",
                                HttpHeaderNames.PATH, "/api/v1/logout",
                                HttpHeaderNames.AUTHORIZATION,
-                               "bearer " + sessionId)).aggregate().join();
+                               "Bearer " + sessionId)).aggregate().join();
     }
 
     public static AggregatedHttpMessage usersMe(HttpClient client, String sessionId) {
@@ -70,7 +70,7 @@ public final class TestAuthMessageUtil {
                 HttpHeaders.of(HttpHeaderNames.METHOD, "GET",
                                HttpHeaderNames.PATH, "/api/v0/users/me",
                                HttpHeaderNames.AUTHORIZATION,
-                               "bearer " + sessionId)).aggregate().join();
+                               "Bearer " + sessionId)).aggregate().join();
     }
 
     private TestAuthMessageUtil() {}


### PR DESCRIPTION
Motivation:

Thrift support has been deprecated long time ago. We have to provide an
HTTP-based version of Java client for Central Dogma.

Modifications:

- Added `ArmeriaCentralDogma` and its builder.
- Added `AbstractCentralDogma` to share the common code between client
  implementations.
- (Breaking) Replaced `RepositoryInfo.lastCommit` with `headRevision`.
- Added `AuthorizationException` so that a user knows when
  authentication failure or permission error occurred.
- Added `AbstractMultiClientTest` to run the integration tests with the
  new client as well as the legacy one.
  - Needed to update the test code to make it work even if the tests run
    more than once.
- Added a new integration test: `MergeTest`
- Added `CentralDogmaRule.legacyClient()`
  - `CentralDogmaRule.client()` now uses the new client.
- Added `CentralDogmaRule.configureClient(ArmeriaCentralDogmaBuilder)`.
- Updated the documentation to use the new client.
- Various clean up in `LegacyCentralDogma` and its builder:
  - Deprecated `LegacyCentralDogmaBuilder`.
  - Added various client-side parameter validations to
    `LegacyCentralDogma` so that the server does not waste time with bad
    input.
  - Fixed incorrect application order of
    `LegacyCentralDogmaBuilder.clientConfigurator()`, which allowed a
    bad user can specify a different `ClientFactory` than what's
    actually configured.
  - Renamed `CentralDogmaClientTimeoutScheduler` to
    `LegacyCentralDogmaTimeoutScheduler`.
- Miscellaneous:
  - Implemented preview-diff operation for HTTP API v1.
  - Fixed `IllegalStateException` which is raised by `Entry.toString()`
    when an `Entry` has no content.
  - Fixed incorrect conversion from `Entry` to `EntryDto` which occurs
    when an `Entry` content is an empty string or a null node.

Result:

- A user can use the new client based on the HTTP API v1.
- HTTP API v1 now has preview-diff operation.
  - Closes #120
- A user can detect authorization failures using `AuthorizationException`.
- (Breaking) A user has to use `RepositoryInfo.headRevision()` or
  `CentralDogma.getHistory()` because `RepositoryInfo.lastCommit()` is
  gone.
