### PR TITLE
Add properties to CentralDogmaConfig for configuring trusted proxy addresses

### DIFF
--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -12,6 +12,8 @@
     }
   ],
   "tls": null,
+  "trustedProxyAddresses": null,
+  "clientAddressSources": null,
   "numWorkers": null,
   "maxNumConnections": null,
   "requestTimeoutMillis": null,
@@ -19,14 +21,20 @@
   "maxFrameLength": null,
   "numRepositoryWorkers": 16,
   "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
-  "webAppEnabled": true,
   "gracefulShutdownTimeout": {
     "quietPeriodMillis": 1000,
     "timeoutMillis": 10000
   },
+  "webAppEnabled": true,
+  "webAppTitle": null,
+  "mirroringEnabled": null,
+  "numMirroringThreads": null,
+  "maxNumFilesPerMirror": null,
+  "maxNumBytesPerMirror": null,
   "replication": {
     "method": "NONE"
   },
+  "csrfTokenRequiredForThrift": null,
   "accessLogFormat": "common",
   "authentication": null
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -491,12 +491,15 @@ public class CentralDogma implements AutoCloseable {
             }
         }
 
+        sb.clientAddressSources(cfg.clientAddressSourceList());
+        sb.clientAddressTrustedProxyFilter(cfg.trustedProxyAddressPredicate());
+
         cfg.numWorkers().ifPresent(
                 numWorkers -> sb.workerGroup(EventLoopGroups.newEventLoopGroup(numWorkers), true));
         cfg.maxNumConnections().ifPresent(sb::maxNumConnections);
         cfg.idleTimeoutMillis().ifPresent(sb::idleTimeoutMillis);
-        cfg.requestTimeoutMillis().ifPresent(sb::defaultRequestTimeoutMillis);
-        cfg.maxFrameLength().ifPresent(sb::defaultMaxRequestLength);
+        cfg.requestTimeoutMillis().ifPresent(sb::requestTimeoutMillis);
+        cfg.maxFrameLength().ifPresent(sb::maxRequestLength);
         cfg.gracefulShutdownTimeout().ifPresent(
                 t -> sb.gracefulShutdownTimeout(t.quietPeriodMillis(), t.timeoutMillis()));
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.function.Predicate;
+
+import org.junit.Test;
+
+import com.linecorp.armeria.server.ClientAddressSource;
+import com.linecorp.centraldogma.internal.Jackson;
+
+public class CentralDogmaConfigTest {
+
+    @Test
+    public void trustedProxyAddress_withCustomClientAddressSources() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"trustedProxyAddresses\": [\n" +
+                                  "    \"10.0.0.1\",\n" +
+                                  "    \"11.0.0.1/24\"\n" +
+                                  "  ],\n" +
+                                  "  \"clientAddressSources\": [\n" +
+                                  "    \"custom-client-address-header\",\n" +
+                                  "    \"PROXY_PROTOCOL\"\n" +
+                                  "  ]\n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
+        assertThat(cfg.clientAddressSources().size()).isEqualTo(2);
+
+        final Predicate<InetAddress> p = cfg.trustedProxyAddressPredicate();
+        assertThat(p.test(InetAddress.getByName("10.0.0.1"))).isTrue();
+        assertThat(p.test(InetAddress.getByName("10.0.0.2"))).isFalse();
+        assertThat(p.test(InetAddress.getByName("11.0.0.1"))).isTrue();
+        assertThat(p.test(InetAddress.getByName("11.0.1.1"))).isFalse();
+
+        final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
+        assertThat(sources.size()).isEqualTo(2);
+        // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
+        //                 https://github.com/line/armeria/pull/1804
+        assertThat(sources.get(0).toString())
+                .isEqualTo(ClientAddressSource.ofHeader("custom-client-address-header").toString());
+        assertThat(sources.get(1).toString()).isEqualTo(ClientAddressSource.ofProxyProtocol().toString());
+    }
+
+    @Test
+    public void trustedProxyAddress_withDefaultClientAddressSources() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"trustedProxyAddresses\": [\n" +
+                                  "    \"10.0.0.1\",\n" +
+                                  "    \"11.0.0.1/24\"\n" +
+                                  "  ]\n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
+        assertThat(cfg.clientAddressSources()).isNull();
+
+        final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
+        assertThat(sources.size()).isEqualTo(3);
+        // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
+        //                 https://github.com/line/armeria/pull/1804
+        assertThat(sources.get(0).toString()).isEqualTo(ClientAddressSource.ofHeader("forwarded").toString());
+        assertThat(sources.get(1).toString()).isEqualTo(
+                ClientAddressSource.ofHeader("x-forwarded-for").toString());
+        assertThat(sources.get(2).toString()).isEqualTo(ClientAddressSource.ofProxyProtocol().toString());
+    }
+
+    @Test
+    public void trustedProxyAddress_withDefaultClientAddressSources_withoutProxyProtocol() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"trustedProxyAddresses\": [\n" +
+                                  "    \"10.0.0.1\",\n" +
+                                  "    \"11.0.0.1/24\"\n" +
+                                  "  ]\n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
+        assertThat(cfg.clientAddressSources()).isNull();
+
+        final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
+        assertThat(sources.size()).isEqualTo(2);
+        // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
+        //                 https://github.com/line/armeria/pull/1804
+        assertThat(sources.get(0).toString()).isEqualTo(ClientAddressSource.ofHeader("forwarded").toString());
+        assertThat(sources.get(1).toString()).isEqualTo(
+                ClientAddressSource.ofHeader("x-forwarded-for").toString());
+    }
+
+    @Test
+    public void noTrustedProxyAddress() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ]\n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.trustedProxyAddresses()).isNull();
+        assertThat(cfg.clientAddressSources()).isNull();
+        assertThat(cfg.clientAddressSourceList()).isEmpty();
+    }
+}

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -24,6 +24,8 @@ defaults:
         }
       ],
       "tls": null,
