### PR TITLE
Send `400 Bad Request` when receiving an invalid SAML request

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -61,7 +61,7 @@ import com.google.common.math.LongMath;
 
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -151,7 +151,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void createProject(AggregatedHttpMessage res) {
+    private static Void createProject(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 201:
@@ -172,7 +172,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void removeProject(AggregatedHttpMessage res) {
+    private static Void removeProject(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 204:
@@ -194,7 +194,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void unremoveProject(AggregatedHttpMessage res) {
+    private static Void unremoveProject(AggregatedHttpResponse res) {
         if (res.status().code() == 200) { // OK
             return null;
         }
@@ -232,7 +232,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void createRepository(AggregatedHttpMessage res) {
+    private static Void createRepository(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 201:
@@ -254,7 +254,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void removeRepository(AggregatedHttpMessage res) {
+    private static Void removeRepository(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 204:
@@ -277,7 +277,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Void unremoveRepository(AggregatedHttpMessage res) {
+    private static Void unremoveRepository(AggregatedHttpResponse res) {
         if (res.status().code() == 200) {
             return null;
         }
@@ -296,7 +296,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Map<String, RepositoryInfo> listRepositories(AggregatedHttpMessage res) {
+    private static Map<String, RepositoryInfo> listRepositories(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 return Streams.stream(toJson(res, JsonNodeType.ARRAY))
@@ -347,7 +347,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Revision normalizeRevision(AggregatedHttpMessage res) {
+    private static Revision normalizeRevision(AggregatedHttpResponse res) {
         if (res.status().code() == 200) {
             return new Revision(getField(toJson(res, JsonNodeType.OBJECT), "revision").asInt());
         }
@@ -378,7 +378,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Map<String, EntryType> listFiles(AggregatedHttpMessage res) {
+    private static Map<String, EntryType> listFiles(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 final ImmutableMap.Builder<String, EntryType> builder = ImmutableMap.builder();
@@ -418,7 +418,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static <T> Entry<T> getFile(Revision normRev, AggregatedHttpMessage res) {
+    private static <T> Entry<T> getFile(Revision normRev, AggregatedHttpResponse res) {
         if (res.status().code() == 200) {
             final JsonNode node = toJson(res, JsonNodeType.OBJECT);
             return toEntry(normRev, node);
@@ -454,7 +454,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static Map<String, Entry<?>> getFiles(Revision normRev, AggregatedHttpMessage res) {
+    private static Map<String, Entry<?>> getFiles(Revision normRev, AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 final JsonNode node = toJson(res, null);
@@ -500,7 +500,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static <T> MergedEntry<T> mergeFiles(AggregatedHttpMessage res) {
+    private static <T> MergedEntry<T> mergeFiles(AggregatedHttpResponse res) {
         if (res.status().code() == 200) {
             final JsonNode node = toJson(res, JsonNodeType.OBJECT);
 
@@ -570,7 +570,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static List<Commit> getHistory(AggregatedHttpMessage res) {
+    private static List<Commit> getHistory(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 final JsonNode node = toJson(res, null);
@@ -615,7 +615,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Nullable
-    private static <T> Change<T> getDiff(AggregatedHttpMessage res) {
+    private static <T> Change<T> getDiff(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 return toChange(toJson(res, JsonNodeType.OBJECT));
@@ -690,7 +690,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static List<Change<?>> getPreviewDiffs(AggregatedHttpMessage res) {
+    private static List<Change<?>> getPreviewDiffs(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 final JsonNode node = toJson(res, JsonNodeType.ARRAY);
@@ -738,7 +738,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
-    private static PushResult push(AggregatedHttpMessage res) {
+    private static PushResult push(AggregatedHttpResponse res) {
         if (res.status().code() == 200) {
             final JsonNode node = toJson(res, JsonNodeType.OBJECT);
             return new PushResult(
@@ -783,7 +783,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Nullable
-    private static Revision watchRepository(AggregatedHttpMessage res) {
+    private static Revision watchRepository(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200: // OK
                 final JsonNode node = toJson(res, JsonNodeType.OBJECT);
@@ -823,7 +823,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Nullable
-    private static <T> Entry<T> watchFile(AggregatedHttpMessage res) {
+    private static <T> Entry<T> watchFile(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200: // OK
                 final JsonNode node = toJson(res, JsonNodeType.OBJECT);
@@ -837,7 +837,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     private <T> CompletableFuture<T> watch(Revision lastKnownRevision, long timeoutMillis,
-                                           String path, Function<AggregatedHttpMessage, T> func) {
+                                           String path, Function<AggregatedHttpResponse, T> func) {
         final RequestHeadersBuilder builder = headersBuilder(HttpMethod.GET, path);
         builder.set(HttpHeaderNames.IF_NONE_MATCH, lastKnownRevision.text())
                .set(HttpHeaderNames.PREFER, "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L);
@@ -964,9 +964,9 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     /**
-     * Parses the content of the specified {@link AggregatedHttpMessage} into a {@link JsonNode}.
+     * Parses the content of the specified {@link AggregatedHttpResponse} into a {@link JsonNode}.
      */
-    private static JsonNode toJson(AggregatedHttpMessage res, @Nullable JsonNodeType expectedNodeType) {
+    private static JsonNode toJson(AggregatedHttpResponse res, @Nullable JsonNodeType expectedNodeType) {
         final String content = toString(res);
         final JsonNode node;
         try {
@@ -983,13 +983,13 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         return node;
     }
 
-    private static <T> T rejectNeitherArrayNorObject(AggregatedHttpMessage res) {
+    private static <T> T rejectNeitherArrayNorObject(AggregatedHttpResponse res) {
         throw new CentralDogmaException(
                 "invalid server response; expected: " + JsonNodeType.OBJECT + " or " + JsonNodeType.ARRAY +
                 ", content: " + toString(res));
     }
 
-    private static String toString(AggregatedHttpMessage res) {
+    private static String toString(AggregatedHttpResponse res) {
         final MediaType contentType = firstNonNull(res.headers().contentType(), MediaType.JSON_UTF_8);
         final Charset charset = contentType.charset().orElse(StandardCharsets.UTF_8);
         return res.content(charset);
@@ -1045,7 +1045,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         throw new Error(); // Never reaches here.
     }
 
-    private static Set<String> handleNameList(AggregatedHttpMessage res) {
+    private static Set<String> handleNameList(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
                 return Streams.stream(toJson(res, JsonNodeType.ARRAY))
@@ -1066,7 +1066,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         return field;
     }
 
-    private static <T> T handleErrorResponse(AggregatedHttpMessage res) {
+    private static <T> T handleErrorResponse(AggregatedHttpResponse res) {
         final HttpStatus status = res.status();
         assert status != null : res;
         if (status.codeClass() != HttpStatusClass.SUCCESS) {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.linecorp.armeria:armeria-bom:0.86.0
+- com.linecorp.armeria:armeria-bom:0.87.0
 
 ch.qos.logback:
   logback-classic:

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProvider.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProvider.java
@@ -23,7 +23,7 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.Service;
-import com.linecorp.armeria.server.ServiceWithPathMappings;
+import com.linecorp.armeria.server.ServiceWithRoutes;
 import com.linecorp.armeria.server.saml.SamlServiceProvider;
 import com.linecorp.centraldogma.server.auth.AuthProvider;
 
@@ -45,7 +45,7 @@ public class SamlAuthProvider implements AuthProvider {
     }
 
     @Override
-    public Iterable<ServiceWithPathMappings<HttpRequest, HttpResponse>> moreServices() {
+    public Iterable<ServiceWithRoutes<HttpRequest, HttpResponse>> moreServices() {
         return ImmutableList.of(sp.newSamlService());
     }
 }

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
@@ -72,7 +72,7 @@ public class SamlAuthTest {
 
     @Test
     public void shouldUseBuiltinWebPageOnlyForLogout() throws Exception {
-        AggregatedHttpMessage resp;
+        AggregatedHttpResponse resp;
 
         // Receive HTML which submits SAMLRequest to IdP.
         resp = rule.httpClient().get(AuthProvider.LOGIN_PATH).aggregate().join();
@@ -89,7 +89,7 @@ public class SamlAuthTest {
 
     @Test
     public void shouldReturnMetadata() {
-        final AggregatedHttpMessage resp = rule.httpClient().get("/saml/metadata").aggregate().join();
+        final AggregatedHttpResponse resp = rule.httpClient().get("/saml/metadata").aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.OK);
         assertThat(resp.headers().contentType()).isEqualTo(MediaType.parse("application/samlmetadata+xml"));
         assertThat(resp.headers().get(HttpHeaderNames.CONTENT_DISPOSITION))

--- a/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
+++ b/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -153,7 +153,7 @@ final class LoginService extends AbstractHttpService {
     /**
      * Returns {@link UsernamePasswordToken} which holds a username and a password.
      */
-    private UsernamePasswordToken usernamePassword(ServiceRequestContext ctx, AggregatedHttpMessage req) {
+    private UsernamePasswordToken usernamePassword(ServiceRequestContext ctx, AggregatedHttpRequest req) {
         // check the Basic HTTP authentication first (https://tools.ietf.org/html/rfc7617)
         final BasicToken basicToken = AuthTokenExtractors.BASIC.apply(RequestHeaders.of(req.headers()));
         if (basicToken != null) {

--- a/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
+++ b/server-auth/shiro/src/test/java/com/linecorp/centraldogma/server/auth/shiro/ShiroLoginAndLogoutTest.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.centraldogma.internal.Jackson;
@@ -69,7 +69,7 @@ public class ShiroLoginAndLogoutTest {
         loginAndLogout(login(client, USERNAME, PASSWORD));
     }
 
-    private void loginAndLogout(AggregatedHttpMessage loginRes) throws Exception {
+    private void loginAndLogout(AggregatedHttpResponse loginRes) throws Exception {
         assertThat(loginRes.status()).isEqualTo(HttpStatus.OK);
 
         // Ensure authorization works.
@@ -101,7 +101,7 @@ public class ShiroLoginAndLogoutTest {
 
     @Test
     public void shouldUseBuiltinWebPages() throws Exception {
-        AggregatedHttpMessage resp;
+        AggregatedHttpResponse resp;
         resp = client.get(AuthProvider.LOGIN_PATH).aggregate().join();
         assertThat(resp.status()).isEqualTo(HttpStatus.MOVED_PERMANENTLY);
         assertThat(resp.headers().get(HttpHeaderNames.LOCATION))

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -24,9 +24,9 @@ import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.HEALTH_CHECK_PATH;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.METRICS_PATH;
 import static com.linecorp.centraldogma.server.auth.AuthProvider.BUILTIN_WEB_BASE_PATH;
-import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGIN_API_PATH_MAPPINGS;
+import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGIN_API_ROUTES;
 import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGIN_PATH;
-import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGOUT_API_PATH_MAPPINGS;
+import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGOUT_API_ROUTES;
 import static com.linecorp.centraldogma.server.auth.AuthProvider.LOGOUT_PATH;
 import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.initializeInternalProject;
 import static java.util.Objects.requireNonNull;
@@ -698,14 +698,14 @@ public class CentralDogma implements AutoCloseable {
 
             // authentication services:
             Optional.ofNullable(authProvider.loginApiService())
-                    .ifPresent(login -> LOGIN_API_PATH_MAPPINGS.forEach(mapping -> sb.service(mapping, login)));
+                    .ifPresent(login -> LOGIN_API_ROUTES.forEach(mapping -> sb.service(mapping, login)));
 
             // Provide logout API by default.
             final Service<HttpRequest, HttpResponse> logout =
                     Optional.ofNullable(authProvider.logoutApiService())
                             .orElseGet(() -> new DefaultLogoutService(executor));
-            for (Route mapping : LOGOUT_API_PATH_MAPPINGS) {
-                sb.service(mapping, decorator.apply(logout));
+            for (Route route : LOGOUT_API_ROUTES) {
+                sb.service(route, decorator.apply(logout));
             }
 
             authProvider.moreServices().forEach(sb::service);

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -72,6 +72,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ServerCacheControl;
 import com.linecorp.armeria.common.metric.MeterIdPrefixFunction;
 import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.common.util.EventLoopGroups;
@@ -79,10 +80,9 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.StartStopSupport;
 import com.linecorp.armeria.common.util.SystemInfo;
 import com.linecorp.armeria.server.AbstractHttpService;
-import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.ServerCacheControl;
 import com.linecorp.armeria.server.ServerPort;
 import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -704,7 +704,7 @@ public class CentralDogma implements AutoCloseable {
             final Service<HttpRequest, HttpResponse> logout =
                     Optional.ofNullable(authProvider.logoutApiService())
                             .orElseGet(() -> new DefaultLogoutService(executor));
-            for (PathMapping mapping : LOGOUT_API_PATH_MAPPINGS) {
+            for (Route mapping : LOGOUT_API_PATH_MAPPINGS) {
                 sb.service(mapping, decorator.apply(logout));
             }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
@@ -69,7 +69,7 @@ public interface AuthProvider {
      * A set of {@link Route}s which handles a login request. It is necessary only if
      * an authentication protocol requires a login feature provided by the server.
      */
-    Set<Route> LOGIN_API_PATH_MAPPINGS =
+    Set<Route> LOGIN_API_ROUTES =
             ImmutableSet.of(Route.builder().exact(API_V0_PATH_PREFIX + "authenticate").build(),
                             Route.builder().exact(API_V1_PATH_PREFIX + "login").build());
 
@@ -77,7 +77,7 @@ public interface AuthProvider {
      * A set of {@link Route}s which handles a logout request. It is necessary only if
      * an authentication protocol requires a logout feature provided by the server.
      */
-    Set<Route> LOGOUT_API_PATH_MAPPINGS =
+    Set<Route> LOGOUT_API_ROUTES =
             ImmutableSet.of(Route.builder().exact(API_V0_PATH_PREFIX + "logout").build(),
                             Route.builder().exact(API_V1_PATH_PREFIX + "logout").build());
 
@@ -107,7 +107,7 @@ public interface AuthProvider {
     /**
      * Returns a {@link Service} which handles a login request sent from the built-in web login page or
      * somewhere implemented by an {@link AuthProvider}. This service would be added to the server
-     * with {@link #LOGIN_API_PATH_MAPPINGS} only if it is provided.
+     * with {@link #LOGIN_API_ROUTES} only if it is provided.
      */
     @Nullable
     default Service<HttpRequest, HttpResponse> loginApiService() {
@@ -117,7 +117,7 @@ public interface AuthProvider {
     /**
      * Returns a {@link Service} which handles a logout request sent from the built-in web logout page or
      * somewhere implemented by an {@link AuthProvider}. This service would be added to the server
-     * with {@link #LOGOUT_API_PATH_MAPPINGS}. If it is not provided, a default service would be added
+     * with {@link #LOGOUT_API_ROUTES}. If it is not provided, a default service would be added
      * because the web console provides a logout button on the navigation bar by default.
      */
     @Nullable

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
@@ -30,9 +30,9 @@ import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseHeaders;
-import com.linecorp.armeria.server.PathMapping;
+import com.linecorp.armeria.server.Route;
 import com.linecorp.armeria.server.Service;
-import com.linecorp.armeria.server.ServiceWithPathMappings;
+import com.linecorp.armeria.server.ServiceWithRoutes;
 
 /**
  * An interface which configures the authentication layer for the Central Dogma server.
@@ -66,20 +66,20 @@ public interface AuthProvider {
     String BUILTIN_WEB_LOGOUT_PATH = BUILTIN_WEB_BASE_PATH + "/logout";
 
     /**
-     * A set of {@link PathMapping}s which handles a login request. It is necessary only if
+     * A set of {@link Route}s which handles a login request. It is necessary only if
      * an authentication protocol requires a login feature provided by the server.
      */
-    Set<PathMapping> LOGIN_API_PATH_MAPPINGS =
-            ImmutableSet.of(PathMapping.ofExact(API_V0_PATH_PREFIX + "authenticate"),
-                            PathMapping.ofExact(API_V1_PATH_PREFIX + "login"));
+    Set<Route> LOGIN_API_PATH_MAPPINGS =
+            ImmutableSet.of(Route.builder().exact(API_V0_PATH_PREFIX + "authenticate").build(),
+                            Route.builder().exact(API_V1_PATH_PREFIX + "login").build());
 
     /**
-     * A set of {@link PathMapping}s which handles a logout request. It is necessary only if
+     * A set of {@link Route}s which handles a logout request. It is necessary only if
      * an authentication protocol requires a logout feature provided by the server.
      */
-    Set<PathMapping> LOGOUT_API_PATH_MAPPINGS =
-            ImmutableSet.of(PathMapping.ofExact(API_V0_PATH_PREFIX + "logout"),
-                            PathMapping.ofExact(API_V1_PATH_PREFIX + "logout"));
+    Set<Route> LOGOUT_API_PATH_MAPPINGS =
+            ImmutableSet.of(Route.builder().exact(API_V0_PATH_PREFIX + "logout").build(),
+                            Route.builder().exact(API_V1_PATH_PREFIX + "logout").build());
 
     /**
      * Returns a {@link Service} which handles a login request from a web browser. By default,
@@ -129,7 +129,7 @@ public interface AuthProvider {
      * Returns additional {@link Service}s which are required for working this {@link AuthProvider}
      * well.
      */
-    default Iterable<ServiceWithPathMappings<HttpRequest, HttpResponse>> moreServices() {
+    default Iterable<ServiceWithRoutes<HttpRequest, HttpResponse>> moreServices() {
         return ImmutableList.of();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/ChangesRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/ChangesRequestConverter.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
 import com.linecorp.centraldogma.common.Change;
@@ -35,7 +35,7 @@ import com.linecorp.centraldogma.common.ChangeType;
 public final class ChangesRequestConverter extends JacksonRequestConverterFunction {
 
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         final JsonNode node = (JsonNode) super.convertRequest(ctx, request, JsonNode.class);
         final ArrayNode changesNode;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CommitMessageRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CommitMessageRequestConverter.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
@@ -34,7 +34,7 @@ import com.linecorp.centraldogma.internal.api.v1.CommitMessageDto;
 public final class CommitMessageRequestConverter extends JacksonRequestConverterFunction {
 
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         if (expectedResultType == CommitMessageDto.class) {
             final JsonNode node = (JsonNode) super.convertRequest(ctx, request, JsonNode.class);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiRequestConverter.java
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.Objects.requireNonNull;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
@@ -44,7 +44,7 @@ public final class HttpApiRequestConverter implements RequestConverterFunction {
     }
 
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         if (expectedResultType == Project.class) {
             final String projectName = ctx.pathParam("projectName");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverter.java
@@ -22,7 +22,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.MergeQuery;
@@ -36,7 +36,7 @@ public class MergeQueryRequestConverter implements RequestConverterFunction {
 
     @Nullable
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         final String queryString = ctx.query();
         if (queryString != null) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverter.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Query;
@@ -39,10 +39,10 @@ public final class QueryRequestConverter implements RequestConverterFunction {
 
     /**
      * Converts the specified {@code request} to {@link Optional} which contains {@link Query} when
-     * the request has a valid file path. {@link Optional#EMPTY} otherwise.
+     * the request has a valid file path. {@link Optional#empty()} otherwise.
      */
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         final String path = getPath(ctx);
         final Optional<Iterable<String>> jsonPaths = getJsonPaths(ctx);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.MoreObjects;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
@@ -44,7 +44,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
      * the request has {@link HttpHeaderNames#IF_NONE_MATCH}. {@link Optional#empty()} otherwise.
      */
     @Override
-    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpMessage request,
+    public Object convertRequest(ServiceRequestContext ctx, AggregatedHttpRequest request,
                                  Class<?> expectedResultType) throws Exception {
         final String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
         if (!isNullOrEmpty(ifNoneMatch)) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.mock;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
@@ -42,8 +42,8 @@ public class CentralDogmaAuthFailureHandlerTest {
 
     @Test
     public void shuttingDown() throws Exception {
-        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, new ShuttingDownException())
-                                                 .aggregate().join();
+        final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, new ShuttingDownException())
+                                                  .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8()).isEqualTo(
@@ -55,8 +55,8 @@ public class CentralDogmaAuthFailureHandlerTest {
 
     @Test
     public void failure() throws Exception {
-        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, new Exception("oops"))
-                                                 .aggregate().join();
+        final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, new Exception("oops"))
+                                                  .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8()).isEqualTo(
@@ -68,8 +68,8 @@ public class CentralDogmaAuthFailureHandlerTest {
 
     @Test
     public void incorrectToken() throws Exception {
-        final AggregatedHttpMessage res = handler.authFailed(delegate, ctx, req, null)
-                                                 .aggregate().join();
+        final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, null)
+                                                  .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(res.contentType()).isEqualTo(MediaType.JSON_UTF_8);
         assertThatJson(res.contentUtf8()).isEqualTo(

--- a/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
@@ -39,7 +39,7 @@ import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.client.encoding.HttpDecodingClient;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
@@ -115,7 +115,7 @@ public class ContentCompressionTest {
                                    HttpApiV1Constants.REPOS + '/' + REPO +
                                    "/contents" + PATH;
 
-        final AggregatedHttpMessage compressedResponse = client.get(contentPath).aggregate().join();
+        final AggregatedHttpResponse compressedResponse = client.get(contentPath).aggregate().join();
         assertThat(compressedResponse.status()).isEqualTo(HttpStatus.OK);
 
         final HttpData content = compressedResponse.content();

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.centraldogma.testing.CentralDogmaRule;
@@ -41,7 +41,7 @@ public class MetricsTest {
     public void metrics() {
         assertThat(rule.dogma().meterRegistry()).containsInstanceOf(PrometheusMeterRegistry.class);
 
-        final AggregatedHttpMessage res = rule.httpClient().get("/monitor/metrics").aggregate().join();
+        final AggregatedHttpResponse res = rule.httpClient().get("/monitor/metrics").aggregate().join();
         logger.debug("Prometheus metrics:\n{}", res.contentUtf8());
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -49,7 +49,7 @@ import org.junit.rules.Timeout;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.centraldogma.internal.Jackson;
@@ -146,7 +146,7 @@ public class ReplicatedLoginAndLogoutTest {
         final int baselineReplicationLogCount = replicationLogCount();
 
         // Log in from the 1st replica.
-        final AggregatedHttpMessage loginRes = login(client1, USERNAME, PASSWORD);
+        final AggregatedHttpResponse loginRes = login(client1, USERNAME, PASSWORD);
         assertThat(loginRes.status()).isEqualTo(HttpStatus.OK);
 
         // Ensure that only one replication log is produced.

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -53,7 +53,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void status() {
-        final AggregatedHttpMessage res = httpClient.get(API_V1_PATH_PREFIX + "status").aggregate().join();
+        final AggregatedHttpResponse res = httpClient.get(API_V1_PATH_PREFIX + "status").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": true, \"replicating\": true }");
@@ -61,7 +61,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void updateStatus_setUnwritable() {
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }]").aggregate().join();
@@ -73,7 +73,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void updateStatus_setUnwritableAndNonReplicating() {
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }," +
@@ -86,7 +86,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void updateStatus_setWritableAndNonReplicating() {
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }," +
@@ -97,7 +97,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void redundantUpdateStatus_Writable() {
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();
@@ -107,7 +107,7 @@ public class AdministrativeServiceTest {
 
     @Test
     public void redundantUpdateStatus_Replicating() {
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/replicating\", \"value\": true }]").aggregate().join();
@@ -120,7 +120,7 @@ public class AdministrativeServiceTest {
         // Enter read-only mode.
         updateStatus_setUnwritable();
         // Try to enter writable mode.
-        final AggregatedHttpMessage res = httpClient.execute(
+        final AggregatedHttpResponse res = httpClient.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -49,7 +49,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
     @Test
     public void addFile() {
-        final AggregatedHttpMessage aRes = addFooJson();
+        final AggregatedHttpResponse aRes = addFooJson();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 2," +
@@ -75,7 +75,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage aRes = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().execute(headers, body).aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 3," +
@@ -101,7 +101,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage aRes = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().execute(headers, body).aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 3," +
@@ -135,7 +135,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage aRes = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().execute(headers, body).aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 2," +
@@ -164,7 +164,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         httpClient().execute(headers, editJsonBody).aggregate().join();
 
         // check whether the change is right
-        final AggregatedHttpMessage res1 = httpClient()
+        final AggregatedHttpResponse res1 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=2&to=3").aggregate().join();
         final JsonNode content1 = Jackson.readTree(res1.contentUtf8()).get(0).get("content");
         assertThat(content1.size()).isOne();
@@ -188,7 +188,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                              editTextBody).aggregate().join();
 
         // check whether the change is right
-        final AggregatedHttpMessage res2 = httpClient()
+        final AggregatedHttpResponse res2 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=4&to=5").aggregate().join();
         final JsonNode content2 = Jackson.readTree(res2.contentUtf8()).get(0).get("content");
         assertThat(content2.textValue()).isEqualToIgnoringCase("--- /a/bar.txt\n" +
@@ -225,7 +225,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         httpClient().execute(headers, body).aggregate().join();
-        final AggregatedHttpMessage aRes = httpClient()
+        final AggregatedHttpResponse aRes = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=3&to=4").aggregate().join();
         final String expectedJson =
                 '[' +
@@ -258,7 +258,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     @Test
     public void getFile() {
         addFooJson();
-        final AggregatedHttpMessage aRes = httpClient().get(CONTENTS_PREFIX + "/foo.json").aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().get(CONTENTS_PREFIX + "/foo.json").aggregate().join();
 
         final String expectedJson =
                 '{' +
@@ -275,7 +275,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     @Test
     public void getFileWithJsonPath() {
         addFooJson();
-        final AggregatedHttpMessage aRes = httpClient()
+        final AggregatedHttpResponse aRes = httpClient()
                 .get(CONTENTS_PREFIX + "/foo.json?jsonpath=$[?(@.a == \"bar\")]&jsonpath=$[0].a")
                 .aggregate().join();
 
@@ -296,7 +296,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         addFooJson();
         addBarTxt();
         // get the list of all files
-        final AggregatedHttpMessage res1 = httpClient()
+        final AggregatedHttpResponse res1 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/**").aggregate().join();
         final String expectedJson1 =
                 '[' +
@@ -322,7 +322,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson1);
 
         // get the list of files only under root
-        final AggregatedHttpMessage res2 = httpClient()
+        final AggregatedHttpResponse res2 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/").aggregate().join();
         final String expectedJson2 =
                 '[' +
@@ -342,7 +342,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson2);
 
         // get the list of all files with revision 2, so only foo.json will be fetched
-        final AggregatedHttpMessage res3 = httpClient()
+        final AggregatedHttpResponse res3 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/**?revision=2").aggregate().join();
         final String expectedJson3 =
                 '[' +
@@ -356,7 +356,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         assertThatJson(res3.contentUtf8()).isEqualTo(expectedJson3);
 
         // get the list with a file path
-        final AggregatedHttpMessage res4 = httpClient()
+        final AggregatedHttpResponse res4 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/foo.json").aggregate().join();
         final String expectedJson4 =
                 '[' +
@@ -376,7 +376,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         addBarTxt();
 
         // get the list of all files
-        final AggregatedHttpMessage res1 = httpClient().get(CONTENTS_PREFIX + "/**").aggregate().join();
+        final AggregatedHttpResponse res1 = httpClient().get(CONTENTS_PREFIX + "/**").aggregate().join();
         final String expectedJson1 =
                 '[' +
                 "   {" +
@@ -402,8 +402,8 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 ']';
         assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson1);
 
-        final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/**?revision=2")
-                                                       .aggregate().join();
+        final AggregatedHttpResponse res2 = httpClient().get(CONTENTS_PREFIX + "/**?revision=2")
+                                                        .aggregate().join();
         final String expectedJson2 =
                 '[' +
                 "   {" +
@@ -432,10 +432,10 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage res1 = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse res1 = httpClient().execute(headers, body).aggregate().join();
         assertThat(ResponseHeaders.of(res1.headers()).status()).isEqualTo(HttpStatus.OK);
 
-        final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/**").aggregate().join();
+        final AggregatedHttpResponse res2 = httpClient().get(CONTENTS_PREFIX + "/**").aggregate().join();
         // /a directory and /a/bar.txt file are left
         assertThat(Jackson.readTree(res2.contentUtf8()).size()).isEqualTo(2);
     }
@@ -454,7 +454,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX + "?revision=2",
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage res = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse res = httpClient().execute(headers, body).aggregate().join();
         assertThat(ResponseHeaders.of(res.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
         assertThatJson(res.contentUtf8()).isEqualTo(
                 '{' +
@@ -486,7 +486,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                             '}';
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage res = httpClient().execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse res = httpClient().execute(headers, body).aggregate().join();
         assertThat(ResponseHeaders.of(res.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
         assertThatJson(res.contentUtf8()).isEqualTo(
                 '{' +
@@ -498,7 +498,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
     @Test
     public void editFileWithJsonPatch() throws IOException {
         addFooJson();
-        final AggregatedHttpMessage res1 = editFooJson();
+        final AggregatedHttpResponse res1 = editFooJson();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 3," +
@@ -507,7 +507,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String actualJson = res1.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
 
-        final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/foo.json").aggregate().join();
+        final AggregatedHttpResponse res2 = httpClient().get(CONTENTS_PREFIX + "/foo.json").aggregate().join();
         assertThat(Jackson.readTree(res2.contentUtf8()).get("content").get("a").textValue())
                 .isEqualToIgnoringCase("baz");
     }
@@ -533,7 +533,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
 
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, CONTENTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        final AggregatedHttpMessage res1 = httpClient().execute(headers, patch).aggregate().join();
+        final AggregatedHttpResponse res1 = httpClient().execute(headers, patch).aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 3," +
@@ -542,7 +542,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final String actualJson = res1.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
 
-        final AggregatedHttpMessage res2 = httpClient().get(CONTENTS_PREFIX + "/a/bar.txt").aggregate().join();
+        final AggregatedHttpResponse res2 = httpClient().get(CONTENTS_PREFIX + "/a/bar.txt").aggregate().join();
         assertThat(Jackson.readTree(res2.contentUtf8()).get("content").textValue())
                 .isEqualTo("text in some file.\n");
     }
@@ -552,7 +552,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         addFooJson();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, CONTENTS_PREFIX,
                                                          HttpHeaderNames.IF_NONE_MATCH, "-1");
-        final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> future = httpClient().execute(headers).aggregate();
 
         assertThatThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
                 .isExactlyInstanceOf(TimeoutException.class);
@@ -560,7 +560,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         editFooJson();
 
         await().atMost(3, TimeUnit.SECONDS).untilAsserted(future::isDone);
-        final AggregatedHttpMessage res = future.join();
+        final AggregatedHttpResponse res = future.join();
 
         final String expectedJson =
                 '{' +
@@ -575,7 +575,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, CONTENTS_PREFIX,
                                                          HttpHeaderNames.IF_NONE_MATCH, "-1",
                                                          HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
-        final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> future = httpClient().execute(headers).aggregate();
         await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(ResponseHeaders.of(future.join().headers()).status()).isSameAs(HttpStatus.NOT_MODIFIED);
     }
@@ -585,7 +585,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, CONTENTS_PREFIX + "/foo.json",
                                                          HttpHeaderNames.IF_NONE_MATCH, "-1",
                                                          HttpHeaderNames.PREFER, "wait=5"); // 5 seconds
-        final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> future = httpClient().execute(headers).aggregate();
         await().between(4, TimeUnit.SECONDS, 6, TimeUnit.SECONDS).until(future::isDone);
         assertThat(ResponseHeaders.of(future.join().headers()).status()).isSameAs(HttpStatus.NOT_MODIFIED);
     }
@@ -595,7 +595,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         addFooJson();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, CONTENTS_PREFIX + "/foo.json",
                                                          HttpHeaderNames.IF_NONE_MATCH, "-1");
-        final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> future = httpClient().execute(headers).aggregate();
 
         assertThatThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
                 .isExactlyInstanceOf(TimeoutException.class);
@@ -618,7 +618,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 '}';
-        final AggregatedHttpMessage res = future.join();
+        final AggregatedHttpResponse res = future.join();
         final String actualJson = res.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
@@ -629,7 +629,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET,
                                                          CONTENTS_PREFIX + "/foo.json?jsonpath=%24.a",
                                                          HttpHeaderNames.IF_NONE_MATCH, "-1");
-        final CompletableFuture<AggregatedHttpMessage> future = httpClient().execute(headers).aggregate();
+        final CompletableFuture<AggregatedHttpResponse> future = httpClient().execute(headers).aggregate();
 
         assertThatThrownBy(() -> future.get(500, TimeUnit.MILLISECONDS))
                 .isExactlyInstanceOf(TimeoutException.class);
@@ -652,7 +652,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "       \"url\": \"/api/v1/projects/myPro/repos/myRepo/contents/foo.json\"" +
                 "   }" +
                 '}';
-        final AggregatedHttpMessage res = future.join();
+        final AggregatedHttpResponse res = future.join();
         final String actualJson = res.contentUtf8();
         assertThatJson(actualJson).isEqualTo(expectedJson);
     }
@@ -681,17 +681,17 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
                 "   }" +
                 ']';
         // List directory without slash.
-        final AggregatedHttpMessage res1 = httpClient()
+        final AggregatedHttpResponse res1 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/a.json").aggregate().join();
         assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
 
         // Listing directory with a slash is same with the listing director without slash which is res1.
-        final AggregatedHttpMessage res2 = httpClient()
+        final AggregatedHttpResponse res2 = httpClient()
                 .get("/api/v1/projects/myPro/repos/myRepo/list/a.json/").aggregate().join();
         assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
     }
 
-    private AggregatedHttpMessage addFooJson() {
+    private AggregatedHttpResponse addFooJson() {
         final String body =
                 '{' +
                 "   \"path\" : \"/foo.json\"," +
@@ -708,7 +708,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         return httpClient().execute(headers, body).aggregate().join();
     }
 
-    private AggregatedHttpMessage editFooJson() {
+    private AggregatedHttpResponse editFooJson() {
         final String body =
                 '{' +
                 "   \"path\" : \"/foo.json\"," +
@@ -731,7 +731,7 @@ public class ContentServiceV1Test extends ContentServiceV1TestBase {
         return httpClient().execute(headers, body).aggregate().join();
     }
 
-    private AggregatedHttpMessage addBarTxt() {
+    private AggregatedHttpResponse addBarTxt() {
         final String body =
                 '{' +
                 "   \"path\" : \"/a/bar.txt\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -86,8 +86,8 @@ public class ListCommitsAndDiffTest {
 
     @Test
     public void listCommits() {
-        final AggregatedHttpMessage aRes = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits")
+                                                      .aggregate().join();
         final String expectedJson =
                 '[' +
                 "   {" +
@@ -135,7 +135,7 @@ public class ListCommitsAndDiffTest {
 
     @Test
     public void listCommitsWithmaxCommits() {
-        final AggregatedHttpMessage aRes =
+        final AggregatedHttpResponse aRes =
                 httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/-1?to=1&maxCommits=2")
                           .aggregate().join();
         final String expectedJson =
@@ -172,8 +172,8 @@ public class ListCommitsAndDiffTest {
 
     @Test
     public void getOneCommit() {
-        final AggregatedHttpMessage aRes = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/2")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/2")
+                                                      .aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 2," +
@@ -193,7 +193,7 @@ public class ListCommitsAndDiffTest {
 
     @Test
     public void getCommitWithPath() {
-        final AggregatedHttpMessage aRes = httpClient
+        final AggregatedHttpResponse aRes = httpClient
                 .get("/api/v1/projects/myPro/repos/myRepo/commits?path=/foo0.json").aggregate().join();
         final String expectedJson =
                 '[' +
@@ -216,8 +216,8 @@ public class ListCommitsAndDiffTest {
 
     @Test
     public void listCommitsWithRevision() {
-        final AggregatedHttpMessage res1 = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits?to=2")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse res1 = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits?to=2")
+                                                      .aggregate().join();
         final String expectedJson =
                 '[' +
                 "   {" +
@@ -248,15 +248,15 @@ public class ListCommitsAndDiffTest {
                 "   }" +
                 ']';
         assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
-        final AggregatedHttpMessage res2 = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/3?to=2")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse res2 = httpClient.get("/api/v1/projects/myPro/repos/myRepo/commits/3?to=2")
+                                                      .aggregate().join();
         assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
     }
 
     @Test
     public void getDiff() {
         editFooFile();
-        final AggregatedHttpMessage aRes = httpClient
+        final AggregatedHttpResponse aRes = httpClient
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=3&to=5").aggregate().join();
         final String expectedJson =
                 '[' +
@@ -287,7 +287,7 @@ public class ListCommitsAndDiffTest {
     @Test
     public void getJsonDiff() {
         editFooFile();
-        final AggregatedHttpMessage aRes = httpClient
+        final AggregatedHttpResponse aRes = httpClient
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?path=/foo0.json&jsonpath=$.a&from=3&to=4")
                 .aggregate().join();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MergeFileTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MergeFileTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -39,8 +39,8 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                              "path=/foo2.json" + '&' +
                              "optional_path=/foo3.json";
 
-        AggregatedHttpMessage aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
-                                                      queryString).aggregate().join();
+        AggregatedHttpResponse aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
+                                                       queryString).aggregate().join();
 
         String expectedJson =
                 '{' +
@@ -75,8 +75,8 @@ public class MergeFileTest extends ContentServiceV1TestBase {
         final String queryString = "optional_path=/no_exist1.json" + '&' +
                                    "optional_path=/no_exist2.json";
 
-        final AggregatedHttpMessage aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
-                                                            queryString).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
+                                                             queryString).aggregate().join();
         assertThat(aRes.status()).isEqualTo(HttpStatus.NOT_FOUND);
         final String expectedJson =
                 '{' +
@@ -107,8 +107,8 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                                    "path=/foo2.json" + '&' +
                                    "path=/foo10.json";
 
-        final AggregatedHttpMessage aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
-                                                            queryString).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
+                                                             queryString).aggregate().join();
         assertThat(aRes.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         final String expectedJson =
                 '{' +
@@ -126,8 +126,8 @@ public class MergeFileTest extends ContentServiceV1TestBase {
                              "path=/foo2.json" + '&' +
                              "jsonpath=$[?(@.b == \"baz\")]&jsonpath=$[0].b";
 
-        AggregatedHttpMessage aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
-                                                      queryString).aggregate().join();
+        AggregatedHttpResponse aRes = httpClient().get("/api/v1/projects/myPro/repos/myRepo/merge?" +
+                                                       queryString).aggregate().join();
         String expectedJson =
                 '{' +
                 "   \"revision\" : 4," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
@@ -62,7 +62,7 @@ public class ProjectServiceV1Test {
 
     @Test
     public void createProject() throws IOException {
-        final AggregatedHttpMessage aRes = createProject("myPro");
+        final AggregatedHttpResponse aRes = createProject("myPro");
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
         assertThat(headers.status()).isEqualTo(HttpStatus.CREATED);
 
@@ -74,7 +74,7 @@ public class ProjectServiceV1Test {
         assertThat(jsonNode.get("createdAt").asText()).isNotNull();
     }
 
-    private static AggregatedHttpMessage createProject(String name) {
+    private static AggregatedHttpResponse createProject(String name) {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, PROJECTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
 
@@ -85,7 +85,7 @@ public class ProjectServiceV1Test {
     @Test
     public void createProjectWithSameName() {
         createProject("myPro");
-        final AggregatedHttpMessage res = createProject("myPro");
+        final AggregatedHttpResponse res = createProject("myPro");
         assertThat(ResponseHeaders.of(res.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
@@ -100,7 +100,7 @@ public class ProjectServiceV1Test {
         createProject("trustin");
         createProject("hyangtack");
         createProject("minwoox");
-        final AggregatedHttpMessage aRes = httpClient.get(PROJECTS_PREFIX).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.get(PROJECTS_PREFIX).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.OK);
         final String expectedJson =
                 '[' +
@@ -138,16 +138,16 @@ public class ProjectServiceV1Test {
     @Test
     public void removeProject() {
         createProject("foo");
-        final AggregatedHttpMessage aRes = httpClient.delete(PROJECTS_PREFIX + "/foo")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.delete(PROJECTS_PREFIX + "/foo")
+                                                      .aggregate().join();
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
         assertThat(ResponseHeaders.of(headers).status()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
     @Test
     public void removeAbsentProject() {
-        final AggregatedHttpMessage aRes = httpClient.delete(PROJECTS_PREFIX + "/foo")
-                                                     .aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.delete(PROJECTS_PREFIX + "/foo")
+                                                      .aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
@@ -159,8 +159,8 @@ public class ProjectServiceV1Test {
         httpClient.delete(PROJECTS_PREFIX + "/hyangtack").aggregate().join();
         httpClient.delete(PROJECTS_PREFIX + "/minwoox").aggregate().join();
 
-        final AggregatedHttpMessage removedRes = httpClient.get(PROJECTS_PREFIX + "?status=removed")
-                                                           .aggregate().join();
+        final AggregatedHttpResponse removedRes = httpClient.get(PROJECTS_PREFIX + "?status=removed")
+                                                            .aggregate().join();
         assertThat(ResponseHeaders.of(removedRes.headers()).status()).isEqualTo(HttpStatus.OK);
         final String expectedJson =
                 '[' +
@@ -173,7 +173,7 @@ public class ProjectServiceV1Test {
                 ']';
         assertThatJson(removedRes.contentUtf8()).isEqualTo(expectedJson);
 
-        final AggregatedHttpMessage remainedRes = httpClient.get(PROJECTS_PREFIX).aggregate().join();
+        final AggregatedHttpResponse remainedRes = httpClient.get(PROJECTS_PREFIX).aggregate().join();
         final String remains = remainedRes.contentUtf8();
         final JsonNode jsonNode = Jackson.readTree(remains);
 
@@ -191,7 +191,7 @@ public class ProjectServiceV1Test {
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH);
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final AggregatedHttpMessage aRes = httpClient.execute(headers, unremovePatch).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.OK);
         final String expectedJson =
                 '{' +
@@ -214,7 +214,7 @@ public class ProjectServiceV1Test {
                                                          "application/json-patch+json");
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final AggregatedHttpMessage aRes = httpClient.execute(headers, unremovePatch).aggregate().join();
+        final AggregatedHttpResponse aRes = httpClient.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -36,7 +36,7 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
@@ -212,7 +212,7 @@ public class PermissionTest {
         final HttpClient client = new HttpClientBuilder(rule.uri("/"))
                 .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer " + secret).build();
 
-        AggregatedHttpMessage response;
+        AggregatedHttpResponse response;
 
         response = client.get("/projects/" + projectName).aggregate().join();
         assertThat(response.status())

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverterTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.MergeSource;
@@ -47,7 +47,7 @@ public class MergeQueryRequestConverterTest {
         @SuppressWarnings("unchecked")
         final MergeQuery<JsonNode> mergeQuery =
                 (MergeQuery<JsonNode>) converter.convertRequest(
-                        ctx, mock(AggregatedHttpMessage.class), null);
+                        ctx, mock(AggregatedHttpRequest.class), null);
         assertThat(mergeQuery).isEqualTo(
                 MergeQuery.ofJsonPath(
                         ImmutableList.of(MergeSource.ofRequired("/foo.json"),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverterTest.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryType;
@@ -90,6 +90,6 @@ public class QueryRequestConverterTest {
 
     @SuppressWarnings("unchecked")
     private static Optional<Query<?>> convert(ServiceRequestContext ctx) throws Exception {
-        return (Optional<Query<?>>) converter.convertRequest(ctx, mock(AggregatedHttpMessage.class), null);
+        return (Optional<Query<?>>) converter.convertRequest(ctx, mock(AggregatedHttpRequest.class), null);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -24,9 +24,10 @@ import java.util.Optional;
 
 import org.junit.Test;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpHeaders;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.internal.api.converter.WatchRequestConverter.WatchRequest;
@@ -38,10 +39,10 @@ public class WatchRequestConverterTest {
     @Test
     public void convertWatchRequest() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpMessage request = mock(AggregatedHttpMessage.class);
-        final HttpHeaders headers = HttpHeaders.of(HttpHeaderNames.IF_NONE_MATCH, "-1",
-                                                   HttpHeaderNames.PREFER, "wait=10");
-
+        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/",
+                                                         HttpHeaderNames.IF_NONE_MATCH, "-1",
+                                                         HttpHeaderNames.PREFER, "wait=10");
         when(request.headers()).thenReturn(headers);
 
         final Optional<WatchRequest> watchRequest = convert(ctx, request);
@@ -53,8 +54,8 @@ public class WatchRequestConverterTest {
     @Test
     public void emptyHeader() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpMessage request = mock(AggregatedHttpMessage.class);
-        final HttpHeaders headers = HttpHeaders.of();
+        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
 
         when(request.headers()).thenReturn(headers);
 
@@ -64,7 +65,7 @@ public class WatchRequestConverterTest {
 
     @SuppressWarnings("unchecked")
     private static Optional<WatchRequest> convert(
-            ServiceRequestContext ctx, AggregatedHttpMessage request) throws Exception {
+            ServiceRequestContext ctx, AggregatedHttpRequest request) throws Exception {
         return (Optional<WatchRequest>) converter.convertRequest(ctx, request, null);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/metadata/ThriftBackwardCompatibilityTest.java
@@ -38,7 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.centraldogma.internal.CsrfToken;
 import com.linecorp.centraldogma.internal.Jackson;
@@ -84,7 +84,7 @@ public class ThriftBackwardCompatibilityTest {
         client.push(projectName, repo1, head, author, "", new Comment("comment"),
                     ImmutableList.of(new Change("/sample.txt", ChangeType.UPSERT_TEXT).setContent("test")));
 
-        AggregatedHttpMessage res;
+        AggregatedHttpResponse res;
         res = httpClient.get(PROJECTS_PREFIX + '/' + projectName + REPOS).aggregate().join();
         final List<JsonNode> nodes = new ArrayList<>();
         Jackson.readTree(res.contentUtf8()).elements().forEachRemaining(nodes::add);

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthMessageUtil.java
@@ -20,7 +20,7 @@ import java.util.Base64;
 import java.util.Base64.Encoder;
 
 import com.linecorp.armeria.client.HttpClient;
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
@@ -39,7 +39,7 @@ public final class TestAuthMessageUtil {
 
     private static final Encoder encoder = Base64.getEncoder();
 
-    public static AggregatedHttpMessage login(HttpClient client, String username, String password) {
+    public static AggregatedHttpResponse login(HttpClient client, String username, String password) {
         return client.execute(
                 RequestHeaders.of(HttpMethod.POST, "/api/v1/login",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.FORM_DATA),
@@ -47,7 +47,7 @@ public final class TestAuthMessageUtil {
                 StandardCharsets.US_ASCII).aggregate().join();
     }
 
-    public static AggregatedHttpMessage loginWithBasicAuth(HttpClient client, String username,
+    public static AggregatedHttpResponse loginWithBasicAuth(HttpClient client, String username,
                                                            String password) {
         return client.execute(
                 RequestHeaders.of(HttpMethod.POST, "/api/v1/login",
@@ -57,13 +57,13 @@ public final class TestAuthMessageUtil {
                      .aggregate().join();
     }
 
-    public static AggregatedHttpMessage logout(HttpClient client, String sessionId) {
+    public static AggregatedHttpResponse logout(HttpClient client, String sessionId) {
         return client.execute(
                 RequestHeaders.of(HttpMethod.POST, "/api/v1/logout",
                                   HttpHeaderNames.AUTHORIZATION, "Bearer " + sessionId)).aggregate().join();
     }
 
-    public static AggregatedHttpMessage usersMe(HttpClient client, String sessionId) {
+    public static AggregatedHttpResponse usersMe(HttpClient client, String sessionId) {
         return client.execute(
                 RequestHeaders.of(HttpMethod.GET, "/api/v0/users/me",
                                   HttpHeaderNames.AUTHORIZATION, "Bearer " + sessionId)).aggregate().join();

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthProvider.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/auth/TestAuthProvider.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-import com.linecorp.armeria.common.AggregatedHttpMessage;
+import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
@@ -83,7 +83,7 @@ public class TestAuthProvider implements AuthProvider {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             return HttpResponse.from(CompletableFuture.supplyAsync(() -> {
-                final AggregatedHttpMessage msg = req.aggregate().join();
+                final AggregatedHttpRequest msg = req.aggregate().join();
                 final String username;
                 final String password;
                 final BasicToken basicToken = AuthTokenExtractors.BASIC.apply(RequestHeaders.of(msg.headers()));
@@ -118,7 +118,7 @@ public class TestAuthProvider implements AuthProvider {
         @Override
         public HttpResponse serve(ServiceRequestContext ctx, HttpRequest req) throws Exception {
             return HttpResponse.from(CompletableFuture.supplyAsync(() -> {
-                final AggregatedHttpMessage msg = req.aggregate().join();
+                final AggregatedHttpRequest msg = req.aggregate().join();
                 final String sessionId =
                         AuthTokenExtractors.OAUTH2.apply(RequestHeaders.of(msg.headers())).accessToken();
                 if (!WRONG_SESSION_ID.equals(sessionId)) {


### PR DESCRIPTION
Modifications:
- Update Armeria: 0.86.0 -> 0.87.0
- Send `400 Bad Request` for `InvalidSamlRequestException`.

Result:
- Closes #379