### PR TITLE
Do not traverse the whole tree when comparing two trees.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
@@ -58,8 +58,8 @@
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
 import org.eclipse.jgit.attributes.Attribute;
-import org.eclipse.jgit.lib.AbbreviatedObjectId;
 import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
 
 /**
  * A value class representing a change to a file.
@@ -108,42 +108,54 @@ final class DiffEntry {
     /**
      * File name of the old (pre-image).
      */
-    String oldPath;
+    private final String oldPath;
 
     /**
      * File name of the new (post-image).
      */
-    String newPath;
+    private final String newPath;
 
     /**
      * diff filter attribute.
      */
-    Attribute diffAttribute;
+    private final Attribute diffAttribute;
 
     /**
      * Old mode of the file, if described by the patch, else null.
      */
-    FileMode oldMode;
+    private final FileMode oldMode;
 
     /**
      * New mode of the file, if described by the patch, else null.
      */
-    FileMode newMode;
+    private final FileMode newMode;
 
     /**
      * General type of change indicated by the patch.
      */
-    ChangeType changeType;
+    private final ChangeType changeType;
 
     /**
      * ObjectId listed on the index line for the old (pre-image).
      */
-    AbbreviatedObjectId oldId;
+    private final ObjectId oldId;
 
     /**
      * ObjectId listed on the index line for the new (post-image).
      */
-    AbbreviatedObjectId newId;
+    private final ObjectId newId;
+
+    DiffEntry(String oldPath, String newPath, Attribute diffAttribute, FileMode oldMode, FileMode newMode,
+              ChangeType changeType, ObjectId oldId, ObjectId newId) {
+        this.oldPath = oldPath;
+        this.newPath = newPath;
+        this.diffAttribute = diffAttribute;
+        this.oldMode = oldMode;
+        this.newMode = newMode;
+        this.changeType = changeType;
+        this.oldId = oldId;
+        this.newId = newId;
+    }
 
     /**
      * Get the old name associated with this file.
@@ -184,6 +196,13 @@ final class DiffEntry {
     }
 
     /**
+     * Returns the {@link Attribute} determining filters to be applied.
+     */
+    public Attribute getDiffAttribute() {
+        return diffAttribute;
+    }
+
+    /**
      * Get the old file mode.
      *
      * @return the old file mode, if described in the patch
@@ -215,7 +234,7 @@ final class DiffEntry {
      *
      * @return the object id; null if there is no index line
      */