+      "trustedProxyAddresses": null,
+      "clientAddressSources": null,
       "numWorkers": null,
       "maxNumConnections": null,
       "requestTimeoutMillis": null,
@@ -76,6 +78,23 @@ Core properties
 
   - the configuration for Transport Layer Security(TLS) support. Specify ``null`` to disable TLS.
     See :ref:`tls` for more information.
+
+- ``trustedProxyAddresses`` (string array)
+
+  - the addresses or ranges of `Classless Inter-domain Routing (CIDR) <https://tools.ietf.org/html/rfc4632>`_
+    blocks of trusted proxy servers. e.g. ``10.0.0.1`` for a single address or ``10.0.0.0/8`` for a CIDR block.
+    With ``trustedProxyAddresses`` and ``clientAddressSources`` properties, you can get a client address
+    who initiated a request from the access log. If ``null`` or an empty array, a remote endpoint of
+    the connected socket is used as a client address.
+
+- ``clientAddressSources`` (string array)
+
+  - the HTTP header names to be used for retrieving a client address. ``PROXY_PROTOCOL`` is reserved keyword
+    for getting the source address specified in a
+    `PROXY protocol <https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt>`_ message.
+    By default, ``forwarded``, ``x-forwarded-for`` and ``PROXY_PROTOCOL`` are used only if
+    ``trustedProxyAddresses`` is configured. Otherwise, a remote endpoint of the connected socket is used
+    as a client address.
 
 - ``numWorkers`` (integer)
 
@@ -336,6 +355,8 @@ in ``dogma.json`` as follows.
         "keyFile": "./cert/centraldogma.key",
         "keyPassword": null
       },
+      "trustedProxyAddresses": null,
+      "clientAddressSources": null,
       "numWorkers": null,
       "maxNumConnections": null,
       "requestTimeoutMillis": null,

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -84,16 +84,16 @@ Core properties
   - the addresses or ranges of `Classless Inter-domain Routing (CIDR) <https://tools.ietf.org/html/rfc4632>`_
     blocks of trusted proxy servers. e.g. ``10.0.0.1`` for a single address or ``10.0.0.0/8`` for a CIDR block.
     With ``trustedProxyAddresses`` and ``clientAddressSources`` properties, you can get a client address
-    who initiated a request from the access log. If ``null`` or an empty array, a remote endpoint of
-    the connected socket is used as a client address.
+    who initiated a request from the access log. If ``null`` or an empty array, the remote address of
+    the connection is used as a client address.
 
 - ``clientAddressSources`` (string array)
 
-  - the HTTP header names to be used for retrieving a client address. ``PROXY_PROTOCOL`` is reserved keyword
+  - the HTTP header names to be used for retrieving a client address. ``PROXY_PROTOCOL`` is a reserved keyword
     for getting the source address specified in a
     `PROXY protocol <https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt>`_ message.
     By default, ``forwarded``, ``x-forwarded-for`` and ``PROXY_PROTOCOL`` are used only if
-    ``trustedProxyAddresses`` is configured. Otherwise, a remote endpoint of the connected socket is used
+    ``trustedProxyAddresses`` is configured. Otherwise, the remote address of the connection is used
     as a client address.
 
 - ``numWorkers`` (integer)

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -92,7 +92,7 @@ Core properties
   - the HTTP header names to be used for retrieving a client address. ``PROXY_PROTOCOL`` is a reserved keyword
     for getting the source address specified in a
     `PROXY protocol <https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt>`_ message.
-    By default, ``forwarded``, ``x-forwarded-for`` and ``PROXY_PROTOCOL`` are used only if
+    By default, ``forwarded``, ``x-forwarded-for`` and ``PROXY_PROTOCOL`` are used when
     ``trustedProxyAddresses`` is configured. Otherwise, the remote address of the connection is used
     as a client address.
 


### PR DESCRIPTION
Motivation:
Currently, there is no way to specify trusted proxy addresses with the configuration.

Modifications:
- Added `trustedProxyAddresses` and `clientAddressSources` properties to `CentralDogmaConfig`.
  - `trustedProxyAddresses` is a list of exact proxy server addresses and CIDR notation.
  - `clientAddressSources` is a list of HTTP header names to be used for retrieving a client address from an HTTP request.
    `PROXY_PROTOCOL` is specially defined for retrieving a client address from a proxy protocol message.
