### PR TITLE
Make client-side watch operations better-documented and less error-prone.

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -427,7 +427,8 @@ public interface CentralDogma {
      */
     default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                         Revision lastKnownRevision, String pathPattern) {
-        return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern, 60000);
+        return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
+                               WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS);
     }
 
     /**
@@ -455,7 +456,8 @@ public interface CentralDogma {
      */
     default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                       Revision lastKnownRevision, Query<T> query) {
-        return watchFile(projectName, repositoryName, lastKnownRevision, query, 60000);
+        return watchFile(projectName, repositoryName, lastKnownRevision, query,
+                         WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS);
     }
 
     /**

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -419,7 +419,23 @@ public interface CentralDogma {
 
     /**
      * Waits for the files matched by the specified {@code pathPattern} to be changed since the specified
-     * {@code lastKnownRevision}.
+     * {@code lastKnownRevision}. If no changes were made within 1 minute, the returned
+     * {@link CompletableFuture} will be completed with {@code null}.
+     *
+     * @return the latest known {@link Revision} which contains the changes for the matched files.
+     *         {@code null} if the files were not changed for 1 minute since the invocation of this method.
+     */
+    default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
+                                                        Revision lastKnownRevision, String pathPattern) {
+        return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern, 60000);
+    }
+
+    /**
+     * Waits for the files matched by the specified {@code pathPattern} to be changed since the specified
+     * {@code lastKnownRevision}.  If no changes were made within the specified {@code timeoutMillis}, the
+     * returned {@link CompletableFuture} will be completed with {@code null}. It is recommended to specify
+     * the largest {@code timeoutMillis} allowed by the server. If unsure, use
+     * {@link #watchRepository(String, String, Revision, String)}.
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
@@ -431,7 +447,23 @@ public interface CentralDogma {
 
     /**
      * Waits for the file matched by the specified {@link Query} to be changed since the specified
-     * {@code lastKnownRevision}.
+     * {@code lastKnownRevision}. If no changes were made within 1 minute, the returned
+     * {@link CompletableFuture} will be completed with {@code null}.
+     *
+     * @return the {@link Entry} which contains the latest known {@link Query} result.
+     *         {@code null} if the file was not changed for 1 minute since the invocation of this method.
+     */
+    default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
+                                                      Revision lastKnownRevision, Query<T> query) {
+        return watchFile(projectName, repositoryName, lastKnownRevision, query, 60000);
+    }
+
+    /**
+     * Waits for the file matched by the specified {@link Query} to be changed since the specified
+     * {@code lastKnownRevision}. If no changes were made within the specified {@code timeoutMillis}, the
+     * returned {@link CompletableFuture} will be completed with {@code null}. It is recommended to specify
+     * the largest {@code timeoutMillis} allowed by the server. If unsure, use
+     * {@link #watchFile(String, String, Revision, Query)}.
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Latest.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Latest.java
@@ -16,7 +16,11 @@
 
 package com.linecorp.centraldogma.client;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Objects;
+
+import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
 
@@ -30,13 +34,14 @@ import com.linecorp.centraldogma.common.Revision;
 public final class Latest<U> {
 
     private final Revision revision;
+    @Nullable
     private final U value;
 
     /**
      * Creates a new instance with the specified {@link Revision} and value.
      */
