### PR TITLE
Change the Java download links to refer to https://adoptopenjdk.net/

### DIFF
--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -1,5 +1,5 @@
 .. _`Apache ZooKeeper`: https://zookeeper.apache.org/
-.. _`Java`: https://www.oracle.com/technetwork/java/javase/downloads/
+.. _`Java`: https://adoptopenjdk.net/
 .. _`JSON path`: https://github.com/json-path/JsonPath
 .. _`pull request`: https://help.github.com/articles/about-pull-requests/
 .. _`the introductory slides`: https://speakerdeck.com/trustin/central-dogma-lines-git-based-highly-available-service-configuration-repository

--- a/site/src/sphinx/setup-installation.rst
+++ b/site/src/sphinx/setup-installation.rst
@@ -6,7 +6,7 @@ Installation
 Prerequisites
 -------------
 Central Dogma server is a Java application that requires Java 8 or above. If your system has no Java installed,
-you need to `download and install Java <https://www.oracle.com/technetwork/java/javase/downloads/>`_ first.
+you need to `download and install Java <https://adoptopenjdk.net/>`_ first.
 Once installed, make sure the ``java`` binary is in your ``PATH`` or the ``JAVA_HOME`` environment variable is
 set correctly.
 


### PR DESCRIPTION
.. for the reduced licensing risks of the users.