### PR TITLE
Fix a bug where `GitRepository.compareTrees()` operation is not cached.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
@@ -32,7 +32,7 @@ import com.github.benmanes.caffeine.cache.Weigher;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.base.MoreObjects;
 
-public final class RepositoryCache {
+public class RepositoryCache {
 
     private static final Logger logger = LoggerFactory.getLogger(RepositoryCache.class);
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -138,7 +138,8 @@ class GitRepository implements Repository {
     private final StampedLock lock = new StampedLock();
     private final Project parent;
     private final Executor repositoryWorker;
-    private final RepositoryCache cache;
+    @VisibleForTesting
+    final RepositoryCache cache;
     private final String name;
     private final org.eclipse.jgit.lib.Repository jGitRepository;
     private final GitRepositoryFormat format;


### PR DESCRIPTION
Motivation:

Even if we enabled cache, `null` can be set to `GitRepository.cache`
depending on how a `GitRepository` was initialized. If it was newly
created, cache will be set properly. Otherwise, it won't be.

Modifications:

- Removed the `childArgs` from `DirectoryBasedStorageManager` and made
  its subtypes call `init()` method explicitly, so that it is less
  error-prone.
- Added a test case that makes sure `GitRepository.cache` is non-null
  for both code path.

Result:

- `GitRepository.compareTrees()` operation is cached properly.