### PR TITLE
Retry client requests on replication lag

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -231,7 +231,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     public <T> CompletableFuture<Entry<T>> getFile(String projectName, String repositoryName,
                                                    Revision revision, Query<T> query) {
 
-        return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+        return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
             final CompletableFuture<GetFileResult> future = run(callback -> {
                 requireNonNull(query, "query");
                 client.getFile(projectName, repositoryName,
@@ -273,7 +273,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<Map<String, Entry<?>>> getFiles(String projectName, String repositoryName,
                                                              Revision revision, String pathPattern) {
 
-        return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+        return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
             final CompletableFuture<List<com.linecorp.centraldogma.internal.thrift.Entry>> future =
                     run(callback -> {
                         validatePathPattern(pathPattern, "pathPattern");

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -65,7 +65,7 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
         });
 
         final EventLoopGroup executor = clientFactory().eventLoopGroup();
-        final int maxRetriesOnReplicationLag = maxRetriesOnReplicationLag();
+        final int maxRetriesOnReplicationLag = maxNumRetriesOnReplicationLag();
         final CentralDogma dogma = new LegacyCentralDogma(executor, builder.build(AsyncIface.class));
         if (maxRetriesOnReplicationLag <= 0) {
             return dogma;

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -439,7 +439,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             requireNonNull(query, "query");
 
             // TODO(trustin) No need to normalize a revision once server response contains it.
-            return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+            return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
                 path.append("/contents").append(query.path());
                 path.append("?revision=").append(normRev.text());
@@ -472,7 +472,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
             validatePathPattern(pathPattern, "pathPattern");
 
             // TODO(trustin) No need to normalize a revision once server response contains it.
-            return normalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
+            return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
                 path.append("/contents");
                 if (pathPattern.charAt(0) != '/') {

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -40,7 +40,7 @@ public final class ArmeriaCentralDogmaBuilder
         final ClientBuilder builder =
                 newClientBuilder(uri, cb -> cb.decorator(HttpDecodingClient.newDecorator()));
         final EventLoopGroup executor = clientFactory().eventLoopGroup();
-        final int maxRetriesOnReplicationLag = maxRetriesOnReplicationLag();
+        final int maxRetriesOnReplicationLag = maxNumRetriesOnReplicationLag();
         final CentralDogma dogma = new ArmeriaCentralDogma(executor,
                                                            builder.build(HttpClient.class),
                                                            accessToken());

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
@@ -58,7 +58,7 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
 
     static final int DEFAULT_PORT = 36462;
 
-    private static final int DEFAULT_MAX_RETRIES_ON_REPLICATION_LAG = 5;
+    private static final int DEFAULT_MAX_NUM_RETRIES_ON_REPLICATION_LAG = 5;
     private static final int DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS = 2;
 
     private ImmutableSet<InetSocketAddress> hosts = ImmutableSet.of();
@@ -67,7 +67,7 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
     @Nullable
     private String selectedProfile;
     private String accessToken = CsrfToken.ANONYMOUS;
-    private int maxRetriesOnReplicationLag = 5;
+    private int maxNumRetriesOnReplicationLag = DEFAULT_MAX_NUM_RETRIES_ON_REPLICATION_LAG;
     private long retryIntervalOnReplicationLagMillis =
             TimeUnit.SECONDS.toMillis(DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS);
 
@@ -370,20 +370,20 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
      *
      * <p>Setting a value greater than {@code 0} to this property will make the client detect such situations
      * and retry automatically. By default, the client will retry up to
-     * {@value #DEFAULT_MAX_RETRIES_ON_REPLICATION_LAG} times.</p>
+     * {@value #DEFAULT_MAX_NUM_RETRIES_ON_REPLICATION_LAG} times.</p>
      */
-    public final B maxRetriesOnReplicationLag(int maxRetriesOnReplicationLag) {
+    public final B maxNumRetriesOnReplicationLag(int maxRetriesOnReplicationLag) {
         checkArgument(maxRetriesOnReplicationLag >= 0,
                       "maxRetriesOnReplicationLag: %s (expected: >= 0)", maxRetriesOnReplicationLag);
-        this.maxRetriesOnReplicationLag = maxRetriesOnReplicationLag;
+        this.maxNumRetriesOnReplicationLag = maxRetriesOnReplicationLag;
         return self();
     }
 
     /**
      * Returns the maximum number of retries to perform when replication lag is detected.
      */
-    protected int maxRetriesOnReplicationLag() {
-        return maxRetriesOnReplicationLag;
+    protected int maxNumRetriesOnReplicationLag() {
+        return maxNumRetriesOnReplicationLag;
     }
 
     /**

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -31,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -41,6 +43,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.net.InetAddresses;
 
+import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.internal.CsrfToken;
 
 /**
@@ -55,12 +58,18 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
 
     static final int DEFAULT_PORT = 36462;
 
+    private static final int DEFAULT_MAX_RETRIES_ON_REPLICATION_LAG = 5;
+    private static final int DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS = 2;
+
     private ImmutableSet<InetSocketAddress> hosts = ImmutableSet.of();
     private boolean useTls;
     private List<String> profileResourcePaths = DEFAULT_PROFILE_RESOURCE_PATHS;
     @Nullable
     private String selectedProfile;
     private String accessToken = CsrfToken.ANONYMOUS;
+    private int maxRetriesOnReplicationLag = 5;
+    private long retryIntervalOnReplicationLagMillis =
+            TimeUnit.SECONDS.toMillis(DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS);
 
     /**
      * Returns {@code this}.
@@ -344,5 +353,66 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
      */
     protected String accessToken() {
         return accessToken;
+    }
+
+    /**
+     * Sets the maximum number of retries to perform when replication lag is detected. For example,
+     * without replication lag detection and retries, the {@code getFile()} in the following example
+     * might fail with a {@link RevisionNotFoundException} when replication is enabled on the server side:
+     * <pre>{@code
+     * CentralDogma dogma = ...;
+     * // getFile() may fail if:
+     * // 1) the replica A serves getFile() while the replica B serves the normalizeRevision() and
+     * // 2) the replica A did not catch up all the commits made in the replica B.
+     * Revision headRevision = dogma.normalizeRevision("proj", "repo", Revision.HEAD).join();
+     * Entry<String> entry = dogma.getFile("proj", "repo", headRevision, Query.ofText("/a.txt")).join();
+     * }</pre>
+     *
+     * <p>Setting a value greater than {@code 0} to this property will make the client detect such situations
+     * and retry automatically. By default, the client will retry up to
+     * {@value #DEFAULT_MAX_RETRIES_ON_REPLICATION_LAG} times.</p>
+     */
+    public final B maxRetriesOnReplicationLag(int maxRetriesOnReplicationLag) {
+        checkArgument(maxRetriesOnReplicationLag >= 0,
+                      "maxRetriesOnReplicationLag: %s (expected: >= 0)", maxRetriesOnReplicationLag);
+        this.maxRetriesOnReplicationLag = maxRetriesOnReplicationLag;
+        return self();
+    }
+
+    /**
+     * Returns the maximum number of retries to perform when replication lag is detected.
+     */
+    protected int maxRetriesOnReplicationLag() {
+        return maxRetriesOnReplicationLag;
+    }
+
+    /**
+     * Sets the interval between retries which occurred due to replication lag. By default, the interval
+     * between retries is {@value #DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS} seconds.
+     */
+    public final B retryIntervalOnReplicationLag(Duration retryIntervalOnReplicationLag) {
+        requireNonNull(retryIntervalOnReplicationLag, "retryIntervalOnReplicationLag");
+        checkArgument(!retryIntervalOnReplicationLag.isNegative(),
+                      "retryIntervalOnReplicationLag: %s (expected: >= 0)", retryIntervalOnReplicationLag);
+        return retryIntervalOnReplicationLagMillis(retryIntervalOnReplicationLag.toMillis());
+    }
+
+    /**
+     * Sets the interval between retries which occurred due to replication lag in milliseconds. By default,
+     * the interval between retries is {@value #DEFAULT_RETRY_INTERVAL_ON_REPLICATION_LAG_SECONDS} seconds.
+     */
+    public final B retryIntervalOnReplicationLagMillis(long retryIntervalOnReplicationLagMillis) {
+        checkArgument(retryIntervalOnReplicationLagMillis >= 0,
+                      "retryIntervalOnReplicationLagMillis: %s (expected: >= 0)",
+                      retryIntervalOnReplicationLagMillis);
+        this.retryIntervalOnReplicationLagMillis = retryIntervalOnReplicationLagMillis;
+        return self();
+    }
+
+    /**
+     * Returns the interval between retries which occurred due to replication lag in milliseconds.
+     */
+    protected long retryIntervalOnReplicationLagMillis() {
+        return retryIntervalOnReplicationLagMillis;
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -54,7 +54,6 @@ import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
-import com.linecorp.centraldogma.common.RevisionRange;
 
 /**
  * A {@link CentralDogma} client that retries the request automatically when a {@link RevisionNotFoundException}

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -1,0 +1,481 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.internal.client;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import javax.annotation.Nullable;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.spotify.futures.CompletableFutures;
+
+import com.linecorp.centraldogma.client.AbstractCentralDogma;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Commit;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.MergeQuery;
+import com.linecorp.centraldogma.common.MergedEntry;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.RevisionNotFoundException;
+
+public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDogma {
+
+    private final CentralDogma delegate;
+    private final int maxRetries;
+    private final long retryIntervalMillis;
+    private final Map<RepoId, Revision> latestKnownRevisions = new LinkedHashMap<RepoId, Revision>() {
+        private static final long serialVersionUID = 3587793379404809027L;
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry<RepoId, Revision> eldest) {
+            // Keep only to up 8192 repositories, which should be enough for almost all cases.
+            return size() > 8192;
+        }
+    };
+
+    public ReplicationLagTolerantCentralDogma(ScheduledExecutorService executor, CentralDogma delegate,
+                                              int maxRetries, long retryIntervalMillis) {
+        super(executor);
+
+        requireNonNull(delegate, "delegate");
+        checkArgument(maxRetries > 0, "maxRetries: %s (expected: > 0)", maxRetries);
+        checkArgument(retryIntervalMillis >= 0,
+                      "retryIntervalMillis: %s (expected: >= 0)", retryIntervalMillis);
+
+        this.delegate = delegate;
+        this.maxRetries = maxRetries;
+        this.retryIntervalMillis = retryIntervalMillis;
+    }
+
+    @Override
+    public CompletableFuture<Void> createProject(String projectName) {
+        return delegate.createProject(projectName);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeProject(String projectName) {
+        return delegate.removeProject(projectName);
+    }
+
+    @Override
+    public CompletableFuture<Void> purgeProject(String projectName) {
+        return delegate.purgeProject(projectName);
+    }
+
+    @Override
+    public CompletableFuture<Void> unremoveProject(String projectName) {
+        return delegate.unremoveProject(projectName);
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listProjects() {
+        return delegate.listProjects();
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listRemovedProjects() {
+        return delegate.listRemovedProjects();
+    }
+
+    @Override
+    public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
+        return delegate.createRepository(projectName, repositoryName);
+    }
+
+    @Override
+    public CompletableFuture<Void> removeRepository(String projectName, String repositoryName) {
+        return delegate.removeRepository(projectName, repositoryName);
+    }
+
+    @Override
+    public CompletableFuture<Void> purgeRepository(String projectName, String repositoryName) {
+        return delegate.purgeRepository(projectName, repositoryName);
+    }
+
+    @Override
+    public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
+        return delegate.unremoveRepository(projectName, repositoryName);
+    }
+
+    @Override
+    public CompletableFuture<Map<String, RepositoryInfo>> listRepositories(String projectName) {
+        return execute(
+                () -> delegate.listRepositories(projectName),
+                (res, cause) -> {
+                    for (RepositoryInfo info : res.values()) {
+                        if (!updateLatestKnownRevision(projectName, info.name(), info.headRevision())) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+    }
+
+    @Override
+    public CompletableFuture<Set<String>> listRemovedRepositories(String projectName) {
+        return delegate.listRemovedRepositories(projectName);
+    }
+
+    @Override
+    public CompletableFuture<Revision> normalizeRevision(
+            String projectName, String repositoryName, Revision revision) {
+        return execute(
+                () -> delegate.normalizeRevision(projectName, repositoryName, revision),
+                (res, cause) -> {
+                    if (cause != null) {
+                        return handleRevisionNotFound(projectName, repositoryName, revision, cause);
+                    }
+
+                    if (revision.isRelative()) {
+                        final Revision headRevision = res.forward(-(revision.major() + 1));
+                        return !updateLatestKnownRevision(projectName, repositoryName, headRevision);
+                    }
+
+                    updateLatestKnownRevision(projectName, repositoryName, revision);
+                    return false;
+                });
+    }
+
+    @Override
+    public CompletableFuture<Map<String, EntryType>> listFiles(
+            String projectName, String repositoryName, Revision revision, String pathPattern) {
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, revision,
+                normRev -> delegate.listFiles(projectName, repositoryName, normRev, pathPattern));
+    }
+
+    @Override
+    public <T> CompletableFuture<Entry<T>> getFile(
+            String projectName, String repositoryName, Revision revision, Query<T> query) {
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, revision,
+                normRev -> delegate.getFile(projectName, repositoryName, normRev, query));
+    }
+
+    @Override
+    public CompletableFuture<Map<String, Entry<?>>> getFiles(
+            String projectName, String repositoryName, Revision revision, String pathPattern) {
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, revision,
+                normRev -> delegate.getFiles(projectName, repositoryName, normRev, pathPattern));
+    }
+
+    @Override
+    public <T> CompletableFuture<MergedEntry<T>> mergeFiles(
+            String projectName, String repositoryName, Revision revision,
+            MergeQuery<T> mergeQuery) {
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, revision,
+                normRev -> delegate.mergeFiles(projectName, repositoryName, normRev, mergeQuery));
+    }
+
+    @Override
+    public CompletableFuture<List<Commit>> getHistory(
+            String projectName, String repositoryName, Revision from,
+            Revision to, String pathPattern) {
+        return normalizeRevisionsAndExecute(
+                projectName, repositoryName, from, to,
+                (normFromRev, normToRev) -> delegate.getHistory(projectName, repositoryName,
+                                                                normFromRev, normToRev, pathPattern));
+    }
+
+    @Override
+    public <T> CompletableFuture<Change<T>> getDiff(
+            String projectName, String repositoryName, Revision from, Revision to, Query<T> query) {
+        return normalizeRevisionsAndExecute(
+                projectName, repositoryName, from, to,
+                (normFromRev, normToRev) -> delegate.getDiff(projectName, repositoryName,
+                                                             normFromRev, normToRev, query));
+    }
+
+    @Override
+    public CompletableFuture<List<Change<?>>> getDiffs(
+            String projectName, String repositoryName, Revision from, Revision to, String pathPattern) {
+        return normalizeRevisionsAndExecute(
+                projectName, repositoryName, from, to,
+                (normFromRev, normToRev) -> delegate.getDiffs(projectName, repositoryName,
+                                                              normFromRev, normToRev, pathPattern));
+    }
+
+    @Override
+    public CompletableFuture<List<Change<?>>> getPreviewDiffs(
+            String projectName, String repositoryName, Revision baseRevision,
+            Iterable<? extends Change<?>> changes) {
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, baseRevision,
+                normBaseRev -> delegate.getPreviewDiffs(projectName, repositoryName, normBaseRev, changes));
+    }
+
+    @Override
+    public CompletableFuture<PushResult> push(
+            String projectName, String repositoryName, Revision baseRevision,
+            String summary, String detail, Markup markup, Iterable<? extends Change<?>> changes) {
+        return execute(
+                () -> delegate.push(projectName, repositoryName, baseRevision,
+                                    summary, detail, markup, changes),
+                pushRetryPredicate(projectName, repositoryName, baseRevision));
+    }
+
+    @Override
+    public CompletableFuture<PushResult> push(
+            String projectName, String repositoryName, Revision baseRevision,
+            Author author, String summary, String detail, Markup markup,
+            Iterable<? extends Change<?>> changes) {
+        return execute(
+                () -> delegate.push(projectName, repositoryName, baseRevision,
+                                    author, summary, detail, markup, changes),
+                pushRetryPredicate(projectName, repositoryName, baseRevision));
+    }
+
+    private BiPredicate<PushResult, Throwable> pushRetryPredicate(
+            String projectName, String repositoryName, Revision baseRevision) {
+
+        return (res, cause) -> {
+            if (cause != null) {
+                return handleRevisionNotFound(projectName, repositoryName, baseRevision, cause);
+            }
+
+            updateLatestKnownRevision(projectName, repositoryName, res.revision());
+            return false;
+        };
+    }
+
+    @Override
+    public CompletableFuture<Revision> watchRepository(
+            String projectName, String repositoryName, Revision lastKnownRevision,
+            String pathPattern, long timeoutMillis) {
+
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, lastKnownRevision,
+                normLastKnownRevision -> {
+                    return delegate.watchRepository(projectName, repositoryName, normLastKnownRevision,
+                                                    pathPattern, timeoutMillis)
+                                   .thenApply(newLastKnownRevision -> {
+                                       if (newLastKnownRevision != null) {
+                                           updateLatestKnownRevision(projectName, repositoryName,
+                                                                     newLastKnownRevision);
+                                       }
+                                       return newLastKnownRevision;
+                                   });
+                });
+    }
+
+    @Override
+    public <T> CompletableFuture<Entry<T>> watchFile(
+            String projectName, String repositoryName, Revision lastKnownRevision,
+            Query<T> query, long timeoutMillis) {
+
+        return normalizeRevisionAndExecute(
+                projectName, repositoryName, lastKnownRevision,
+                normLastKnownRevision -> {
+                    return delegate.watchFile(projectName, repositoryName, normLastKnownRevision,
+                                              query, timeoutMillis)
+                                   .thenApply(entry -> {
+                                       if (entry != null) {
+                                           updateLatestKnownRevision(projectName, repositoryName,
+                                                                     entry.revision());
+                                       }
+                                       return entry;
+                                   });
+                });
+    }
+
+    private <T> CompletableFuture<T> normalizeRevisionAndExecute(
+            String projectName, String repositoryName, Revision revision,
+            Function<Revision, CompletableFuture<T>> taskRunner) {
+        return normalizeRevision(projectName, repositoryName, revision)
+                .thenCompose(normRev -> execute(
+                        () -> taskRunner.apply(normRev),
+                        (res, cause) -> cause != null &&
+                                        handleRevisionNotFound(projectName, repositoryName, normRev, cause)));
+    }
+
+    private <T> CompletableFuture<T> normalizeRevisionsAndExecute(
+            String projectName, String repositoryName, Revision from, Revision to,
+            BiFunction<Revision, Revision, CompletableFuture<T>> taskRunner) {
+
+        return CompletableFutures.allAsList(ImmutableList.of(
+                normalizeRevision(projectName, repositoryName, from),
+                normalizeRevision(projectName, repositoryName, to)))
+                .thenCompose(normRevs -> {
+                    final Revision normFromRev = normRevs.get(0);
+                    final Revision normToRev = normRevs.get(1);
+                    return execute(
+                            () -> taskRunner.apply(normFromRev, normToRev),
+                            (res, cause) -> {
+                                if (cause == null) {
+                                    return false;
+                                }
+                                final Revision normRev = normFromRev.compareTo(normToRev) > 0 ? normFromRev
+                                                                                              : normToRev;
+                                return handleRevisionNotFound(projectName, repositoryName, normRev, cause);
+                            });
+                });
+    }
+
+    private <T> CompletableFuture<T> execute(
+            Supplier<CompletableFuture<T>> taskRunner,
+            BiPredicate<T, Throwable> retryPredicate) {
+        return execute(taskRunner, retryPredicate, 0);
+    }
+
+    private <T> CompletableFuture<T> execute(
+            Supplier<CompletableFuture<T>> taskRunner,
+            BiPredicate<T, Throwable> retryPredicate,
+            int attemptsSoFar) {
+
+        return CompletableFutures.handleCompose(taskRunner.get(), (res, cause) -> {
+            final int nextAttemptsSoFar = attemptsSoFar + 1;
+            if (!retryPredicate.test(res, cause) || nextAttemptsSoFar > maxRetries) {
+                if (cause == null) {
+                    return CompletableFuture.completedFuture(res);
+                } else {
+                    return CompletableFutures.exceptionallyCompletedFuture(cause);
+                }
+            }
+
+            final CompletableFuture<T> nextAttemptFuture = new CompletableFuture<>();
+            executor().schedule(() -> {
+                try {
+                    execute(taskRunner, retryPredicate, nextAttemptsSoFar).handle((newRes, newCause) -> {
+                        if (newCause != null) {
+                            nextAttemptFuture.completeExceptionally(newCause);
+                        } else {
+                            nextAttemptFuture.complete(newRes);
+                        }
+                        return null;
+                    });
+                } catch (Throwable t) {
+                    nextAttemptFuture.completeExceptionally(t);
+                }
+            }, retryIntervalMillis, TimeUnit.MILLISECONDS);
+
+            return nextAttemptFuture;
+        }).toCompletableFuture();
+    }
+
+    /**
+     * Handles a {@link RevisionNotFoundException} and returns whether the request must be retried.
+     */
+    private boolean handleRevisionNotFound(
+            String projectName, String repositoryName, Revision revision, Throwable cause) {
+
+        requireNonNull(cause, "cause");
+
+        // Retry if we got `RevisionNotFoundException` for an existent revision.
+        if (!(cause instanceof RevisionNotFoundException)) {
+            return false;
+        }
+
+        final Revision latestKnownRevision = latestKnownRevision(projectName, repositoryName);
+        if (latestKnownRevision == null) {
+            return false;
+        }
+
+        if (revision.isRelative()) {
+            return revision.major() + latestKnownRevision.major() >= 0;
+        } else {
+            return revision.major() <= latestKnownRevision.major();
+        }
+    }
+
+    @Nullable
+    @VisibleForTesting
+    Revision latestKnownRevision(String projectName, String repositoryName) {
+        synchronized (latestKnownRevisions) {
+            return latestKnownRevisions.get(new RepoId(projectName, repositoryName));
+        }
+    }
+
+    /**
+     * Updates the latest known revision for the specified repository.
+     *
+     * @return {@code true} if the latest known revision has been updated to the specified {@link Revision} or
+     *         the latest known revision is equal to the specified {@link Revision}. {@code false} otherwise.
+     */
+    private boolean updateLatestKnownRevision(String projectName, String repositoryName, Revision newRevision) {
+        final RepoId id = new RepoId(projectName, repositoryName);
+        synchronized (latestKnownRevisions) {
+            final Revision oldRevision = latestKnownRevisions.get(id);
+            if (oldRevision == null) {
+                latestKnownRevisions.put(id, newRevision);
+                return true;
+            }
+
+            final int comparison = oldRevision.compareTo(newRevision);
+            if (comparison < 0) {
+                latestKnownRevisions.put(id, newRevision);
+                return true;
+            }
+
+            return comparison == 0;
+        }
+    }
+
+    private static final class RepoId {
+        private final String projectName;
+        private final String repositoryName;
+
+        RepoId(String projectName, String repositoryName) {
+            this.projectName = projectName;
+            this.repositoryName = repositoryName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof RepoId)) {
+                return false;
+            }
+            final RepoId that = (RepoId) o;
+            return projectName.equals(that.projectName) && repositoryName.equals(that.repositoryName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(projectName, repositoryName);
+        }
+
+        @Override
+        public String toString() {
+            return projectName + '/' + repositoryName;
+        }
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -399,13 +399,13 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                             if (cause == null) {
                                 return false;
                             }
+
                             final Revision normBaseRev = normFromRev.compareTo(normToRev) > 0 ? normFromRev
                                                                                               : normToRev;
                             return handleRevisionNotFound(projectName, repositoryName, normBaseRev, cause);
                         });
             });
         }
-
     }
 
     /**

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -53,6 +53,10 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 
+/**
+ * A {@link CentralDogma} client that retries the request automatically when a {@link RevisionNotFoundException}
+ * was raised but it is certain that a given {@link Revision} exists.
+ */
 public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDogma {
 
     private final CentralDogma delegate;
@@ -390,14 +394,14 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     }
 
     /**
-     * Handles a {@link RevisionNotFoundException} and returns whether the request must be retried.
+     * Returns {@code true} to indicate that the request must be retried if {@code cause} is
+     * a {@link RevisionNotFoundException} and the specified {@link Revision} is supposed to exist.
      */
     private boolean handleRevisionNotFound(
             String projectName, String repositoryName, Revision revision, Throwable cause) {
 
         requireNonNull(cause, "cause");
 
-        // Retry if we got `RevisionNotFoundException` for an existent revision.
         if (!(cause instanceof RevisionNotFoundException)) {
             return false;
         }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -16,7 +16,9 @@
 package com.linecorp.centraldogma.internal.client;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.CompletableFuture.completedFuture;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -347,6 +349,14 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
             String projectName, String repositoryName, Revision from, Revision to,
             BiFunction<Revision, Revision, CompletableFuture<T>> taskRunner) {
 
+        if (to == null) {
+            return exceptionallyCompletedFuture(new NullPointerException("to"));
+        }
+
+        if (from == null) {
+            return exceptionallyCompletedFuture(new NullPointerException("from"));
+        }
+
         final int distance = to.major() - from.major();
         final Revision baseRevision = to.compareTo(from) >= 0 ? to : from;
 
@@ -392,9 +402,9 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
             final int nextAttemptsSoFar = attemptsSoFar + 1;
             if (!retryPredicate.test(res, cause) || nextAttemptsSoFar > maxRetries) {
                 if (cause == null) {
-                    return CompletableFuture.completedFuture(res);
+                    return completedFuture(res);
                 } else {
-                    return CompletableFutures.exceptionallyCompletedFuture(cause);
+                    return exceptionallyCompletedFuture(cause);
                 }
             }
 

--- a/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.internal.client;
+
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.ProjectNotFoundException;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.common.RevisionNotFoundException;
+
+public class ReplicationLagTolerantCentralDogmaTest {
+
+    private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    @AfterClass
+    public static void shutdownExecutor() {
+        executor.shutdown();
+    }
+
+    @Test
+    public void normalizeRevision() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        // Make sure the latest known revision is remembered on `normalizeRevision()`.
+        final Revision latestRevision = new Revision(2);
+        for (int i = 1; i <= latestRevision.major(); i++) {
+            final Revision revision = new Revision(i);
+            when(delegate.normalizeRevision(any(), any(), any())).thenReturn(completedFuture(revision));
+
+            assertThat(dogma.normalizeRevision("foo", "bar", Revision.HEAD).join()).isEqualTo(revision);
+
+            verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.HEAD);
+            verifyNoMoreInteractions(delegate);
+            reset(delegate);
+
+            assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(revision);
+        }
+
+        // Make sure:
+        // 1) The client retries when older revision is found.
+        // 2) The latest known revision remains unchanged.
+        //// Return an old revision once and then the correct revision to simulate a replication lag.
+        when(delegate.normalizeRevision(any(), any(), any())).thenReturn(
+                // Raise an error on the 1st attempt.
+                exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                // Return an old revision on the 2nd attempt.
+                completedFuture(latestRevision.backward(1)),
+                // Return the correct revision finally.
+                completedFuture(latestRevision));
+        //// The client should not return the old revision but the correct revision.
+        assertThat(dogma.normalizeRevision("foo", "bar", Revision.HEAD).join()).isEqualTo(latestRevision);
+        //// 3 attempts must be made, but no more.
+        verify(delegate, times(3)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
+
+        // Make sure the absolute revisions are normalized as well.
+        final Revision newLatestRevision = latestRevision.forward(1);
+        when(delegate.normalizeRevision(any(), any(), any())).thenReturn(completedFuture(newLatestRevision));
+        assertThat(dogma.normalizeRevision("foo", "bar", newLatestRevision).join())
+                .isEqualTo(newLatestRevision);
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", newLatestRevision);
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(newLatestRevision);
+
+        // Make sure that the client does not retry indefinitely.
+        //// Keep returning an old revision.
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(completedFuture(Revision.INIT));
+        //// Give up and return the old revision.
+        assertThat(dogma.normalizeRevision("foo", "bar", Revision.HEAD).join()).isEqualTo(Revision.INIT);
+        verify(delegate, times(4)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+        //// Keep failing with an error.
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(exceptionallyCompletedFuture(new RevisionNotFoundException()));
+        //// Give up and raise an exception.
+        assertThatThrownBy(() -> dogma.normalizeRevision("foo", "bar", Revision.HEAD).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(RevisionNotFoundException.class);
+        verify(delegate, times(4)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void normalizeRevisionAndExecute() throws Exception {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        final Revision latestRevision = new Revision(3);
+        when(delegate.normalizeRevision(any(), any(), any())).thenReturn(completedFuture(latestRevision));
+        when(delegate.getFile(any(), any(), any(), any(Query.class))).thenReturn(
+                exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                completedFuture(Entry.ofJson(latestRevision, "/foo.json", "{ \"a\": \"b\" }")));
+
+        assertThat(dogma.getFile("foo", "bar", Revision.HEAD, Query.ofJson("/foo.json")).join())
+                .isEqualTo(Entry.ofJson(latestRevision, "/foo.json", "{ \"a\": \"b\" }"));
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verify(delegate, times(3)).getFile("foo", "bar", latestRevision, Query.ofJson("/foo.json"));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void normalizeRevisionsAndExecute() throws Exception {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        when(delegate.normalizeRevision(any(), any(), eq(new Revision(-2))))
+                .thenReturn(completedFuture(Revision.INIT));
+        when(delegate.normalizeRevision(any(), any(), eq(Revision.HEAD)))
+                .thenReturn(completedFuture(new Revision(2)));
+        when(delegate.getDiff(any(), any(), any(), any(), any(Query.class))).thenReturn(
+                exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                completedFuture(Change.ofJsonUpsert("/foo.json", "{ \"a\": \"b\" }")));
+
+        assertThat(dogma.getDiff("foo", "bar", new Revision(-2), new Revision(-1),
+                                 Query.ofJson("/foo.json")).join())
+                .isEqualTo(Change.ofJsonUpsert("/foo.json", "{ \"a\": \"b\" }"));
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", new Revision(-2));
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verify(delegate, times(3)).getDiff("foo", "bar", Revision.INIT, new Revision(2),
+                                           Query.ofJson("/foo.json"));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void listRepositories() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        // `listRepository()` must remember the latest known revisions.
+        final Revision latestRevision = new Revision(2);
+        for (int i = 1; i <= latestRevision.major(); i++) {
+            final Revision revision = new Revision(i);
+            when(delegate.listRepositories(any())).thenReturn(completedFuture(
+                    ImmutableMap.of("bar", new RepositoryInfo("bar", revision))));
+            assertThat(dogma.listRepositories("foo").join()).isEqualTo(
+                    ImmutableMap.of("bar", new RepositoryInfo("bar", revision)));
+            verify(delegate, times(1)).listRepositories("foo");
+            verifyNoMoreInteractions(delegate);
+            reset(delegate);
+            assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(revision);
+        }
+
+        // Make sure:
+        // 1) The client retries when older revision is found.
+        // 2) The latest known revision remains unchanged.
+        //// Return an old revision once and then the correct revision to simulate a replication lag.
+        when(delegate.listRepositories(any())).thenReturn(
+                // Return an old revision on the 1st attempt.
+                completedFuture(ImmutableMap.of(
+                        "bar", new RepositoryInfo("bar", latestRevision.backward(1)))),
+                // Return the correct revision on the 2nd attempt.
+                completedFuture(ImmutableMap.of(
+                        "bar", new RepositoryInfo("bar", latestRevision))));
+        //// The client should not return the old revision but the correct revision.
+        assertThat(dogma.listRepositories("foo").join())
+                .isEqualTo(ImmutableMap.of("bar", new RepositoryInfo("bar", latestRevision)));
+        //// 3 attempts must be made, but no more.
+        verify(delegate, times(2)).listRepositories("foo");
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
+
+        // Make sure that the client does not retry indefinitely.
+        //// Keep returning an old revision.
+        when(delegate.listRepositories(any())).thenReturn(completedFuture(
+                ImmutableMap.of("bar", new RepositoryInfo("bar", Revision.INIT))));
+        //// Give up and return the old revision.
+        assertThat(dogma.listRepositories("foo").join()).isEqualTo(
+                ImmutableMap.of("bar", new RepositoryInfo("bar", Revision.INIT)));
+        verify(delegate, times(4)).listRepositories("foo");
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void retryOnlyOnRevisionNotFoundException() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(exceptionallyCompletedFuture(new ProjectNotFoundException()));
+
+        assertThatThrownBy(() -> dogma.normalizeRevision("foo", "bar", Revision.HEAD).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(ProjectNotFoundException.class);
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void push() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        final PushResult pushResult = new PushResult(new Revision(3), 42L);
+        when(delegate.push(any(), any(), any(), any(), any(), any(), any(Iterable.class)))
+                .thenReturn(completedFuture(pushResult));
+
+        assertThat(dogma.push("foo", "bar", Revision.HEAD, "summary", "detail", Markup.MARKDOWN,
+                              ImmutableList.of(Change.ofTextUpsert("/a.txt", "a"))).join())
+                .isEqualTo(pushResult);
+
+        // On successful push, latest known revision must be remembered.
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(pushResult.revision());
+    }
+
+    @Test
+    public void pushWithRetries() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        // Make the client remember the latest known revision.
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(completedFuture(new Revision(3)));
+
+        assertThat(dogma.normalizeRevision("foo", "bar", new Revision(-2)).join())
+                .isEqualTo(new Revision(3));
+
+        //// Note that the revision -2 has been resolved into the revision 3,
+        //// which means the revision -1 is the revision 4.
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(new Revision(4));
+        reset(delegate);
+
+        // Attempt to push at the base revision 4, which should succeed after retries.
+        final PushResult pushResult = new PushResult(new Revision(5), 42L);
+        when(delegate.push(any(), any(), any(), any(), any(), any(), any(Iterable.class)))
+                .thenReturn(exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                            exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                            completedFuture(pushResult));
+
+        assertThat(dogma.push("foo", "bar", new Revision(4), "summary", "detail", Markup.MARKDOWN,
+                              ImmutableList.of(Change.ofTextUpsert("/a.txt", "a"))).join())
+                .isEqualTo(pushResult);
+
+        // On successful push, latest known revision must be remembered.
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(pushResult.revision());
+
+        verify(delegate, times(3)).push("foo", "bar", new Revision(4), "summary", "detail", Markup.MARKDOWN,
+                                        ImmutableList.of(Change.ofTextUpsert("/a.txt", "a")));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void watchRepository() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        // Make sure `watchRepository()` remembers the latest revision.
+        final Revision latestRevision = new Revision(3);
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(completedFuture(Revision.INIT));
+        when(delegate.watchRepository(any(), any(), any(), any(), anyLong()))
+                .thenReturn(completedFuture(latestRevision));
+
+        assertThat(dogma.watchRepository("foo", "bar", Revision.INIT, "/**", 10000L).join())
+                .isEqualTo(latestRevision);
+
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.INIT);
+        verify(delegate, times(1)).watchRepository("foo", "bar", Revision.INIT, "/**", 10000L);
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+
+        // Make sure `getFile()` at HEAD revision does not fetch an outdated entry.
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(completedFuture(latestRevision));
+        when(delegate.getFile(any(), any(), any(), any(Query.class)))
+                .thenReturn(exceptionallyCompletedFuture(new RevisionNotFoundException()),
+                            completedFuture(Entry.ofText(latestRevision, "/a.txt", "a")));
+
+        assertThat(dogma.getFile("foo", "bar", Revision.HEAD, Query.ofText("/a.txt")).join())
+                .isEqualTo(Entry.ofText(latestRevision, "/a.txt", "a"));
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.HEAD);
+        verify(delegate, times(2)).getFile("foo", "bar", latestRevision, Query.ofText("/a.txt"));
+        verifyNoMoreInteractions(delegate);
+    }
+
+    @Test
+    public void watchFile() {
+        final CentralDogma delegate = mock(CentralDogma.class);
+        final ReplicationLagTolerantCentralDogma dogma =
+                new ReplicationLagTolerantCentralDogma(executor, delegate, 3, 0);
+
+        // Make sure `watchFile()` remembers the latest revision.
+        final Revision latestRevision = new Revision(3);
+        final Entry<String> latestEntry = Entry.ofText(latestRevision, "/a.txt", "a");
+        when(delegate.normalizeRevision(any(), any(), any()))
+                .thenReturn(completedFuture(Revision.INIT));
+        when(delegate.watchFile(any(), any(), any(), (Query<String>) any(), anyLong()))
+                .thenReturn(completedFuture(latestEntry));
+
+        assertThat(dogma.watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L).join())
+                .isEqualTo(latestEntry);
+
+        assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
+
+        verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.INIT);
+        verify(delegate, times(1)).watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L);
+        verifyNoMoreInteractions(delegate);
+        reset(delegate);
+    }
+}

--- a/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.AfterClass;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;


### PR DESCRIPTION
Motivation:

A client sometimes gets different entries from different replicas in the
same Central Dogma cluster, mainly due to replication lag, i.e. Even if
you learned that the latest revision of a repository in replica A is 42,
you may fail to get a file at revision 42 from replica B.

Currently, in such a case, our Java client simply fails with
`RevisionNotFoundException`, which is confusing to our users.

We could instead keep the latest known revision numbers of the
repositories and retry a few more times when it is certain that a
`RevisionNotFoundException` was raised due to the replication lag.

Modifications:

- Make all shortcut methods in `CentralDogma` final in
  `AbstractCentralDogma` so that a dev can focus on less number of
  methods.
- Add `ReplicationLagTolerantCentralDogma`
- Add the properties related with replication lag tolerance to
  `AbstractCentralDogmaBuilder`:
  - `maxRetriesOnReplicationLag`
  - `retryIntervalOnReplicationLag`

Result:

- Replication lag is detected and the request is retried automatically.
- Fixes #435