### PR TITLE
Wait until process is terminated in stop script / Add visual feedback while waiting

### DIFF
--- a/dist/src/bin/common.sh
+++ b/dist/src/bin/common.sh
@@ -2,36 +2,39 @@
 #
 # This script checks if the following environment variables exist and sets their default values if necessary.
 # -----------------------------------------------------------------------------------------------------------
-# APP_HOME        (Optional) The base directory of the application.
-#                 If not set, the parent directory of this script is used.
+# APP_HOME             (Optional) The base directory of the application.
+#                      If not set, the parent directory of this script is used.
 #
-# APP_LIB_DIR     (Optional) The directory which contains the .JAR files
-#                 If not set, '$APP_HOME/lib' is used.
+# APP_LIB_DIR          (Optional) The directory which contains the .JAR files
+#                      If not set, '$APP_HOME/lib' is used.
 #
-# APP_LOG_DIR     (Optional) The directory where the log files are written out
-#                 If not set, '$APP_HOME/log' is used.
+# APP_LOG_DIR          (Optional) The directory where the log files are written out
+#                      If not set, '$APP_HOME/log' is used.
 #
-# APP_MAIN        (Required) The fully qualified class name of the application
+# APP_LOGBACK_APPENDER (Optional) The name of the Logback appender to use
+#                      If not set, 'FILE' is used.
 #
-# APP_NAME        (Required) The name of the application
+# APP_MAIN             (Required) The fully qualified class name of the application
 #
-# APP_OPTS        (Optional) The application options
+# APP_NAME             (Required) The name of the application
 #
-# APP_PID_FILE    (Optional) The path to the PID file which contains the ID of the application process.
-#                 If not set, '$APP_HOME/$APP_NAME.pid' is used.
+# APP_OPTS             (Optional) The application options
 #
-# APP_STDOUT_FILE (Optional) The path to the file that contains the stdout console output
-#                 If not set, '$APP_LOG_DIR/$APP_NAME.stdout' is used.
+# APP_PID_FILE         (Optional) The path to the PID file which contains the ID of the application process.
+#                      If not set, '$APP_HOME/$APP_NAME.pid' is used.
 #
-# APP_STDERR_FILE (Optional) The path to the file that contains the stderr console output
-#                 If not set, '$APP_LOG_DIR/$APP_NAME.stderr' is used.
+# APP_STDOUT_FILE      (Optional) The path to the file that contains the stdout console output
+#                      If not set, '$APP_LOG_DIR/$APP_NAME.stdout' is used.
 #
-# APP_WAIT_TIME   (Optional) Wait the specified seconds for the service to start or stop.
-#                 If not set, 60 seconds are used.
+# APP_STDERR_FILE      (Optional) The path to the file that contains the stderr console output
+#                      If not set, '$APP_LOG_DIR/$APP_NAME.stderr' is used.
 #
-# JAVA_HOME       (Required) The location of the installed JDK/JRE
+# APP_WAIT_TIME        (Optional) Wait the specified seconds for the service to start or stop.
+#                      If not set, 60 seconds are used.
 #
-# JAVA_OPTS       (Optional) The JVM options
+# JAVA_HOME            (Required) The location of the installed JDK/JRE
+#
+# JAVA_OPTS            (Optional) The JVM options
 #
 
 set -e
@@ -80,6 +83,10 @@ if [[ -z "$APP_LOG_DIR" ]]; then
   APP_LOG_DIR="$APP_HOME/log"
 fi
 
+if [[ -z "$APP_LOGBACK_APPENDER" ]]; then
+  APP_LOGBACK_APPENDER='FILE'
+fi
+
 if [[ -z "$APP_STDOUT_FILE" ]]; then
   APP_STDOUT_FILE="$APP_LOG_DIR/$APP_NAME".stdout
 fi
@@ -107,6 +114,7 @@ export APP_BIN_DIR \
        APP_HOME \
        APP_LIB_DIR \
        APP_LOG_DIR \
+       APP_LOGBACK_APPENDER \
        APP_MAIN \
        APP_NAME \
        APP_OPTS \
@@ -119,17 +127,18 @@ export APP_BIN_DIR \
 
 eecho "Environment variables:"
 eecho "======================"
-eecho "APP_BIN_DIR:     $APP_BIN_DIR"
-eecho "APP_HOME:        $APP_HOME"
-eecho "APP_LIB_DIR:     $APP_LIB_DIR"
-eecho "APP_LOG_DIR:     $APP_LOG_DIR"
-eecho "APP_MAIN:        $APP_MAIN"
-eecho "APP_NAME:        $APP_NAME"
-eecho "APP_OPTS:        $APP_OPTS"
-eecho "APP_PID_FILE:    $APP_PID_FILE"
-eecho "APP_STDOUT_FILE: $APP_STDOUT_FILE"
-eecho "APP_STDERR_FILE: $APP_STDERR_FILE"
-eecho "APP_WAIT_TIME:   $APP_WAIT_TIME"
-eecho "JAVA_HOME:       $JAVA_HOME"
-eecho "JAVA_OPTS:       $JAVA_OPTS"
+eecho "APP_BIN_DIR:          $APP_BIN_DIR"
+eecho "APP_HOME:             $APP_HOME"
+eecho "APP_LIB_DIR:          $APP_LIB_DIR"
+eecho "APP_LOG_DIR:          $APP_LOG_DIR"
+eecho "APP_LOGBACK_APPENDER: $APP_LOGBACK_APPENDER"
+eecho "APP_MAIN:             $APP_MAIN"
+eecho "APP_NAME:             $APP_NAME"
+eecho "APP_OPTS:             $APP_OPTS"
+eecho "APP_PID_FILE:         $APP_PID_FILE"
+eecho "APP_STDOUT_FILE:      $APP_STDOUT_FILE"
+eecho "APP_STDERR_FILE:      $APP_STDERR_FILE"
+eecho "APP_WAIT_TIME:        $APP_WAIT_TIME"
+eecho "JAVA_HOME:            $JAVA_HOME"
+eecho "JAVA_OPTS:            $JAVA_OPTS"
 eecho

