### PR TITLE
Add `revision` property to `EntryDto`

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -99,12 +99,7 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
-import io.netty.util.AsciiString;
-
 final class ArmeriaCentralDogma extends AbstractCentralDogma {
-
-    // TODO(trustin): Replace with HttpHeaderNames.PREFER.
-    private static final AsciiString HEADER_NAME_PREFER = HttpHeaderNames.of("prefer");
 
     private static final MediaType JSON_PATCH_UTF8 = MediaType.JSON_PATCH.withCharset(StandardCharsets.UTF_8);
 
@@ -386,6 +381,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             requireNonNull(revision, "revision");
             requireNonNull(query, "query");
 
+            // TODO(trustin) No need to normalize a revision once server response contains it.
             return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
                 path.append("/contents").append(query.path());
@@ -418,6 +414,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             requireNonNull(revision, "revision");
             validatePathPattern(pathPattern, "pathPattern");
 
+            // TODO(trustin) No need to normalize a revision once server response contains it.
             return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
                 path.append("/contents");
@@ -812,7 +809,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
                                            String path, Function<AggregatedHttpMessage, T> func) {
         final HttpHeaders headers = headers(HttpMethod.GET, path)
                 .set(HttpHeaderNames.IF_NONE_MATCH, lastKnownRevision.text())
-                .set(HEADER_NAME_PREFER, "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L);
+                .set(HttpHeaderNames.PREFER, "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L);
 
         try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
             ctx.setResponseTimeoutMillis(

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/EntryDto.java
@@ -29,9 +29,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Revision;
 
 @JsonInclude(Include.NON_NULL)
 public class EntryDto<T> {
+
+    private final Revision revision;
 
     private final String path;
 
@@ -41,30 +44,37 @@ public class EntryDto<T> {
 
     private final String url;
 
-    public EntryDto(String path, EntryType type, String projectName, String repoName, @Nullable T content) {
+    public EntryDto(Revision revision, String path, EntryType type,
+                    String projectName, String repoName, @Nullable T content) {
+        this.revision = requireNonNull(revision, "revision");
         this.path = requireNonNull(path, "path");
         this.type = requireNonNull(type, "type");
         this.content = content;
         url = PROJECTS_PREFIX + '/' + projectName + REPOS + '/' + repoName + CONTENTS + path;
     }
 
-    @JsonProperty("path")
+    @JsonProperty
+    public Revision revision() {
+        return revision;
+    }
+
+    @JsonProperty
     public String path() {
         return path;
     }
 
-    @JsonProperty("type")
+    @JsonProperty
     public EntryType type() {
         return type;
     }
 
-    @JsonProperty("content")
+    @JsonProperty
     @Nullable
     public T content() {
         return content;
     }
 
-    @JsonProperty("url")
+    @JsonProperty
     @Nullable
     public String url() {
         return url;
@@ -73,6 +83,7 @@ public class EntryDto<T> {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("revision", revision)
                           .add("path", path)
                           .add("type", type)
                           .add("content", content).toString();

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
@@ -78,7 +78,7 @@ public class SamlAuthTest {
         resp = rule.httpClient().get(AuthProvider.LOGIN_PATH).aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.OK);
         assertThat(resp.headers().contentType()).isEqualTo(MediaType.HTML_UTF_8);
-        assertThat(resp.content().toStringUtf8()).contains("<input type=\"hidden\" name=\"SAMLRequest\"");
+        assertThat(resp.contentUtf8()).contains("<input type=\"hidden\" name=\"SAMLRequest\"");
 
         // Redirect to built-in web logout page.
         resp = rule.httpClient().get(AuthProvider.LOGOUT_PATH).aggregate().join();
@@ -97,7 +97,7 @@ public class SamlAuthTest {
 
         // Check ACS URLs for the service provider.
         final int port = rule.serverAddress().getPort();
-        assertThat(resp.content().toStringUtf8())
+        assertThat(resp.contentUtf8())
                 .contains("entityID=\"test-sp\"")
                 .contains("<md:AssertionConsumerService " +
                           "Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" " +

--- a/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
+++ b/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
@@ -165,9 +165,8 @@ final class LoginService extends AbstractHttpService {
                                  "The content type of a login request must be '%s'.", MediaType.FORM_DATA);
         }
 
-        final Map<String, List<String>> parameters = new QueryStringDecoder(
-                req.content().toStringUtf8(), false).parameters();
-
+        final Map<String, List<String>> parameters = new QueryStringDecoder(req.contentUtf8(),
+                                                                            false).parameters();
         // assume that the grant_type is "password"
         final List<String> usernames = parameters.get("username");
         final List<String> passwords = parameters.get("password");

--- a/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
+++ b/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
@@ -73,7 +73,7 @@ public class ShiroLoginAndLogoutTest {
         assertThat(loginRes.status()).isEqualTo(HttpStatus.OK);
 
         // Ensure authorization works.
-        final AccessToken accessToken = Jackson.readValue(loginRes.content().toStringUtf8(), AccessToken.class);
+        final AccessToken accessToken = Jackson.readValue(loginRes.contentUtf8(), AccessToken.class);
         final String sessionId = accessToken.accessToken();
 
         assertThat(usersMe(client, sessionId).status()).isEqualTo(HttpStatus.OK);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -151,7 +151,7 @@ public class RepositoryService extends AbstractService {
                                    ServiceRequestContext ctx) {
         final CommitMessageDto commitMessage;
         try {
-            final JsonNode node = Jackson.readTree(message.content().toStringUtf8());
+            final JsonNode node = Jackson.readTree(message.contentUtf8());
             commitMessage = Jackson.convertValue(node.get("commitMessage"), CommitMessageDto.class);
         } catch (IOException e) {
             throw new IllegalArgumentException("invalid data to be parsed", e);
@@ -242,7 +242,7 @@ public class RepositoryService extends AbstractService {
 
     private static Entry<CommitMessageDto, Change<?>> commitMessageAndChange(AggregatedHttpMessage message) {
         try {
-            final JsonNode node = Jackson.readTree(message.content().toStringUtf8());
+            final JsonNode node = Jackson.readTree(message.contentUtf8());
             final CommitMessageDto commitMessage =
                     Jackson.convertValue(node.get("commitMessage"), CommitMessageDto.class);
             final EntryDto file = Jackson.convertValue(node.get("file"), EntryDto.class);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -58,23 +58,29 @@ final class DtoConverter {
                                  repository.creationTimeMillis());
     }
 
-    public static <T> EntryDto<T> convert(Repository repository, Entry<T> entry, boolean withContent) {
+    public static <T> EntryDto<T> convert(Repository repository, Revision revision,
+                                          Entry<T> entry, boolean withContent) {
         requireNonNull(entry, "entry");
         if (withContent && entry.hasContent()) {
-            return convert(repository, entry.path(), entry.type(), entry.content());
+            return convert(repository, revision, entry.path(), entry.type(), entry.content());
         }
-        return convert(repository, entry.path(), entry.type());
+        return convert(repository, revision, entry.path(), entry.type());
     }
 
-    public static <T> EntryDto<T> convert(Repository repository, String path, EntryType type) {
-        return convert(repository, path, type, null);
+    private static <T> EntryDto<T> convert(Repository repository, Revision revision,
+                                           String path, EntryType type) {
+        return convert(repository, revision, path, type, null);
     }
 
-    public static <T> EntryDto<T> convert(Repository repository, String path, EntryType type,
-                                          @Nullable T content) {
+    private static <T> EntryDto<T> convert(Repository repository, Revision revision, String path,
+                                           EntryType type, @Nullable T content) {
         requireNonNull(repository, "repository");
-        return new EntryDto<>(requireNonNull(path, "path"), requireNonNull(type, "type"),
-                              repository.parent().name(), repository.name(), content);
+        return new EntryDto<>(requireNonNull(revision, "revision"),
+                              requireNonNull(path, "path"),
+                              requireNonNull(type, "type"),
+                              repository.parent().name(),
+                              repository.name(),
+                              content);
     }
 
     public static PushResultDto convert(Revision revision, long commitTimeMillis) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.AggregatedHttpMessage;
@@ -32,17 +31,11 @@ import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
-import io.netty.util.AsciiString;
-
 /**
  * A request converter that converts to {@link WatchRequest} when the request contains
  * {@link HttpHeaderNames#IF_NONE_MATCH}.
  */
 public final class WatchRequestConverter implements RequestConverterFunction {
-
-    // TODO(trustin): Replace with HttpHeaderNames.PREFER.
-    @VisibleForTesting
-    static final AsciiString HEADER_NAME_PREFER = HttpHeaderNames.of("prefer");
 
     private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(120);
 
@@ -56,7 +49,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
         final String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
         if (!isNullOrEmpty(ifNoneMatch)) {
             final Revision lastKnownRevision = new Revision(ifNoneMatch);
-            final String prefer = request.headers().get(HEADER_NAME_PREFER);
+            final String prefer = request.headers().get(HttpHeaderNames.PREFER);
             final long timeoutMillis;
             if (!isNullOrEmpty(prefer)) {
                 timeoutMillis = getTimeoutMillis(prefer);

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -153,7 +153,7 @@ public class ReplicatedLoginAndLogoutTest {
         assertThat(replicationLogCount()).isEqualTo(baselineReplicationLogCount + 1);
 
         // Ensure authorization works at the 2nd replica.
-        final AccessToken accessToken = Jackson.readValue(loginRes.content().toStringUtf8(), AccessToken.class);
+        final AccessToken accessToken = Jackson.readValue(loginRes.contentUtf8(), AccessToken.class);
         final String sessionId = accessToken.accessToken();
         await().pollDelay(Duration.TWO_HUNDRED_MILLISECONDS)
                .pollInterval(Duration.ONE_SECOND)

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -55,7 +55,7 @@ public class AdministrativeServiceTest {
     public void status() {
         final AggregatedHttpMessage res = httpClient.get(API_V1_PATH_PREFIX + "status").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": true, \"replicating\": true }");
     }
 
@@ -67,7 +67,7 @@ public class AdministrativeServiceTest {
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }]").aggregate().join();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": false, \"replicating\": true }");
     }
 
@@ -80,7 +80,7 @@ public class AdministrativeServiceTest {
                 " { \"op\": \"replace\", \"path\": \"/replicating\", \"value\": false }]").aggregate().join();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": false, \"replicating\": false }");
     }
 
@@ -126,7 +126,7 @@ public class AdministrativeServiceTest {
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": true, \"replicating\": true }");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -40,12 +40,7 @@ import com.linecorp.centraldogma.common.ChangeConflictException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.internal.Jackson;
 
-import io.netty.util.AsciiString;
-
 public class ContentServiceV1Test extends ContentServiceV1TestBase {
-
-    // TODO(trustin): Replace with HttpHeaderNames.PREFER.
-    private static final AsciiString HEADER_NAME_PREFER = HttpHeaderNames.of("prefer");
 
     // TODO(minwoox) replace this unit test using nested structure in junit 5
     // Rule is used instead of ClassRule because the listFiles is
@@ -59,7 +54,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 2," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -85,7 +80,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 3," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -111,7 +106,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 3," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -145,7 +140,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 2," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -170,7 +165,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         // check whether the change is right
         final AggregatedHttpMessage res1 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=2&to=3").aggregate().join();
-        final JsonNode content1 = Jackson.readTree(res1.content().toStringUtf8()).get(0).get("content");
+        final JsonNode content1 = Jackson.readTree(res1.contentUtf8()).get(0).get("content");
         assertThat(content1.size()).isOne();
         assertThat(content1.get(0).toString()).isEqualToIgnoringCase(
                 "{\"op\":\"safeReplace\",\"path\":\"/a\",\"oldValue\":\"bar\",\"value\":\"baz\"}");
@@ -193,7 +188,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         // check whether the change is right
         final AggregatedHttpMessage res2 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=4&to=5").aggregate().join();
-        final JsonNode content2 = Jackson.readTree(res2.content().toStringUtf8()).get(0).get("content");
+        final JsonNode content2 = Jackson.readTree(res2.contentUtf8()).get(0).get("content");
         assertThat(content2.textValue()).isEqualToIgnoringCase("--- /a/bar.txt\n" +
                                                                "+++ /a/bar.txt\n" +
                                                                "@@ -1,1 +1,1 @@\n" +
@@ -254,7 +249,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "       }]" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -265,12 +260,13 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
         final String expectedJson =
                 '{' +
+                "   \"revision\": 2," +
                 "   \"path\": \"/foo.json\"," +
                 "   \"type\": \"JSON\"," +
                 "   \"content\" : {\"a\":\"bar\"}," +
                 "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -283,12 +279,13 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
         final String expectedJson =
                 '{' +
+                "   \"revision\": 2," +
                 "   \"path\": \"/foo.json\"," +
                 "   \"type\": \"JSON\"," +
                 "   \"content\" : \"bar\"," +
                 "   \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
+        final String actualJson = aRes.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -302,23 +299,25 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson1 =
                 '[' +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a/bar.txt\"" +
                 "   }," +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
-        final String actualJson1 = res1.content().toStringUtf8();
-        assertThatJson(actualJson1).isEqualTo(expectedJson1);
+        assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson1);
 
         // get the list of files only under root
         final AggregatedHttpMessage res2 = httpClient()
@@ -326,18 +325,19 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson2 =
                 '[' +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
-        final String actualJson2 = res2.content().toStringUtf8();
-        assertThatJson(actualJson2).isEqualTo(expectedJson2);
+        assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson2);
 
         // get the list of all files with revision 2, so only foo.json will be fetched
         final AggregatedHttpMessage res3 = httpClient()
@@ -345,17 +345,27 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson3 =
                 '[' +
                 "   {" +
+                "       \"revision\": 2," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
-        assertThatJson(expectedJson3).isEqualTo(res3.content().toStringUtf8());
+        assertThatJson(res3.contentUtf8()).isEqualTo(expectedJson3);
 
         // get the list with a file path
         final AggregatedHttpMessage res4 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/foo.json").aggregate().join();
-        assertThatJson(expectedJson3).isEqualTo(res4.content().toStringUtf8());
+        final String expectedJson4 =
+                '[' +
+                "   {" +
+                "       \"revision\": 3," +
+                "       \"path\": \"/foo.json\"," +
+                "       \"type\": \"JSON\"," +
+                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
+                "   }" +
+                ']';
+        assertThatJson(res4.contentUtf8()).isEqualTo(expectedJson4);
     }
 
     @Test
@@ -368,39 +378,41 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson1 =
                 '[' +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/a\"," +
                 "       \"type\": \"DIRECTORY\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a\"" +
                 "   }," +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/a/bar.txt\"," +
                 "       \"type\": \"TEXT\"," +
                 "       \"content\" : \"text in the file.\\n\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a/bar.txt\"" +
                 "   }," +
                 "   {" +
+                "       \"revision\": 3," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\" : {\"a\":\"bar\"}," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
-        final String actualJson1 = res1.content().toStringUtf8();
-        assertThatJson(actualJson1).isEqualTo(expectedJson1);
+        assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson1);
 
         final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/**?revision=2")
                                                        .aggregate().join();
         final String expectedJson2 =
                 '[' +
                 "   {" +
+                "       \"revision\": 2," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\" : {\"a\":\"bar\"}," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 ']';
-        final String actualJson2 = res2.content().toStringUtf8();
-        assertThatJson(actualJson2).isEqualTo(expectedJson2);
+        assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson2);
     }
 
     @Test
@@ -423,7 +435,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
         final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/**").aggregate().join();
         // /a directory and /a/bar.txt file are left
-        assertThat(Jackson.readTree(res2.content().toStringUtf8()).size()).isEqualTo(2);
+        assertThat(Jackson.readTree(res2.contentUtf8()).size()).isEqualTo(2);
     }
 
     @Test
@@ -442,7 +454,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                                                .contentType(MediaType.JSON);
         final AggregatedHttpMessage res = httpClient().execute(headers, body).aggregate().join();
         assertThat(res.headers().status()).isEqualTo(HttpStatus.CONFLICT);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 '{' +
                 "  \"exception\": \"" + ChangeConflictException.class.getName() + "\"," +
                 "  \"message\": \"${json-unit.ignore}\"" +
@@ -474,7 +486,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                                                .contentType(MediaType.JSON);
         final AggregatedHttpMessage res = httpClient().execute(headers, body).aggregate().join();
         assertThat(res.headers().status()).isEqualTo(HttpStatus.CONFLICT);
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(
+        assertThatJson(res.contentUtf8()).isEqualTo(
                 '{' +
                 "  \"exception\": \"" + RedundantChangeException.class.getName() + "\"," +
                 "  \"message\": \"${json-unit.ignore}\"" +
@@ -490,11 +502,11 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 3," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = res1.content().toStringUtf8();
+        final String actualJson = res1.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
 
         final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/foo.json").aggregate().join();
-        assertThat(Jackson.readTree(res2.content().toStringUtf8()).get("content").get("a").textValue())
+        assertThat(Jackson.readTree(res2.contentUtf8()).get("content").get("a").textValue())
                 .isEqualToIgnoringCase("baz");
     }
 
@@ -525,11 +537,11 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   \"revision\": 3," +
                 "   \"pushedAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = res1.content().toStringUtf8();
+        final String actualJson = res1.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
 
         final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/a/bar.txt").aggregate().join();
-        assertThat(Jackson.readTree(res2.content().toStringUtf8()).get("content").textValue())
+        assertThat(Jackson.readTree(res2.contentUtf8()).get("content").textValue())
                 .isEqualTo("text in some file.\n");
     }
 
@@ -552,7 +564,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '{' +
                 "   \"revision\" : 3" +
                 '}';
-        final String actualJson = res.content().toStringUtf8();
+        final String actualJson = res.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -560,7 +572,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     public void watchRepositoryTimeout() {
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, CONTENTS_PREFIX)
                                                .add(HttpHeaderNames.IF_NONE_MATCH, "-1")
-                                               .add(HEADER_NAME_PREFER, "wait=5"); // 5 seconds
+                                               .add(HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
         final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
         await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(future.join().headers().status()).isSameAs(HttpStatus.NOT_MODIFIED);
@@ -570,7 +582,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     public void watchFileTimeout() {
         final HttpHeaders headers = HttpHeaders.of(HttpMethod.GET, CONTENTS_PREFIX + "/foo.json")
                                                .add(HttpHeaderNames.IF_NONE_MATCH, "-1")
-                                               .add(HEADER_NAME_PREFER, "wait=5"); // 5 seconds
+                                               .add(HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
         final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
         await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(future.join().headers().status()).isSameAs(HttpStatus.NOT_MODIFIED);
@@ -597,6 +609,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '{' +
                 "   \"revision\" : 4," +
                 "   \"entry\": {" +
+                "       \"revision\" : 4," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\": {\"a\":\"baz\"}," +
@@ -604,7 +617,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   }" +
                 '}';
         final AggregatedHttpMessage res = future.join();
-        final String actualJson = res.content().toStringUtf8();
+        final String actualJson = res.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -630,6 +643,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '{' +
                 "   \"revision\" : 4," +
                 "   \"entry\": {" +
+                "       \"revision\" : 4," +
                 "       \"path\": \"/foo.json\"," +
                 "       \"type\": \"JSON\"," +
                 "       \"content\": \"baz\"," +
@@ -637,7 +651,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   }" +
                 '}';
         final AggregatedHttpMessage res = future.join();
-        final String actualJson = res.content().toStringUtf8();
+        final String actualJson = res.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
 
@@ -658,6 +672,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String expectedJson =
                 '[' +
                 "   {" +
+                "       \"revision\": 2," +
                 "       \"path\": \"/a.json/b.json\"," +
                 "       \"type\": \"DIRECTORY\"," +
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/a.json/b.json\"" +
@@ -666,12 +681,12 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         // List directory without slash.
         final AggregatedHttpMessage res1 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/a.json").aggregate().join();
-        assertThatJson(res1.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
 
         // Listing directory with a slash is same with the listing director without slash which is res1.
         final AggregatedHttpMessage res2 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/a.json/").aggregate().join();
-        assertThatJson(res2.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
     }
 
     private AggregatedHttpMessage addFooJson() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -128,8 +128,7 @@ public class ListCommitsAndDiffTest {
                 "       }" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -166,8 +165,7 @@ public class ListCommitsAndDiffTest {
                 "       }" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -188,8 +186,7 @@ public class ListCommitsAndDiffTest {
                 "       \"markup\": \"PLAINTEXT\"" +
                 "   }" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -212,8 +209,7 @@ public class ListCommitsAndDiffTest {
                 "       }" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -249,12 +245,10 @@ public class ListCommitsAndDiffTest {
                 "       }" +
                 "   }" +
                 ']';
-        final String actualJson1 = res1.content().toStringUtf8();
-        assertThatJson(actualJson1).isEqualTo(expectedJson);
+        assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
         final AggregatedHttpMessage res2 = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/3?to=2")
                                                      .aggregate().join();
-        final String actualJson2 = res2.content().toStringUtf8();
-        assertThatJson(actualJson2).isEqualTo(expectedJson);
+        assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -285,8 +279,7 @@ public class ListCommitsAndDiffTest {
                 "       }]" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -307,8 +300,7 @@ public class ListCommitsAndDiffTest {
                 "       \"value\": \"baz0\"" +
                 "   }]" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     private static void editFooFile() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MergeFileTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MergeFileTest.java
@@ -51,8 +51,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "   }," +
                 "   \"paths\" : [\"/foo.json\", \"/foo1.json\", \"/foo2.json\"] " +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
 
         queryString = "path=/foo.json" + '&' +
                       "path=/foo1.json" + '&' +
@@ -66,7 +65,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "     \"exception\": \"com.linecorp.centraldogma.common.EntryNotFoundException\"," +
                 "     \"message\": \"Entry '/foo3.json (revision: 4)' does not exist.\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -83,7 +82,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "     \"exception\": \"com.linecorp.centraldogma.common.EntryNotFoundException\"," +
                 "     \"message\": \"Entry '/no_exist1.json,/no_exist2.json (revision: 4)' does not exist.\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -115,7 +114,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "     \"exception\": \"com.linecorp.centraldogma.common.QueryExecutionException\"," +
                 "     \"message\": \"Failed to merge tree. /a/ type: NUMBER (expected: STRING)\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -128,7 +127,6 @@ public class MergeFileTest extends ContentServiceV1TestBase {
 
         AggregatedHttpMessage aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
                                                       queryString).aggregate().join();
-        final String actualJson = aRes.content().toStringUtf8();
         String expectedJson =
                 '{' +
                 "   \"revision\" : 4," +
@@ -136,7 +134,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "   \"content\" : \"baz\"," +
                 "   \"paths\" : [\"/foo.json\", \"/foo1.json\", \"/foo2.json\"] " +
                 '}';
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
 
         queryString = "path=/foo.json" + '&' +
                       "path=/foo1.json" + '&' +
@@ -150,7 +148,7 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                 "     \"exception\": \"com.linecorp.centraldogma.common.QueryExecutionException\"," +
                 "     \"message\": \"JSON path evaluation failed: $.c\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     private void addFilesForMergeJson() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -68,7 +68,7 @@ public class ProjectServiceV1Test {
         final String location = headers.get(HttpHeaderNames.LOCATION);
         assertThat(location).isEqualTo("/api/v1/projects/myPro");
 
-        final JsonNode jsonNode = Jackson.readTree(aRes.content().toStringUtf8());
+        final JsonNode jsonNode = Jackson.readTree(aRes.contentUtf8());
         assertThat(jsonNode.get("name").asText()).isEqualTo("myPro");
         assertThat(jsonNode.get("createdAt").asText()).isNotNull();
     }
@@ -91,7 +91,7 @@ public class ProjectServiceV1Test {
                 "   \"exception\": \"" + ProjectExistsException.class.getName() + "\"," +
                 "   \"message\": \"Project 'myPro' exists already.\"" +
                 '}';
-        assertThatJson(res.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(res.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -131,8 +131,7 @@ public class ProjectServiceV1Test {
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -171,11 +170,10 @@ public class ProjectServiceV1Test {
                 "       \"name\": \"minwoox\"" +
                 "   }" +
                 ']';
-        final String actualJson = removedRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(removedRes.contentUtf8()).isEqualTo(expectedJson);
 
         final AggregatedHttpMessage remainedRes = httpClient.get(PROJECTS_PREFIX).aggregate().join();
-        final String remains = remainedRes.content().toStringUtf8();
+        final String remains = remainedRes.contentUtf8();
         final JsonNode jsonNode = Jackson.readTree(remains);
 
         // only trustin project is left
@@ -204,8 +202,7 @@ public class ProjectServiceV1Test {
                 "   \"url\": \"/api/v1/projects/bar\"," +
                 "   \"createdAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -80,7 +80,7 @@ public class RepositoryServiceV1Test {
         final String location = headers.get(HttpHeaderNames.LOCATION);
         assertThat(location).isEqualTo("/api/v1/projects/myPro/repos/myRepo");
 
-        final JsonNode jsonNode = Jackson.readTree(aRes.content().toStringUtf8());
+        final JsonNode jsonNode = Jackson.readTree(aRes.contentUtf8());
         assertThat(jsonNode.get("name").asText()).isEqualTo("myRepo");
         assertThat(jsonNode.get("headRevision").asInt()).isOne();
         assertThat(jsonNode.get("createdAt").asText()).isNotNull();
@@ -106,7 +106,7 @@ public class RepositoryServiceV1Test {
                 "  \"exception\": \"" + RepositoryExistsException.class.getName() + "\"," +
                 "  \"message\": \"Repository 'myPro/myRepo' exists already.\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class RepositoryServiceV1Test {
                 "  \"exception\": \"" + ProjectNotFoundException.class.getName() + "\"," +
                 "  \"message\": \"Project 'absentProject' does not exist.\"" +
                 '}';
-        assertThatJson(aRes.content().toStringUtf8()).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -163,8 +163,7 @@ public class RepositoryServiceV1Test {
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }" +
                 ']';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -210,11 +209,10 @@ public class RepositoryServiceV1Test {
                 "       \"name\": \"minwoox\"" +
                 "   }" +
                 ']';
-        final String actualJson = removedRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(removedRes.contentUtf8()).isEqualTo(expectedJson);
 
         final AggregatedHttpMessage remainedRes = httpClient.get(REPOS_PREFIX).aggregate().join();
-        final String remains = remainedRes.content().toStringUtf8();
+        final String remains = remainedRes.contentUtf8();
         final JsonNode jsonNode = Jackson.readTree(remains);
 
         // dogma, meta and trustin repositories are left
@@ -244,8 +242,7 @@ public class RepositoryServiceV1Test {
                 "   \"url\": \"/api/v1/projects/myPro/repos/foo\"," +
                 "   \"createdAt\": \"${json-unit.ignore}\"" +
                 '}';
-        final String actualJson = aRes.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
@@ -265,8 +262,6 @@ public class RepositoryServiceV1Test {
         createRepository("foo");
         final AggregatedHttpMessage res = httpClient.get(REPOS_PREFIX + "/foo/revision/-1")
                                                     .aggregate().join();
-        final String expectedJson = "{\"revision\":1}";
-        final String actualJson = res.content().toStringUtf8();
-        assertThatJson(actualJson).isEqualTo(expectedJson);
+        assertThatJson(res.contentUtf8()).isEqualTo("{\"revision\":1}");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.centraldogma.server.internal.api.converter;
 
-import static com.linecorp.centraldogma.server.internal.api.converter.WatchRequestConverter.HEADER_NAME_PREFER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,7 +41,7 @@ public class WatchRequestConverterTest {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final AggregatedHttpMessage request = mock(AggregatedHttpMessage.class);
         final HttpHeaders headers = new DefaultHttpHeaders().add(HttpHeaderNames.IF_NONE_MATCH, "-1")
-                                                            .add(HEADER_NAME_PREFER, "wait=10");
+                                                            .add(HttpHeaderNames.PREFER, "wait=10");
 
         when(request.headers()).thenReturn(headers);
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -87,7 +87,7 @@ public class ThriftBackwardCompatibilityTest {
         AggregatedHttpMessage res;
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName + REPOS).aggregate().join();
         final List<JsonNode> nodes = new ArrayList<>();
-        Jackson.readTree(res.content().toStringUtf8()).elements().forEachRemaining(nodes::add);
+        Jackson.readTree(res.contentUtf8()).elements().forEachRemaining(nodes::add);
 
         assertThat(nodes.stream().map(n -> n.get("name").textValue()).collect(Collectors.toList()))
                 .containsAnyOf(REPO_DOGMA, REPO_META, repo1);
@@ -95,7 +95,7 @@ public class ThriftBackwardCompatibilityTest {
         ProjectMetadata metadata;
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
-        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
         assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();
@@ -105,7 +105,7 @@ public class ThriftBackwardCompatibilityTest {
         client.removeRepository(projectName, repo1);
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
-        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
         assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNotNull();
@@ -115,7 +115,7 @@ public class ThriftBackwardCompatibilityTest {
         client.unremoveRepository(projectName, repo1);
 
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
-        metadata = Jackson.readValue(res.content().toStringUtf8(), ProjectMetadata.class);
+        metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
         assertThat(metadata.repos().size()).isEqualTo(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthProvider.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthProvider.java
@@ -90,8 +90,7 @@ public class TestAuthProvider implements AuthProvider {
                     username = basicToken.username();
                     password = basicToken.password();
                 } else {
-                    final QueryStringDecoder decoder =
-                            new QueryStringDecoder(msg.content().toStringUtf8(), false);
+                    final QueryStringDecoder decoder = new QueryStringDecoder(msg.contentUtf8(), false);
                     username = decoder.parameters().get("username").get(0);
                     password = decoder.parameters().get("password").get(0);
                 }
@@ -129,4 +128,3 @@ public class TestAuthProvider implements AuthProvider {
         }
     }
 }
-


### PR DESCRIPTION
Motivation:

We currently do not return the revision of an entry. The reasoning
behind this behavior is that the response would contain duplicate
'revision' fields if a user requested more than one entry. Because of
that, there's a problem that a user could not notice quickly which
version of a file is loaded into his/her service.

Modifications:

- Added `revision` property to `EntryDto`
- Miscellaneous:
  - Used `HttpHeaderNames.PREFER` which reappeared in Armeria 0.83.0
  - Used `HttpData.toStringUtf8()` instead of `.content().toStringUtf8()`

Result:

- Closes #310