-    AbbreviatedObjectId getOldId() {
+    ObjectId getOldId() {
         return oldId;
     }
 
@@ -224,7 +243,7 @@ final class DiffEntry {
      *
      * @return the object id; null if there is no index line
      */
-    AbbreviatedObjectId getNewId() {
+    ObjectId getNewId() {
         return newId;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2008-2013, Google Inc.
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import org.eclipse.jgit.attributes.Attribute;
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.FileMode;
+
+/**
+ * A value class representing a change to a file.
+ */
+final class DiffEntry {
+    /**
+     * General type of change a single file-level patch describes.
+     */
+    enum ChangeType {
+        /**
+         * Add a new file to the project.
+         */
+        ADD,
+        /**
+         * Modify an existing file in the project (content and/or mode).
+         */
+        MODIFY,
+        /**
+         * Delete an existing file from the project.
+         */
+        DELETE,
+        /**
+         * Rename an existing file to a new location.
+         */
+        RENAME,
+        /**
+         * Copy an existing file to a new location, keeping the original.
+         */
+        COPY
+    }
+
+    /**
+     * Specify the old or new side for more generalized access.
+     */
+    enum Side {
+        /**
+         * The old side of a DiffEntry.
+         */
+        OLD,
+        /**
+         * The new side of a DiffEntry.
+         */
+        NEW
+    }
+
+    /**
+     * File name of the old (pre-image).
+     */
+    String oldPath;
+
+    /**
+     * File name of the new (post-image).
+     */
+    String newPath;
+
+    /**
+     * diff filter attribute.
+     */
+    Attribute diffAttribute;
+
+    /**
+     * Old mode of the file, if described by the patch, else null.
+     */
+    FileMode oldMode;
+
+    /**
+     * New mode of the file, if described by the patch, else null.
+     */
+    FileMode newMode;
+
+    /**
+     * General type of change indicated by the patch.
+     */
+    ChangeType changeType;
+
+    /**
+     * ObjectId listed on the index line for the old (pre-image).
+     */
+    AbbreviatedObjectId oldId;
+
+    /**
+     * ObjectId listed on the index line for the new (post-image).
+     */
+    AbbreviatedObjectId newId;
+
+    /**
+     * Get the old name associated with this file.
+     *
+     * <p>The meaning of the old name can differ depending on the semantic meaning
+     * of this patch:
+     * <ul>
+     * <li><i>file add</i>: always <code>/dev/null</code></li>
+     * <li><i>file modify</i>: always {@link #getNewPath()}</li>
+     * <li><i>file delete</i>: always the file being deleted</li>
+     * <li><i>file copy</i>: source file the copy originates from</li>
+     * <li><i>file rename</i>: source file the rename originates from</li>
+     * </ul>
+     *
+     * @return old name for this file.
+     */
+    String getOldPath() {
+        return oldPath;
+    }
+
+    /**
+     * Get the new name associated with this file.
+     *
+     * <p>The meaning of the new name can differ depending on the semantic meaning
+     * of this patch:
+     * <ul>
+     * <li><i>file add</i>: always the file being created</li>
+     * <li><i>file modify</i>: always {@link #getOldPath()}</li>
+     * <li><i>file delete</i>: always <code>/dev/null</code></li>
+     * <li><i>file copy</i>: destination file the copy ends up at</li>
+     * <li><i>file rename</i>: destination file the rename ends up at</li>
+     * </ul>
+     *
+     * @return new name for this file.
+     */
+    String getNewPath() {
+        return newPath;
+    }
+
+    /**
+     * Get the old file mode.
+     *
+     * @return the old file mode, if described in the patch
+     */
+    FileMode getOldMode() {
+        return oldMode;
+    }
+
+    /**
+     * Get the new file mode.
+     *
+     * @return the new file mode, if described in the patch
+     */
+    FileMode getNewMode() {
+        return newMode;
+    }
+
+    /**
+     * Get the change type.
+     *
+     * @return the type of change this patch makes on {@link #getNewPath()}
+     */
+    ChangeType getChangeType() {
+        return changeType;
+    }
+
+    /**
+     * Get the old object id from the <code>index</code>.
+     *
+     * @return the object id; null if there is no index line
+     */
+    AbbreviatedObjectId getOldId() {
+        return oldId;
+    }
+
+    /**
+     * Get the new object id from the <code>index</code>.
+     *
+     * @return the object id; null if there is no index line
+     */
+    AbbreviatedObjectId getNewId() {
+        return newId;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder();
+        buf.append("DiffEntry[");
+        buf.append(changeType);
+        buf.append(' ');
+        switch (changeType) {
+            case ADD:
+                buf.append(newPath);
+                break;
+            case COPY:
+            case RENAME:
+                buf.append(oldPath + "->" + newPath);
+                break;
+            case DELETE:
+                buf.append(oldPath);
+                break;
+            case MODIFY:
+                buf.append(oldPath);
+                break;
+        }
+        buf.append(']');
+        return buf.toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffEntry.java
@@ -163,7 +163,7 @@ final class DiffEntry {
      * <p>The meaning of the old name can differ depending on the semantic meaning
      * of this patch:
      * <ul>
-     * <li><i>file add</i>: always <code>/dev/null</code></li>
+     * <li><i>file add</i>: always {@code /dev/null}</li>
      * <li><i>file modify</i>: always {@link #getNewPath()}</li>
      * <li><i>file delete</i>: always the file being deleted</li>
      * <li><i>file copy</i>: source file the copy originates from</li>
@@ -184,7 +184,7 @@ final class DiffEntry {
      * <ul>
      * <li><i>file add</i>: always the file being created</li>
      * <li><i>file modify</i>: always {@link #getOldPath()}</li>
-     * <li><i>file delete</i>: always <code>/dev/null</code></li>
+     * <li><i>file delete</i>: always {@code /dev/null}</li>
      * <li><i>file copy</i>: destination file the copy ends up at</li>
      * <li><i>file rename</i>: destination file the rename ends up at</li>
      * </ul>
@@ -230,7 +230,7 @@ final class DiffEntry {
     }
 
     /**
-     * Get the old object id from the <code>index</code>.
+     * Get the old object id from the {@code index}.
      *
      * @return the object id; null if there is no index line
      */
@@ -239,7 +239,7 @@ final class DiffEntry {
     }
 
     /**
-     * Get the new object id from the <code>index</code>.
+     * Get the new object id from the {@code index}.
      *
      * @return the object id; null if there is no index line
      */
@@ -262,8 +262,6 @@ final class DiffEntry {
                 buf.append(oldPath + "->" + newPath);
                 break;
             case DELETE:
-                buf.append(oldPath);
-                break;
             case MODIFY:
                 buf.append(oldPath);
                 break;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffGenerator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffGenerator.java
@@ -62,7 +62,6 @@ import java.io.IOException;
 import java.util.function.Predicate;
 
 import org.eclipse.jgit.dircache.DirCacheIterator;
-import org.eclipse.jgit.internal.JGitText;
 import org.eclipse.jgit.lib.AbbreviatedObjectId;
 import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.Constants;
@@ -130,17 +129,7 @@ final class DiffGenerator {
         walk.addTree(a);
         walk.addTree(b);
         walk.setRecursive(true);
-
         walk.setFilter(AndTreeFilter.create(filter, getDiffTreeFilterFor(a, b)));
-
-        return scan(walk, matcher);
-    }
-
-    static boolean scan(TreeWalk walk, Predicate<DiffEntry> matcher) throws IOException {
-        if (walk.getTreeCount() != 2) {
-            throw new IllegalArgumentException(
-                    JGitText.get().treeWalkMustHaveExactlyTwoTrees);
-        }
 
         final MutableObjectId idBuf = new MutableObjectId();
         while (walk.next()) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffGenerator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffGenerator.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+/*
+ * Copyright (C) 2009, Google Inc.
+ * Copyright (C) 2008-2009, Johannes E. Schindelin <johannes.schindelin@gmx.de>
+ * and other copyright owners as documented in the project's IP log.
+ *
+ * This program and the accompanying materials are made available
+ * under the terms of the Eclipse Distribution License v1.0 which
+ * accompanies this distribution, is reproduced below, and is
+ * available at http://www.eclipse.org/org/documents/edl-v10.php
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ * - Neither the name of the Eclipse Foundation, Inc. nor the
+ *   names of its contributors may be used to endorse or promote
+ *   products derived from this software without specific prior
+ *   written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+ * CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+import org.eclipse.jgit.dircache.DirCacheIterator;
+import org.eclipse.jgit.internal.JGitText;
+import org.eclipse.jgit.lib.AbbreviatedObjectId;
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.MutableObjectId;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.EmptyTreeIterator;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.eclipse.jgit.treewalk.WorkingTreeIterator;
+import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
+import org.eclipse.jgit.treewalk.filter.IndexDiffFilter;
+import org.eclipse.jgit.treewalk.filter.NotIgnoredFilter;
+import org.eclipse.jgit.treewalk.filter.TreeFilter;
+
+import com.linecorp.centraldogma.server.internal.storage.StorageException;
+import com.linecorp.centraldogma.server.internal.storage.repository.git.DiffEntry.ChangeType;
+
+final class DiffGenerator {
+
+    /**
+     * Magical SHA1 used for file adds or deletes.
+     */
+    private static final AbbreviatedObjectId A_ZERO = AbbreviatedObjectId.fromObjectId(ObjectId.zeroId());
+
+    /**
+     * Magical file name used for file adds or deletes.
+     */
+    private static final String DEV_NULL = "/dev/null"; //$NON-NLS-1$
+
+    static boolean scan(Repository repository, AnyObjectId a, AnyObjectId b,
+                        TreeFilter filter, Predicate<DiffEntry> matcher) {
+        try (ObjectReader reader = repository.newObjectReader();
+             RevWalk rw = new RevWalk(reader)) {
+            final RevTree aTree = a != null ? rw.parseTree(a) : null;
+            final RevTree bTree = b != null ? rw.parseTree(b) : null;
+            return scan(reader, aTree, bTree, filter, matcher);
+        } catch (IOException e) {
+            throw new StorageException("failed to compare two objects: " + a + " vs. " + b, e);
+        }
+    }
+
+    static boolean scan(Repository repository, AbstractTreeIterator a, AbstractTreeIterator b,
+                        TreeFilter filter, Predicate<DiffEntry> matcher) throws IOException {
+        try (ObjectReader reader = repository.newObjectReader()) {
+            return scan(reader, a, b, filter, matcher);
+        }
+    }
+
+    private static boolean scan(ObjectReader reader, RevTree a, RevTree b,
+                                TreeFilter filter, Predicate<DiffEntry> matcher) throws IOException {
+        final AbstractTreeIterator aIterator = makeIteratorFromTreeOrNull(reader, a);
+        final AbstractTreeIterator bIterator = makeIteratorFromTreeOrNull(reader, b);
+        return scan(reader, aIterator, bIterator, filter, matcher);
+    }
+
+    private static boolean scan(ObjectReader reader, AbstractTreeIterator a, AbstractTreeIterator b,
+                                TreeFilter filter, Predicate<DiffEntry> matcher) throws IOException {
+        final TreeWalk walk = new TreeWalk(reader);
+        walk.addTree(a);
+        walk.addTree(b);
+        walk.setRecursive(true);
+
+        walk.setFilter(AndTreeFilter.create(filter, getDiffTreeFilterFor(a, b)));
+
+        return scan(walk, matcher);
+    }
+
+    static boolean scan(TreeWalk walk, Predicate<DiffEntry> matcher) throws IOException {
+        if (walk.getTreeCount() != 2) {
+            throw new IllegalArgumentException(
+                    JGitText.get().treeWalkMustHaveExactlyTwoTrees);
+        }
+
+        final MutableObjectId idBuf = new MutableObjectId();
+        while (walk.next()) {
+            final DiffEntry entry = new DiffEntry();
+
+            walk.getObjectId(idBuf, 0);
+            entry.oldId = AbbreviatedObjectId.fromObjectId(idBuf);
+
+            walk.getObjectId(idBuf, 1);
+            entry.newId = AbbreviatedObjectId.fromObjectId(idBuf);
+
+            entry.oldMode = walk.getFileMode(0);
+            entry.newMode = walk.getFileMode(1);
+            entry.newPath = entry.oldPath = walk.getPathString();
+
+            if (walk.getAttributesNodeProvider() != null) {
+                entry.diffAttribute = walk.getAttributes()
+                                          .get(Constants.ATTR_DIFF);
+            }
+
+            if (entry.oldMode == FileMode.MISSING) {
+                entry.oldPath = DEV_NULL;
+                entry.changeType = ChangeType.ADD;
+                if (matcher.test(entry)) {
+                    return true;
+                }
+            } else if (entry.newMode == FileMode.MISSING) {
+                entry.newPath = DEV_NULL;
+                entry.changeType = ChangeType.DELETE;
+                if (matcher.test(entry)) {
+                    return true;
+                }
+            } else if (!entry.oldId.equals(entry.newId)) {
+                entry.changeType = ChangeType.MODIFY;
+                if (sameType(entry.oldMode, entry.newMode)) {
+                    if (matcher.test(entry)) {
+                        return true;
+                    }
+                } else {
+                    final DiffEntry[] brokenEntries = breakModify(entry);
+                    if (matcher.test(brokenEntries[0])) {
+                        return true;
+                    }
+                    if (matcher.test(brokenEntries[1])) {
+                        return true;
+                    }
+                }
+            } else if (entry.oldMode != entry.newMode) {
+                entry.changeType = ChangeType.MODIFY;
+                if (matcher.test(entry)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static AbstractTreeIterator makeIteratorFromTreeOrNull(ObjectReader reader, RevTree tree)
+            throws IOException {
+        if (tree == null) {
+            return new EmptyTreeIterator();
+        }
+
+        final CanonicalTreeParser parser = new CanonicalTreeParser();
+        parser.reset(reader, tree);
+        return parser;
+    }
+
+    private static TreeFilter getDiffTreeFilterFor(AbstractTreeIterator a, AbstractTreeIterator b) {
+        if (a instanceof DirCacheIterator && b instanceof WorkingTreeIterator) {
+            return new IndexDiffFilter(0, 1);
+        }
+
+        if (a instanceof WorkingTreeIterator && b instanceof DirCacheIterator) {
+            return new IndexDiffFilter(1, 0);
+        }
+
+        TreeFilter filter = TreeFilter.ANY_DIFF;
+        if (a instanceof WorkingTreeIterator) {
+            filter = AndTreeFilter.create(new NotIgnoredFilter(0), filter);
+        }
+        if (b instanceof WorkingTreeIterator) {
+            filter = AndTreeFilter.create(new NotIgnoredFilter(1), filter);
+        }
+        return filter;
+    }
+
+    static boolean sameType(FileMode a, FileMode b) {
+        // Files have to be of the same type in order to rename them.
+        // We would never want to rename a file to a gitlink, or a
+        // symlink to a file.
+        //
+        final int aType = a.getBits() & FileMode.TYPE_MASK;
+        final int bType = b.getBits() & FileMode.TYPE_MASK;
+        return aType == bType;
+    }
+
+    /**
+     * Breaks apart a DiffEntry into two entries, one DELETE and one ADD.
+     *
+     * @param entry
+     *            the DiffEntry to break apart.
+     * @return a list containing two entries. Calling {@link DiffEntry#getChangeType()}
+     *         on the first entry will return ChangeType.DELETE. Calling it on
+     *         the second entry will return ChangeType.ADD.
+     */
+    static DiffEntry[] breakModify(DiffEntry entry) {
+        final DiffEntry del = new DiffEntry();
+        del.oldId = entry.getOldId();
+        del.oldMode = entry.getOldMode();
+        del.oldPath = entry.getOldPath();
+
+        del.newId = A_ZERO;
+        del.newMode = FileMode.MISSING;
+        del.newPath = DEV_NULL;
+        del.changeType = ChangeType.DELETE;
+        del.diffAttribute = entry.diffAttribute;
+
+        final DiffEntry add = new DiffEntry();
+        add.oldId = A_ZERO;
+        add.oldMode = FileMode.MISSING;
+        add.oldPath = DEV_NULL;
+
+        add.newId = entry.getNewId();
+        add.newMode = entry.getNewMode();
+        add.newPath = entry.getNewPath();
+        add.changeType = ChangeType.ADD;
+        add.diffAttribute = entry.diffAttribute;
+        return new DiffEntry[] { del, add };
+    }
+
+    private DiffGenerator() {}
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
@@ -165,18 +165,21 @@ final class DiffScanner {
                     return true;
                 }
             } else if (!oldId.equals(newId)) {
-                final DiffEntry entry = new DiffEntry(path, path, diffAttribute, oldMode, newMode,
-                                                      ChangeType.MODIFY, oldId, newId);
                 if (sameType(oldMode, newMode)) {
+                    final DiffEntry entry = new DiffEntry(path, path, diffAttribute, oldMode, newMode,
+                                                          ChangeType.MODIFY, oldId, newId);
                     if (matcher.test(entry)) {
                         return true;
                     }
                 } else {
-                    final DiffEntry[] brokenEntries = breakModify(entry);
-                    if (matcher.test(brokenEntries[0])) {
+                    if (matcher.test(new DiffEntry(path, DEV_NULL, diffAttribute,
+                                                   oldMode, FileMode.MISSING, ChangeType.DELETE,
+                                                   oldId, ObjectId.zeroId()))) {
                         return true;
                     }
-                    if (matcher.test(brokenEntries[1])) {
+                    if (matcher.test(new DiffEntry(DEV_NULL, path, diffAttribute,
+                                                   FileMode.MISSING, newMode, ChangeType.ADD,
+                                                   ObjectId.zeroId(), newId))) {
                         return true;
                     }
                 }
@@ -229,25 +232,6 @@ final class DiffScanner {
         final int aType = a.getBits() & FileMode.TYPE_MASK;
         final int bType = b.getBits() & FileMode.TYPE_MASK;
         return aType == bType;
-    }
-
-    /**
-     * Breaks apart a DiffEntry into two entries, one DELETE and one ADD.
-     *
-     * @param entry the DiffEntry to break apart.
-     * @return a list containing two entries. Calling {@link DiffEntry#getChangeType()}
-     *         on the first entry will return ChangeType.DELETE. Calling it on
-     *         the second entry will return ChangeType.ADD.
-     */
-    static DiffEntry[] breakModify(DiffEntry entry) {
-        return new DiffEntry[] {
-                new DiffEntry(entry.getOldPath(), DEV_NULL, entry.getDiffAttribute(),
-                              entry.getOldMode(), FileMode.MISSING, ChangeType.DELETE,
-                              entry.getOldId(), ObjectId.zeroId()),
-                new DiffEntry(DEV_NULL, entry.getNewPath(), entry.getDiffAttribute(),
-                              FileMode.MISSING, entry.getNewMode(), ChangeType.ADD,
-                              ObjectId.zeroId(), entry.getNewId())
-        };
     }
 
     private DiffScanner() {}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -683,7 +683,7 @@ class GitRepository implements Repository {
             final CanonicalTreeParser p = new CanonicalTreeParser();
             p.reset(reader, baseTreeId);
             final ImmutableList.Builder<DiffEntry> builder = ImmutableList.builder();
-            DiffGenerator.scan(jGitRepository, p, new DirCacheIterator(dirCache), TreeFilter.ALL, entry -> {
+            DiffScanner.scan(jGitRepository, p, new DirCacheIterator(dirCache), TreeFilter.ALL, entry -> {
                 builder.add(entry);
                 return false;
             });
@@ -1307,7 +1307,7 @@ class GitRepository implements Repository {
         final boolean matches;
         readLock();
         try (RevWalk revWalk = new RevWalk(jGitRepository)) {
-            matches = DiffGenerator.scan(
+            matches = DiffScanner.scan(
                     jGitRepository, toTreeId(revWalk, range.from()), toTreeId(revWalk, range.to()),
                     TreeFilter.ALL, e -> {
                         final String path;
@@ -1362,7 +1362,7 @@ class GitRepository implements Repository {
     }
 
     private void notifyWatchers(Revision newRevision, @Nullable ObjectId prevTreeId, ObjectId nextTreeId) {
-        DiffGenerator.scan(jGitRepository, prevTreeId, nextTreeId, TreeFilter.ALL, entry -> {
+        DiffScanner.scan(jGitRepository, prevTreeId, nextTreeId, TreeFilter.ALL, entry -> {
             switch (entry.getChangeType()) {
                 case ADD:
                     commitWatchers.notify(newRevision, entry.getNewPath());
@@ -1412,7 +1412,7 @@ class GitRepository implements Repository {
             diffFormatter.setPathFilter(filter);
 
             final ImmutableList.Builder<DiffEntry> builder = ImmutableList.builder();
-            DiffGenerator.scan(jGitRepository, prevTreeId, nextTreeId, filter, entry -> {
+            DiffScanner.scan(jGitRepository, prevTreeId, nextTreeId, filter, entry -> {
                 builder.add(entry);
                 return false;
             });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -714,9 +714,9 @@ class GitRepository implements Repository {
                         }
 
                         final JsonNode oldJsonNode =
-                                Jackson.readTree(reader.open(diffEntry.getOldId().toObjectId()).getBytes());
+                                Jackson.readTree(reader.open(diffEntry.getOldId()).getBytes());
                         final JsonNode newJsonNode =
-                                Jackson.readTree(reader.open(diffEntry.getNewId().toObjectId()).getBytes());
+                                Jackson.readTree(reader.open(diffEntry.getNewId()).getBytes());
                         final JsonPatch patch =
                                 JsonPatch.generate(oldJsonNode, newJsonNode, ReplaceMode.SAFE);
 


### PR DESCRIPTION
Motivation:

Unless a user requests a full diff, we do not really need to traverse
the whole tree. We can stop comparing as soon as we found what we're
looking for.

Modifications:

- Fork jGit's `DiffFormatter` and `DiffEntry` so that we can stop the
  tree traversal loop while comparing two trees.
- Stop the tree traversal loop in `blockingFindLatestRevision()` and
  `notifyWatchers`.

Result:

- Watching takes less time in a repository with many files.