### PR TITLE
Improve the overall look and feel of the web site

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -148,7 +148,7 @@ junit:
     - https://junit.org/junit4/javadoc/4.12/
 
 kr.motd.gradle:
-  sphinx-gradle-plugin: { version: '2.3.1' }
+  sphinx-gradle-plugin: { version: '2.4.0' }
 
 me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.4.8' }

--- a/site/src/sphinx/_static/add_badges.js
+++ b/site/src/sphinx/_static/add_badges.js
@@ -1,38 +1,40 @@
-// Append the Slack invitation and project badges at the end of the menu (sidenav).
-function addSlackInvitation(parent) {
-  var li = document.createElement('li');
-  li.className = 'toctree-l1';
-  var div = document.createElement('div');
-  div.className = 'slack-invitation';
-  var script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = 'https://line-slacknow.herokuapp.com/central-dogma/slackin.js';
-  div.appendChild(script);
-  li.appendChild(div);
-  parent.appendChild(li);
-}
-
+// Append the project badges at the end of the menu (sidenav).
 function addBadge(parent, src, href) {
-  var img = document.createElement('img');
-  img.src = src;
-  var a = document.createElement('a');
-  a.href = href;
-  a.appendChild(img);
-  parent.appendChild(a);
+  var obj = document.createElement('object');
+  obj.data = src;
+
+  if (typeof href === 'string') {
+    obj.style.pointerEvents = 'none';
+    var a = document.createElement('a');
+    a.href = href;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    a.appendChild(obj);
+    parent.appendChild(a);
+  } else {
+    parent.appendChild(obj);
+  }
   parent.appendChild(document.createElement('br'));
 }
+
 
 function addBadges(parent) {
   var li = document.createElement('li');
   li.className = 'toctree-l1';
   var div = document.createElement('div');
   div.className = 'project-badges';
+  addBadge(div, 'https://img.shields.io/github/stars/line/centraldogma.svg?style=social');
+  addBadge(div, 'https://img.shields.io/badge/chat-on%20slack-brightgreen.svg?style=social',
+    'https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWRlZTZmZDljNDY3OTBmN2Y1NDAwMGUzMTMzNmFlOTYzNzYyNDNmNmM5YTk3YmExM2M4NGRkOTY2NTE1MDJhODY');
   addBadge(div, 'https://img.shields.io/travis/line/centraldogma/master.svg?style=flat-square',
     'https://travis-ci.org/line/centraldogma');
   addBadge(div, 'https://img.shields.io/appveyor/ci/line/centraldogma/master.svg?label=appveyor&style=flat-square',
     'https://ci.appveyor.com/project/line/centraldogma/branch/master');
   addBadge(div, 'https://img.shields.io/maven-central/v/com.linecorp.centraldogma/centraldogma-common.svg?style=flat-square',
-    'https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.linecorp.centraldogma%22');
+    'https://search.maven.org/search?q=g:com.linecorp.centraldogma');
+  addBadge(div, 'https://img.shields.io/github/commit-activity/m/line/centraldogma.svg?style=flat-square',
+    'https://github.com/line/centraldogma/pulse');
+  addBadge(div, 'https://img.shields.io/github/issues/line/centraldogma/good-first-issue.svg?label=good%20first%20issues&style=flat-square');
   addBadge(div, 'https://img.shields.io/codecov/c/github/line/centraldogma/master.svg?style=flat-square',
     'https://codecov.io/gh/line/centraldogma');
   li.appendChild(div);
@@ -44,7 +46,6 @@ if (menus.length > 0) {
   var menu = menus[0];
   var lists = menu.getElementsByTagName('ul');
   if (lists.length > 0) {
-    addSlackInvitation(lists[0]);
     addBadges(lists[0]);
   }
 }

