### PR TITLE
Update dependencies

### DIFF
--- a/client/java-spring-boot1-autoconfigure/build.gradle
+++ b/client/java-spring-boot1-autoconfigure/build.gradle
@@ -1,10 +1,10 @@
 dependencies {
     compile project(':client:java-armeria-legacy')
     compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.21.RELEASE'
+    compile 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'
 
     testCompile project(':client:java-armeria')
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.21.RELEASE'
+    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE'
     testRuntime 'org.hibernate.validator:hibernate-validator'
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,7 +3,7 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.linecorp.armeria:armeria-bom:0.89.0
+- com.linecorp.armeria:armeria-bom:0.90.1
 
 ch.qos.logback:
   logback-classic:
@@ -50,9 +50,9 @@ com.fasterxml.jackson.datatype:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.7.0'
+    version: '2.8.0'
     javadocs:
-    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.7.0/
+    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.8.0/
 
 com.github.jengelman.gradle.plugins:
   shadow: { version: '5.1.0' }
@@ -110,7 +110,7 @@ com.linecorp.armeria:
     - https://line.github.io/armeria/apidocs/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.22' }
+  checkstyle: { version: '8.23' }
 
 com.spotify:
   completable-futures:
@@ -192,7 +192,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.12.2' }
+  assertj-core: { version: '3.13.2' }
 
 org.awaitility:
   awaitility: { version: '3.1.6' }
@@ -220,7 +220,7 @@ org.openjdk.jmh:
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.26' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.28' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -230,7 +230,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.1.6.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.1.7.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -66,7 +66,6 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpHeaders;
@@ -96,7 +95,7 @@ import com.linecorp.armeria.server.encoding.HttpEncodingService;
 import com.linecorp.armeria.server.file.HttpFile;
 import com.linecorp.armeria.server.file.HttpFileBuilder;
 import com.linecorp.armeria.server.file.HttpFileServiceBuilder;
-import com.linecorp.armeria.server.healthcheck.HttpHealthCheckService;
+import com.linecorp.armeria.server.healthcheck.HealthCheckService;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.metric.MetricCollectingService;
 import com.linecorp.armeria.server.metric.PrometheusExpositionService;
@@ -525,7 +524,7 @@ public class CentralDogma implements AutoCloseable {
 
         sb.service("/title", webAppTitleFile(cfg.webAppTitle(), SystemInfo.hostname()).asService());
 
-        sb.service(HEALTH_CHECK_PATH, new HttpHealthCheckService());
+        sb.service(HEALTH_CHECK_PATH, HealthCheckService.of());
 
         // TODO(hyangtack): This service is temporarily added to support redirection from '/docs' to '/docs/'.
         //                  It would be removed if this kind of redirection is handled by Armeria.
@@ -789,8 +788,6 @@ public class CentralDogma implements AutoCloseable {
 
         // Bind global thread pool metrics.
         ExecutorServiceMetrics.monitor(registry, ForkJoinPool.commonPool(), "commonPool");
-        sb.blockingTaskExecutor(ExecutorServiceMetrics.monitor(
-                registry, CommonPools.blockingTaskExecutor(), "blockingTaskExecutor"));
     }
 
     private void doStop() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
@@ -95,7 +95,7 @@ public final class AuthConfig {
         this((AuthProviderFactory) AuthConfig.class
                      .getClassLoader()
                      .loadClass(requireNonNull(factoryClassName, "factoryClassName"))
-                     .newInstance(),
+                     .getDeclaredConstructor().newInstance(),
              administrators != null ? ImmutableSet.copyOf(administrators) : ImmutableSet.of(),
              firstNonNull(caseSensitiveLoginNames, false),
              firstNonNull(sessionCacheSpec, DEFAULT_SESSION_CACHE_SPEC),

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
@@ -46,6 +46,6 @@ public class UserService extends AbstractService {
     public HttpResponse usersMe() throws Exception {
         final User user = AuthUtil.currentUser();
         return HttpResponse.of(HttpStatus.OK, MediaType.JSON_UTF_8,
-                               HttpData.of(Jackson.writeValueAsBytes(user)));
+                               HttpData.wrap(Jackson.writeValueAsBytes(user)));
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/util/RestfulJsonResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/util/RestfulJsonResponseConverter.java
@@ -51,7 +51,7 @@ public class RestfulJsonResponseConverter implements ResponseConverterFunction {
             final HttpData httpData =
                     resObj != null &&
                     resObj.getClass() == Object.class ? EMPTY_RESULT
-                                                      : HttpData.of(Jackson.writeValueAsBytes(resObj));
+                                                      : HttpData.wrap(Jackson.writeValueAsBytes(resObj));
 
             final ResponseHeadersBuilder builder = headers.toBuilder();
             if (HttpMethod.POST == request.method()) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CreateApiResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/CreateApiResponseConverter.java
@@ -65,7 +65,7 @@ public final class CreateApiResponseConverter implements ResponseConverterFuncti
                 builder.add(HttpHeaderNames.LOCATION, url);
             }
 
-            return HttpResponse.of(builder.build(), HttpData.of(Jackson.writeValueAsBytes(jsonNode)),
+            return HttpResponse.of(builder.build(), HttpData.wrap(Jackson.writeValueAsBytes(jsonNode)),
                                    trailingHeaders);
         } catch (JsonProcessingException e) {
             logger.debug("Failed to convert a response:", e);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiResponseConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/HttpApiResponseConverter.java
@@ -66,7 +66,7 @@ public final class HttpApiResponseConverter implements ResponseConverterFunction
                 resHeaders = headers;
             }
 
-            final HttpData httpData = HttpData.of(Jackson.writeValueAsBytes(resObj));
+            final HttpData httpData = HttpData.wrap(Jackson.writeValueAsBytes(resObj));
             return HttpResponse.of(resHeaders, httpData, trailingHeaders);
         } catch (JsonProcessingException e) {
             logger.debug("Failed to convert a response:", e);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -29,6 +29,7 @@ import java.util.regex.Pattern;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.RemoteSetUrlCommand;
+import org.eclipse.jgit.api.RemoteSetUrlCommand.UriType;
 import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.FileMode;
 import org.eclipse.jgit.lib.ObjectId;
@@ -273,13 +274,13 @@ public final class GitMirror extends AbstractMirror {
             // Set the remote URLs.
             final URIish uri = new URIish(jGitUri);
             final RemoteSetUrlCommand remoteSetUrl = git.remoteSetUrl();
-            remoteSetUrl.setName(Constants.DEFAULT_REMOTE_NAME);
-            remoteSetUrl.setUri(uri);
+            remoteSetUrl.setRemoteName(Constants.DEFAULT_REMOTE_NAME);
+            remoteSetUrl.setRemoteUri(uri);
 
-            remoteSetUrl.setPush(false);
+            remoteSetUrl.setUriType(UriType.FETCH);
             remoteSetUrl.call();
 
-            remoteSetUrl.setPush(true);
+            remoteSetUrl.setUriType(UriType.PUSH);
             remoteSetUrl.call();
 
             // XXX(trustin): Do not garbage-collect a Git repository while the server is serving the clients

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -216,10 +216,10 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     public void normalizeRevision(String projectName, String repositoryName, Revision revision,
                                   AsyncMethodCallback resultHandler) {
 
-        handle(projectManager.get(projectName).repos().get(repositoryName)
-                             .normalize(convert(revision))
-                             .thenApply(Converter::convert),
-               resultHandler);
+        final com.linecorp.centraldogma.common.Revision normalized =
+                projectManager.get(projectName).repos().get(repositoryName)
+                              .normalizeNow(convert(revision));
+        resultHandler.onComplete(convert(normalized));
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
@@ -120,7 +120,7 @@ public class ContentCompressionTest {
 
         final HttpData content = compressedResponse.content();
         try (Reader in = new InputStreamReader(new InflaterInputStream(new ByteArrayInputStream(
-                content.array(), content.offset(), content.length())), StandardCharsets.UTF_8)) {
+                content.array(), 0, content.length())), StandardCharsets.UTF_8)) {
 
             assertThat(CharStreams.toString(in)).contains(CONTENT);
         }


### PR DESCRIPTION
- Armeria 0.89.0 -> 0.90.0
- Caffeine 2.7.0 -> 2.8.0
- SLF4J 1.7.26 -> 1.7.28
- Spring Boot 2.1.6 -> 2.1.7, 1.5.21 -> 1.5.22
- Build
  - AssertJ 3.12.2 -> 3.13.2
  - Checkstyle 8.22 -> 8.23
- Remove deprecated API usage