### PR TITLE
Refer a cross-project task as a path rather than as a reference

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -16,10 +16,7 @@ buildscript {
 apply plugin: 'com.boazj.log'
 apply plugin: 'com.bmuschko.docker-remote-api'
 
-evaluationDependsOn(':cli')
-evaluationDependsOn(':server')
-evaluationDependsOn(':server-auth:saml')
-evaluationDependsOn(':server-auth:shiro')
+evaluationDependsOn(':cli') // Need to evaluate first because otherwise its tasks are not available.
 
 ext {
     distDir = "${project.buildDir}/dist"
@@ -50,18 +47,17 @@ task copyLicenses(group: 'Build',
     include "/licenses/**"
 }
 
+def serverProjects = [project(':server'), project(':server-auth:saml'), project(':server-auth:shiro')]
+
 task copyLib(group: 'Build',
              description: "Copies JARs into ${project.ext.relativeDistDir}/lib",
-             dependsOn: project(':server').tasks.jar,
              type: Copy) {
-
-    from project(':server').configurations.runtime
-    from project(':server').tasks.jar
     from project.configurations.runtime
-    from project(':server-auth:saml').configurations.runtime
-    from project(':server-auth:saml').tasks.jar
-    from project(':server-auth:shiro').configurations.runtime
-    from project(':server-auth:shiro').tasks.jar
+    serverProjects.each { p ->
+        dependsOn p.tasks.jar.path
+        from p.configurations.runtime
+        from p.tasks.jar
+    }
     into "${project.ext.distDir}/lib"
 
     doLast {

--- a/shaded-test/build.gradle
+++ b/shaded-test/build.gradle
@@ -27,7 +27,7 @@ project.ext.requiredProjects.each { addDependencies it }
 
 task allShadedJars {
     project.ext.requiredProjects.each { testProject ->
-        dependsOn testProject.tasks.assemble
+        dependsOn testProject.tasks.assemble.path
     }
 }
 
@@ -52,8 +52,8 @@ requiredProjects.each { testProject ->
     def shadedTestTask = tasks.create(shadedName(testProject, 'Test'), Test) {
         Configuration cfg = configurations.getByName(shadedName(testProject))
         dependsOn cfg
-        dependsOn tasks.allShadedJars
-        dependsOn tasks.copyJavaAgents
+        dependsOn tasks.allShadedJars.path
+        dependsOn tasks.copyJavaAgents.path
         dependsOn shadedTestJarExtractTask
 
         // The tests against the shaded artifacts should run after testing against the unshaded ones.
@@ -71,7 +71,7 @@ requiredProjects.each { testProject ->
         }
     }
 
-    tasks.shadedTest.dependsOn shadedTestTask
+    tasks.shadedTest.dependsOn shadedTestTask.path
 }
 
 jacocoTestReport {

--- a/site/build.gradle
+++ b/site/build.gradle
@@ -31,7 +31,10 @@ task javadoc(type: Javadoc,
     destinationDir = project.file("${project.buildDir}/site/apidocs")
 
     def javadocProjects = projectsWithFlags('java', 'publish')
-    javadocProjects.each { source it.sourceSets.main.java.srcDirs }
+    javadocProjects.each {
+        source it.sourceSets.main.java.srcDirs
+        dependsOn it.tasks.compileJava.path
+    }
     classpath = javadocProjects.inject(project.files()) { result, project ->
         result.from(project.sourceSets.main.compileClasspath)
         result.from(project.sourceSets.main.runtimeClasspath)


### PR DESCRIPTION
Related: https://github.com/line/gradle-scripts/pull/61
Motivation:

When configure-on-demand is enabled, inter-project dependencies are
calculated correctly only when task dependency is specified as a task
path string. See:

- https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:configuration_on_demand

> The task dependencies declared via task path are supported and cause
> relevant projects to be configured.
> Example: someTask.dependsOn(":someOtherProject:someOtherTask")

Modifications:

- Use `Task.path` when referring to a task in a different project to
  call `Task.dependsOn()`

Result:

- Fixes a bug where a certain project is not configured when it has to
  be, causing a weird compilation error due to unconfigured dependencies.