### PR TITLE
Add more languages to Highlight.js / Overall highliting cleanup

### DIFF
--- a/site/src/sphinx/_templates/layout.html
+++ b/site/src/sphinx/_templates/layout.html
@@ -16,6 +16,9 @@
   </div>
   <script type="text/javascript" src="{{ pathto('_static/add_badges.js', 1) }}"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/gradle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/protobuf.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/thrift.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/yaml.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.6.0/highlightjs-line-numbers.min.js"></script>
   <script>

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -28,15 +28,16 @@ The authentication configuration consists of the following properties:
 .. code-block:: json
 
     {
-        ...
-        "authentication": {
-            "factoryClassName": "the fully-qualified class name of an AuthenticationProviderFactory",
-            "administrators": [],
-            "caseSensitiveLoginNames": false,
-            "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
-            "sessionTimeoutMillis": 604800000,
-            "sessionValidationSchedule": "0 30 */4 ? * *",
-            "properties": null
+      ...
+      "authentication": {
+        "factoryClassName": "the fully-qualified class name of an AuthenticationProviderFactory",
+        "administrators": [],
+        "caseSensitiveLoginNames": false,
+        "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
+        "sessionTimeoutMillis": 604800000,
+        "sessionValidationSchedule": "0 30 */4 ? * *",
+        "properties": null
+      }
     }
 
 - ``factoryClassName`` (string)
@@ -85,40 +86,40 @@ the authentication to.
 .. code-block:: json
 
     {
-        ...
-        "authentication": {
-            "factoryClassName": "com.linecorp.centraldogma.server.auth.saml.SamlAuthProviderFactory",
-            "administrators": [],
-            "caseSensitiveLoginNames": false,
-            "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
-            "sessionTimeoutMillis": 604800000,
-            "sessionValidationSchedule": "0 30 */4 ? * *",
-            "properties": {
-                "entityId": "dogma",
-                "hostname": "dogma-example.linecorp.com",
-                "signingKey": "signing",
-                "encryptionKey": "encryption",
-                "keyStore": {
-                    "type": "PKCS12",
-                    "path": "./conf/saml.jks",
-                    "password": null,
-                    "keyPasswords": {
-                        "signing": null,
-                        "encryption": null
-                    },
-                    "signatureAlgorithm": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
-                },
-                "idp": {
-                    "entityId": "some-idp",
-                    "uri": "https://idp.some-service.com/saml/single_sign_on_service",
-                    "binding": "HTTP_POST",
-                    "signingKey": "some-idp",
-                    "encryptionKey": "some-idp",
-                    "subjectLoginNameIdFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
-                    "attributeLoginName": null
-                }
-            }
+      ...
+      "authentication": {
+        "factoryClassName": "com.linecorp.centraldogma.server.auth.saml.SamlAuthProviderFactory",
+        "administrators": [],
+        "caseSensitiveLoginNames": false,
+        "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
+        "sessionTimeoutMillis": 604800000,
+        "sessionValidationSchedule": "0 30 */4 ? * *",
+        "properties": {
+          "entityId": "dogma",
+          "hostname": "dogma-example.linecorp.com",
+          "signingKey": "signing",
+          "encryptionKey": "encryption",
+          "keyStore": {
+            "type": "PKCS12",
+            "path": "./conf/saml.jks",
+            "password": null,
+            "keyPasswords": {
+              "signing": null,
+              "encryption": null
+            },
+            "signatureAlgorithm": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+          },
+          "idp": {
+            "entityId": "some-idp",
+            "uri": "https://idp.some-service.com/saml/single_sign_on_service",
+            "binding": "HTTP_POST",
+            "signingKey": "some-idp",
+            "encryptionKey": "some-idp",
+            "subjectLoginNameIdFormat": "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+            "attributeLoginName": null
+          }
         }
+      }
     }
 
 The following describes the meaning of SAML-specific properties.
@@ -221,16 +222,16 @@ in the ``properties`` property.
 .. code-block:: json
 
     {
-        ...
-        "authentication": {
-            "factoryClassName": "com.linecorp.centraldogma.server.auth.shiro.ShiroAuthProviderFactory",
-            "administrators": [],
-            "caseSensitiveLoginNames": false,
-            "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
-            "sessionTimeoutMillis": 604800000,
-            "sessionValidationSchedule": "0 30 */4 ? * *",
-            "properties": "./conf/shiro.ini"
-        }
+      ...
+      "authentication": {
+        "factoryClassName": "com.linecorp.centraldogma.server.auth.shiro.ShiroAuthProviderFactory",
+        "administrators": [],
+        "caseSensitiveLoginNames": false,
+        "sessionCacheSpec": "maximumSize=8192,expireAfterWrite=604800s",
+        "sessionTimeoutMillis": 604800000,
+        "sessionValidationSchedule": "0 30 */4 ? * *",
+        "properties": "./conf/shiro.ini"
+      }
     }
 
 You may configure ``conf/shiro.ini`` simply as follows, which uses a local database system of `Apache Shiro`_:

--- a/site/src/sphinx/client-cli.rst
+++ b/site/src/sphinx/client-cli.rst
@@ -26,9 +26,8 @@ Creating projects and repositories
 ----------------------------------
 Use the ``new`` command to create a project:
 
-.. code-block:: bash
+.. code-block:: shell
 
-    # Create two projects.
     $ dogma new projFoo
     Created: /projFoo
     $ dogma new projBar
@@ -36,7 +35,7 @@ Use the ``new`` command to create a project:
 
 ``new`` command is also used for creating a repository:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma new projFoo/repoA
     Created: /projFoo/repoA
@@ -47,7 +46,7 @@ Use the ``ls`` command to list projects, repositories or files.
 
 To list projects, specify no arguments:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma ls
     [
@@ -73,7 +72,7 @@ To list projects, specify no arguments:
 
 To list repositories, specify a project name:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma ls projFoo
     [
@@ -93,10 +92,9 @@ To list repositories, specify a project name:
 To list files or directories in a repository, specify a project name, a repository name and more.
 But before that, let's add a sample file to use under ``samples`` directory:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ echo '{"a":"b"}' > a.json
-
     $ dogma put projFoo/repoA/samples/a.json a.json -m "Add a.json"
     Put: /projFoo/repoA/samples/a.json
 
@@ -104,7 +102,7 @@ We will learn more about adding and editing files in a repository later in the s
 
 Then, list the directory:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma ls projFoo/repoA/samples
     [
@@ -119,7 +117,7 @@ Retrieving a file
 -----------------
 Use the ``cat`` command to retrieve the content of a file:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma cat projFoo/repoA/samples/a.json
     {
@@ -128,21 +126,21 @@ Use the ``cat`` command to retrieve the content of a file:
 
 You can also query a JSON file using JSON path with a flag ``--jsonpath`` or simply ``-j``:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma cat --jsonpath '$.a' projFoo/repoA/samples/a.json
     "b"
 
 You can use multiple JSON paths as well:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma cat -j '$[?(@.a != "notMyValue")]' -j '$[0].a' projFoo/repoA/samples/a.json
     "b"
 
 Alternatively, you can use the ``get`` command to download the file:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma get projFoo/repoA/samples/a.json
     Downloaded: bar.json
@@ -155,14 +153,13 @@ You can add, edit or remove an individual file in a repository using ``put``, ``
 
 First, let's create a JSON file and add it:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ echo '[1, 2, 3]' > three.json
-
     $ dogma put projFoo/repoA/numbers/3.json three.json
     Put: /projFoo/repoA/numbers/3.json
 
-The command above uploads ``three.json`` as ``3.json`` under ``/projFoo/repoA/numbers/``.
+The above command uploads ``three.json`` as ``3.json`` under ``/projFoo/repoA/numbers/``.
 
 If you don't specify the file name, the file name will be attached automatically. For example,
 if you do ``dogma put projFoo/repoA/numbers/ three.json``, then ``/projFoo/repoA/numbers/three.json`` will be added.
@@ -176,7 +173,7 @@ if you do ``dogma put projFoo/repoA/numbers/ three.json``, then ``/projFoo/repoA
 
 And then, check it out:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma cat projFoo/repoA/numbers/3.json
     [
@@ -192,14 +189,14 @@ And then, check it out:
 
 With the ``edit`` command, you can edit a file using a text editor:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma edit projFoo/repoA/numbers/3.json
     ... Text editor shows up ...
 
 Use the ``rm`` command to remove a file:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma rm projFoo/repoA/samples/foo.txt
     Removed: /projFoo/repoA/samples/foo.txt
@@ -209,7 +206,7 @@ Specifying a revision
 Most commands have an option called ``--revision`` which makes the commands retrieve a file at a specific
 revision. If not specified, the client assumes ``-1`` which means the latest revision in the repository:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma cat --revision -1 projFoo/repoA/numbers/3.json
     ... Success ...
@@ -220,7 +217,7 @@ Watching a file
 ---------------
 You can be noticed when a file on the Central Dogma server is changed using the ``watch`` command:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma watch --revision 8 projFoo/repoA/numbers/3.json
     Watcher noticed updated file: projFoo/repoA/numbers/3.json, rev=9
@@ -229,7 +226,7 @@ You can be noticed when a file on the Central Dogma server is changed using the 
 The ``revision`` option represents that you want to watch the change of the file after the revision.
 If you want to keep watching it, use ``--streaming`` option:
 
-.. code-block:: bash
+.. code-block:: shell
 
     $ dogma watch --revision 8 --streaming projFoo/repoA/numbers/3.json
     Watcher noticed updated file: projFoo/repoA/numbers/3.json, rev=9
@@ -239,7 +236,7 @@ If you want to keep watching it, use ``--streaming`` option:
     Watcher noticed updated file: projFoo/repoA/numbers/3.json, rev=11
     Content: ...
 
-    // press CTRL+C
+    <Press CTRL+C>
     Received an interrupt, stopping watcher...
 
 Use the ``--help`` option
@@ -247,8 +244,9 @@ Use the ``--help`` option
 The ``dogma`` client provides more commands and features than what's demonstrated in this tutorial. ``--help``
 option will show the full usage of the client:
 
-.. code-block:: bash
+.. code-block:: shell
 
+    $ dogma --help
     NAME:
        Central Dogma - Central Dogma client
 
@@ -277,8 +275,9 @@ option will show the full usage of the client:
 
 Appending the ``--help`` option after a command will print the detailed usage for the command:
 
-.. code-block:: bash
+.. code-block:: shell
 
+    $ dogma ls --help
     DESCRIPTION:
        Lists the projects, repositories or files
 

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -17,32 +17,24 @@ Adding ``centraldogma-client`` as a dependency
 Gradle:
 
 .. parsed-literal::
-    :class: highlight-groovy
+    :class: highlight-gradle
 
-    ...
     dependencies {
-        ...
         compile 'com.linecorp.centraldogma:centraldogma-client-armeria:\ |release|\ '
-        ...
     }
-    ...
 
 Maven:
 
 .. parsed-literal::
     :class: highlight-xml
 
-    ...
     <dependencies>
-      ...
       <dependency>
         <groupId>com.linecorp.centraldogma</groupId>
         <artifactId>centraldogma-client-armeria</artifactId>
         <version>\ |release|\ </version>
       </dependency>
-      ...
     </dependencies>
-    ...
 
 Creating a client
 -----------------
@@ -421,12 +413,13 @@ the replicas in the ``beta`` profile support ``http`` only:
 
 You may want to archive this file into a JAR file and distribute it as the *official* client profiles via
 a Maven repository, so that your users get the up-to-date host list easily. For example, a user could put
-``centraldogma-profiles-1.0.jar`` into his or her class path::
+``centraldogma-profiles-1.0.jar`` into his or her class path:
+
+.. code-block:: shell
 
     $ cat centraldogma-profiles.json
     [ { "name": "beta",    "priority": 0, "hosts": [ ... ] },
       { "name": "release", "priority": 0, "hosts": [ ... ] } ]
-
     $ jar cvf centraldogma-profiles-1.0.jar centraldogma-profiles.json
     added manifest
     adding: centraldogma-profiles.json
@@ -476,7 +469,9 @@ Using DNS-based lookup
 Central Dogma Java client always retrieves all the IP addresses of a host from the current system DNS server or
 the ``/etc/host`` file. Instead of specifying all the individual replica addresses in a client profile,
 consider specifying a single host name that's very unlikely to change in the client profile and add multiple
-``A`` or ``AAAA`` DNS records to the host name::
+``A`` or ``AAAA`` DNS records to the host name:
+
+.. code-block:: shell
 
     $ cat centraldogma-profiles.json
     [ {
@@ -487,9 +482,7 @@ consider specifying a single host name that's very unlikely to change in the cli
         "port": 36462
       } ]
     } ]
-
     $ dig all.dogma.example.com
-
     ; <<>> DiG 9.12.1-P2 <<>> all.dogma.example.com
     ;; global options: +cmd
     ;; Got answer:
@@ -520,32 +513,24 @@ client very easily. First, add ``centraldogma-client-spring-boot-starter`` into 
 Gradle:
 
 .. parsed-literal::
-    :class: highlight-groovy
+    :class: highlight-gradle
 
-    ...
     dependencies {
-        ...
         compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot-starter:\ |release|\ '
-        ...
     }
-    ...
 
 Maven:
 
 .. parsed-literal::
     :class: highlight-xml
 
-    ...
     <dependencies>
-      ...
       <dependency>
         <groupId>com.linecorp.centraldogma</groupId>
         <artifactId>centraldogma-client-spring-boot-starter</artifactId>
         <version>\ |release|\ </version>
       </dependency>
-      ...
     </dependencies>
-    ...
 
 Then, add a new section called ``centraldogma`` to your Spring Boot application configuration, which is often
 named ``application.yml``:

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -33,13 +33,16 @@ Give it a try!
 |download| now and give it a try (`Java`_ required):
 
 .. parsed-literal::
+    :class: highlight-shell
 
     $ tar zxvf centraldogma-\ |release|\ .tgz
     $ cd centraldogma-\ |release|\ /
     $ bin/startup
-    # Open http://127.0.0.1:36462/ in your browser for administrative console.
+    <Open http://127.0.0.1:36462/ in your browser for administrative console.>
 
-Using Docker? Launch our image at `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_::
+Using Docker? Launch our image at `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_:
+
+.. code-block:: shell
 
     $ docker run -p 36462:36462 line/centraldogma
 

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -175,7 +175,9 @@ repositories defined in ``/mirrors.json``:
 
 .. note::
 
-    You may want to convert your private key into a JSON string using a ``perl`` command::
+    You may want to convert your private key into a JSON string using a ``perl`` command:
+
+    .. code-block:: shell
 
         $ cat ~/.ssh/id_rsa | perl -p -0 -e 's/\r?\n/\\n/g'
 

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -383,7 +383,7 @@ Java client, call the ``useTls()`` method when building a ``CentralDogma`` insta
 .. code-block:: java
 
     CentralDogma dogma = new ArmeriaCentralDogmaBuilder()
-            .host("centraldogma.example.com", 36462)
+            .host("centraldogma.example.com", 8443)
             .accessToken("appToken-********")
             .useTls()
             .build();

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -232,7 +232,7 @@ example shows the configuration of the first replica in a 3-replica cluster:
         "numWorkers": null,
         "maxLogCount": null,
         "minLogAgeMillis": null
-      },
+      }
     }
 
 - ``method`` (string)
@@ -377,12 +377,13 @@ in ``dogma.json`` as follows.
     - the password of the private key file. Specify ``null`` if no password is set. Note that ``null``
       (no password) and ``"null"`` (password is 'null') are different.
 
-If you run your Central Dogma with TLS, you need to enable TLS on the client side as well. Call the
-``useTls()`` method when building a ``CentralDogma`` instance:
+If you run your Central Dogma with TLS, you need to enable TLS on the client side as well. In case of
+Java client, call the ``useTls()`` method when building a ``CentralDogma`` instance:
 
 .. code-block:: java
 
-    CentralDogma dogma = new LegacyCentralDogmaBuilder()
+    CentralDogma dogma = new ArmeriaCentralDogmaBuilder()
             .host("centraldogma.example.com", 36462)
+            .accessToken("appToken-********")
             .useTls()
             .build();

--- a/site/src/sphinx/setup-installation.rst
+++ b/site/src/sphinx/setup-installation.rst
@@ -15,6 +15,7 @@ Download
 |download| the tarball and extract it into your preferred location:
 
 .. parsed-literal::
+    :class: highlight-shell
 
     $ tar zxvf centraldogma-\ |release|\ .tgz
 
@@ -24,17 +25,17 @@ The distribution is shipped with a simple configuration with replication disable
 immediately:
 
 .. parsed-literal::
+    :class: highlight-shell
 
     $ cd centraldogma-\ |release|\ /
     $ bin/startup
     ...
     Started up centraldogma successfully: <pid>
-
-    # Open http://127.0.0.1:36462/ in your browser for administrative console.
+    <Open http://127.0.0.1:36462/ in your browser for administrative console.>
 
 To stop the server, use the ``bin/shutdown`` script:
 
-.. parsed-literal::
+.. code-block:: shell
 
     $ bin/shutdown
     ...
@@ -42,19 +43,25 @@ To stop the server, use the ``bin/shutdown`` script:
 
 .. tip::
 
-    If you are working with source code instead of binary distribution, you can use the Gradle tasks::
+    If you are working with source code instead of binary distribution, you can use the Gradle tasks:
+
+    .. code-block:: shell
 
         $ ./gradlew startup
         $ ./gradlew shutdown
 
-    You can also tail the log file::
+    You can also tail the log file:
+
+    .. code-block:: shell
 
         $ ./gradlew tail
 
 Running on Docker
 -----------------
 You can also pull Central Dogma image from `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_
-and then run it on your Docker::
+and then run it on your Docker:
+
+.. code-block:: shell
 
     $ docker run -p 36462:36462 line/centraldogma
 


### PR DESCRIPTION
- Added `thrift`, `protobuf` and `gradle`.
- Used `shell` instead of `bash` for shell interaction examples
  - Made minor changes to ensure Highlight.js highlights better.
- Used `ArmeriaCentralDogmaBuilder` in `setup-configuration.rst`.