### PR TITLE
Automatic purging of removed repositories and projects

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -117,6 +117,14 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
+    public CompletableFuture<Void> purgeProject(String projectName) {
+        return run(callback -> {
+            validateProjectName(projectName);
+            client.purgeProject(projectName, callback);
+        });
+    }
+
+    @Override
     public CompletableFuture<Void> unremoveProject(String projectName) {
         return run(callback -> {
             validateProjectName(projectName);
@@ -148,6 +156,14 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
         return run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);
             client.removeRepository(projectName, repositoryName, callback);
+        });
+    }
+
+    @Override
+    public CompletableFuture<Void> purgeRepository(String projectName, String repositoryName) {
+        return run(callback -> {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            client.purgeRepository(projectName, repositoryName, callback);
         });
     }
 

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -111,6 +111,17 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
+    public void purgeProject() throws Exception {
+        doAnswer(invocation -> {
+            final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
+            callback.onComplete(null);
+            return null;
+        }).when(iface).purgeProject(any(), any());
+        assertThat(client.purgeProject("project").get()).isNull();
+        verify(iface).purgeProject(eq("project"), any());
+    }
+
+    @Test
     public void unremoveProject() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
@@ -163,6 +174,17 @@ public class LegacyCentralDogmaTest {
         }).when(iface).removeRepository(anyString(), anyString(), any());
         assertThat(client.removeRepository("project", "repo").get()).isNull();
         verify(iface).removeRepository(eq("project"), eq("repo"), any());
+    }
+
+    @Test
+    public void purgeRepository() throws Exception {
+        doAnswer(invocation -> {
+            final AsyncMethodCallback<Void> callback = invocation.getArgument(2);
+            callback.onComplete(null);
+            return null;
+        }).when(iface).purgeRepository(anyString(), anyString(), any());
+        assertThat(client.purgeRepository("project", "repo").get()).isNull();
+        verify(iface).purgeRepository(eq("project"), eq("repo"), any());
     }
 
     @Test

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -189,19 +189,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             return client.execute(
                     headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
                          .aggregate()
-                         .thenApply(ArmeriaCentralDogma::purgeProject);
+                         .thenApply(ArmeriaCentralDogma::handlePurgeResult);
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
-    }
-
-    private static Void purgeProject(AggregatedHttpResponse res) {
-        switch (res.status().code()) {
-            case 200:
-            case 204:
-                return null;
-        }
-        return handleErrorResponse(res);
     }
 
     @Override
@@ -293,13 +284,13 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             return client.execute(headers(HttpMethod.DELETE,
                                           pathBuilder(projectName, repositoryName).append(REMOVED).toString()))
                          .aggregate()
-                         .thenApply(ArmeriaCentralDogma::purgeRepository);
+                         .thenApply(ArmeriaCentralDogma::handlePurgeResult);
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
     }
 
