### PR TITLE
Allow sending an access token with `LegacyCentralDogmaBuilder`

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -24,7 +24,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
-import com.linecorp.centraldogma.internal.CsrfToken;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
 /**
@@ -49,10 +48,11 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
                .decorator(HttpDecodingClient.newDecorator())
                .rpcDecorator(LegacyCentralDogmaTimeoutScheduler::new);
 
+        final String authorization = "Bearer " + accessToken();
         builder.decorator((delegate, ctx, req) -> {
             if (!req.headers().contains(HttpHeaderNames.AUTHORIZATION)) {
                 // To prevent CSRF attack, we add 'Authorization' header to every request.
-                req.headers().set(HttpHeaderNames.AUTHORIZATION, "Bearer " + CsrfToken.ANONYMOUS);
+                req.headers().set(HttpHeaderNames.AUTHORIZATION, authorization);
             }
             return delegate.execute(ctx, req);
         });

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -15,9 +15,6 @@
  */
 package com.linecorp.centraldogma.client.armeria;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
-
 import java.net.UnknownHostException;
 
 import com.linecorp.armeria.client.ClientBuilder;
@@ -25,23 +22,9 @@ import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.internal.CsrfToken;
 
 public final class ArmeriaCentralDogmaBuilder
         extends AbstractArmeriaCentralDogmaBuilder<ArmeriaCentralDogmaBuilder> {
-
-    private String accessToken = CsrfToken.ANONYMOUS;
-
-    /**
-     * Sets the access token to use when authenticating a client.
-     */
-    public ArmeriaCentralDogmaBuilder accessToken(String accessToken) {
-        requireNonNull(accessToken, "accessToken");
-        checkArgument(!accessToken.isEmpty(), "accessToken is empty.");
-        this.accessToken = accessToken;
-        return this;
-    }
-
     /**
      * Returns a newly-created {@link CentralDogma} instance.
      *
@@ -56,6 +39,6 @@ public final class ArmeriaCentralDogmaBuilder
         builder.factory(clientFactory());
         builder.decorator(HttpDecodingClient.newDecorator());
         return new ArmeriaCentralDogma(clientFactory().eventLoopGroup(),
-                                       builder.build(HttpClient.class), accessToken);
+                                       builder.build(HttpClient.class), accessToken());
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
@@ -41,6 +41,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.net.InetAddresses;
 
+import com.linecorp.centraldogma.internal.CsrfToken;
+
 /**
  * Builds a {@link CentralDogma} client.
  */
@@ -58,6 +60,7 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
     private List<String> profileResourcePaths = DEFAULT_PROFILE_RESOURCE_PATHS;
     @Nullable
     private String selectedProfile;
+    private String accessToken = CsrfToken.ANONYMOUS;
 
     /**
      * Returns {@code this}.
@@ -324,5 +327,22 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
      */
     protected final Set<InetSocketAddress> hosts() {
         return hosts;
+    }
+
+    /**
+     * Sets the access token to use when authenticating a client.
+     */
+    public final B accessToken(String accessToken) {
+        requireNonNull(accessToken, "accessToken");
+        checkArgument(!accessToken.isEmpty(), "accessToken is empty.");
+        this.accessToken = accessToken;
+        return self();
+    }
+
+    /**
+     * Returns the access token to use when authenticating a client.
+     */
+    protected String accessToken() {
+        return accessToken;
     }
 }


### PR DESCRIPTION
Motivation:

As a preparatory step to enable proper authorization to the Thrift
endpoint, we have to provide a way to specify a non-anonymous access
token when constructing a legacy Thrift client.

Modifications:

- Move up `accessToken()` to `AbstractCentralDogma`.
- Use the specified access token in `LegacyCentralDogmaBuilder`.

Result:

- A user can specify non-anonymous access token when using a legacy
  Thrift client.