### PR TITLE
Update dependencies

### DIFF
--- a/client/java-spring-boot1-autoconfigure/build.gradle
+++ b/client/java-spring-boot1-autoconfigure/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(':client:java-armeria-legacy')
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.20.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.21.RELEASE'
 
     testCompile project(':client:java-armeria')
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.20.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.21.RELEASE'
     testRuntime 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.linecorp.armeria:armeria-bom:0.85.0
+- com.linecorp.armeria:armeria-bom:0.86.0
 
 ch.qos.logback:
   logback-classic:
@@ -32,7 +32,7 @@ com.cronutils:
 
 com.fasterxml.jackson.core:
   jackson-annotations:
-    version: &JACKSON_VERSION '2.9.8'
+    version: &JACKSON_VERSION '2.9.9'
     javadocs:
     - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
   jackson-core:
@@ -227,7 +227,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.4.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.5.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
@@ -173,6 +173,7 @@ final class SamlAuthSsoHandler implements SamlSingleSignOnHandler {
     @Override
     public HttpResponse loginFailed(ServiceRequestContext ctx, AggregatedHttpMessage req,
                                     @Nullable MessageContext<Response> message, Throwable cause) {
+        // TODO(hyangtack) Fix here once https://github.com/line/armeria/issues/1780 is resolved.
         return HttpApiUtil.newResponse(ctx, HttpStatus.INTERNAL_SERVER_ERROR, cause);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -39,6 +39,7 @@ import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.server.internal.admin.service.TokenNotFoundException;
+import com.linecorp.centraldogma.server.internal.storage.RequestAlreadyTimedOutException;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryMetadataException;
 
 /**
@@ -108,7 +109,7 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
             return newResponse(ctx, HttpStatus.BAD_REQUEST, cause);
         }
 
-        if (cause instanceof IllegalStateException) {
+        if (cause instanceof RequestAlreadyTimedOutException) {
             return newResponse(ctx, HttpStatus.SERVICE_UNAVAILABLE, cause);
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -108,6 +108,10 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
             return newResponse(ctx, HttpStatus.BAD_REQUEST, cause);
         }
 
+        if (cause instanceof IllegalStateException) {
+            return newResponse(ctx, HttpStatus.SERVICE_UNAVAILABLE, cause);
+        }
+
         return newResponse(ctx, HttpStatus.INTERNAL_SERVER_ERROR, cause);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RequestAlreadyTimedOutException.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RequestAlreadyTimedOutException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage;
+
+/**
+ * Indicates that the request has already timed out.
+ */
+public class RequestAlreadyTimedOutException extends IllegalStateException {
+
+    private static final long serialVersionUID = -7292042179379070882L;
+
+    public RequestAlreadyTimedOutException() {
+    }
+
+    public RequestAlreadyTimedOutException(String message) {
+        super(message);
+    }
+
+    public RequestAlreadyTimedOutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public RequestAlreadyTimedOutException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/FailFastUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/FailFastUtil.java
@@ -22,11 +22,12 @@ import org.slf4j.Logger;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.centraldogma.server.internal.storage.RequestAlreadyTimedOutException;
 
 final class FailFastUtil {
 
-    private static final IllegalStateException REQUEST_ALREADY_TIMED_OUT =
-            Exceptions.clearTrace(new IllegalStateException("Request already timed out."));
+    private static final RequestAlreadyTimedOutException REQUEST_ALREADY_TIMED_OUT =
+            Exceptions.clearTrace(new RequestAlreadyTimedOutException("Request already timed out."));
 
     static {
         REQUEST_ALREADY_TIMED_OUT.initCause(null);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -58,6 +58,7 @@ import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.WatchService;
 import com.linecorp.centraldogma.server.internal.metadata.MetadataService;
+import com.linecorp.centraldogma.server.internal.storage.RequestAlreadyTimedOutException;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
@@ -340,7 +341,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                 final WatchRepositoryResult wrr = new WatchRepositoryResult();
                 wrr.setRevision(convert(res));
                 resultHandler.onComplete(wrr);
-            } else if (cause instanceof CancellationException) {
+            } else if (cause instanceof CancellationException ||
+                       cause instanceof RequestAlreadyTimedOutException) {
                 resultHandler.onComplete(CentralDogmaConstants.EMPTY_WATCH_REPOSITORY_RESULT);
             } else {
                 logAndInvokeOnError("watchRepository", resultHandler, cause);
@@ -382,7 +384,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                 wfr.setType(convert(res.type()));
                 wfr.setContent(res.contentAsText());
                 resultHandler.onComplete(wfr);
-            } else if (cause instanceof CancellationException) {
+            } else if (cause instanceof CancellationException ||
+                       cause instanceof RequestAlreadyTimedOutException) {
                 resultHandler.onComplete(CentralDogmaConstants.EMPTY_WATCH_FILE_RESULT);
             } else {
                 logAndInvokeOnError("watchFile", resultHandler, cause);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -32,6 +32,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.thrift.async.AsyncMethodCallback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.internal.thrift.Author;
@@ -63,6 +65,8 @@ import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
+
+    private static final Logger logger = LoggerFactory.getLogger(CentralDogmaServiceImpl.class);
 
     private static final IllegalArgumentException RESERVED_REPOSITORY_EXCEPTION =
             Exceptions.clearTrace(new IllegalArgumentException(
@@ -341,9 +345,10 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                 final WatchRepositoryResult wrr = new WatchRepositoryResult();
                 wrr.setRevision(convert(res));
                 resultHandler.onComplete(wrr);
-            } else if (cause instanceof CancellationException ||
-                       cause instanceof RequestAlreadyTimedOutException) {
+            } else if (cause instanceof CancellationException) {
                 resultHandler.onComplete(CentralDogmaConstants.EMPTY_WATCH_REPOSITORY_RESULT);
+            } else if (cause instanceof RequestAlreadyTimedOutException) {
+                logger.warn("Ignoring the exception raised when a request has already timed out.");
             } else {
                 logAndInvokeOnError("watchRepository", resultHandler, cause);
             }
@@ -384,9 +389,10 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                 wfr.setType(convert(res.type()));
                 wfr.setContent(res.contentAsText());
                 resultHandler.onComplete(wfr);
-            } else if (cause instanceof CancellationException ||
-                       cause instanceof RequestAlreadyTimedOutException) {
+            } else if (cause instanceof CancellationException) {
                 resultHandler.onComplete(CentralDogmaConstants.EMPTY_WATCH_FILE_RESULT);
+            } else if (cause instanceof RequestAlreadyTimedOutException) {
+                logger.warn("Ignoring the exception raised when a request has already timed out.");
             } else {
                 logAndInvokeOnError("watchFile", resultHandler, cause);
             }


### PR DESCRIPTION
Modifications:
- Update dependencies:
  - Armeria 0.85.0 -> 0.86.0
  - Jackson 2.9.8 -> 2.9.9
  - Spring Boot
    - 2.1.4.RELEASE -> 2.1.5.RELEASE
    - 1.5.20.RELEASE -> 1.5.21.RELEASE
- Misc
  - `503 Service Unavailable` is now returned if `RequestAlreadyTimedOutException` is thrown. (related to https://github.com/line/centraldogma/issues/392)