--- a/site/src/sphinx/_static/center_page.js
+++ b/site/src/sphinx/_static/center_page.js
@@ -1,48 +1,79 @@
-var head = document.head || document.getElementsByTagName('head')[0];
-var style = null;
+(function() {
+  var head = document.head || document.getElementsByTagName('head')[0];
+  var style = null;
+  var mobileScreenWidth = 768;
 
-// Centers the page content dynamically.
-function centerPage() {
-  if (style) {
-    head.removeChild(style);
-    style = null;
-  }
-
-  var windowWidth = window.innerWidth;
-  if (windowWidth <= 768) {
-    return;
-  }
-
+  // Make sure this value is equal to the width of .wy-nav-content in overrides.css.
+  var initialContentWidth = 960;
+  // Make sure this value is equal to the width of .wy-nav-side in theme.css.
   var sideWidth = 300;
-  var contentWidth = 800;
-  var ribbonWidth = 150;
-  var leftMargin = Math.max(0, (windowWidth - sideWidth - contentWidth) / 2);
-  var scrollbarWidth = document.body ? windowWidth - document.body.clientWidth : 0;
-  var css = '';
+  // Keeps the current width of .wy-nav-content.
+  var contentWidth = initialContentWidth;
 
-  css += '.wy-nav-side { left: ' + leftMargin + 'px; }';
-  css += "\n";
-  css += '.wy-nav-content-wrap { margin-left: ' + (sideWidth + leftMargin) + 'px; }';
-  css += "\n";
-  css += '.github-fork-ribbon-wrapper.right { left: ' + 
-         (Math.min(windowWidth - scrollbarWidth, sideWidth + contentWidth + leftMargin) - ribbonWidth) + 'px; }';
-  css += "\n";
+  // Centers the page content dynamically.
+  function centerPage() {
+    if (style) {
+      head.removeChild(style);
+      style = null;
+    }
 
-  var newStyle = document.createElement('style');
-  newStyle.type = 'text/css';
-  if (newStyle.styleSheet) {
-    newStyle.styleSheet.cssText = css;
-  } else {
-    newStyle.appendChild(document.createTextNode(css));
+    var windowWidth = window.innerWidth;
+    if (windowWidth <= mobileScreenWidth) {
+      return;
+    }
+
+    var leftMargin = Math.max(0, (windowWidth - sideWidth - contentWidth) / 2);
+    var scrollbarWidth = document.body ? windowWidth - document.body.clientWidth : 0;
+    var css = '';
+
+    css += '.wy-nav-side { left: ' + leftMargin + 'px; }';
+    css += "\n";
+    css += '.wy-nav-content-wrap { margin-left: ' + (sideWidth + leftMargin) + 'px; }';
+    css += "\n";
+    css += '.github-fork-ribbon { margin-right: ' + (leftMargin - scrollbarWidth) + 'px; }';
+    css += "\n";
+
+    var newStyle = document.createElement('style');
+    newStyle.type = 'text/css';
+    if (newStyle.styleSheet) {
+      newStyle.styleSheet.cssText = css;
+    } else {
+      newStyle.appendChild(document.createTextNode(css));
+    }
+
+    head.appendChild(newStyle);
+    style = newStyle;
   }
 
-  head.appendChild(newStyle);
-  style = newStyle;
-}
+  centerPage();
+  window.addEventListener('resize', centerPage);
+  // Adjust the position of the 'fork me at GitHub' ribbon after document.body is available,
+  // so that we can calculate the width of the scroll bar correctly.
+  window.addEventListener('DOMContentLoaded', centerPage);
 
-centerPage();
-window.addEventListener('resize', centerPage);
-// Adjust the position of the 'fork me at GitHub' ribbon after document.body is available,
-// so that we can calculate the width of the scroll bar correctly.
-window.addEventListener('DOMContentLoaded', centerPage);
+  // Allow a user to drag the left or right edge of the content to resize the content.
+  if (interact) {
+    interact('.wy-nav-content').resizable({
+      edges: {left: true, right: true, bottom: false, top: false},
+      modifiers: [
+        interact.modifiers.restrictEdges({
+          outer: 'parent',
+          endOnly: true
+        }),
 
+        interact.modifiers.restrictSize({
+          min: {
+            width: initialContentWidth,
+            height: 0
+          }
+        })
+      ]
+    }).on('resizemove', function (event) {
+      var style = event.target.style;
+      // Double the amount of change because the page is centered.
+      contentWidth += event.deltaRect.width * 2;
+      style.maxWidth = contentWidth + 'px';
+      centerPage();
+    });
+  }
+})();

--- a/site/src/sphinx/_static/overrides.css
+++ b/site/src/sphinx/_static/overrides.css
@@ -1,19 +1,20 @@
-@import url('https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.1.1/gh-fork-ribbon.min.css');
-@import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,400i,700,700i');
-@import url('https://fonts.googleapis.com/css?family=Inconsolata:400,700');
+@import url('https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.2/gh-fork-ribbon.min.css');
+@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700,700i|Merriweather:700,700i');
+@import url('https://cdn.jsdelivr.net/npm/hack-font@3/build/web/hack.css');
 
 html, body, .wy-grid-for-nav {
-  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
-  font-weight: normal;
-  font-size: 15px;
-  line-height: 1.42857143;
+  font-family: 'Lato', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica', 'Arial',
+  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
   background: #f0f0f0;
   margin: 0;
   word-break: break-word;
 }
 
 .wy-nav-side {
-  font-size: 17px;
+  font-size: 18px;
 }
 
 .wy-nav-top {
@@ -26,7 +27,7 @@ html, body, .wy-grid-for-nav {
 
 .wy-nav-content {
   background: white;
-  max-width: 800px;
+  max-width: 960px;
   margin: 0;
 }
 
@@ -42,6 +43,10 @@ html, body, .wy-grid-for-nav {
   font-size: 125%;
 }
 
+.wy-side-nav-search input {
+  font-family: inherit;
+}
+
 .wy-side-nav-search > a {
   margin: 0;
   display: block;
@@ -54,7 +59,6 @@ html, body, .wy-grid-for-nav {
   padding: 0;
 }
 
-.wy-menu .slack-invitation,
 .wy-menu .project-badges {
   padding: 0.4em 1.45em 0 1.45em;
   display: block;
@@ -79,7 +83,7 @@ html, body, .wy-grid-for-nav {
 
 /* Hide the Github fork ribbon on mobile view. */
 @media screen and (max-width: 768px) {
-  .github-fork-ribbon-wrapper {
+  .github-fork-ribbon {
     display: none;
   }
 }
@@ -95,35 +99,38 @@ html, body, .wy-grid-for-nav {
   margin-top: 0.225em;
 }
 
-/* Make sure the invitation dialog appears on top of the menu whose z-index is 200. */
-.__slackin {
-  z-index: 1000;
-}
-
+/* Headings */
 h1, h2, h3, h4, h5, h6 {
-  font-weight: inherit;
+  font-family: 'Merriweather', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI',
+  'Helvetica', 'Arial', serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+  font-weight: 700;
+  margin-bottom: 16px;
 }
 
-/* Code blocks and literals */
+/* Code block wrappers */
+.rst-content div[class*='highlight'] {
+  overflow: inherit;
+}
+
+/* Both code blocks and literals */
 pre, code, kbd, var, samp, tt,
-.rst-content div[class*='highlight'] pre,
-.rst-content pre.literal-block,
-.rst-content code.literal,
-.rst-content tt.literal,
+div[class*='highlight'] pre, .rst-content div[class*='highlight'] pre,
+pre.literal-block, .rst-content pre.literal-block,
+code.literal, .rst-content code.literal,
+tt.literal, .rst-content tt.literal,
 .wy-menu-vertical li code,
 .wy-menu-vertical li tt {
-  font-family: 'Inconsolata', 'Consolas', 'Menlo', 'Monaco', 'Lucida Console', 'Liberation Mono',
-               'DejaVu Sans Mono', monospace;
+  font-family: 'Hack', 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier', monospace;
   font-weight: inherit;
+  font-size: 87.5%;
   word-break: break-all;
 }
 
-/* Code blocks */
+/* Code blocks only */
 pre,
-.rst-content div[class*='highlight'] pre,
-.rst-content pre.literal-block {
+div[class*='highlight'] pre, .rst-content div[class*='highlight'] pre,
+pre.literal-block, .rst-content pre.literal-block {
   padding: 8px 12px 12px 12px;
-  font-size: inherit;
   overflow-x: auto;
   overflow-y: hidden;
   color: inherit;
@@ -132,12 +139,7 @@ pre,
   width: 99.9%;
 }
 
-/* Code block wrappers */
-.rst-content div[class*='highlight'] {
-  overflow: inherit;
-}
-
-/* Literals */
+/* Literals only */
 code, kbd, var, samp, tt,
 tt.literal, .rst-content tt.literal,
 code.literal, .rst-content code.literal {
@@ -145,7 +147,6 @@ code.literal, .rst-content code.literal {
   padding-right: 0;
   background: rgba(0,0,0,0.05);
   border-radius: 3px;
-  font-size: inherit;
   color: inherit;
   border: none;
   white-space: pre-wrap;
@@ -187,8 +188,8 @@ a .highlight * {
   color: inherit !important;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
+.btn, .rst-content {
+  font-family: inherit;
 }
 
 /* Use justify-align and hyphenation. */
@@ -246,7 +247,7 @@ p, .rst-content li, .wy-menu li {
 
 /* Do not add left-margin for line-blocks */
 .rst-content .line-block {
-  margin-left: 0px;
+  margin-left: 0;
 }
 
 /* Adjust the height of the top navbar */
@@ -261,12 +262,14 @@ p, .rst-content li, .wy-menu li {
 
 /* Plural suffix inside code should not be monospaced. */
 code .plural-suffix {
-  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
+  font-family: 'Lato', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Helvetica', 'Arial',
+  sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 /* highlightjs style begins */
 div.hljs {
   background: inherit;
+  padding: 0;
 }
 pre.hljs {
   background: rgba(0, 0, 0, 0.01); /* 1% darker background */
@@ -274,7 +277,6 @@ pre.hljs {
 td.hljs-ln-numbers {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
-  -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
@@ -308,6 +310,6 @@ td.hljs-ln-code {
 }
 
 .wy-menu-vertical li.current a {
-  border-right-width: 0px;
+  border-right-width: 0;
 }
 /* Central Dogma branding ends. */

--- a/site/src/sphinx/_templates/layout.html
+++ b/site/src/sphinx/_templates/layout.html
@@ -4,23 +4,21 @@
 {% set sticky_navigation = True %}
 {% set extra_css_files = ['_static/overrides.css'] %}
 {% block extrahead %}
+  <script src="https://cdn.jsdelivr.net/npm/interactjs@1.4.0/dist/interact.min.js"></script>
   <script src="{{ pathto('_static/center_page.js', 1) }}"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/default.min.css">
   {{ super() }}
 {% endblock %}
 {% block footer %}
-  <div class="github-fork-ribbon-wrapper right">
-    <div class="github-fork-ribbon">
-      <a href="https://github.com/line/centraldogma">Fork me at GitHub</a>
-    </div>
-  </div>
+  <a class="github-fork-ribbon" href="https://github.com/line/centraldogma"
+     data-ribbon="Fork me on GitHub" title="Fork me on GitHub">Fork me on GitHub</a>
   <script type="text/javascript" src="{{ pathto('_static/add_badges.js', 1) }}"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/gradle.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/protobuf.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/thrift.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/yaml.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.6.0/highlightjs-line-numbers.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlightjs-line-numbers.js/2.7.0/highlightjs-line-numbers.min.js"></script>
   <script>
     document.querySelectorAll('div.hljs > pre').forEach(function(block) {
       hljs.highlightBlock(block);

--- a/site/src/sphinx/conf.py
+++ b/site/src/sphinx/conf.py
@@ -19,7 +19,7 @@ def load_properties(filepath, sep='=', comment_char='#'):
 
 def load_yaml(filepath):
     with open(filepath, 'r') as f:
-        return yaml.load(f)
+        return yaml.load(f, Loader=yaml.FullLoader)
 
 # Load the gradle.properties and dependencies.yml.
 rootDir = os.path.dirname(os.path.abspath(__file__)) + '/../../..'

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -110,5 +110,5 @@ Read more
     API documentation <apidocs/index.html#://>
     Source cross-reference <xref/index.html#://>
     Questions and answers <https://github.com/line/centraldogma/issues?q=label%3Aquestion-answered>
-    Fork me at GitHub <https://github.com/line/centraldogma>
+    Fork me on GitHub <https://github.com/line/centraldogma>
     Contributing <https://github.com/line/centraldogma/blob/master/CONTRIBUTING.md>


### PR DESCRIPTION
Motivation:

It's always better looking nicer.

Modifications:

- Typography
  - Increased the overall font size and line height a little bit for
    readability.
  - Changed the heading font from Source Sans Pro to Merriweather
    because it is more distinguished from body text.
  - Changed the body font from Source Sans Pro to Lato because Source
    Sans Pro is relatively smaller and denser than other sans-serif
    fonts, making the CSS customization harder.
    - Lato is the default font used by the Sphinx theme we are using,
      which means one less thing to worry.
  - Changed the monospace font from Inconsolata to Hack because:
    - Inconsolata looks thin when paired with Lato.
    - Hack is my favorite font. :-)
- Layout
  - Increased the width of the content pane from 800px to 960px.
  - Made the content pane resizable by dragging its left or right edge.
- Badges
  - Replaced the Slack badge with a custom badge from Shields.io,
    simplifying `add_badges.js`.
  - Used `<object>` tag instead of `<img>` tag so that the badges are
    unaffected by our CSS and the hyperlinks embedded in the `.svg`
    images are preserved.
  - Added more badges:
    - GitHub stars
    - Commit activity
    - Good first issues
- Dependencies
  - gh-fork-ribbon 0.1.1 -> 0.2.2
  - highlightjs-line-numbers.js 2.6.0 -> 2.7.0
  - sphinx-gradle-plugin 2.3.1 -> 2.4.0
- Miscellaneous
  - `0px` -> `0`
  - Cleaned up code block and literal styles
  - Fixed a bug where wrong fonts were being used in the search bar and
    prev/next buttons.

Result:

- Looking better.