### PR TITLE
Update requestTimeout when using Thrift watch API

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -29,7 +29,6 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.RequestConverterFunction;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 
 /**
  * A request converter that converts to {@link WatchRequest} when the request contains
@@ -56,9 +55,6 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             } else {
                 timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
             }
-            // Update timeout according to the watch API specifications.
-            ctx.setRequestTimeoutMillis(
-                    WatchTimeout.makeReasonable(timeoutMillis, ctx.requestTimeoutMillis()));
             return Optional.of(new WatchRequest(lastKnownRevision, timeoutMillis));
         }
         return Optional.empty();


### PR DESCRIPTION
Motivation:
We update the request timeout when a client sends a watch request using HTTP API, but we don't in Thrift.

Modification:
- Update `requestTimeoutMillis` when using Thrift watch API.

Result:
- No more `RequestAlreadyTimedOutException`.