### PR TITLE
Apply `ArmeriaClientConfigurator` after the internal decorators

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -42,11 +42,9 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
         final Endpoint endpoint = endpoint();
         final String scheme = "tbinary+" + (isUseTls() ? "https" : "http") + "://";
         final String uri = scheme + endpoint.authority() + "/cd/thrift/v1";
-        final ClientBuilder builder = new ClientBuilder(uri);
-        clientConfigurator().configure(builder);
-        builder.factory(clientFactory())
-               .decorator(HttpDecodingClient.newDecorator())
-               .rpcDecorator(LegacyCentralDogmaTimeoutScheduler::new);
+        final ClientBuilder builder =
+                newClientBuilder(uri, cb -> cb.decorator(HttpDecodingClient.newDecorator())
+                                              .rpcDecorator(LegacyCentralDogmaTimeoutScheduler::new));
 
         final String authorization = "Bearer " + accessToken();
         builder.decorator((delegate, ctx, req) -> {

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -34,10 +34,8 @@ public final class ArmeriaCentralDogmaBuilder
         final Endpoint endpoint = endpoint();
         final String scheme = "none+" + (isUseTls() ? "https" : "http") + "://";
         final String uri = scheme + endpoint.authority();
-        final ClientBuilder builder = new ClientBuilder(uri);
-        clientConfigurator().configure(builder);
-        builder.factory(clientFactory());
-        builder.decorator(HttpDecodingClient.newDecorator());
+        final ClientBuilder builder =
+                newClientBuilder(uri, cb -> cb.decorator(HttpDecodingClient.newDecorator()));
         return new ArmeriaCentralDogma(clientFactory().eventLoopGroup(),
                                        builder.build(HttpClient.class), accessToken());
     }


### PR DESCRIPTION
Motivation:

When we introduce an HTTP-based Central Dogma client implementation, we
slightly adjusted how decorators are added. As a result, the
`ArmeriaClientConfigurator` was being invoked before the internal
decorators were added.

Modifications:

- Move the common logic required for configuring an Armeria
  `ClientBuilder` to `AbstractArmeriaCentralDogmaBuilder.newClientBuilder()`.
- The customization of a `ClientBuilder` is always performed in the
  following order:
  - Builder-specific customizers are applied first.
  - `ArmeriaClientConfigurator` is applied next.
  - `ClientBuilder.clientFactory()` is set finally.
- Added a test case that verifies the customization ordering.

Result:

- Consistent customization order.
- Fixes the regression caused by 20583b1e74d583a5d5d12412e9cdb8af232f460f