### PR TITLE
Fix a bug where access token in `application.yml` is not set to `Arme…

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -107,6 +107,12 @@ public class CentralDogmaClientAutoConfiguration {
             builder.useTls(useTls);
         }
 
+        // Set access token.
+        final String accessToken = settings.getAccessToken();
+        if (accessToken != null) {
+            builder.accessToken(accessToken);
+        }
+
         // Set profile or hosts.
         final String profile = settings.getProfile();
         final List<String> hosts = settings.getHosts();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
@@ -55,5 +55,6 @@ public class CentralDogmaClientAutoConfigurationOtherPropsTest {
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isTrue();
         assertThat(settings.getHealthCheckIntervalMillis()).isEqualTo(60000);
+        assertThat(settings.getAccessToken()).isEqualTo("my-dogma-access-token");
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
@@ -1,3 +1,4 @@
 centraldogma:
   use-tls: true
   health-check-interval-millis: 60000
+  accessToken: my-dogma-access-token


### PR DESCRIPTION
…riaCentralDogmaBuilder`.

Motivation:

`centraldogma.access-token` in Spring Boot `application.yml` had no
effect at all.

Modifications:

- Set the access token specified in `application.yml` to
  `ArmeriaCentralDogmaBuilder`.

Result:

- One less silly bugs