### PR TITLE
Send a JSON response for authentication failures

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -600,6 +600,7 @@ public class CentralDogma implements AutoCloseable {
                                      .add(new ApplicationTokenAuthorizer(mds::findTokenBySecret)
                                                   .orElse(new SessionTokenAuthorizer(sessionManager,
                                                                                      authCfg.administrators())))
+                                     .onFailure(new CentralDogmaAuthFailureHandler())
                                      .newDecorator());
         } else {
             decorator = MetadataServiceInjector

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.AuthFailureHandler;
+import com.linecorp.centraldogma.common.AuthorizationException;
+import com.linecorp.centraldogma.common.ShuttingDownException;
+import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
+
+final class CentralDogmaAuthFailureHandler implements AuthFailureHandler<HttpRequest, HttpResponse> {
+
+    private static final Logger logger = LoggerFactory.getLogger(CentralDogmaAuthFailureHandler.class);
+
+    private static final AuthorizationException AUTHORIZATION_EXCEPTION = new AuthorizationException("", false);
+
+    @Override
+    public HttpResponse authFailed(Service<HttpRequest, HttpResponse> delegate,
+                                   ServiceRequestContext ctx, HttpRequest req,
+                                   @Nullable Throwable cause) throws Exception {
+        if (cause != null) {
+            if (!(cause instanceof ShuttingDownException)) {
+                logger.warn("Unexpected exception during authorization:", cause);
+            }
+            return HttpApiUtil.newResponse(ctx, HttpStatus.INTERNAL_SERVER_ERROR, cause);
+        }
+
+        return HttpApiUtil.newResponse(ctx, HttpStatus.UNAUTHORIZED, AUTHORIZATION_EXCEPTION);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.nullToEmpty;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Locale;
@@ -167,7 +168,7 @@ public final class HttpApiUtil {
             }
         }
 
-        final String m = message != null ? message : status.reasonPhrase();
+        final String m = nullToEmpty(message);
         node.put("message", m);
 
         // TODO(hyangtack) Need to introduce a new field such as 'stackTrace' in order to return

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.Service;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.centraldogma.common.ShuttingDownException;
+
+public class CentralDogmaAuthFailureHandlerTest {
+
+    private final CentralDogmaAuthFailureHandler handler = new CentralDogmaAuthFailureHandler();
+    @SuppressWarnings("unchecked")
+    private final Service<HttpRequest, HttpResponse> delegate = mock(Service.class);
+    private final HttpRequest req = HttpRequest.of(HttpMethod.GET, "/");
+    private final ServiceRequestContext ctx = ServiceRequestContext.of(req);
+
+    @Test
+    public void shuttingDown() throws Exception {
+        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, new ShuttingDownException())
+                                                 .aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(res.contentUtf8()).isEqualTo(
+                '{' +
+                "  \"exception\": \"com.linecorp.centraldogma.common.ShuttingDownException\"," +
+                "  \"message\":\"\"" +
+                '}');
+    }
+
+    @Test
+    public void failure() throws Exception {
+        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, new Exception("oops"))
+                                                 .aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+        assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(res.contentUtf8()).isEqualTo(
+                '{' +
+                "  \"exception\": \"java.lang.Exception\"," +
+                "  \"message\":\"oops\"" +
+                '}');
+    }
+
+    @Test
+    public void incorrectToken() throws Exception {
+        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, null)
+                                                 .aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
+        assertThatJson(res.contentUtf8()).isEqualTo(
+                '{' +
+                "  \"exception\": \"com.linecorp.centraldogma.common.AuthorizationException\"," +
+                "  \"message\":\"\"" +
+                '}');
+    }
+}


### PR DESCRIPTION
Motivation:

Central Dogma server sends a response without content when authorization
fails. We could respond with JSON so that the clients knows the exact
cause of the failure.

Modifications:

- Use `HttpApiUtil` to build an authentication failure response.
- Do not use `HttpStatus.reasonPhrase()` when exception message is
  missing, because it often mismatches with the actual exception type,
  e.g. `ShuttingDownException` having `Internal Server Error` message.

Result:

- Proper response even on authentication failure
- `message` field in an error response is empty if an exception does not
  have a message.