### PR TITLE
Use `jakarta.annotation-api` instead of `javax.annotation-api`

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -215,6 +215,11 @@ This product depends on Javassist, distributed by Shigeru Chiba:
   * License: licenses/LICENSE.javassist.mpl11.html (Mozilla Public License v1.1)
   * Homepage: http://www.javassist.org/
 
+This product depends on jakarta.annotation API, distributed by the Eclipse Project for Common Annotations project:
+
+  * License: licenses/LICENSE.jakarta-annotation.epl20.txt (Eclipse Public License v2.0)
+  * Homepage: https://github.com/eclipse-ee4j/common-annotations-api
+
 This product depends on javax.inject API, distributed by the JSR-330 Expert Group:
 
   * License: licenses/LICENSE.javax-inject.al20.txt (Apache License v2.0)

--- a/common-legacy/build.gradle
+++ b/common-legacy/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Thrift
     compile 'org.apache.thrift:libthrift'
-    compileOnly 'javax.annotation:javax.annotation-api'
+    compileOnly 'jakarta.annotation:jakarta.annotation-api'
 }
 
 tasks.compileThrift.doLast {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -135,8 +135,8 @@ io.micrometer:
     javadocs:
     - https://static.javadoc.io/io.micrometer/micrometer-registry-prometheus/1.1.4/
 
-javax.annotation:
-  javax.annotation-api: { version: '1.3.2' }
+jakarta.annotation:
+  jakarta.annotation-api: { version: '1.3.4' }
 
 javax.inject:
   javax.inject: { version: '1' }


### PR DESCRIPTION
.. because Jakarta EE has taken over the ownership.