### PR TITLE
Respond '204 No Content' when attempting to get no content.

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/Entry.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Entry.java
@@ -171,7 +171,7 @@ public final class Entry<T> implements ContentHolder<T> {
     @Override
     public T content() {
         if (content == null) {
-            throw new IllegalStateException(type() + " does not have content");
+            throw new EntryNoContentException(type, revision, path);
         }
         return content;
     }

--- a/common/src/main/java/com/linecorp/centraldogma/common/EntryNoContentException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/EntryNoContentException.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.common;
+
+/**
+ * A {@link CentralDogmaException} that is raised when attempted to access content in no-content entry.
+ */
+public class EntryNoContentException extends CentralDogmaException {
+
+    private static final long serialVersionUID = -5883457273730768714L;
+
+    /**
+     * Creates a new instance.
+     */
+    public EntryNoContentException() {}
+
+    /**
+     * Creates a new instance.
+     */
+    public EntryNoContentException(EntryType type, Revision revision, String path) {
+        this(path + " (type: " + type + ", revision: " + revision.text() + ')');
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public EntryNoContentException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public EntryNoContentException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public EntryNoContentException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     * @param writableStackTrace whether or not the stack trace should be writable
+     */
+    public EntryNoContentException(String message, boolean writableStackTrace) {
+        super(message, writableStackTrace);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected EntryNoContentException(String message, Throwable cause, boolean enableSuppression,
+                                      boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/common/src/main/java/com/linecorp/centraldogma/common/EntryNoContentException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/EntryNoContentException.java
@@ -17,7 +17,7 @@
 package com.linecorp.centraldogma.common;
 
 /**
- * A {@link CentralDogmaException} that is raised when attempted to access content in no-content entry.
+ * A {@link CentralDogmaException} that is raised when attempted to retrieve the content from a directory entry.
  */
 public class EntryNoContentException extends CentralDogmaException {
 

--- a/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
@@ -35,11 +35,11 @@ public class EntryTest {
         assertThat(e.revision()).isEqualTo(new Revision(1));
         assertThat(e.hasContent()).isFalse();
         e.ifHasContent(unused -> fail());
-        assertThatThrownBy(e::content).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(e::contentAsJson).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(e::contentAsText).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(e::contentAsPrettyText).isInstanceOf(IllegalStateException.class);
-        assertThatThrownBy(() -> e.contentAsJson(JsonNode.class)).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(e::content).isInstanceOf(EntryNoContentException.class);
+        assertThatThrownBy(e::contentAsJson).isInstanceOf(EntryNoContentException.class);
+        assertThatThrownBy(e::contentAsText).isInstanceOf(EntryNoContentException.class);
+        assertThatThrownBy(e::contentAsPrettyText).isInstanceOf(EntryNoContentException.class);
+        assertThatThrownBy(() -> e.contentAsJson(JsonNode.class)).isInstanceOf(EntryNoContentException.class);
 
         // directory vs. directory
         final Entry<Void> e2 = Entry.ofDirectory(new Revision(1), "/");

--- a/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/FileManagementTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryNoContentException;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Revision;
 
@@ -80,7 +81,7 @@ public class FileManagementTest extends AbstractMultiClientTest {
         assertThat(dir.type()).isEqualTo(EntryType.DIRECTORY);
         assertThat(dir.path()).isEqualTo(testRootWithoutSlash);
         assertThat(dir.hasContent()).isFalse();
-        assertThatThrownBy(dir::content).isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(dir::content).isInstanceOf(EntryNoContentException.class);
 
         files.values().forEach(f -> {
             if (f.type() != EntryType.DIRECTORY) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -30,6 +30,7 @@ import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.HttpStatusException;
 import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.EntryNoContentException;
 import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.ProjectNotFoundException;
@@ -62,6 +63,9 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                .put(EntryNotFoundException.class,
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.NOT_FOUND, cause,
                                                      "Entry '%s' does not exist.", cause.getMessage()))
+               .put(EntryNoContentException.class,
+                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.NO_CONTENT, cause,
+                                                     "Entry '%s' does not have content.", cause.getMessage()))
                .put(ProjectExistsException.class,
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.CONFLICT, cause,
                                                      "Project '%s' exists already.", cause.getMessage()))

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -64,8 +64,7 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.NOT_FOUND, cause,
                                                      "Entry '%s' does not exist.", cause.getMessage()))
                .put(EntryNoContentException.class,
-                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.NO_CONTENT, cause,
-                                                     "Entry '%s' does not have content.", cause.getMessage()))
+                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.NO_CONTENT, cause))
                .put(ProjectExistsException.class,
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.CONFLICT, cause,
                                                      "Project '%s' exists already.", cause.getMessage()))

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -64,7 +64,7 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.NOT_FOUND, cause,
                                                      "Entry '%s' does not exist.", cause.getMessage()))
                .put(EntryNoContentException.class,
-                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.NO_CONTENT, cause))
+                    (ctx, req, cause) -> HttpResponse.of(HttpStatus.NO_CONTENT))
                .put(ProjectExistsException.class,
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.CONFLICT, cause,
                                                      "Project '%s' exists already.", cause.getMessage()))

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -190,6 +190,8 @@ public final class HttpApiUtil {
 
         // TODO(minwoox) refine the error message
         try {
+            // TODO(trustin): Use HttpStatus.isContentEmpty().
+            //                https://github.com/line/armeria/pull/2058
             if (status == HttpStatus.NO_CONTENT) {
                 return HttpResponse.of(HttpStatus.NO_CONTENT);
             } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -169,8 +169,7 @@ public final class HttpApiUtil {
             case /* NO_CONTENT */ 204:
             case /* RESET_CONTENT */ 205:
             case /* NOT_MODIFIED */ 304:
-                throw new IllegalArgumentException("no-content status can not create a response. status: " +
-                                                   status.code());
+                throw new IllegalArgumentException("Can't create a response with content for: " + status);
         }
 
         final ObjectNode node = JsonNodeFactory.instance.objectNode();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -190,7 +190,11 @@ public final class HttpApiUtil {
 
         // TODO(minwoox) refine the error message
         try {
-            return HttpResponse.of(status, MediaType.JSON_UTF_8, Jackson.writeValueAsBytes(node));
+            if (status == HttpStatus.NO_CONTENT) {
+                return HttpResponse.of(HttpStatus.NO_CONTENT);
+            } else {
+                return HttpResponse.of(status, MediaType.JSON_UTF_8, Jackson.writeValueAsBytes(node));
+            }
         } catch (JsonProcessingException e) {
             // should not reach here
             throw new Error(e);


### PR DESCRIPTION
This is my first PR at Central-Dogma that might be insufficient, Please advise the insufficient part.🙏
(Is it okay for me to send a PR on a defect issue? 👀)

Motivation:
#414

Modifications:
- Added `EntryNoContentException`.
- If the content of the entry is `null`, an `EntryNoContentException` is thrown.
- If occur `EntryNoContentException`, respond `204 No-Content` Response with `No-Body`.

Result:
- If the content of the entry is `null`,  return a `204 No-Content` Response.