### PR TITLE
Bump jcommander to 1.78

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -12,7 +12,7 @@ ch.qos.logback:
     - https://logback.qos.ch/apidocs/
 
 com.beust:
-  jcommander: { version: '1.75' }
+  jcommander: { version: '1.78' }
 
 com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }


### PR DESCRIPTION
Without this, the project doesn't compile with JDK8 because the library author made a mistake.
He fixed it in https://github.com/cbeust/jcommander/commit/a2860db4b28e3be7d03878e8d402163ec79cf7d2