-    private static Void purgeRepository(AggregatedHttpResponse res) {
+    private static Void handlePurgeResult(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 204:

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -24,6 +24,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.linecorp.centraldogma.internal.Util.unsafeCast;
 import static com.linecorp.centraldogma.internal.Util.validatePathPattern;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REMOVED;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
 import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.util.Objects.requireNonNull;
@@ -182,6 +183,28 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
+    public CompletableFuture<Void> purgeProject(String projectName) {
+        try {
+            validateProjectName(projectName);
+            return client.execute(
+                    headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::purgeProject);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void purgeProject(AggregatedHttpResponse res) {
+        switch (res.status().code()) {
+            case 200:
+            case 204:
+                return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
     public CompletableFuture<Void> unremoveProject(String projectName) {
         try {
             validateProjectName(projectName);
@@ -255,6 +278,28 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     private static Void removeRepository(AggregatedHttpResponse res) {
+        switch (res.status().code()) {
+            case 200:
+            case 204:
+                return null;
+        }
+        return handleErrorResponse(res);
+    }
+
+    @Override
+    public CompletableFuture<Void> purgeRepository(String projectName, String repositoryName) {
+        try {
+            validateProjectAndRepositoryName(projectName, repositoryName);
+            return client.execute(headers(HttpMethod.DELETE,
+                                          pathBuilder(projectName, repositoryName).append(REMOVED).toString()))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::purgeRepository);
+        } catch (Exception e) {
+            return exceptionallyCompletedFuture(e);
+        }
+    }
+
+    private static Void purgeRepository(AggregatedHttpResponse res) {
         switch (res.status().code()) {
             case 200:
             case 204:

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -56,6 +56,11 @@ public interface CentralDogma {
     CompletableFuture<Void> removeProject(String projectName);
 
     /**
+     * Purges a project that was removed before.
+     */
+    CompletableFuture<Void> purgeProject(String projectName);
+
+    /**
      * Unremoves a project.
      */
     CompletableFuture<Void> unremoveProject(String projectName);
@@ -84,6 +89,11 @@ public interface CentralDogma {
      * {@link #unremoveRepository(String, String)}.
      */
     CompletableFuture<Void> removeRepository(String projectName, String repositoryName);
+
+    /**
+     * Purges a repository that was removed before.
+     */
+    CompletableFuture<Void> purgeRepository(String projectName, String repositoryName);
 
     /**
      * Unremoves a repository.

--- a/common-legacy/src/main/thrift/CentralDogma.thrift
+++ b/common-legacy/src/main/thrift/CentralDogma.thrift
@@ -259,6 +259,11 @@ service CentralDogmaService {
     void removeProject(1: string name) throws (1: CentralDogmaException e),
 
     /**
+     * Purges a project.
+     */
+    void purgeProject(1: string name) throws (1: CentralDogmaException e),
+
+    /**
      * Unremoves a project.
      */
     void unremoveProject(1: string name) throws (1: CentralDogmaException e),
@@ -282,6 +287,11 @@ service CentralDogmaService {
      * Removes a repository.
      */
     void removeRepository(1: string projectName, 2: string repositoryName) throws (1: CentralDogmaException e),
+
+    /**
+     * Purges a repository.
+     */
+    void purgeRepository(1: string projectName, 2: string repositoryName) throws (1: CentralDogmaException e),
 
     /**
      * Unremoves a repository.

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
@@ -42,5 +42,7 @@ public final class HttpApiV1Constants {
 
     public static final String METRICS_PATH = "/monitor/metrics";
 
+    public static final String REMOVED = "/removed";
+
     private HttpApiV1Constants() {}
 }

--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -20,6 +20,7 @@
   "idleTimeoutMillis": null,
   "maxFrameLength": null,
   "numRepositoryWorkers": 16,
+  "maxRemovedRepositoryAgeMillis": null,
   "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
   "gracefulShutdownTimeout": {
     "quietPeriodMillis": 1000,

--- a/it/src/test/java/com/linecorp/centraldogma/it/ProjectManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/ProjectManagementTest.java
@@ -89,4 +89,14 @@ public class ProjectManagementTest extends AbstractMultiClientTest {
         final Set<String> names = client().listRemovedProjects().join();
         assertThat(names).containsExactly(rule.removedProject());
     }
+
+    @Test
+    public void testPurgeProject() throws Exception {
+        client().purgeProject(rule.removedProject()).join();
+        final Set<String> names = client().listRemovedProjects().join();
+        assertThat(names).doesNotContain(rule.removedProject());
+        // revert the purged project
+        client().createProject(rule.removedProject()).join();
+        client().removeProject(rule.removedProject()).join();
+    }
 }

--- a/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/RepositoryManagementTest.java
@@ -81,6 +81,21 @@ public class RepositoryManagementTest extends AbstractMultiClientTest {
     }
 
     @Test
+    public void testPurgeRepository() {
+        try {
+            client().purgeRepository(rule.project(), rule.removedRepo()).join();
+            final Map<String, RepositoryInfo> repos = client().listRepositories(rule.project()).join();
+            assertThat(repos).doesNotContainKeys(rule.removedRepo());
+            final Set<String> removedRepos = client().listRemovedRepositories(rule.project()).join();
+            assertThat(removedRepos).doesNotContain(rule.removedRepo());
+        } finally {
+            // Revert a removed project.
+            client().createRepository(rule.project(), rule.removedRepo()).join();
+            client().removeRepository(rule.project(), rule.removedRepo()).join();
+        }
+    }
+
+    @Test
     public void testListRepositories() throws Exception {
         final Map<String, RepositoryInfo> repos = client().listRepositories(rule.project()).join();
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -300,7 +300,7 @@ public final class CentralDogmaBuilder {
 
     /**
      * Sets the maximum allowed age of removed projects and repositories before they are purged.
-     * Set 0 to disable automatic purge.
+     * Set {@code 0} to disable automatic purge.
      * If unspecified, the default of {@value #DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS} milliseconds is used.
      */
     public CentralDogmaBuilder maxRemovedRepositoryAge(Duration maxRemovedRepositoryAge) {
@@ -312,7 +312,7 @@ public final class CentralDogmaBuilder {
     /**
      * Sets the maximum allowed age, in milliseconds of removed projects and repositories
      * before they are purged.
-     * Set 0 to disable automatic purge.
+     * Set {@code 0} to disable automatic purge.
      * If unspecified, the default of {@value #DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS} milliseconds is used.
      */
     public CentralDogmaBuilder maxRemovedRepositoryAgeMillis(long maxRemovedRepositoryAgeMillis) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -70,6 +70,7 @@ public final class CentralDogmaBuilder {
     static final int DEFAULT_NUM_MIRRORING_THREADS = 16;
     static final int DEFAULT_MAX_NUM_FILES_PER_MIRROR = 8192;
     static final long DEFAULT_MAX_NUM_BYTES_PER_MIRROR = 32 * 1048576; // 32 MiB
+    static final long DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS = 604_800_000;  // 7 days
 
     static final String DEFAULT_REPOSITORY_CACHE_SPEC =
             "maximumWeight=134217728," + // Cache up to apx. 128-megachars.
@@ -91,6 +92,8 @@ public final class CentralDogmaBuilder {
     // Central Dogma properties
     private final File dataDir;
     private int numRepositoryWorkers = DEFAULT_NUM_REPOSITORY_WORKERS;
+    private long maxRemovedRepositoryAgeMillis = DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS;
+
     @Nullable
     private String repositoryCacheSpec = DEFAULT_REPOSITORY_CACHE_SPEC;
     private boolean webAppEnabled = true;
@@ -292,6 +295,28 @@ public final class CentralDogmaBuilder {
      */
     public CentralDogmaBuilder numRepositoryWorkers(int numRepositoryWorkers) {
         this.numRepositoryWorkers = numRepositoryWorkers;
+        return this;
+    }
+
+    /**
+     * Sets the maximum allowed age of removed projects and repositories before they are purged.
+     * Set 0 to disable automatic purge.
+     * If unspecified, the default of {@value #DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS} milliseconds is used.
+     */
+    public CentralDogmaBuilder maxRemovedRepositoryAge(Duration maxRemovedRepositoryAge) {
+        maxRemovedRepositoryAgeMillis(
+                requireNonNull(maxRemovedRepositoryAge, "maxRemovedRepositoryAge").toMillis());
+        return this;
+    }
+
+    /**
+     * Sets the maximum allowed age, in milliseconds of removed projects and repositories
+     * before they are purged.
+     * Set 0 to disable automatic purge.
+     * If unspecified, the default of {@value #DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS} milliseconds is used.
+     */
+    public CentralDogmaBuilder maxRemovedRepositoryAgeMillis(long maxRemovedRepositoryAgeMillis) {
+        this.maxRemovedRepositoryAgeMillis = maxRemovedRepositoryAgeMillis;
         return this;
     }
 
@@ -508,7 +533,8 @@ public final class CentralDogmaBuilder {
         return new CentralDogmaConfig(dataDir, ports, tls, trustedProxyAddresses, clientAddressSources,
                                       numWorkers, maxNumConnections,
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
-                                      numRepositoryWorkers, repositoryCacheSpec, gracefulShutdownTimeout,
+                                      numRepositoryWorkers, repositoryCacheSpec,
+                                      maxRemovedRepositoryAgeMillis, gracefulShutdownTimeout,
                                       webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
                                       null, accessLogFormat, authCfg);

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -25,6 +25,7 @@ import static com.linecorp.armeria.server.ClientAddressSource.ofHeader;
 import static com.linecorp.armeria.server.ClientAddressSource.ofProxyProtocol;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_NUM_FILES_PER_MIRROR;
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_MIRRORING_THREADS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_REPOSITORY_WORKERS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_REPOSITORY_CACHE_SPEC;
@@ -96,6 +97,7 @@ public final class CentralDogmaConfig {
 
     // Repository
     private final Integer numRepositoryWorkers;
+    private final long maxRemovedRepositoryAgeMillis;
 
     // Cache
     private final String repositoryCacheSpec;
@@ -144,8 +146,8 @@ public final class CentralDogmaConfig {
             @JsonProperty("maxFrameLength") @Nullable Integer maxFrameLength,
             @JsonProperty("numRepositoryWorkers") @Nullable Integer numRepositoryWorkers,
             @JsonProperty("repositoryCacheSpec") @Nullable String repositoryCacheSpec,
-            @JsonProperty("gracefulShutdownTimeout") @Nullable
-                    GracefulShutdownTimeout gracefulShutdownTimeout,
+            @JsonProperty("maxRemovedRepositoryAgeMillis") @Nullable Long maxRemovedRepositoryAgeMillis,
+            @JsonProperty("gracefulShutdownTimeout") @Nullable GracefulShutdownTimeout gracefulShutdownTimeout,
             @JsonProperty("webAppEnabled") @Nullable Boolean webAppEnabled,
             @JsonProperty("webAppTitle") @Nullable String webAppTitle,
             @JsonProperty("mirroringEnabled") @Nullable Boolean mirroringEnabled,
@@ -173,8 +175,13 @@ public final class CentralDogmaConfig {
         this.numRepositoryWorkers = firstNonNull(numRepositoryWorkers, DEFAULT_NUM_REPOSITORY_WORKERS);
         checkArgument(this.numRepositoryWorkers > 0,
                       "numRepositoryWorkers: %s (expected: > 0)", this.numRepositoryWorkers);
+        this.maxRemovedRepositoryAgeMillis = firstNonNull(maxRemovedRepositoryAgeMillis,
+                                                          DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS);
+        checkArgument(this.maxRemovedRepositoryAgeMillis >= 0,
+                      "maxRemovedRepositoryAgeMillis: %s (expected: >= 0)", this.maxRemovedRepositoryAgeMillis);
         this.repositoryCacheSpec = validateCacheSpec(
                 firstNonNull(repositoryCacheSpec, DEFAULT_REPOSITORY_CACHE_SPEC));
+
         this.webAppEnabled = firstNonNull(webAppEnabled, true);
         this.webAppTitle = webAppTitle;
         this.mirroringEnabled = firstNonNull(mirroringEnabled, true);
@@ -266,6 +273,11 @@ public final class CentralDogmaConfig {
     @JsonProperty
     int numRepositoryWorkers() {
         return numRepositoryWorkers;
+    }
+
+    @JsonProperty
+    public long maxRemovedRepositoryAgeMillis() {
+        return maxRemovedRepositoryAgeMillis;
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 import javax.annotation.Nullable;
 
@@ -122,8 +123,10 @@ final class PluginGroup {
      * Starts the {@link Plugin}s managed by this {@link PluginGroup}.
      */
     CompletableFuture<Void> start(CentralDogmaConfig config, ProjectManager projectManager,
-                                  CommandExecutor commandExecutor, MeterRegistry meterRegistry) {
-        final PluginContext context = new PluginContext(config, projectManager, commandExecutor, meterRegistry);
+                                  CommandExecutor commandExecutor, MeterRegistry meterRegistry,
+                                  ScheduledExecutorService purgeWorker) {
+        final PluginContext context = new PluginContext(config, projectManager, commandExecutor, meterRegistry,
+                                                        purgeWorker);
         return startStop.start(context, context, true);
     }
 
@@ -131,8 +134,10 @@ final class PluginGroup {
      * Stops the {@link Plugin}s managed by this {@link PluginGroup}.
      */
     CompletableFuture<Void> stop(CentralDogmaConfig config, ProjectManager projectManager,
-                                 CommandExecutor commandExecutor, MeterRegistry meterRegistry) {
-        return startStop.stop(new PluginContext(config, projectManager, commandExecutor, meterRegistry));
+                                 CommandExecutor commandExecutor, MeterRegistry meterRegistry,
+                                 ScheduledExecutorService purgeWorker) {
+        return startStop.stop(
+                new PluginContext(config, projectManager, commandExecutor, meterRegistry, purgeWorker));
     }
 
     private class PluginGroupStartStop extends StartStopSupport<PluginContext, PluginContext, Void, Void> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -42,9 +42,11 @@ import com.linecorp.centraldogma.server.auth.Session;
 @JsonSubTypes({
         @Type(value = CreateProjectCommand.class, name = "CREATE_PROJECT"),
         @Type(value = RemoveProjectCommand.class, name = "REMOVE_PROJECT"),
+        @Type(value = PurgeProjectCommand.class, name = "PURGE_PROJECT"),
         @Type(value = UnremoveProjectCommand.class, name = "UNREMOVE_PROJECT"),
         @Type(value = CreateRepositoryCommand.class, name = "CREATE_REPOSITORY"),
         @Type(value = RemoveRepositoryCommand.class, name = "REMOVE_REPOSITORY"),
+        @Type(value = PurgeRepositoryCommand.class, name = "PURGE_REPOSITORY"),
         @Type(value = UnremoveRepositoryCommand.class, name = "UNREMOVE_REPOSITORY"),
         @Type(value = PushCommand.class, name = "PUSH"),
         @Type(value = CreateSessionCommand.class, name = "CREATE_SESSIONS"),
@@ -116,6 +118,29 @@ public interface Command<T> {
     static Command<Void> unremoveProject(@Nullable Long timestamp, Author author, String name) {
         requireNonNull(author, "author");
         return new UnremoveProjectCommand(timestamp, author, name);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to purge a project that was removed before.
+     *
+     * @param author the author who is restoring the project
+     * @param name the name of the project which is supposed to be restored
+     */
+    static Command<Void> purgeProject(Author author, String name) {
+        requireNonNull(author, "author");
+        return new PurgeProjectCommand(null, author, name);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to purge a project that was removed before.
+     *
+     * @param timestamp the purging time of the project, in milliseconds
+     * @param author the author who is restoring the project
+     * @param name the name of the project which is supposed to be restored
+     */
+    static Command<Void> purgeProject(@Nullable Long timestamp, Author author, String name) {
+        requireNonNull(author, "author");
+        return new PurgeProjectCommand(timestamp, author, name);
     }
 
     /**
@@ -191,6 +216,33 @@ public interface Command<T> {
                                             String projectName, String repositoryName) {
         requireNonNull(author, "author");
         return new UnremoveRepositoryCommand(timestamp, author, projectName, repositoryName);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to purge a repository.
+     *
+     * @param author the author who is removing the repository
+     * @param projectName the name of the project
+     * @param repositoryName the name of the repository which is supposed to be purge
+     */
+    static Command<Void> purgeRepository(Author author,
+                                         String projectName, String repositoryName) {
+        requireNonNull(author, "author");
+        return new PurgeRepositoryCommand(null, author, projectName, repositoryName);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to purge a repository.
+     *
+     * @param timestamp the purging time of the repository, in milliseconds
+     * @param author the author who is removing the repository
+     * @param projectName the name of the project
+     * @param repositoryName the name of the repository which is supposed to be purge
+     */
+    static Command<Void> purgeRepository(@Nullable Long timestamp, Author author,
+                                          String projectName, String repositoryName) {
+        requireNonNull(author, "author");
+        return new PurgeRepositoryCommand(timestamp, author, projectName, repositoryName);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -223,7 +223,7 @@ public interface Command<T> {
      *
      * @param author the author who is removing the repository
      * @param projectName the name of the project
-     * @param repositoryName the name of the repository which is supposed to be purge
+     * @param repositoryName the name of the repository which is supposed to be purged
      */
     static Command<Void> purgeRepository(Author author,
                                          String projectName, String repositoryName) {
@@ -237,7 +237,7 @@ public interface Command<T> {
      * @param timestamp the purging time of the repository, in milliseconds
      * @param author the author who is removing the repository
      * @param projectName the name of the project
-     * @param repositoryName the name of the repository which is supposed to be purge
+     * @param repositoryName the name of the repository which is supposed to be purged
      */
     static Command<Void> purgeRepository(@Nullable Long timestamp, Author author,
                                           String projectName, String repositoryName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
@@ -34,7 +34,9 @@ public enum CommandType {
     SAVE_PLUGIN(Void.class),
     REMOVE_PLUGIN(Void.class),
     CREATE_SESSION(Void.class),
-    REMOVE_SESSION(Void.class);
+    REMOVE_SESSION(Void.class),
+    PURGE_PROJECT(Void.class),
+    PURGE_REPOSITORY(Void.class);
 
     /**
      * The type of an object which is returned as a result after executing the command.

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/PurgeProjectCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/PurgeProjectCommand.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
+
+/**
+ * A {@link Command} which is used for purging a project that was removed before.
+ */
+public class PurgeProjectCommand extends RootCommand<Void> {
+
+    private final String projectName;
+
+    @JsonCreator
+    PurgeProjectCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                        @JsonProperty("author") @Nullable Author author,
+                        @JsonProperty("projectName") String projectName) {
+        super(CommandType.PURGE_PROJECT, timestamp, author);
+        this.projectName = requireNonNull(projectName, "projectName");
+    }
+
+    @JsonProperty
+    public String projectName() {
+        return projectName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PurgeProjectCommand)) {
+            return false;
+        }
+
+        final PurgeProjectCommand that = (PurgeProjectCommand) obj;
+        return super.equals(obj) &&
+               projectName.equals(that.projectName);
+    }
+
+    @Override
+    public int hashCode() {
+        return projectName.hashCode() * 31 + super.hashCode();
+    }
+
+    @Override
+    ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                    .add("projectName", projectName);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
+
+/**
+ * A {@link Command} which is used for purging a repository that was removed before.
+ */
+public class PurgeRepositoryCommand extends ProjectCommand<Void> {
+
+    private final String repositoryName;
+
+    @JsonCreator
+    PurgeRepositoryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                           @JsonProperty("author") @Nullable Author author,
+                           @JsonProperty("projectName") String projectName,
+                           @JsonProperty("repositoryName") String repositoryName) {
+
+        super(CommandType.PURGE_REPOSITORY, timestamp, author, projectName);
+        this.repositoryName = requireNonNull(repositoryName, "repositoryName");
+    }
+
+    @JsonProperty
+    public String repositoryName() {
+        return repositoryName;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof PurgeRepositoryCommand)) {
+            return false;
+        }
+
+        final PurgeRepositoryCommand that = (PurgeRepositoryCommand) obj;
+        return super.equals(obj) &&
+               repositoryName.equals(that.repositoryName);
+    }
+
+    @Override
+    public int hashCode() {
+        return repositoryName.hashCode() * 31 + super.hashCode();
+    }
+
+    @Override
+    ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                    .add("repositoryName", repositoryName);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
@@ -99,6 +99,10 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
             return (CompletableFuture<T>) unremoveProject((UnremoveProjectCommand) command);
         }
 
+        if (command instanceof PurgeProjectCommand) {
+            return (CompletableFuture<T>) purgeProject((PurgeProjectCommand) command);
+        }
+
         if (command instanceof CreateRepositoryCommand) {
             return (CompletableFuture<T>) createRepository((CreateRepositoryCommand) command);
         }
@@ -109,6 +113,10 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
 
         if (command instanceof UnremoveRepositoryCommand) {
             return (CompletableFuture<T>) unremoveRepository((UnremoveRepositoryCommand) command);
+        }
+
+        if (command instanceof PurgeRepositoryCommand) {
+            return (CompletableFuture<T>) purgeRepository((PurgeRepositoryCommand) command);
         }
 
         if (command instanceof PushCommand) {
@@ -149,6 +157,13 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
         }, repositoryWorker);
     }
 
+    private CompletableFuture<Void> purgeProject(PurgeProjectCommand c) {
+        return CompletableFuture.supplyAsync(() -> {
+            projectManager.markForPurge(c.projectName());
+            return null;
+        }, repositoryWorker);
+    }
+
     // Repository operations
 
     private CompletableFuture<Void> createRepository(CreateRepositoryCommand c) {
@@ -168,6 +183,13 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
     private CompletableFuture<Void> unremoveRepository(UnremoveRepositoryCommand c) {
         return CompletableFuture.supplyAsync(() -> {
             projectManager.get(c.projectName()).repos().unremove(c.repositoryName());
+            return null;
+        }, repositoryWorker);
+    }
+
+    private CompletableFuture<Void> purgeRepository(PurgeRepositoryCommand c) {
+        return CompletableFuture.supplyAsync(() -> {
+            projectManager.get(c.projectName()).repos().markForPurge(c.repositoryName());
             return null;
         }, repositoryWorker);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingService.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableScheduledFuture;
+import com.google.common.util.concurrent.ListeningScheduledExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+
+/**
+ * A service class for purging projects and repositories that were removed before.
+ */
+public class PurgeSchedulingService {
+
+    private static final Logger logger = LoggerFactory.getLogger(PurgeSchedulingService.class);
+
+    /**
+     * How often to run the storage purge schedules. i.e. every minute.
+     */
+    private static final Duration TICK = Duration.ofMinutes(1);
+
+    private final ProjectManager projectManager;
+    private final ScheduledExecutorService purgeWorker;
+    private final long maxRemovedRepositoryAgeMillis;
+    private final StoragePurgingScheduler storagePurgingScheduler = new StoragePurgingScheduler();
+
+    public PurgeSchedulingService(ProjectManager projectManager, ScheduledExecutorService purgeWorker,
+                                  long maxRemovedRepositoryAgeMillis) {
+        this.projectManager = requireNonNull(projectManager, "projectManager");
+        this.purgeWorker = requireNonNull(purgeWorker, "purgeWorker");
+        checkArgument(maxRemovedRepositoryAgeMillis >= 0,
+                      "maxRemovedRepositoryAgeMillis: %s (expected: >= 0)", maxRemovedRepositoryAgeMillis);
+        this.maxRemovedRepositoryAgeMillis = maxRemovedRepositoryAgeMillis;
+    }
+
+    public void start(CommandExecutor commandExecutor,
+                      MetadataService metadataService) {
+        if (isDisabled()) {
+            return;
+        }
+        requireNonNull(commandExecutor, "commandExecutor");
+        requireNonNull(metadataService, "metadataService");
+        cleanPurgedFiles();
+        storagePurgingScheduler.start(() -> {
+            try {
+                schedulePurgeData(commandExecutor, metadataService);
+            } catch (Exception e) {
+                logger.warn("Unexpected purging service failure", e);
+            }
+        });
+    }
+
+    public boolean isStarted() {
+        return storagePurgingScheduler.isStarted();
+    }
+
+    public void stop() {
+        if (!isDisabled()) {
+            storagePurgingScheduler.stop();
+        }
+    }
+
+    private void cleanPurgedFiles() {
+        projectManager.purgeMarked();
+        projectManager.list().forEach((unused, project) -> project.repos().purgeMarked());
+    }
+
+    @VisibleForTesting
+    void schedulePurgeData(CommandExecutor commandExecutor,
+                           MetadataService metadataService) {
+        final long minAllowedTimestamp = System.currentTimeMillis() - maxRemovedRepositoryAgeMillis;
+        final Predicate<Instant> olderThanMinAllowed =
+                removedAt -> removedAt.toEpochMilli() < minAllowedTimestamp;
+
+        purgeProject(commandExecutor, olderThanMinAllowed);
+        purgeRepository(commandExecutor, metadataService, olderThanMinAllowed);
+    }
+
+    private void purgeProject(CommandExecutor commandExecutor,
+                              Predicate<Instant> olderThanMinAllowed) {
+        projectManager
+                .listRemoved()
+                .forEach((projectName, removal) -> {
+                    if (olderThanMinAllowed.test(removal)) {
+                        commandExecutor
+                                .execute(Command.purgeProject(Author.SYSTEM, projectName)).join();
+                    }
+                });
+    }
+
+    private void purgeRepository(CommandExecutor commandExecutor,
+                                 MetadataService metadataService,
+                                 Predicate<Instant> olderThanMinAllowed) {
+        projectManager
+                .list()
+                .forEach((unused, project) -> {
+                    project.repos().listRemoved()
+                           .forEach((repoName, removal) -> {
+                               if (olderThanMinAllowed.test(removal)) {
+                                   commandExecutor.execute(Command.purgeRepository(Author.SYSTEM,
+                                                                                   project.name(),
+                                                                                   repoName))
+                                                  .join();
+                                   metadataService.purgeRepo(Author.SYSTEM, project.name(), repoName).join();
+                               }
+                           });
+                });
+    }
+
+    private boolean isDisabled() {
+        return maxRemovedRepositoryAgeMillis == 0;
+    }
+
+    private final class StoragePurgingScheduler {
+
+        @Nullable
+        private volatile ListeningScheduledExecutorService scheduler;
+
+        public boolean isStarted() {
+            return scheduler != null;
+        }
+
+        public synchronized void start(Runnable task) {
+            if (isStarted()) {
+                return;
+            }
+            requireNonNull(task, "task");
+            scheduler = MoreExecutors.listeningDecorator(purgeWorker);
+            final ListenableScheduledFuture<?> future = scheduler.scheduleWithFixedDelay(
+                    task,
+                    TICK.getSeconds(), TICK.getSeconds(), TimeUnit.SECONDS);
+
+            Futures.addCallback(future, new FutureCallback<Object>() {
+                @Override
+                public void onSuccess(@Nullable Object result) {}
+
+                @Override
+                public void onFailure(Throwable cause) {
+                    logger.error("Storage purge scheduler stopped due to an unexpected exception:", cause);
+                }
+            }, purgeWorker);
+        }
+
+        public synchronized void stop() {
+            final ExecutorService scheduler = this.scheduler;
+
+            try {
+                final boolean interrupted = terminate(scheduler);
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            } finally {
+                this.scheduler = null;
+            }
+        }
+
+        private boolean terminate(ExecutorService executor) {
+            if (executor == null) {
+                return false;
+            }
+
+            boolean interrupted = false;
+            for (;;) {
+                executor.shutdownNow();
+                try {
+                    if (executor.awaitTermination(1, TimeUnit.MINUTES)) {
+                        break;
+                    }
+                } catch (InterruptedException e) {
+                    // Propagate later.
+                    interrupted = true;
+                }
+            }
+
+            return interrupted;
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.plugin.Plugin;
+import com.linecorp.centraldogma.server.plugin.PluginContext;
+import com.linecorp.centraldogma.server.plugin.PluginTarget;
+
+public final class PurgeSchedulingServicePlugin implements Plugin {
+
+    @Nullable
+    private volatile PurgeSchedulingService purgeSchedulingService;
+
+    @Override
+    public PluginTarget target() {
+        return PluginTarget.LEADER_ONLY;
+    }
+
+    @Override
+    public synchronized CompletionStage<Void> start(PluginContext context) {
+        requireNonNull(context, "context");
+
+        PurgeSchedulingService purgeSchedulingService = this.purgeSchedulingService;
+        if (purgeSchedulingService == null) {
+            final CentralDogmaConfig cfg = context.config();
+            purgeSchedulingService = new PurgeSchedulingService(context.projectManager(),
+                                                                context.purgeWorker(),
+                                                                cfg.maxRemovedRepositoryAgeMillis());
+            this.purgeSchedulingService = purgeSchedulingService;
+        }
+        final MetadataService metadataService = new MetadataService(context.projectManager(),
+                                                                    context.commandExecutor());
+        purgeSchedulingService.start(context.commandExecutor(), metadataService);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public synchronized CompletionStage<Void> stop(PluginContext context) {
+        final PurgeSchedulingService purgeSchedulingService = this.purgeSchedulingService;
+        if (purgeSchedulingService != null && purgeSchedulingService.isStarted()) {
+            purgeSchedulingService.stop();
+        }
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public boolean isEnabled(CentralDogmaConfig config) {
+        return requireNonNull(config, "config").maxRemovedRepositoryAgeMillis() > 0;
+    }
+
+    @Nullable
+    public PurgeSchedulingService scheduledPurgingService() {
+        return purgeSchedulingService;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("target", target())
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
@@ -80,7 +80,9 @@ public final class PurgeSchedulingServicePlugin implements Plugin {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+                          .omitNullValues()
                           .add("target", target())
+                          .add("purgeSchedulingService", purgeSchedulingService)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Storage management for Central Dogma projects and repositories.
+ */
+@NonNullByDefault
+package com.linecorp.centraldogma.server.internal.storage;
+
+import com.linecorp.centraldogma.common.util.NonNullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -67,7 +67,8 @@ public class DefaultProject implements Project {
     /**
      * Opens an existing project.
      */
-    DefaultProject(File rootDir, Executor repositoryWorker, @Nullable RepositoryCache cache) {
+    DefaultProject(File rootDir, Executor repositoryWorker, Executor purgeWorker,
+                   @Nullable RepositoryCache cache) {
         requireNonNull(rootDir, "rootDir");
         requireNonNull(repositoryWorker, "repositoryWorker");
 
@@ -76,7 +77,7 @@ public class DefaultProject implements Project {
         }
 
         name = rootDir.getName();
-        repos = newRepoManager(rootDir, repositoryWorker, cache);
+        repos = newRepoManager(rootDir, repositoryWorker, purgeWorker, cache);
 
         boolean success = false;
         try {
@@ -92,8 +93,8 @@ public class DefaultProject implements Project {
     /**
      * Creates a new project.
      */
-    DefaultProject(File rootDir, Executor repositoryWorker, @Nullable RepositoryCache cache,
-                   long creationTimeMillis, Author author) {
+    DefaultProject(File rootDir, Executor repositoryWorker, Executor purgeWorker,
+                   long creationTimeMillis, Author author, @Nullable RepositoryCache cache) {
         requireNonNull(rootDir, "rootDir");
         requireNonNull(repositoryWorker, "repositoryWorker");
 
@@ -102,7 +103,7 @@ public class DefaultProject implements Project {
         }
 
         name = rootDir.getName();
-        repos = newRepoManager(rootDir, repositoryWorker, cache);
+        repos = newRepoManager(rootDir, repositoryWorker, purgeWorker, cache);
 
         boolean success = false;
         try {
@@ -116,10 +117,11 @@ public class DefaultProject implements Project {
         }
     }
 
-    private RepositoryManager newRepoManager(File rootDir, Executor repositoryWorker,
+    private RepositoryManager newRepoManager(File rootDir, Executor repositoryWorker, Executor purgeWorker,
                                              @Nullable RepositoryCache cache) {
         // Enable caching if 'cache' is not null.
-        final GitRepositoryManager gitRepos = new GitRepositoryManager(this, rootDir, repositoryWorker, cache);
+        final GitRepositoryManager gitRepos =
+                new GitRepositoryManager(this, rootDir, repositoryWorker, purgeWorker, cache);
         return cache == null ? gitRepos : new CachingRepositoryManager(gitRepos, cache);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectManager.java
@@ -41,9 +41,9 @@ public class DefaultProjectManager extends DirectoryBasedStorageManager<Project>
     @Nullable
     private final RepositoryCache cache;
 
-    public DefaultProjectManager(File rootDir, Executor repositoryWorker, MeterRegistry meterRegistry,
-                                 @Nullable String cacheSpec) {
-        super(rootDir, Project.class);
+    public DefaultProjectManager(File rootDir, Executor repositoryWorker, Executor purgeWorker,
+                                 MeterRegistry meterRegistry, @Nullable String cacheSpec) {
+        super(rootDir, Project.class, purgeWorker);
 
         requireNonNull(meterRegistry, "meterRegistry");
         requireNonNull(repositoryWorker, "repositoryWorker");
@@ -64,12 +64,12 @@ public class DefaultProjectManager extends DirectoryBasedStorageManager<Project>
 
     @Override
     protected Project openChild(File childDir) throws Exception {
-        return new DefaultProject(childDir, repositoryWorker, cache);
+        return new DefaultProject(childDir, repositoryWorker, purgeWorker(), cache);
     }
 
     @Override
     protected Project createChild(File childDir, Author author, long creationTimeMillis) throws Exception {
-        return new DefaultProject(childDir, repositoryWorker, cache, creationTimeMillis, author);
+        return new DefaultProject(childDir, repositoryWorker, purgeWorker(), creationTimeMillis, author, cache);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -19,10 +19,10 @@ package com.linecorp.centraldogma.server.internal.storage.project;
 import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
 import static java.util.Objects.requireNonNull;
 
+import java.time.Instant;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import com.linecorp.centraldogma.common.Author;
@@ -78,7 +78,7 @@ public class SafeProjectManager implements ProjectManager {
     }
 
     @Override
-    public Set<String> listRemoved() {
+    public Map<String, Instant> listRemoved() {
         return delegate().listRemoved();
     }
 
@@ -92,6 +92,17 @@ public class SafeProjectManager implements ProjectManager {
     public Project unremove(String name) {
         validateProjectName(name);
         return delegate().unremove(name);
+    }
+
+    @Override
+    public void purgeMarked() {
+        delegate().purgeMarked();
+    }
+
+    @Override
+    public void markForPurge(String name) {
+        validateProjectName(name);
+        delegate().markForPurge(name);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -18,12 +18,12 @@ package com.linecorp.centraldogma.server.internal.storage.repository;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
@@ -101,7 +101,7 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     }
 
     @Override
-    public Set<String> listRemoved() {
+    public Map<String, Instant> listRemoved() {
         return delegate.listRemoved();
     }
 
@@ -117,6 +117,19 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     public Repository unremove(String name) {
         ensureOpen();
         return repos.computeIfAbsent(name, n -> repoWrapper.apply(delegate.unremove(n)));
+    }
+
+    @Override
+    public void purgeMarked() {
+        delegate.purgeMarked();
+    }
+
+    @Override
+    public void markForPurge(String name) {
+        repos.compute(name, (n, v) -> {
+            delegate.markForPurge(name);
+            return null;
+        });
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
@@ -53,14 +53,15 @@ public class GitRepositoryManager extends DirectoryBasedStorageManager<Repositor
     private final RepositoryCache cache;
 
     public GitRepositoryManager(Project parent, File rootDir, Executor repositoryWorker,
-                                @Nullable RepositoryCache cache) {
-        this(parent, rootDir, GitRepositoryFormat.V1, repositoryWorker, cache);
+                                Executor purgeWorker, @Nullable RepositoryCache cache) {
+        this(parent, rootDir, GitRepositoryFormat.V1, repositoryWorker, purgeWorker, cache);
     }
 
     public GitRepositoryManager(Project parent, File rootDir, GitRepositoryFormat preferredFormat,
-                                Executor repositoryWorker, @Nullable RepositoryCache cache) {
+                                Executor repositoryWorker, Executor purgeWorker,
+                                @Nullable RepositoryCache cache) {
 
-        super(rootDir, Repository.class);
+        super(rootDir, Repository.class, purgeWorker);
         this.parent = requireNonNull(parent, "parent");
         this.preferredFormat = requireNonNull(preferredFormat, "preferredFormat");
         this.repositoryWorker = requireNonNull(repositoryWorker, "repositoryWorker");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -130,6 +130,11 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     }
 
     @Override
+    public void purgeProject(String name, AsyncMethodCallback resultHandler) {
+        handleAsVoidResult(executor.execute(Command.purgeProject(SYSTEM, name)), resultHandler);
+    }
+
+    @Override
     public void unremoveProject(String name, AsyncMethodCallback resultHandler) {
         // Restore the project first then update its metadata as 'active'.
         handleAsVoidResult(executor.execute(Command.unremoveProject(SYSTEM, name))
@@ -150,7 +155,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
 
     @Override
     public void listRemovedProjects(AsyncMethodCallback resultHandler) {
-        handle(projectManager::listRemoved, resultHandler);
+        handle(() -> projectManager.listRemoved().keySet(), resultHandler);
     }
 
     @Override
@@ -180,6 +185,13 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     }
 
     @Override
+    public void purgeRepository(String projectName, String repositoryName, AsyncMethodCallback resultHandler) {
+        handleAsVoidResult(executor.execute(Command.purgeRepository(SYSTEM, projectName, repositoryName))
+                                   .thenCompose(unused -> mds.purgeRepo(SYSTEM, projectName, repositoryName)),
+                           resultHandler);
+    }
+
+    @Override
     public void unremoveRepository(String projectName, String repositoryName,
                                    AsyncMethodCallback resultHandler) {
         handleAsVoidResult(executor.execute(Command.unremoveRepository(SYSTEM, projectName, repositoryName))
@@ -197,7 +209,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
 
     @Override
     public void listRemovedRepositories(String projectName, AsyncMethodCallback resultHandler) {
-        handle(() -> projectManager.get(projectName).repos().listRemoved(), resultHandler);
+        handle(() -> projectManager.get(projectName).repos().listRemoved().keySet(), resultHandler);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -196,7 +196,8 @@ public class MetadataService {
                 Change.ofJsonPatch(METADATA_JSON,
                                    asJsonArray(new TestAbsenceOperation(path),
                                                new AddOperation(path, Jackson.valueToTree(newMember))));
-        final String commitSummary = "Add a member '" + newMember.id() + "' to the project " + projectName;
+        final String commitSummary =
+                "Add a member '" + newMember.id() + "' to the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -210,7 +211,8 @@ public class MetadataService {
         requireNonNull(projectName, "projectName");
         requireNonNull(member, "member");
 
-        final String commitSummary = "Remove the member '" + member.id() + "' from the project " + projectName;
+        final String commitSummary =
+                "Remove the member '" + member.id() + "' from the project '" + projectName + '\'';
         return metadataRepo.push(
                 projectName, Project.REPO_DOGMA, author, commitSummary,
                 () -> fetchMetadata(projectName).thenApply(
@@ -245,7 +247,7 @@ public class MetadataService {
                 new ReplaceOperation(JsonPointer.compile("/members" + encodeSegment(member.id()) + "/role"),
                                      Jackson.valueToTree(projectRole)).toJsonNode());
         final String commitSummary = "Updates the role of the member '" + member.id() +
-                                     "' as '" + projectRole + "' for the project " + projectName;
+                                     "' as '" + projectRole + "' for the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -289,7 +291,7 @@ public class MetadataService {
                                                new AddOperation(path,
                                                                 Jackson.valueToTree(newRepositoryMetadata))));
         final String commitSummary =
-                "Add a repo '" + newRepositoryMetadata.id() + "' to the project " + projectName;
+                "Add a repo '" + newRepositoryMetadata.id() + "' to the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change)
                            .handle((revision, cause) -> {
                                if (cause != null) {
@@ -318,7 +320,25 @@ public class MetadataService {
                                    asJsonArray(new TestAbsenceOperation(path),
                                                new AddOperation(path, Jackson.valueToTree(
                                                        UserAndTimestamp.of(author)))));
-        final String commitSummary = "Remove the repo '" + repoName + "' from the project " + projectName;
+        final String commitSummary =
+                "Remove the repo '" + repoName + "' from the project '" + projectName + '\'';
+        return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
+    }
+
+    /**
+     * Purge a {@link RepositoryMetadata} of the specified {@code repoName} from the specified
+     * {@code projectName}.
+     */
+    public CompletableFuture<Revision> purgeRepo(Author author, String projectName, String repoName) {
+        requireNonNull(author, "author");
+        requireNonNull(projectName, "projectName");
+        requireNonNull(repoName, "repoName");
+
+        final JsonPointer path = JsonPointer.compile("/repos" + encodeSegment(repoName));
+        final Change<JsonNode> change = Change.ofJsonPatch(METADATA_JSON,
+                                                           new RemoveOperation(path).toJsonNode());
+        final String commitSummary =
+                "Purge the repo '" + repoName + "' from the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -335,7 +355,8 @@ public class MetadataService {
                 Change.ofJsonPatch(METADATA_JSON,
                                    new RemoveOperation(JsonPointer.compile(
                                            "/repos" + encodeSegment(repoName) + "/removal")).toJsonNode());
-        final String commitSummary = "Restore the repo '" + repoName + "' from the project " + projectName;
+        final String commitSummary =
+                "Restore the repo '" + repoName + "' from the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -357,8 +378,8 @@ public class MetadataService {
                 Change.ofJsonPatch(METADATA_JSON,
                                    new ReplaceOperation(path, Jackson.valueToTree(perRolePermissions))
                                            .toJsonNode());
-        final String commitSummary = "Update the role permission of the '" + repoName +
-                                     "' in the project " + projectName;
+        final String commitSummary =
+                "Update the role permission of the '" + repoName + "' in the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -392,7 +413,7 @@ public class MetadataService {
                                        asJsonArray(new TestAbsenceOperation(path),
                                                    new AddOperation(path, Jackson.valueToTree(registration))));
             final String commitSummary = "Add a token '" + registration.id() +
-                                         "' to the project " + projectName + " with a role '" + role + '\'';
+                                         "' to the project '" + projectName + "' with a role '" + role + '\'';
             return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
         });
     }
@@ -419,7 +440,7 @@ public class MetadataService {
 
     private CompletableFuture<Revision> removeToken(String projectName, Author author, String appId,
                                                     boolean quiet) {
-        final String commitSummary = "Remove the token '" + appId + "' from the project " + projectName;
+        final String commitSummary = "Remove the token '" + appId + "' from the project '" + projectName + '\'';
         return metadataRepo.push(
                 projectName, Project.REPO_DOGMA, author, commitSummary,
                 () -> fetchMetadata(projectName).thenApply(metadataWithRevision -> {
@@ -461,7 +482,7 @@ public class MetadataService {
                                    new ReplaceOperation(path, Jackson.valueToTree(registration))
                                            .toJsonNode());
         final String commitSummary = "Update the role of a token '" + token.appId() +
-                                     "' as '" + role + "' for the project " + projectName;
+                                     "' as '" + role + "' for the project '" + projectName + '\'';
         return metadataRepo.push(projectName, Project.REPO_DOGMA, author, commitSummary, change);
     }
 
@@ -480,10 +501,10 @@ public class MetadataService {
 
         return getProject(projectName).thenCompose(project -> {
             ensureProjectMember(project, member);
-            return addPermissionAtPointer(author, projectName,
-                                          perUserPermissionPointer(repoName, member.id()), permission,
-                                          "Add permission of '" + member.id() +
-                                          "' as '" + permission + "' to the project " + projectName);
+            final String commitSummary = "Add permission of '" + member.id() +
+                                         "' as '" + permission + "' to the project '" + projectName + '\n';
+            return addPermissionAtPointer(author, projectName, perUserPermissionPointer(repoName, member.id()),
+                                          permission, commitSummary);
         });
     }
 
@@ -502,7 +523,7 @@ public class MetadataService {
         return removePermissionAtPointer(author, projectName,
                                          perUserPermissionPointer(repoName, memberId),
                                          "Remove permission of the '" + memberId +
-                                         "' from the project " + projectName);
+                                         "' from the project '" + projectName + '\'');
     }
 
     /**
@@ -522,7 +543,7 @@ public class MetadataService {
         return replacePermissionAtPointer(author, projectName,
                                           perUserPermissionPointer(repoName, memberId), permission,
                                           "Update permission of the '" + memberId +
-                                          "' as '" + permission + "' for the project " + projectName);
+                                          "' as '" + permission + "' for the project '" + projectName + '\'');
     }
 
     /**
@@ -543,7 +564,7 @@ public class MetadataService {
             return addPermissionAtPointer(author, projectName,
                                           perTokenPermissionPointer(repoName, appId), permission,
                                           "Add permission of the token '" + appId +
-                                          "' as '" + permission + "' to the project " + projectName);
+                                          "' as '" + permission + "' to the project '" + projectName + '\'');
         });
     }
 
@@ -561,7 +582,7 @@ public class MetadataService {
         return removePermissionAtPointer(author, projectName,
                                          perTokenPermissionPointer(repoName, appId),
                                          "Remove permission of the token '" + appId +
-                                         "' from the project " + projectName);
+                                         "' from the project '" + projectName + '\'');
     }
 
     /**
@@ -580,7 +601,7 @@ public class MetadataService {
         return replacePermissionAtPointer(author, projectName,
                                           perTokenPermissionPointer(repoName, appId), permission,
                                           "Update permission of the token '" + appId +
-                                          "' as '" + permission + "' for the project " + projectName);
+                                          "' as '" + permission + "' for the project '" + projectName + '\'');
     }
 
     /**
@@ -778,7 +799,7 @@ public class MetadataService {
                                                new AddOperation(secretPath,
                                                                 Jackson.valueToTree(newToken.id()))));
         return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
-                              "Add a token: '" + newToken.id(), change);
+                              "Add a token: " + newToken.id(), change);
     }
 
     /**
@@ -796,7 +817,7 @@ public class MetadataService {
             futures[i++] = removeToken(p.name(), author, appId, true).toCompletableFuture();
         }
         return CompletableFuture.allOf(futures).thenCompose(unused -> tokenRepo.push(
-                INTERNAL_PROJ, Project.REPO_DOGMA, author, "Remove the token: '" + appId,
+                INTERNAL_PROJ, Project.REPO_DOGMA, author, "Remove the token: " + appId,
                 () -> tokenRepo.fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
                                .thenApply(tokens -> {
                                    final Token token = tokens.object().get(appId);
@@ -823,7 +844,7 @@ public class MetadataService {
         requireNonNull(appId, "appId");
 
         return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
-                              "Enable the token: '" + appId,
+                              "Enable the token: " + appId,
                               () -> tokenRepo
                                       .fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
                                       .thenApply(tokens -> {
@@ -854,7 +875,7 @@ public class MetadataService {
         requireNonNull(appId, "appId");
 
         return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
-                              "Disable the token: '" + appId,
+                              "Disable the token: " + appId,
                               () -> tokenRepo
                                       .fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
                                       .thenApply(tokens -> {
@@ -904,7 +925,7 @@ public class MetadataService {
         requireNonNull(user, "user");
 
         checkArgument(project.members().values().stream().anyMatch(member -> member.login().equals(user.id())),
-                      user.id() + " is not a member of the project " + project.name());
+                      user.id() + " is not a member of the project '" + project.name() + '\'');
     }
 
     /**
@@ -915,7 +936,7 @@ public class MetadataService {
         requireNonNull(appId, "appId");
 
         checkArgument(project.tokens().containsKey(appId),
-                      appId + " is not a token of the project " + project.name());
+                      appId + " is not a token of the project '" + project.name() + '\'');
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -326,7 +326,7 @@ public class MetadataService {
     }
 
     /**
-     * Purge a {@link RepositoryMetadata} of the specified {@code repoName} from the specified
+     * Purges a {@link RepositoryMetadata} of the specified {@code repoName} from the specified
      * {@code projectName}.
      */
     public CompletableFuture<Revision> purgeRepo(Author author, String projectName, String repoName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
@@ -56,7 +56,7 @@ public final class PluginContext {
         this.projectManager = requireNonNull(projectManager, "projectManager");
         this.commandExecutor = requireNonNull(commandExecutor, "commandExecutor");
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
-        this.purgeWorker = purgeWorker;
+        this.purgeWorker = requireNonNull(purgeWorker, "purgeWorker");
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
@@ -17,6 +17,8 @@ package com.linecorp.centraldogma.server.plugin;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.concurrent.ScheduledExecutorService;
+
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -34,6 +36,7 @@ public final class PluginContext {
     private final ProjectManager projectManager;
     private final CommandExecutor commandExecutor;
     private final MeterRegistry meterRegistry;
+    private final ScheduledExecutorService purgeWorker;
 
     /**
      * Creates a new instance.
@@ -42,15 +45,18 @@ public final class PluginContext {
      * @param projectManager the instance which has the operations for the {@link Project}s
      * @param commandExecutor the executor which executes the {@link Command}s
      * @param meterRegistry the {@link MeterRegistry} of the Central Dogma server
+     * @param purgeWorker the {@link ScheduledExecutorService} for the purging service
      */
     public PluginContext(CentralDogmaConfig config,
                          ProjectManager projectManager,
                          CommandExecutor commandExecutor,
-                         MeterRegistry meterRegistry) {
+                         MeterRegistry meterRegistry,
+                         ScheduledExecutorService purgeWorker) {
         this.config = requireNonNull(config, "config");
         this.projectManager = requireNonNull(projectManager, "projectManager");
         this.commandExecutor = requireNonNull(commandExecutor, "commandExecutor");
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
+        this.purgeWorker = purgeWorker;
     }
 
     /**
@@ -79,5 +85,12 @@ public final class PluginContext {
      */
     public MeterRegistry meterRegistry() {
         return meterRegistry;
+    }
+
+    /**
+     * Returns the {@link ScheduledExecutorService} of {@code purgeWorker}.
+     */
+    public ScheduledExecutorService purgeWorker() {
+        return purgeWorker;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/StorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/StorageManager.java
@@ -96,12 +96,12 @@ public interface StorageManager<T> {
     T unremove(String name);
 
     /**
-     * Purges a set of names for the elements which have been marked for purging.
+     * Purges a set of names for the elements which have been marked for purge.
      */
     void purgeMarked();
 
     /**
-     * Marks an element with the specified {@code name} for purge.
+     * Marks the specified {@code name} element for purge.
      *
      * @param name the name of an element which is supposed to be purged
      */

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/StorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/StorageManager.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.centraldogma.server.storage;
 
+import java.time.Instant;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 
 import com.linecorp.centraldogma.common.Author;
@@ -77,9 +77,9 @@ public interface StorageManager<T> {
     Map<String, T> list();
 
     /**
-     * Returns a set of names for the elements which have been removed.
+     * Returns all removed elements as a {@link Map} of the name and the removal timestamp.
      */
-    Set<String> listRemoved();
+    Map<String, Instant> listRemoved();
 
     /**
      * Removes an element with the specified {@code name}.
@@ -94,6 +94,18 @@ public interface StorageManager<T> {
      * @param name the name of an element which is supposed to be restored
      */
     T unremove(String name);
+
+    /**
+     * Purges a set of names for the elements which have been marked for purging.
+     */
+    void purgeMarked();
+
+    /**
+     * Marks an element with the specified {@code name} for purge.
+     *
+     * @param name the name of an element which is supposed to be purged
+     */
+    void markForPurge(String name);
 
     /**
      * Ensures that this manager is open.

--- a/server/src/main/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
+++ b/server/src/main/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
@@ -1,1 +1,2 @@
 com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin
+com.linecorp.centraldogma.server.internal.storage.PurgeSchedulingServicePlugin

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -15,7 +15,9 @@
  */
 package com.linecorp.centraldogma.server;
 
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetAddress;
 import java.util.List;
@@ -169,5 +171,76 @@ public class CentralDogmaConfigTest {
         assertThat(cfg.trustedProxyAddresses()).isNull();
         assertThat(cfg.clientAddressSources()).isNull();
         assertThat(cfg.clientAddressSourceList()).isEmpty();
+    }
+
+    @Test
+    public void maxRemovedRepositoryAgeMillis() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"maxRemovedRepositoryAgeMillis\": 50000 \n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.maxRemovedRepositoryAgeMillis()).isEqualTo(50000);
+    }
+
+    @Test
+    public void maxRemovedRepositoryAgeMillis_withDefault() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ]\n" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.maxRemovedRepositoryAgeMillis()).isEqualTo(DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS);
+    }
+
+    @Test
+    public void maxRemovedRepositoryAgeMillis_withNegativeValue() throws Exception {
+        assertThatThrownBy(() ->
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"maxRemovedRepositoryAgeMillis\": -50000 \n" +
+                                  '}',
+                                  CentralDogmaConfig.class)
+        ).hasCauseInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
+
+public class PurgeProjectCommandTest {
+    @Test
+    public void testJsonConversion() {
+        assertJsonConversion(new PurgeProjectCommand(1234L, Author.SYSTEM, "foo"),
+                             Command.class,
+                             '{' +
+                             "  \"type\": \"PURGE_PROJECT\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
+                             "  \"projectName\": \"foo\"" +
+                             '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final PurgeProjectCommand c = (PurgeProjectCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"PURGE_PROJECT\"," +
+                "  \"projectName\": \"foo\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.internal.Jackson;
+
+public class PurgeRepositoryCommandTest {
+
+    @Test
+    public void testJsonConversion() {
+        assertJsonConversion(new PurgeRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
+                             Command.class,
+                             '{' +
+                             "  \"type\": \"PURGE_REPOSITORY\"," +
+                             "  \"timestamp\": 1234," +
+                             "  \"author\": {" +
+                             "    \"name\": \"System\"," +
+                             "    \"email\": \"system@localhost.localdomain\"" +
+                             "  }," +
+                             "  \"projectName\": \"foo\"," +
+                             "  \"repositoryName\": \"bar\"" +
+                             '}');
+    }
+
+    @Test
+    public void backwardCompatibility() throws Exception {
+        final PurgeRepositoryCommand c = (PurgeRepositoryCommand) Jackson.readValue(
+                '{' +
+                "  \"type\": \"PURGE_REPOSITORY\"," +
+                "  \"projectName\": \"foo\"," +
+                "  \"repositoryName\": \"bar\"" +
+                '}', Command.class);
+
+        assertThat(c.author()).isEqualTo(Author.SYSTEM);
+        assertThat(c.timestamp()).isNotZero();
+        assertThat(c.projectName()).isEqualTo("foo");
+        assertThat(c.repositoryName()).isEqualTo("bar");
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -152,6 +152,15 @@ public class ProjectServiceV1Test {
     }
 
     @Test
+    public void purgeProject() {
+        removeProject();
+        final AggregatedHttpResponse aRes = httpClient.delete(PROJECTS_PREFIX + "/foo/removed")
+                                                      .aggregate().join();
+        final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
+        assertThat(ResponseHeaders.of(headers).status()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
     public void listRemovedProjects() throws IOException {
         createProject("trustin");
         createProject("hyangtack");

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -34,6 +34,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.google.common.util.concurrent.MoreExecutors;
+
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.HttpClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -98,7 +100,9 @@ public class PermissionTest {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             final ProjectManager pm = new DefaultProjectManager(
-                    rootDir.newFolder(), ForkJoinPool.commonPool(), NoopMeterRegistry.get(), null);
+                    rootDir.newFolder(), ForkJoinPool.commonPool(), MoreExecutors.directExecutor(),
+                    NoopMeterRegistry.get(), null
+            );
             final CommandExecutor executor = new StandaloneCommandExecutor(
                     pm, ForkJoinPool.commonPool(), null, null, null);
             executor.start().join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/DefaultProjectManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/DefaultProjectManagerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License
+ */
+
+package com.linecorp.centraldogma.server.internal.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import com.google.common.util.concurrent.MoreExecutors;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.internal.storage.project.DefaultProjectManager;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
+
+import io.micrometer.core.instrument.MeterRegistry;
+
+public class DefaultProjectManagerTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void testProjectPurgeMarked() throws IOException {
+        final AtomicInteger counter = new AtomicInteger();
+        final DefaultProjectManager pm = new DefaultProjectManager(
+                folder.newFolder(),
+                MoreExecutors.directExecutor(),
+                (Runnable r) -> counter.incrementAndGet(),
+                mock(MeterRegistry.class),
+                null);
+
+        final String projectName = "foo";
+        final String repoName = "bar";
+        final Project project = pm.create(projectName, Author.SYSTEM);
+        final RepositoryManager repos = project.repos();
+        repos.create(repoName, Author.SYSTEM);
+        repos.remove(repoName);
+        repos.markForPurge(repoName);
+        repos.purgeMarked();
+        assertThat(counter.get()).isEqualTo(1);
+
+        pm.remove(projectName);
+        pm.markForPurge(projectName);
+        pm.purgeMarked();
+        assertThat(counter.get()).isEqualTo(2);
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServiceTest.java
@@ -93,7 +93,7 @@ public class PurgeSchedulingServiceTest {
     @Test
     public void testSchedule() throws InterruptedException {
         Thread.sleep(10); // let removed files be purged
-        service.schedulePurgeData(rule.executor(), metadataService);
+        service.purgeProjectAndRepository(rule.executor(), metadataService);
         verify(rule.executor()).execute(isA(PurgeProjectCommand.class));
         verify(rule.executor()).execute(isA(PurgeRepositoryCommand.class));
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServiceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.concurrent.Executor;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.command.PurgeProjectCommand;
+import com.linecorp.centraldogma.server.command.PurgeRepositoryCommand;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerRule;
+
+public class PurgeSchedulingServiceTest {
+
+    private static final String PROJA_ACTIVE = "proja";
+    private static final String REPOA_REMOVED = "repoa";
+    private static final String PROJB_REMOVED = "projb";
+    private static final Author AUTHOR = Author.SYSTEM;
+    private static final long MAX_REMOVED_REPOSITORY_AGE_MILLIS = 1;
+
+    private PurgeSchedulingService service;
+    private MetadataService metadataService;
+
+    @Rule
+    public final ProjectManagerRule rule = new ProjectManagerRule() {
+        @Override
+        protected ProjectManager newProjectManager(Executor repositoryWorker, Executor purgeWorker) {
+            return spy(super.newProjectManager(repositoryWorker, unused -> { /* noop for test */}));
+        }
+
+        @Override
+        protected CommandExecutor newCommandExecutor(ProjectManager projectManager, Executor worker) {
+            return spy(super.newCommandExecutor(projectManager, worker));
+        }
+
+        @Override
+        protected void afterExecutorStarted() {
+            metadataService = new MetadataService(projectManager(), executor());
+
+            executor().execute(Command.createProject(AUTHOR, PROJA_ACTIVE)).join();
+            executor().execute(Command.createRepository(AUTHOR, PROJA_ACTIVE, REPOA_REMOVED)).join();
+            metadataService.addRepo(AUTHOR, PROJA_ACTIVE, REPOA_REMOVED).join();
+            executor().execute(Command.removeRepository(AUTHOR, PROJA_ACTIVE, REPOA_REMOVED)).join();
+            metadataService.removeRepo(AUTHOR, PROJA_ACTIVE, REPOA_REMOVED).join();
+
+            executor().execute(Command.createProject(AUTHOR, PROJB_REMOVED)).join();
+            executor().execute(Command.removeProject(AUTHOR, PROJB_REMOVED)).join();
+        }
+    };
+
+    @Before
+    public void init() {
+        service = new PurgeSchedulingService(rule.projectManager(),
+                                             rule.purgeWorker(),
+                                             MAX_REMOVED_REPOSITORY_AGE_MILLIS);
+    }
+
+    @Test
+    public void testClear() throws InterruptedException {
+        rule.executor().execute(Command.purgeRepository(AUTHOR, PROJA_ACTIVE, REPOA_REMOVED)).join();
+        rule.executor().execute(Command.purgeProject(AUTHOR, PROJB_REMOVED)).join();
+
+        service.start(rule.executor(), metadataService);
+        verify(rule.projectManager()).purgeMarked();
+        service.stop();
+    }
+
+    @Test
+    public void testSchedule() throws InterruptedException {
+        Thread.sleep(10); // let removed files be purged
+        service.schedulePurgeData(rule.executor(), metadataService);
+        verify(rule.executor()).execute(isA(PurgeProjectCommand.class));
+        verify(rule.executor()).execute(isA(PurgeRepositoryCommand.class));
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
@@ -39,6 +39,7 @@ import com.cronutils.model.CronType;
 import com.cronutils.model.definition.CronDefinitionBuilder;
 import com.cronutils.parser.CronParser;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.metric.NoopMeterRegistry;
 import com.linecorp.centraldogma.common.Author;
@@ -89,7 +90,7 @@ public class DefaultMetaRepositoryTest {
     @BeforeClass
     public static void init() throws Exception {
         pm = new DefaultProjectManager(rootDir.getRoot(), ForkJoinPool.commonPool(),
-                                       NoopMeterRegistry.get(), null);
+                                       MoreExecutors.directExecutor(), NoopMeterRegistry.get(), null);
     }
 
     @AfterClass

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
@@ -31,6 +31,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import com.google.common.util.concurrent.MoreExecutors;
+
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
@@ -138,6 +140,6 @@ public class GitRepositoryManagerTest {
 
     private GitRepositoryManager newRepositoryManager() {
         return new GitRepositoryManager(mock(Project.class), rootDir(), ForkJoinPool.commonPool(),
-                                        mock(RepositoryCache.class));
+                                        MoreExecutors.directExecutor(), mock(RepositoryCache.class));
     }
 }

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -32,6 +32,7 @@ defaults:
       "idleTimeoutMillis": null,
       "maxFrameLength": null,
       "numRepositoryWorkers": 16,
+      "maxRemovedRepositoryAgeMillis": null,
       "repositoryCacheSpec": "maximumWeight=134217728,expireAfterAccess=5m",
       "webAppEnabled": true,
       "webAppTitle": null,
@@ -129,6 +130,12 @@ Core properties
 
   - the number of worker threads dedicated to handling repository reads and writes.
     If ``null``, the default value of '16 threads' is used.
+
+- ``maxRemovedRepositoryAgeMillis`` (integer)
+
+ - the maximum allowed age of removed projects and repositories before they are purged.
+   Set 0 to disable automatic purge.
+   If ``null``, the default value of '604800000 milliseconds' (7 days) is used.
 
 - ``repositoryCacheSpec`` (string)
 


### PR DESCRIPTION
Motivation:
The repositories and projects that were removed by users just renamed with having the suffix of `.removed`.
If the number of deleted files increases, it takes up a lot of disk space.
We can reduce wasted disk space by permanently deleting files which are older than configured.

Modifications:
* Add `PurgeProjectCommand` and `PurgeRepositoryCommand` and their thrift, rest api.
* Add `markForPurge()` and `purgeMarked()` method to mark and permanently delete a project or a repository directory.
* Add `PurgeSchedulingService` and `PurgeSchedulingServicePlugin` to purge automitically.
  * When the scheduler get started, it cleans up purged projects and repositories
    which were not deleted before.
* Add a new configuration `maxRemovedRepositoryAgeMillis` and update its documentation.
  * Setting 0 to `maxRemovedRepositoryAgeMillis` means disable the automatic purging.
* Record removal time into `removal.timestamp` file when a project/repository is removed.
* Change return type of `Set<String> listRemove()` into
  `Map<String, Instant> listRemoved()` to get a removal timestamp.

Result:
* A user who has permission can purge a repository or a project on demand.
* Removed repositories and projects are pursed automatically.

Fixes #47
