### PR TITLE
Make `ArmeriaCentralDogma` handle `2xx` responses better.

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
@@ -96,4 +96,20 @@ public class FileManagementTest extends AbstractMultiClientTest {
         assertThat(files).hasSize(NUM_FILES);
         files.values().forEach(t -> assertThat(t).isEqualTo(EntryType.JSON));
     }
+
+    @Test
+    public void testListFilesEmpty() throws Exception {
+        final Map<String, EntryType> files = client().listFiles(
+                rule.project(), rule.repo1(), Revision.HEAD, TEST_ROOT + "*.none").join();
+        assertThat(files).isEmpty();
+    }
+
+    @Test
+    public void testListFilesSingle() throws Exception {
+        final String path = TEST_ROOT + "0.json";
+        final Map<String, EntryType> files = client().listFiles(
+                rule.project(), rule.repo1(), Revision.HEAD, path).join();
+        assertThat(files).hasSize(1);
+        assertThat(files.get(path)).isEqualTo(EntryType.JSON);
+    }
 }


### PR DESCRIPTION
Motivation:

Central Dogma server sometimes gives a `204 No Content` response when
the result is an empty list. However, `ArmeriaCentralDogma` does not
always handle it properly.

Modifivations:

- Handle `204 No Content` and `200 OK` responses wherever possible, so
  that subtle changes in the response specification do not affect the
  client.

Result:

- `ArmeriaCentralDogma` does not fail for some operations such as
  `listFiles()` even if the server responds with a `204 No Content`.