### PR TITLE
Make webAppTitle fully customizable

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/Main.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/Main.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -241,7 +242,11 @@ public final class Main {
             final int pid = POSIXFactory.getPOSIX().getpid();
             final Path temp = Files.createTempFile("central-dogma", ".tmp");
             Files.write(temp, Integer.toString(pid).getBytes());
-            Files.move(temp, file.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            try {
+                Files.move(temp, file.toPath(), StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temp, file.toPath());
+            }
 
             logger.debug("A PID file has been created: {}", file);
         }

--- a/server/src/main/resources/webapp/i18n/en.main.json
+++ b/server/src/main/resources/webapp/i18n/en.main.json
@@ -1,7 +1,6 @@
 {
   "window": {
-    "title": "Central Dogma",
-    "title_with_hostname": "Central Dogma at {{hostname}}"
+    "title": "Central Dogma"
   },
 
   "navbar": {

--- a/server/src/main/resources/webapp/index.html
+++ b/server/src/main/resources/webapp/index.html
@@ -66,11 +66,11 @@
 <script src="scripts/components/entities/project.service.js"></script>
 <script src="scripts/components/entities/repository.service.js"></script>
 <script src="scripts/components/entities/settings.service.js"></script>
-<script src="scripts/components/hostname/hostname.service.js"></script>
 <script src="scripts/components/language/language.service.js"></script>
 <script src="scripts/components/language/language.controller.js"></script>
 <script src="scripts/components/navbar/navbar.directive.js"></script>
 <script src="scripts/components/navbar/navbar.controller.js"></script>
+<script src="scripts/components/title/title.service.js"></script>
 <script src="scripts/components/user/user.service.js"></script>
 <script src="scripts/components/util/ace-editor.directive.js"></script>
 <script src="scripts/components/util/api.service.js"></script>

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.controller.js
@@ -3,12 +3,12 @@
 angular.module('CentralDogmaAdmin')
     .controller('NavbarController',
                 function ($scope, $rootScope, $state, $q, $uibModal, $window,
-                          Hostname, Principal) {
+                          Title, Principal) {
 
                   $scope.isAuthenticated = Principal.isAuthenticated;
 
-                  Hostname.get().then(function (data) {
+                  Title.get().then(function (data) {
+                    $scope.title = data.title;
                     $scope.hostname = data.hostname;
-                    $scope.title = angular.isDefined(data.title) ? data.title : "";
                   });
                 });

--- a/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
+++ b/server/src/main/resources/webapp/scripts/components/navbar/navbar.html
@@ -8,10 +8,8 @@
         <span class="icon-bar"></span>
       </button>
       <a href="#/" class="navbar-brand">
-        <span ng-hide="hostname" translate>window.title</span>
-        <span ng-show="hostname">{{ 'window.title_with_hostname' |
-                                    translate: "{ hostname: '" + hostname + "' }" }}</span>&#xA0;
-        <span ng-show="title">{{ title }}</span>
+        <span ng-show="title">{{ title |
+                                 translate: "{ hostname: '" + hostname + "' }" }}</span>&#xA0;
       </a>
     </div>
     <div class="collapse navbar-collapse" id="navbar-collapse" ng-switch="isAuthenticated()">

--- a/server/src/main/resources/webapp/scripts/components/title/title.service.js
+++ b/server/src/main/resources/webapp/scripts/components/title/title.service.js
@@ -1,12 +1,12 @@
 'use strict';
 
 angular.module('CentralDogmaAdmin')
-    .factory('Hostname',
+    .factory('Title',
              function ($http, $q) {
                return {
                  get: function() {
                    var deferred = $q.defer();
-                   $http.get('/hostname').then(function (response) {
+                   $http.get('/title').then(function (response) {
                      deferred.resolve(response.data);
                    }, function (response) {
                      deferred.reject(response.status);

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -124,6 +124,8 @@ Core properties
 - ``webAppTitle`` (string)
 
   - the title text which is displayed on the navigation bar of the web-based administrative console.
+    If ``null``, the default value of ``Central Dogma at {{hostname}}`` is used. Note that ``{{hostname}}``
+    will be replaced with the actual hostname that the server is running on.
 
 - ``gracefulShutdownTimeout``
 


### PR DESCRIPTION
Motivation:
A user could configure the title of web-based administrative console by #348. But it is only available to add some text to the end of pre-defined title which is `Central Dogma at ..hostname..`. We think it would be more useful if a user can customize the entire title of the web console.

Modifications:
- Made the entire title of the web console customizable.
  - A user can use ``{{hostname}}`` as a variable of the actual hostname that the server is running on.
- Updated site document.
- Misc
  - Try to move pidfile again silently when it caught `AtomicMoveNotSupportedException`.

Result:
- Closes #43
- Usability.