--- a/dist/src/bin/shutdown
+++ b/dist/src/bin/shutdown
@@ -21,21 +21,56 @@ else
   exit 100
 fi
 
+
 # Shut the application down
 set +e
 eecho "Shutting down $APP_NAME ($(cat "$APP_PID_FILE")) .."
 
 kill -TERM $PID
 
+# Wait until the PID file is removed by the application.
+WAITING=1
 COUNT=0
-while [[ $APP_WAIT_TIME -eq 0 ]] || [[ $COUNT -lt $APP_WAIT_TIME ]]; do
-  sleep 1
+eecho -n "Waiting for PID file deletion up to $APP_WAIT_TIME second(s) .."
+while true; do
   if [[ ! -f "$APP_PID_FILE" ]]; then
-    eecho "Shut down $APP_NAME successfully."
-    exit 0
+    eecho ' done'
+    break
   fi
-  COUNT=`expr $COUNT + 1`
+
+  ((COUNT++))
+  sleep 1
+  eecho -n '.'
+
+  if [[ $APP_WAIT_TIME -ne 0 ]] && [[ $COUNT -ge $APP_WAIT_TIME ]]; then
+    eecho ' timed out'
+    WAITING=0
+    break
+  fi
 done
+
+if [[ "$WAITING" -eq 1 ]]; then
+  # Wait until the process is actually gone.
+  eecho -n "Waiting for process $PID to terminate up to $APP_WAIT_TIME second(s) .."
+  while true; do
+    if kill -0 $PID >/dev/null 2>&1; then
+      # Process still exists.
+      ((COUNT++))
+      sleep 1
+      eecho -n '.'
+
+      if [[ $APP_WAIT_TIME -ne 0 ]] && [[ $COUNT -ge $APP_WAIT_TIME ]]; then
+        eecho ' timed out'
+        WAITING=0
+        break
+      fi
+    else
+      eecho ' done'
+      eecho "Shut down $APP_NAME successfully."
+      exit 0
+    fi
+  done
+fi
 
 eecho "Failed to shut down $APP_NAME"
 exit 255

--- a/dist/src/bin/startup
+++ b/dist/src/bin/startup
@@ -53,12 +53,13 @@ nohup "$JAVA_HOME"/bin/java \
   &
 
 COUNT=0
-while [[ $APP_WAIT_TIME -eq 0 ]] || [[ $COUNT -lt $APP_WAIT_TIME ]]; do
-  sleep 1
+eecho -n "Waiting for PID file creation up to $APP_WAIT_TIME second(s) .."
+while true; do
   if [[ -f "$APP_PID_FILE" ]]; then
     PID=$(cat "$APP_PID_FILE")
     kill -0 $PID > /dev/null 2>&1
     if [[ $? -eq 0 ]]; then
+      eecho ' done'
       eecho "Started up $APP_NAME successfully: $PID"
       if [[ $NODETACH -eq 1 ]]; then
         trap "$APP_BIN_DIR/shutdown" SIGINT SIGTERM SIGKILL SIGHUP
@@ -66,9 +67,18 @@ while [[ $APP_WAIT_TIME -eq 0 ]] || [[ $COUNT -lt $APP_WAIT_TIME ]]; do
       fi
       exit 0
     fi
+    eecho " invalid PID: $PID"
     break
   fi
-  COUNT=`expr $COUNT + 1`
+
+  sleep 1
+  ((COUNT++))
+  eecho -n '.'
+
+  if [[ $APP_WAIT_TIME -ne 0 ]] && [[ $COUNT -ge $APP_WAIT_TIME ]]; then
+    eecho ' timed out'
+    break
+  fi
 done
 
 eecho "Failed to start up $APP_NAME"


### PR DESCRIPTION
Motivation:

Our `shutdown` shell script sometimes exists even before the JVM
process is fully terminated, which can cause race conditions when
restarting a server.

Also, it'd be nice if there is some visual feedback which tells a user
that the shell scripts are waiting for something.

Modifivations:

- Updated `shutdown` script to wait until the JVM process is fully
  terminated.
- Updated `startup` and `shutdown` script to print a dot (.) every
  second while waiting for a process or a PID file.
- Miscellaneous:
  - Added back `APP_LOGBACK_APPENDER`

Result:

- Server restart does not fail anymore.
- A user can wait more patiently.