### PR TITLE
Cache the diff result in `DiffScanner`

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
@@ -58,7 +58,11 @@
  */
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.eclipse.jgit.attributes.Attribute;
@@ -81,19 +85,57 @@ import org.eclipse.jgit.treewalk.filter.AndTreeFilter;
 import org.eclipse.jgit.treewalk.filter.IndexDiffFilter;
 import org.eclipse.jgit.treewalk.filter.NotIgnoredFilter;
 import org.eclipse.jgit.treewalk.filter.TreeFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.server.internal.storage.StorageException;
 import com.linecorp.centraldogma.server.internal.storage.repository.git.DiffEntry.ChangeType;
 
 final class DiffScanner {
 
+    private static final Logger logger = LoggerFactory.getLogger(DiffScanner.class);
+
     /**
      * Magical file name used for file adds or deletes.
      */
     private static final String DEV_NULL = "/dev/null";
 
-    static boolean scan(Repository repository, AnyObjectId a, AnyObjectId b,
-                        TreeFilter filter, Predicate<DiffEntry> matcher) {
+    private static final LoadingCache<CacheKey, List<DiffEntry>> cache =
+            Caffeine.newBuilder().maximumSize(8192).expireAfterAccess(Duration.ofMinutes(10)).build(key -> {
+                final ImmutableList.Builder<DiffEntry> builder = ImmutableList.builder();
+                scan(key.repo, key.oidA, key.oidB, TreeFilter.ALL, e -> {
+                    builder.add(e);
+                    return false;
+                });
+                logger.info("Cache miss: {}", key);
+                return builder.build();
+            });
+
+    static boolean scanCached(Repository repository, AnyObjectId a, AnyObjectId b,
+                              TreeFilter filter, Predicate<DiffEntry> matcher) {
+        if (filter == TreeFilter.ALL) {
+            final CacheKey key = new CacheKey(repository, a, b);
+            final List<DiffEntry> entries = cache.get(key);
+            if (entries != null) {
+                for (DiffEntry e : entries) {
+                    if (matcher.test(e)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        }
+
+        // Uncached version.
+        return scan(repository, a, b, filter, matcher);
+    }
+
+    private static boolean scan(Repository repository, AnyObjectId a, AnyObjectId b,
+                                TreeFilter filter, Predicate<DiffEntry> matcher) {
         try (ObjectReader reader = repository.newObjectReader();
              RevWalk rw = new RevWalk(reader)) {
             final RevTree aTree = a != null ? rw.parseTree(a) : null;
@@ -235,4 +277,43 @@ final class DiffScanner {
     }
 
     private DiffScanner() {}
+
+    private static final class CacheKey {
+        final Repository repo;
+        final AnyObjectId oidA;
+        final AnyObjectId oidB;
+
+        CacheKey(Repository repo, AnyObjectId oidA, AnyObjectId oidB) {
+            this.repo = requireNonNull(repo, "repo");
+            this.oidA = requireNonNull(oidA, "a");
+            this.oidB = requireNonNull(oidB, "b");
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            final CacheKey that = (CacheKey) o;
+            return repo == that.repo && oidA.equals(that.oidA) && oidB.equals(that.oidB);
+        }
+
+        @Override
+        public int hashCode() {
+            return (System.identityHashCode(repo) * 31 + oidA.hashCode()) * 31 + oidB.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return "CacheKey{" +
+                   "repo=" + repo +
+                   ", a=" + oidA +
+                   ", b=" + oidB +
+                   '}';
+        }
+    }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DiffScanner.java
@@ -280,13 +280,13 @@ final class DiffScanner {
 
     private static final class CacheKey {
         final Repository repo;
-        final AnyObjectId oidA;
-        final AnyObjectId oidB;
+        final ObjectId oidA;
+        final ObjectId oidB;
 
         CacheKey(Repository repo, AnyObjectId oidA, AnyObjectId oidB) {
             this.repo = requireNonNull(repo, "repo");
-            this.oidA = requireNonNull(oidA, "a");
-            this.oidB = requireNonNull(oidB, "b");
+            this.oidA = requireNonNull(oidA, "a").toObjectId();
+            this.oidB = requireNonNull(oidB, "b").toObjectId();
         }
 
         @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -1330,7 +1330,7 @@ class GitRepository implements Repository {
         final boolean matches;
         readLock();
         try (RevWalk revWalk = new RevWalk(jGitRepository)) {
-            matches = DiffScanner.scan(
+            matches = DiffScanner.scanCached(
                     jGitRepository, toTreeId(revWalk, range.from()), toTreeId(revWalk, range.to()),
                     TreeFilter.ALL, e -> {
                         final String path;
@@ -1394,7 +1394,7 @@ class GitRepository implements Repository {
     }
 
     private void notifyWatchers(Revision newRevision, @Nullable ObjectId prevTreeId, ObjectId nextTreeId) {
-        DiffScanner.scan(jGitRepository, prevTreeId, nextTreeId, TreeFilter.ALL, entry -> {
+        DiffScanner.scanCached(jGitRepository, prevTreeId, nextTreeId, TreeFilter.ALL, entry -> {
             switch (entry.getChangeType()) {
                 case ADD:
                     commitWatchers.notify(newRevision, entry.getNewPath());
@@ -1444,7 +1444,7 @@ class GitRepository implements Repository {
             diffFormatter.setPathFilter(filter);
 
             final ImmutableList.Builder<DiffEntry> builder = ImmutableList.builder();
-            DiffScanner.scan(jGitRepository, prevTreeId, nextTreeId, filter, entry -> {
+            DiffScanner.scanCached(jGitRepository, prevTreeId, nextTreeId, filter, entry -> {
                 builder.add(entry);
                 return false;
             });


### PR DESCRIPTION
Motivation:

Even if we stop our traversal as early as possible, the traversal can
take long time if there are many files in a tree and the given path
pattern matches small number of files only.

Modifications:

- Cache the complete diff result if `TreeFilter.ALL` is specified, so
  that tree traversal between the same tree pairs is performed only once.

Result:

- Hopefully better `watch*()` performance in a repository with many
  files.