### PR TITLE
Add logging to `ReplicationLagTolerantCentralDogma`

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.client.armeria.legacy;
 import java.net.UnknownHostException;
 
 import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.encoding.HttpDecodingClient;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -71,7 +72,13 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
             return dogma;
         } else {
             return new ReplicationLagTolerantCentralDogma(
-                    executor, dogma, maxRetriesOnReplicationLag, retryIntervalOnReplicationLagMillis());
+                    executor, dogma, maxRetriesOnReplicationLag, retryIntervalOnReplicationLagMillis(),
+                    () -> {
+                        // FIXME(trustin): Note that this will always return `null` due to a known limitation
+                        //                 in Armeria: https://github.com/line/armeria/issues/760
+                        final ClientRequestContext ctx = ClientRequestContext.currentOrNull();
+                        return ctx != null ? ctx.remoteAddress() : null;
+                    });
         }
     }
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.client.armeria;
 import java.net.UnknownHostException;
 
 import com.linecorp.armeria.client.ClientBuilder;
+import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.Endpoint;
 import com.linecorp.armeria.client.HttpClient;
 import com.linecorp.armeria.client.encoding.HttpDecodingClient;
@@ -48,7 +49,13 @@ public final class ArmeriaCentralDogmaBuilder
             return dogma;
         } else {
             return new ReplicationLagTolerantCentralDogma(
-                    executor, dogma, maxRetriesOnReplicationLag, retryIntervalOnReplicationLagMillis());
+                    executor, dogma, maxRetriesOnReplicationLag, retryIntervalOnReplicationLagMillis(),
+                    () -> {
+                        // FIXME(trustin): Note that this will always return `null` due to a known limitation
+                        //                 in Armeria: https://github.com/line/armeria/issues/760
+                        final ClientRequestContext ctx = ClientRequestContext.currentOrNull();
+                        return ctx != null ? ctx.remoteAddress() : null;
+                    });
         }
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -261,7 +261,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
 
                     @Override
                     public String toString() {
-                        return "getFile(" + projectName + ", " + repositoryName + ", " +
+                        return "getFiles(" + projectName + ", " + repositoryName + ", " +
                                revision + ", " + pathPattern + ')';
                     }
                 });
@@ -405,7 +405,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "push(" + projectName + ", " + repositoryName + ", " +
-                               baseRevision + ", ...)";
+                               baseRevision + ", " + summary + ", ...)";
                     }
                 },
                 pushRetryPredicate(projectName, repositoryName, baseRevision));
@@ -553,7 +553,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
 
                             @Override
                             public String toString() {
-                                return taskRunner + " with (" + normFromRev + ", " + normToRev + ')';
+                                return taskRunner + " with [" + normFromRev + ", " + normToRev + ']';
                             }
                         },
                         (res, cause) -> {

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -580,7 +580,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
 
                             @Override
                             public String toString() {
-                                return taskRunner + " with (" + normFromRev + ", " + normToRev + ')';
+                                return taskRunner + " with [" + normFromRev + ", " + normToRev + ']';
                             }
                         },
                         (res, cause) -> {


### PR DESCRIPTION
Motivation:

It is currently hard to know how many retries are done by
`ReplicationLagTolerantCentralDogma`, due to lack of logging.

Modifications:

- Log when retrying, giving up retrying or succeeded.

Result:

- Fixes #447
- A user gets enough information to infer why
  `RevisionNotFoundException` occurred.

Known issues:

- Armeria currently does not set the thread-local context for Thrift
  callbacks and `StreamMessage` subscribers, which means
  `currentReplicaHint` will always be `null`.
  - See: https://github.com/line/armeria/issues/760