### PR TITLE
Add missing `evaluationDependsOn` to dist/build.gradle

### DIFF
--- a/.post-release-msg
+++ b/.post-release-msg
@@ -19,7 +19,8 @@
 
    ./gradlew :dist:docker
    docker login
-   docker push line/centraldogma
+   docker push line/centraldogma:${releaseVersion}
+   docker push line/centraldogma:latest
 
 6. Copy the web site generated to the 'gh-pages' branch. e.g.
 

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'base'
 
 ext {
     def defaultClientRepoUrl = 'https://github.com/line/centraldogma-go.git'
-    def defaultClientTag = 'c07c29ad5b8093c85a68f23e6c8272443bc2cc1a'
+    def defaultClientTag = '9ea08a6cc33e5cf68c19ee0618c235265478097a'
 
     goVersion = '1.11.2'
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -18,6 +18,8 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 
 evaluationDependsOn(':cli')
 evaluationDependsOn(':server')
+evaluationDependsOn(':server-auth:saml')
+evaluationDependsOn(':server-auth:shiro')
 
 ext {
     distDir = "${project.buildDir}/dist"


### PR DESCRIPTION
Modifications:
- Added the following lines to `dist/build.gradle`.
```
evaluationDependsOn(':server-auth:saml')
evaluationDependsOn(':server-auth:shiro')
```
- Misc
  - Fixed docker push commands in `.post-release-msg`.
  - Updated CLI tag to `9ea08a6cc33e5cf68c19ee0618c235265478097a`.