### PR TITLE
Add the default metadata when a repository has missing metadata

### DIFF
--- a/common-legacy/build.gradle
+++ b/common-legacy/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     // Thrift
     compile 'org.apache.thrift:libthrift'
+    compileOnly 'javax.annotation:javax.annotation-api'
 }
 
 tasks.compileThrift.doLast {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -135,6 +135,9 @@ io.micrometer:
     javadocs:
     - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.1.4/
 
+javax.annotation:
+  javax.annotation-api: { version: '1.3.2' }
+
 javax.inject:
   javax.inject: { version: '1' }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/PerRolePermissions.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/PerRolePermissions.java
@@ -20,10 +20,13 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Sets;
 
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
@@ -60,51 +63,63 @@ public class PerRolePermissions {
     /**
      * {@link Permission}s for a {@link ProjectRole#OWNER}.
      */
-    private final Collection<Permission> owner;
+    private final Set<Permission> owner;
 
     /**
      * {@link Permission}s for a {@link ProjectRole#MEMBER}.
      */
-    private final Collection<Permission> member;
+    private final Set<Permission> member;
 
     /**
      * {@link Permission}s for a {@link ProjectRole#GUEST}.
      */
-    private final Collection<Permission> guest;
+    private final Set<Permission> guest;
 
     /**
      * Creates an instance.
      */
     @JsonCreator
-    public PerRolePermissions(@JsonProperty("owner") Collection<Permission> owner,
-                              @JsonProperty("member") Collection<Permission> member,
-                              @JsonProperty("guest") Collection<Permission> guest) {
-        this.owner = copyOf(requireNonNull(owner, "owner"));
-        this.member = copyOf(requireNonNull(member, "member"));
-        this.guest = copyOf(requireNonNull(guest, "guest"));
-    }
-
-    private static EnumSet<Permission> copyOf(Collection<Permission> input) {
-        // Avoid IllegalArgumentException raised from EnumSet.copyOf() when the input is empty.
-        if (input.isEmpty()) {
-            return EnumSet.noneOf(Permission.class);
-        }
-        return EnumSet.copyOf(input);
+    public PerRolePermissions(@JsonProperty("owner") Iterable<Permission> owner,
+                              @JsonProperty("member") Iterable<Permission> member,
+                              @JsonProperty("guest") Iterable<Permission> guest) {
+        this.owner = Sets.immutableEnumSet(requireNonNull(owner, "owner"));
+        this.member = Sets.immutableEnumSet(requireNonNull(member, "member"));
+        this.guest = Sets.immutableEnumSet(requireNonNull(guest, "guest"));
     }
 
     @JsonProperty
-    public Collection<Permission> owner() {
+    public Set<Permission> owner() {
         return owner;
     }
 
     @JsonProperty
-    public Collection<Permission> member() {
+    public Set<Permission> member() {
         return member;
     }
 
     @JsonProperty
-    public Collection<Permission> guest() {
+    public Set<Permission> guest() {
         return guest;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(owner, member, guest);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        final PerRolePermissions that = (PerRolePermissions) o;
+        return owner.equals(that.owner) &&
+               member.equals(that.member) &&
+               guest.equals(that.guest);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.RepositoryNotFoundException;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerRule;
+
+/**
+ * Makes sure {@link MetadataService} adds the default metadata of a repository when the {@code metadata.json}
+ * does not contain the repository metadata.
+ */
+public class MissingRepositoryMetadataTest {
+
+    @Rule
+    public final ProjectManagerRule rule = new ProjectManagerRule() {
+        @Override
+        protected void afterExecutorStarted() {
+            MigrationUtil.migrate(projectManager(), executor());
+            // Create a project and its metadata here.
+            executor().execute(Command.createProject(AUTHOR, PROJ)).join();
+        }
+    };
+
+    private static final Author AUTHOR = Author.SYSTEM;
+    private static final String PROJ = "proj";
+
+    @Test
+    public void missingRepositoryMetadata() throws Exception {
+        final ProjectManager pm = rule.projectManager();
+        final RepositoryManager rm = pm.get(PROJ).repos();
+        final CommandExecutor executor = rule.executor();
+
+        // Create a new repository without adding metadata.
+        rm.create("repo", AUTHOR);
+        assertThat(rm.get("repo")).isNotNull();
+
+        // Try to access the repository metadata, which will trigger its auto-generation.
+        final MetadataService mds = new MetadataService(pm, executor);
+        final RepositoryMetadata metadata = mds.getRepo(PROJ, "repo").join();
+        assertThat(metadata.id()).isEqualTo("repo");
+        assertThat(metadata.name()).isEqualTo("repo");
+        assertThat(metadata.perRolePermissions()).isEqualTo(PerRolePermissions.DEFAULT);
+        assertThat(metadata.perTokenPermissions()).isEmpty();
+        assertThat(metadata.perUserPermissions()).isEmpty();
+
+        // However, the metadata of a non-existent repository must not trigger auto-generation.
+        assertThatThrownBy(() -> mds.getRepo(PROJ, "missing").join())
+                .hasCauseInstanceOf(RepositoryNotFoundException.class)
+                .hasMessageContaining("missing");
+    }
+}


### PR DESCRIPTION
Motivation:

When a dev forgets to call `MetadataService.addRepo()` after creating a
repository, a non-admin user will not be able to see the repository from
the listing due to missing metadata.

Modifications:

- Add a workaround that adds the default metadata to the repositories
  without missing metadata.
- Miscellaneous:
  - Add a missing compile-time only dependency of `common-legacy`
  - Change the permission container type of `PerRolePermissions` from
    `Collection` to `Set`.

Result:

- Repositories with missing metadata will be fixed automatically.