### PR TITLE
Remove plugin usage for `com.bmuschko.docker-remote-api`

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -14,7 +14,6 @@ buildscript {
 }
 
 apply plugin: 'com.boazj.log'
-apply plugin: 'com.bmuschko.docker-remote-api'
 
 evaluationDependsOn(':cli')
 evaluationDependsOn(':server')


### PR DESCRIPTION
As related, https://github.com/bmuschko/gradle-docker-plugin/pull/852