### PR TITLE
Use the new HTTP-based client for Spring Boot integration

### DIFF
--- a/client/java-spring-boot-autoconfigure/build.gradle
+++ b/client/java-spring-boot-autoconfigure/build.gradle
@@ -1,7 +1,8 @@
 dependencies {
     compile project(':client:java-armeria-legacy')
-    compile 'javax.validation:validation-api'
+    compileOnly 'javax.validation:validation-api'
     compile 'org.springframework.boot:spring-boot-starter'
+    annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
     testCompile project(':client:java-armeria')
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.client.spring;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Qualifier;
@@ -29,6 +30,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Condition;
 import org.springframework.context.annotation.ConditionContext;
@@ -39,16 +41,19 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.core.type.MethodMetadata;
 
+import com.google.common.net.HostAndPort;
+
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.ArmeriaClientConfigurator;
-import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
 
 /**
  * Spring bean configuration for {@link CentralDogma} client.
  */
 @Configuration
 @ConditionalOnMissingBean(CentralDogma.class)
+@EnableConfigurationProperties(CentralDogmaSettings.class)
 public class CentralDogmaClientAutoConfiguration {
 
     /**
@@ -76,15 +81,48 @@ public class CentralDogmaClientAutoConfiguration {
     @Bean
     public CentralDogma client(
             Environment env,
+            CentralDogmaSettings settings,
             @ForCentralDogma ClientFactory clientFactory,
             Optional<ArmeriaClientConfigurator> armeriaClientConfigurator) throws UnknownHostException {
 
-        return new LegacyCentralDogmaBuilder()
-                .clientFactory(clientFactory)
-                .profile(env.getActiveProfiles())
-                .clientConfigurator(cb -> armeriaClientConfigurator.ifPresent(
-                        configurator -> configurator.configure(cb)))
-                .build();
+        final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
+
+        builder.clientFactory(clientFactory);
+        builder.clientConfigurator(cb -> armeriaClientConfigurator.ifPresent(
+                configurator -> configurator.configure(cb)));
+
+        // Set health check interval.
+        final Long healthCheckIntervalMillis = settings.getHealthCheckIntervalMillis();
+        if (healthCheckIntervalMillis != null) {
+            builder.healthCheckIntervalMillis(healthCheckIntervalMillis);
+        }
+
+        // Enable or disable TLS.
+        final Boolean useTls = settings.getUseTls();
+        if (useTls != null) {
+            builder.useTls(useTls);
+        }
+
+        // Set profile or hosts.
+        final String profile = settings.getProfile();
+        final List<String> hosts = settings.getHosts();
+        if (profile != null) {
+            builder.profile(CentralDogmaClientAutoConfiguration.class.getClassLoader(), profile);
+        } else if (hosts != null) {
+            for (String h : hosts) {
+                final HostAndPort hostAndPort = HostAndPort.fromString(h);
+                if (hostAndPort.hasPort()) {
+                    builder.host(hostAndPort.getHost(), hostAndPort.getPort());
+                } else {
+                    builder.host(hostAndPort.getHost());
+                }
+            }
+        } else {
+            // Use the currently active Spring Boot profiles if neither profile nor hosts was specified.
+            builder.profile(env.getActiveProfiles());
+        }
+
+        return builder.build();
     }
 
     /**
@@ -96,6 +134,10 @@ public class CentralDogmaClientAutoConfiguration {
         @Override
         public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
             final ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+            if (beanFactory == null) {
+                return true;
+            }
+
             final String[] beanNames =
                     BeanFactoryUtils.beanNamesForTypeIncludingAncestors(beanFactory, ClientFactory.class);
 

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -111,6 +111,10 @@ public class CentralDogmaClientAutoConfiguration {
         final String profile = settings.getProfile();
         final List<String> hosts = settings.getHosts();
         if (profile != null) {
+            if (hosts != null) {
+                throw new IllegalStateException(
+                        "'hosts' and 'profile' are mutually exclusive. Do not set both of them.");
+            }
             builder.profile(CentralDogmaClientAutoConfiguration.class.getClassLoader(), profile);
         } else if (hosts != null) {
             for (String h : hosts) {

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 import javax.inject.Qualifier;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
@@ -55,6 +57,8 @@ import com.linecorp.centraldogma.client.armeria.ArmeriaClientConfigurator;
 @ConditionalOnMissingBean(CentralDogma.class)
 @EnableConfigurationProperties(CentralDogmaSettings.class)
 public class CentralDogmaClientAutoConfiguration {
+
+    private static final Logger logger = LoggerFactory.getLogger(CentralDogmaClientAutoConfiguration.class);
 
     /**
      * A {@link Qualifier} annotation that tells {@link CentralDogmaClientAutoConfiguration} to use a specific
@@ -119,7 +123,10 @@ public class CentralDogmaClientAutoConfiguration {
             }
         } else {
             // Use the currently active Spring Boot profiles if neither profile nor hosts was specified.
-            builder.profile(env.getActiveProfiles());
+            final String[] springBootProfiles = env.getActiveProfiles();
+            logger.info("Using the Spring Boot profiles as the source of the Central Dogma client profile: {}",
+                        springBootProfiles);
+            builder.profile(springBootProfiles);
         }
 
         return builder.build();

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -32,16 +32,16 @@ import com.google.common.base.MoreObjects;
 /**
  * Settings for a Central Dogma client.
  *
- * <h3>Example with {@code "host"} option</h3>
+ * <h3>Example with {@code "hosts"} option</h3>
  * <pre>{@code
  * centraldogma:
  *   hosts:
  *   - replica1.examples.com:36462
  *   - replica2.examples.com:36462
  *   - replica3.examples.com:36462
- *   accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
- *   healthCheckIntervalMillis: 15000
- *   useTls: false
+ *   access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+ *   health-check-interval-millis: 15000
+ *   use-tls: false
  * }</pre>
  *
  * <h3>Example with {@code "profile"} option</h3>

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.spring;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.PositiveOrZero;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Settings for a Central Dogma client.
+ *
+ * <h3>Example with {@code "host"} option</h3>
+ * <pre>{@code
+ * centraldogma:
+ *   hosts:
+ *   - replica1.examples.com:36462
+ *   - replica2.examples.com:36462
+ *   - replica3.examples.com:36462
+ *   accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+ *   healthCheckIntervalMillis: 15000
+ *   useTls: false
+ * }</pre>
+ *
+ * <h3>Example with {@code "profile"} option</h3>
+ * <pre>{@code
+ * centraldogma:
+ *   profile: beta
+ *   accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+ *   healthCheckIntervalMillis: 15000
+ *   useTls: false
+ * }</pre>
+ *
+ * <p>Note that {@code "healthCheckIntervalMillis"} and {@code "useTls"} are optional.</p>
+ */
+@ConfigurationProperties(prefix = "centraldogma")
+@Validated
+public class CentralDogmaSettings {
+    /**
+     * The Central Dogma client profile name. If not specified, {@code "hosts"} must be specified.
+     */
+    @Nullable
+    private String profile;
+
+    /**
+     * The list of Central Dogma hosts. e.g. {@code "foo.example.com"} or {@code "foo.example.com:36462"}.
+     * If not specified, {@code "profile"} must be specified.
+     */
+    @Nullable
+    private List<String> hosts;
+
+    /**
+     * The access token which is used to authenticate the Central Dogma client.
+     */
+    @Nullable
+    private String accessToken;
+
+    /**
+     * The number of milliseconds between each health-check requests to Central Dogma servers.
+     * {@code 0} disables the health check requests.
+     */
+    @Nullable
+    private Long healthCheckIntervalMillis;
+
+    /**
+     * Whether to use a TLS connection when communicating with a Central Dogma server.
+     */
+    @Nullable
+    private Boolean useTls;
+
+    /**
+     * Returns the Central Dogma client profile name.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public String getProfile() {
+        return profile;
+    }
+
+    /**
+     * Sets the Central Dogma client profile name.
+     */
+    public void setProfile(@NotBlank String profile) {
+        this.profile = profile;
+    }
+
+    /**
+     * Returns the list of Central Dogma hosts.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    /**
+     * Sets the list of Central Dogma hosts.
+     */
+    public void setHosts(@NotEmpty List<String> hosts) {
+        // Cannot use ImmutableList.copyOf() because Spring Boot 1.x attempts an add() call on it.
+        this.hosts = new ArrayList<>(hosts);
+    }
+
+    /**
+     * Returns the access token which is used to authenticate the Central Dogma client.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    /**
+     * Sets the access token which is used to authenticate the Central Dogma client.
+     */
+    public void setAccessToken(@NotBlank String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    /**
+     * Returns the number of milliseconds between each health-check requests to Central Dogma servers.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public Long getHealthCheckIntervalMillis() {
+        return healthCheckIntervalMillis;
+    }
+
+    /**
+     * Sets the number of milliseconds between each health-check requests to Central Dogma servers.
+     */
+    public void setHealthCheckIntervalMillis(@PositiveOrZero long healthCheckIntervalMillis) {
+        this.healthCheckIntervalMillis = healthCheckIntervalMillis;
+    }
+
+    /**
+     * Returns whether to use a TLS connection when communicating with a Central Dogma server.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public Boolean getUseTls() {
+        return useTls;
+    }
+
+    /**
+     * Sets whether to use a TLS connection when communicating with a Central Dogma server.
+     */
+    public void setUseTls(boolean useTls) {
+        this.useTls = useTls;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("profile", profile)
+                          .add("hosts", hosts)
+                          .add("accessToken", accessToken != null ? "********" : null)
+                          .add("healthCheckIntervalMillis", healthCheckIntervalMillis)
+                          .add("useTls", useTls)
+                          .toString();
+    }
+}

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -48,9 +48,9 @@ import com.google.common.base.MoreObjects;
  * <pre>{@code
  * centraldogma:
  *   profile: beta
- *   accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
- *   healthCheckIntervalMillis: 15000
- *   useTls: false
+ *   access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+ *   health-check-interval-millis: 15000
+ *   use-tls: false
  * }</pre>
  *
  * <p>Note that {@code "healthCheckIntervalMillis"} and {@code "useTls"} are optional.</p>

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaAutoConfigurationTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaAutoConfigurationTest.java
@@ -48,11 +48,11 @@ public class CentralDogmaAutoConfigurationTest {
     }
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
     @ForCentralDogma
-    ClientFactory clientFactory;
+    private ClientFactory clientFactory;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2019 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -28,12 +28,12 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationTest.TestConfiguration;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationSpringProfileTest.TestConfiguration;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = TestConfiguration.class)
-@ActiveProfiles({ "local", "confTest" })
-public class CentralDogmaClientAutoConfigurationTest {
+@ActiveProfiles({ "local", "useHosts", "confTest" })
+public class CentralDogmaClientAutoConfigurationHostsTest {
     @Configuration
     @Import(CentralDogmaClientAutoConfiguration.class)
     public static class TestConfiguration {}
@@ -41,8 +41,19 @@ public class CentralDogmaClientAutoConfigurationTest {
     @Inject
     CentralDogma client;
 
+    @Inject
+    CentralDogmaSettings settings;
+
     @Test
     public void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
+    }
+
+    @Test
+    public void settings() {
+        assertThat(settings.getHosts()).containsExactly("alice.com", "bob.com:8080", "charlie.com:36462");
+        assertThat(settings.getProfile()).isNull();
+        assertThat(settings.getUseTls()).isNull();
+        assertThat(settings.getHealthCheckIntervalMillis()).isNull();
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
@@ -39,10 +39,10 @@ public class CentralDogmaClientAutoConfigurationHostsTest {
     public static class TestConfiguration {}
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
-    CentralDogmaSettings settings;
+    private CentralDogmaSettings settings;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationSpringProfileTest.TestConfiguration;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "otherProps", "confTest" })
+public class CentralDogmaClientAutoConfigurationOtherPropsTest {
+    @Configuration
+    @Import(CentralDogmaClientAutoConfiguration.class)
+    public static class TestConfiguration {}
+
+    @Inject
+    CentralDogma client;
+
+    @Inject
+    CentralDogmaSettings settings;
+
+    @Test
+    public void centralDogmaClient() throws Exception {
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    public void settings() {
+        assertThat(settings.getHosts()).isNull();
+        assertThat(settings.getProfile()).isNull();
+        assertThat(settings.getUseTls()).isTrue();
+        assertThat(settings.getHealthCheckIntervalMillis()).isEqualTo(60000);
+    }
+}

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
@@ -39,10 +39,10 @@ public class CentralDogmaClientAutoConfigurationOtherPropsTest {
     public static class TestConfiguration {}
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
-    CentralDogmaSettings settings;
+    private CentralDogmaSettings settings;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
@@ -39,10 +39,10 @@ public class CentralDogmaClientAutoConfigurationProfileTest {
     public static class TestConfiguration {}
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
-    CentralDogmaSettings settings;
+    private CentralDogmaSettings settings;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationSpringProfileTest.TestConfiguration;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "useProfile", "confTest" })
+public class CentralDogmaClientAutoConfigurationProfileTest {
+    @Configuration
+    @Import(CentralDogmaClientAutoConfiguration.class)
+    public static class TestConfiguration {}
+
+    @Inject
+    CentralDogma client;
+
+    @Inject
+    CentralDogmaSettings settings;
+
+    @Test
+    public void centralDogmaClient() throws Exception {
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    public void settings() {
+        assertThat(settings.getHosts()).isNull();
+        assertThat(settings.getProfile()).isEqualTo("myprofile");
+        assertThat(settings.getUseTls()).isNull();
+        assertThat(settings.getHealthCheckIntervalMillis()).isNull();
+    }
+}

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
@@ -39,10 +39,10 @@ public class CentralDogmaClientAutoConfigurationSpringProfileTest {
     public static class TestConfiguration {}
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
-    CentralDogmaSettings settings;
+    private CentralDogmaSettings settings;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.inject.Inject;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationSpringProfileTest.TestConfiguration;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "confTest" })
+public class CentralDogmaClientAutoConfigurationSpringProfileTest {
+    @Configuration
+    @Import(CentralDogmaClientAutoConfiguration.class)
+    public static class TestConfiguration {}
+
+    @Inject
+    CentralDogma client;
+
+    @Inject
+    CentralDogmaSettings settings;
+
+    @Test
+    public void centralDogmaClient() throws Exception {
+        assertThat(client).isNotNull();
+    }
+
+    @Test
+    public void settings() {
+        assertThat(settings.getHosts()).isNull();
+        assertThat(settings.getProfile()).isNull();
+        assertThat(settings.getUseTls()).isNull();
+        assertThat(settings.getHealthCheckIntervalMillis()).isNull();
+    }
+}

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
@@ -64,18 +64,18 @@ public class CentralDogmaClientAutoConfigurationWithClientFactoryTest {
     private static class TestBean {}
 
     @Inject
-    CentralDogma client;
+    private CentralDogma client;
 
     @Inject
-    TestBean testBean;
+    private TestBean testBean;
 
     @Inject
     @Qualifier("other")
-    ClientFactory clientFactoryForTest;
+    private ClientFactory clientFactoryForTest;
 
     @Inject
     @ForCentralDogma
-    ClientFactory clientFactoryForCentralDogma;
+    private ClientFactory clientFactoryForCentralDogma;
 
     @Test
     public void centralDogmaClient() throws Exception {

--- a/client/java-spring-boot-autoconfigure/src/test/resources/centraldogma-profiles-test.json
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/centraldogma-profiles-test.json
@@ -8,9 +8,34 @@
         "port": 36462
       },
       {
+        "host": "foo.com",
+        "protocol": "https",
+        "port": 36463
+      },
+      {
         "host": "bar.com",
         "protocol": "http",
         "port": 8080
+      },
+      {
+        "host": "bar.com",
+        "protocol": "https",
+        "port": 8443
+      }
+    ]
+  },
+  {
+    "name": "myprofile",
+    "hosts": [
+      {
+        "host": "baz.com",
+        "protocol": "http",
+        "port": 8080
+      },
+      {
+        "host": "qux.com",
+        "protocol": "http",
+        "port": 36462
       }
     ]
   }

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
@@ -1,0 +1,3 @@
+centraldogma:
+  use-tls: true
+  health-check-interval-millis: 60000

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useHosts.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useHosts.yml
@@ -1,0 +1,5 @@
+centraldogma:
+  hosts:
+  - alice.com
+  - bob.com:8080
+  - charlie.com:36462

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useProfile.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useProfile.yml
@@ -1,0 +1,2 @@
+centraldogma:
+  profile: myprofile

--- a/site/src/sphinx/_templates/layout.html
+++ b/site/src/sphinx/_templates/layout.html
@@ -5,7 +5,7 @@
 {% set extra_css_files = ['_static/overrides.css'] %}
 {% block extrahead %}
   <script src="{{ pathto('_static/center_page.js', 1) }}"></script>
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/styles/default.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/default.min.css">
   {{ super() }}
 {% endblock %}
 {% block footer %}
@@ -15,8 +15,9 @@
     </div>
   </div>
   <script type="text/javascript" src="{{ pathto('_static/add_badges.js', 1) }}"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.3.0/highlightjs-line-numbers.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/yaml.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.6.0/highlightjs-line-numbers.min.js"></script>
   <script>
     document.querySelectorAll('div.hljs > pre').forEach(function(block) {
       hljs.highlightBlock(block);

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -557,7 +557,7 @@ named ``application.yml``:
       - replica1.example.com:36462
       - replica2.example.com:36462
       - replica3.example.com:36462
-      accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+      access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
 
 If you prefer using client profiles as described in :ref:`using_client_profiles`, use the ``profile`` property:
 
@@ -565,6 +565,7 @@ If you prefer using client profiles as described in :ref:`using_client_profiles`
 
     centraldogma:
       profile: beta
+      access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
 
 If neither ``hosts`` nor ``profile`` property is specified, currently active
 `Spring Boot profile <https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html>`_
@@ -581,6 +582,7 @@ You can also enable a TLS connection or override the default health check reques
 
     centraldogma:
       profile: staging
+      access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
       use-tls: true
       health-check-interval-millis: 15000
 

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -515,7 +515,7 @@ client profile JAR again.
 Spring Boot integration
 -----------------------
 If you are using `Spring Framework <https://spring.io/>`_, you can inject :api:`com.linecorp.centraldogma.client.CentralDogma`
-client very easily. First, add ``centraldogma-client-spring-boot-autoconfigure`` into your dependencies.
+client very easily. First, add ``centraldogma-client-spring-boot-starter`` into your dependencies.
 
 Gradle:
 
@@ -525,7 +525,7 @@ Gradle:
     ...
     dependencies {
         ...
-        compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot-autoconfigure:\ |release|\ '
+        compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot-starter:\ |release|\ '
         ...
     }
     ...
@@ -540,7 +540,7 @@ Maven:
       ...
       <dependency>
         <groupId>com.linecorp.centraldogma</groupId>
-        <artifactId>centraldogma-client-spring-boot-autoconfigure</artifactId>
+        <artifactId>centraldogma-client-spring-boot-starter</artifactId>
         <version>\ |release|\ </version>
       </dependency>
       ...

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -515,17 +515,73 @@ client profile JAR again.
 Spring Boot integration
 -----------------------
 If you are using `Spring Framework <https://spring.io/>`_, you can inject :api:`com.linecorp.centraldogma.client.CentralDogma`
-client very easily.
+client very easily. First, add ``centraldogma-client-spring-boot-autoconfigure`` into your dependencies.
 
-1. Add ``centraldogma-client-spring-boot-autoconfigure`` into your dependencies.
-2. Add the client profile to your class path, as described in :ref:`using_client_profiles`.
+Gradle:
 
-A new :api:`com.linecorp.centraldogma.client.CentralDogma` client will be created and injected using your
-`Spring Boot profile <https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html>`_.
-When more than one profile is active, the last matching one will be used from ``/centraldogma-profiles-test.json``
-or ``/centraldogma-profiles.json``.
+.. parsed-literal::
+    :class: highlight-groovy
 
-Once configured correctly, you would be able to run an application like the following:
+    ...
+    dependencies {
+        ...
+        compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot-autoconfigure:\ |release|\ '
+        ...
+    }
+    ...
+
+Maven:
+
+.. parsed-literal::
+    :class: highlight-xml
+
+    ...
+    <dependencies>
+      ...
+      <dependency>
+        <groupId>com.linecorp.centraldogma</groupId>
+        <artifactId>centraldogma-client-spring-boot-autoconfigure</artifactId>
+        <version>\ |release|\ </version>
+      </dependency>
+      ...
+    </dependencies>
+    ...
+
+Then, add a new section called ``centraldogma`` to your Spring Boot application configuration, which is often
+named ``application.yml``:
+
+.. code-block:: yaml
+
+    centraldogma:
+      hosts:
+      - replica1.example.com:36462
+      - replica2.example.com:36462
+      - replica3.example.com:36462
+      accessToken: appToken-cffed349-d573-457f-8f74-4727ad9341ce
+
+If you prefer using client profiles as described in :ref:`using_client_profiles`, use the ``profile`` property:
+
+.. code-block:: yaml
+
+    centraldogma:
+      profile: beta
+
+If neither ``hosts`` nor ``profile`` property is specified, currently active
+`Spring Boot profile <https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-profiles.html>`_
+will be used as the client profile. When more than one Spring Boot profile are active, the last matching one
+will be chosen.
+
+You can also enable a TLS connection or override the default health check request interval:
+
+.. code-block:: yaml
+
+    centraldogma:
+      profile: staging
+      use-tls: true
+      health-check-interval-millis: 15000
+
+Once configured correctly, a new :api:`com.linecorp.centraldogma.client.CentralDogma` client will be created and
+injected into your application like the following:
 
 .. code-block:: java
 

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -571,6 +571,10 @@ If neither ``hosts`` nor ``profile`` property is specified, currently active
 will be used as the client profile. When more than one Spring Boot profile are active, the last matching one
 will be chosen.
 
+.. note::
+
+    Do not confuse 'Central Dogma client profile' with 'Spring Boot profile'.
+
 You can also enable a TLS connection or override the default health check request interval:
 
 .. code-block:: yaml


### PR DESCRIPTION
Motivation:

Spring Boot integration currently uses `LegacyCentralDogma` which has
been deprecated.

Modifications:

- Added `CentralDogmaSettings` so that a user can specify:
  - hosts or profile
  - access token
  - whether to use TLS
  - health check request interval
- Updated the documentation.

Result:

- A user can specify a Central Dogma client profile explicitly,
  without using Spring Boot profiles.
- A user can configure all properties of a Central Dogma client when
  using Spring Boot integration.
- (Breaking) A user must specify an access token if the target Central
  Dogma server has access control enabled.