-    public Latest(Revision revision, U value) {
-        this.revision = revision;
+    public Latest(Revision revision, @Nullable U value) {
+        this.revision = requireNonNull(revision, "revision");
         this.value = value;
     }
 
@@ -50,6 +55,7 @@ public final class Latest<U> {
     /**
      * Returns the latest known value.
      */
+    @Nullable
     public U value() {
         return value;
     }
@@ -63,12 +69,12 @@ public final class Latest<U> {
             return false;
         }
         final Latest<?> that = (Latest<?>) o;
-        return Objects.equals(revision, that.revision) && Objects.equals(value, that.value);
+        return revision.equals(that.revision) && Objects.equals(value, that.value);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(revision) * 31 + Objects.hashCode(value);
+        return revision.hashCode() * 31 + Objects.hashCode(value);
     }
 
     @Override

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client;
+
+import java.util.concurrent.TimeUnit;
+
+final class WatchConstants {
+
+    static final long DEFAULT_WATCH_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    static final int RECOMMENDED_AWAIT_TIMEOUT_SECONDS = 20;
+
+    private WatchConstants() {}
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -67,10 +67,10 @@ public interface Watcher<T> extends AutoCloseable {
      * even when the server is unavailable.
      *
      * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
-     *                a trade-off. If you specify a smaller timeout, this method will take less time even if
-     *                the server is not responsive, at the risk of {@link TimeoutException}. If you specify
-     *                a larger timeout, you will have a better chance of successful retrieval. It is generally
-     *                recommended to use a value not less than
+     *                a trade-off. If you specify a smaller timeout, this method will have a higher chance of
+     *                throwing a {@link TimeoutException} when the server does not respond in time.
+     *                If you specify a larger timeout, you will have a better chance of successful retrieval.
+     *                It is generally recommended to use a value not less than
      *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds so that
      *                the client can retry at least a few times before timing out.
      *                Consider using {@link #awaitInitialValue(long, TimeUnit, Object)} with a sensible default
@@ -99,8 +99,8 @@ public interface Watcher<T> extends AutoCloseable {
      * to retrieve the initial value from the server.
      *
      * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
-     *                a trade-off. If you specify a smaller timeout, this method will take less time even if
-     *                the server is not responsive, at the risk of falling back to the {@code defaultValue}.
+     *                a trade-off. If you specify a smaller timeout, this method will have a higher chance of
+     *                falling back to the {@code defaultValue} when the server does not respond in time.
      *                If you specify a larger timeout, you will have a better chance of retrieving
      *                an up-to-date initial value. It is generally recommended to use a value not less than
      *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -68,7 +68,7 @@ public interface Watcher<T> extends AutoCloseable {
      *
      * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
      *                a trade-off. If you specify a smaller timeout, this method will take less time even if
-     *                the server is note responsive, at the risk of {@link TimeoutException}. If you specify
+     *                the server is not responsive, at the risk of {@link TimeoutException}. If you specify
      *                a larger timeout, you will have a better chance of successful retrieval. It is generally
      *                recommended to use a value not less than
      *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds so that

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -69,7 +69,7 @@ public interface Watcher<T> extends AutoCloseable {
      * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
      *                a trade-off. If you specify a smaller timeout, this method will take less time even if
      *                the server is note responsive, at the risk of {@link TimeoutException}. If you specify
-     *                a larger timeout, you'll have a better chance of successful retrieval. It is generally
+     *                a larger timeout, you will have a better chance of successful retrieval. It is generally
      *                recommended to use a value not less than
      *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds so that
      *                the client can retry at least a few times before timing out.
@@ -101,8 +101,8 @@ public interface Watcher<T> extends AutoCloseable {
      * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
      *                a trade-off. If you specify a smaller timeout, this method will take less time even if
      *                the server is not responsive, at the risk of falling back to the {@code defaultValue}.
-     *                If you specify a larger timeout, you'll have a better chance of retrieving an up-to-date
-     *                initial value. It is generally recommended to use a value not less than
+     *                If you specify a larger timeout, you will have a better chance of retrieving
+     *                an up-to-date initial value. It is generally recommended to use a value not less than
      *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds
      *                so that the client can retry at least a few times before timing out.
      * @param unit the {@link TimeUnit} of {@code timeout}.

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -66,9 +66,15 @@ public interface Watcher<T> extends AutoCloseable {
      * a {@link TimeoutException} properly if the initial value must be available
      * even when the server is unavailable.
      *
-     * @param timeout the maximum amount of time to wait for the initial value. It is recommended to use a
-     *                value larger than 30 seconds at least so that the client can retry at least a few times
-     *                before timing out.
+     * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
+     *                a trade-off. If you specify a smaller timeout, this method will take less time even if
+     *                the server is note responsive, at the risk of {@link TimeoutException}. If you specify
+     *                a larger timeout, you'll have a better chance of successful retrieval. It is generally
+     *                recommended to use a value not less than
+     *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds so that
+     *                the client can retry at least a few times before timing out.
+     *                Consider using {@link #awaitInitialValue(long, TimeUnit, Object)} with a sensible default
+     *                value if you cannot tolerate a timeout or need to use a small timeout.
      * @param unit the {@link TimeUnit} of {@code timeout}.
      *
      * @return the {@link Latest} object that contains the initial value and the {@link Revision} where
@@ -92,9 +98,13 @@ public interface Watcher<T> extends AutoCloseable {
      * Waits for the initial value to be available and returns the specified default value if failed
      * to retrieve the initial value from the server.
      *
-     * @param timeout the maximum amount of time to wait for the initial value. It is recommended to use a
-     *                value larger than 30 seconds at least so that the client can retry at least a few times
-     *                before timing out.
+     * @param timeout the maximum amount of time to wait for the initial value. Note that timeout is basically
+     *                a trade-off. If you specify a smaller timeout, this method will take less time even if
+     *                the server is not responsive, at the risk of falling back to the {@code defaultValue}.
+     *                If you specify a larger timeout, you'll have a better chance of retrieving an up-to-date
+     *                initial value. It is generally recommended to use a value not less than
+     *                {@value WatchConstants#RECOMMENDED_AWAIT_TIMEOUT_SECONDS} seconds
+     *                so that the client can retry at least a few times before timing out.
      * @param unit the {@link TimeUnit} of {@code timeout}.
      * @param defaultValue the default value to use when timed out.
      *

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -54,7 +54,6 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     private static final long MIN_INTERVAL_MILLIS = DELAY_ON_SUCCESS_MILLIS * 2;
     private static final long MAX_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(1);
     private static final double JITTER_RATE = 0.2;
-    private static final long WATCH_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
     private static long nextDelayMillis(int numAttemptsSoFar) {
         final long nextDelayMillis;
@@ -222,8 +221,8 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
         }
 
         final Revision lastKnownRevision = latest != null ? latest.revision() : Revision.INIT;
-        final CompletableFuture<Latest<T>> f = doWatch(client, projectName, repositoryName, lastKnownRevision,
-                                                       WATCH_TIMEOUT_MILLIS);
+        final CompletableFuture<Latest<T>> f = doWatch(client, projectName, repositoryName, lastKnownRevision
+        );
 
         currentWatchFuture = f;
         f.whenComplete((result, cause) -> currentWatchFuture = null)
@@ -280,8 +279,7 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     }
 
     protected abstract CompletableFuture<Latest<T>> doWatch(
-            CentralDogma client, String projectName, String repositoryName,
-            Revision lastKnownRevision, long timeoutMillis);
+            CentralDogma client, String projectName, String repositoryName, Revision lastKnownRevision);
 
     private void notifyListeners() {
         if (isStopped()) {

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -221,8 +221,7 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
         }
 
         final Revision lastKnownRevision = latest != null ? latest.revision() : Revision.INIT;
-        final CompletableFuture<Latest<T>> f = doWatch(client, projectName, repositoryName, lastKnownRevision
-        );
+        final CompletableFuture<Latest<T>> f = doWatch(client, projectName, repositoryName, lastKnownRevision);
 
         currentWatchFuture = f;
         f.whenComplete((result, cause) -> currentWatchFuture = null)

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
@@ -45,9 +45,8 @@ public final class FileWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision,
-                                                   long timeoutMillis) {
-        return client.watchFile(projectName, repositoryName, lastKnownRevision, query, timeoutMillis)
+                                                   String repositoryName, Revision lastKnownRevision) {
+        return client.watchFile(projectName, repositoryName, lastKnownRevision, query)
                      .thenApply(result -> {
                          if (result == null) {
                              return null;

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -42,10 +42,8 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision,
-                                                   long timeoutMillis) {
-        return client.watchRepository(projectName, repositoryName, lastKnownRevision,
-                                      pathPattern, timeoutMillis)
+                                                   String repositoryName, Revision lastKnownRevision) {
+        return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern)
                      .thenApply(revision -> {
                          if (revision == null) {
                              return null;

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -165,7 +165,8 @@ You can get a merged file from a repository:
                                                    MergeSource.ofRequired("/b.json"),
                                                    MergeSource.ofRequired("/c.json"));
     CompletableFuture<MergedEntry<JsonNode>> future =
-            dogma.mergeFiles("myProj", "myRepo", Revision.HEAD, MergeQuery.ofJson(mergeSources));
+            dogma.mergeFiles("myProj", "myRepo", Revision.HEAD,
+                             MergeQuery.ofJson(mergeSources));
 
     MergedEntry<JsonNode> mergedEntry = future.join();
     assert mergedEntry.type() == EntryType.JSON
@@ -210,7 +211,8 @@ Let's consider that the contents of the ``/a.json``, ``/b.json`` and ``/c.json``
 
     {
       "someObject": {
-        "nullInSomeObject": 100 // Replace the null with 100. null can be converted to any type.
+        // Replace the null with 100. null can be converted to any type.
+        "nullInSomeObject": 100
       }
     }
 
@@ -240,7 +242,8 @@ You can mark some files involved in the merge process as optional.
                                                    MergeSource.ofOptional("/b.json"), // <-- It's optional!
                                                    MergeSource.ofRequired("/c.json"));
     CompletableFuture<MergedEntry<JsonNode>> future =
-            dogma.mergeFiles("myProj", "myRepo", Revision.HEAD, MergeQuery.ofJson(mergeSources));
+            dogma.mergeFiles("myProj", "myRepo", Revision.HEAD,
+                             MergeQuery.ofJson(mergeSources));
 
 Note that we used ``MergeSource.ofOptional("/b.json")``, which tells to include the ``/b.json`` file only if it
 exists in the repository. If it does not exist, ``/a.json`` and ``/c.json`` will be merged sequentially.
@@ -282,7 +285,8 @@ You can also push a commit into a repository programmatically:
                        Change.ofRemoval("/b.json"));
 
     Commit commit = future.join();
-    System.err.println("Pushed a commit " + commit.revision() + " at " + commit.whenAsText());
+    System.err.printf("Pushed a commit %s at %s%n",
+                      commit.revision(), commit.whenAsText());
 
 In this example, we pushed a commit that contains two changes: one that adds ``/c.json`` and the other that
 removes ``/b.json``.
@@ -318,20 +322,46 @@ the process. The client library provides an easy way to watch a file:
     import com.linecorp.centraldogma.client.Watcher;
 
     CentralDogma dogma = ...;
-    Watcher<JsonNode> watcher = dogma.fileWatcher("myProj", "myRepo",
-                                                  Query.ofJsonPath("/some_file.json", "$.foo"));
+    Watcher<JsonNode> watcher =
+            dogma.fileWatcher("myProj", "myRepo",
+                              Query.ofJsonPath("/some_file.json", "$.foo"));
     // Register a callback for changes.
     watcher.watch((revision, value) -> {
-        System.err.println("Foo has been updated to " + value + " (revision: " + revision + ')');
+        System.err.printf("Updated to %s at %s%n", value, revision);
     });
 
     // Alternatively, without using a callback:
-    watcher.awaitInitialValue();                // Wait until the initial value is available.
-    Latest<JsonNode> latest = watcher.latest(); // Get the latest value.
-    System.err.println("Current foo: " + latest.value() + " (revision: " + latest.revision() + ')');
+    Latest<JsonNode> latest = watcher.awaitInitialValue(); // Wait for the initial value.
+    System.err.printf("Initial: %s at %s%n", latest.value(), latest.revision());
 
 You would want to register a callback to the ``Watcher`` or check the return value of ``Watcher.latest()``
 periodically to apply the new settings to your application.
+
+Preparing for unavailability
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+It is possible that the servers are not available when you are waiting for the initial value. To prevent from
+your application from awaiting indefinitely, you can specify a timeout and a default value when calling
+the ``awaitInitialValue()`` method:
+
+.. code-block:: java
+
+    import static java.util.concurrent.TimeUnit.MINUTES;
+
+    CentralDogma dogma = ...;
+    Watcher<JsonNode> watcher = dogma.fileWatcher(..., Query.ofJsonPath(...));
+    JsonNode initialValue = watcher.awaitInitialValue(1, MINUTES, someDefaultValue);
+
+    // If you are interested in the Revision of the initial value, you can:
+    JsonNode initialValue;
+    try {
+        Latest<JsonNode> latest = watcher.awaitInitialValue(1, MINUTES);
+        System.err.printf("Initial: %s at %s%n", latest.value(), latest.revision());
+        initialValue = latest.value();
+    } catch (TimeoutException e) {
+        System.err.printf("Default: %s%n", someDefaultValue);
+        initialValue = someDefaultValue;
+    }
+
 
 Specifying multiple hosts
 -------------------------
@@ -361,7 +391,9 @@ You can load the list of the Central Dogma servers from one of the following JSO
 .. code-block:: java
 
     ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
-    // Loads the profile 'beta' from /centraldogma-profiles-test.json or /centraldogma-profiles.json
+    // Loads the profile 'beta' from:
+    // - /centraldogma-profiles-test.json or
+    // - /centraldogma-profiles.json
     builder.profile("beta");
     CentralDogma dogma = builder.build();
 

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -362,12 +362,12 @@ the ``awaitInitialValue()`` method:
         initialValue = someDefaultValue;
     }
 
-Note that a timeout is basically a trade-off. If you specify a smaller timeout, ``awaitInitialValue()`` will
-take less time even if the server is not responsive, at the risk of getting a ``TimeoutException`` or
-falling back to the default value. If you specify a larger timeout, you will have a better chance of
-successful retrieval. It is generally recommended to use a value not less than 20 seconds so that
-the client can retry at least a few times before timing out. Consider specifying a sensible default value
-if you cannot tolerate a timeout or need to use a small timeout.
+Note that a timeout is basically a trade-off. If you specify a smaller timeout, you will have a higher chance
+of getting a ``TimeoutException`` or falling back to the default value when the server does not respond in time.
+If you specify a larger timeout, you will have a better chance of successful retrieval. It is generally
+recommended to use a value not less than 20 seconds so that the client can retry at least a few times before
+timing out. Consider specifying a sensible default value if you need to use a small timeout or want to make
+sure your application is not affected when the servers have an issue.
 
 Alternatively, you can choose not to use ``awaitInitialValue()`` at all if the value being retrieved is not
 part of a critical path, e.g. span collection rate in distributed tracing. In such a case, you can simply

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -345,16 +345,16 @@ the ``awaitInitialValue()`` method:
 
 .. code-block:: java
 
-    import static java.util.concurrent.TimeUnit.MINUTES;
+    import static java.util.concurrent.TimeUnit.SECONDS;
 
     CentralDogma dogma = ...;
     Watcher<JsonNode> watcher = dogma.fileWatcher(..., Query.ofJsonPath(...));
-    JsonNode initialValue = watcher.awaitInitialValue(1, MINUTES, someDefaultValue);
+    JsonNode initialValue = watcher.awaitInitialValue(20, SECONDS, someDefaultValue);
 
     // If you are interested in the Revision of the initial value, you can:
     JsonNode initialValue;
     try {
-        Latest<JsonNode> latest = watcher.awaitInitialValue(1, MINUTES);
+        Latest<JsonNode> latest = watcher.awaitInitialValue(20, SECONDS);
         System.err.printf("Initial: %s at %s%n", latest.value(), latest.revision());
         initialValue = latest.value();
     } catch (TimeoutException e) {
@@ -362,6 +362,14 @@ the ``awaitInitialValue()`` method:
         initialValue = someDefaultValue;
     }
 
+.. note::
+
+    A timeout is basically a trade-off. If you specify a smaller timeout, ``awaitInitialValue()`` will
+    take less time even if the server is not responsive, at the risk of getting a ``TimeoutException`` or
+    falling back to the default value. If you specify a larger timeout, you'll will have a better chance of
+    successful retrieval. It is generally recommended to use a value not less than 20 seconds so that
+    the client can retry at least a few times before timing out. Consider specifying a sensible default value
+    if you cannot tolerate a timeout or need to use a small timeout.
 
 Specifying multiple hosts
 -------------------------

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -366,7 +366,7 @@ the ``awaitInitialValue()`` method:
 
     A timeout is basically a trade-off. If you specify a smaller timeout, ``awaitInitialValue()`` will
     take less time even if the server is not responsive, at the risk of getting a ``TimeoutException`` or
-    falling back to the default value. If you specify a larger timeout, you'll will have a better chance of
+    falling back to the default value. If you specify a larger timeout, you will have a better chance of
     successful retrieval. It is generally recommended to use a value not less than 20 seconds so that
     the client can retry at least a few times before timing out. Consider specifying a sensible default value
     if you cannot tolerate a timeout or need to use a small timeout.


### PR DESCRIPTION
Motivation:

It seems like our users sometimes specify way too small timeout value
when they use `watch*()` operations or `Watcher`s. A small timeout value
can lead to a failure to fetch the initial value, preventing the startup
of the user application when it relies entirely on Central Dogma.

Modifications:

- Added `CentralDogma.watchFile/Repository()` variants that do not
  require the `timeoutMillis` parameter.
  - Explicitly recommended using the variants without timeout parameter.
- Added a `Watcher.awaitInitialValue()` variant that falls back to the
  default value when it failed to retrieve the initial value from the
  server.
- Added the 'Preparing for unavailability' subsection.
- Miscellaneous:
  - Cleaned up the example snippets.
  - Improved the indentation of the example snippets.

Result:

- Watch operations are better-documented.
- If a user reads the documentation, he or she will make less mistakes
  and an informed decision about what to do when the server is
  unavailable.