### PR TITLE
Add Spring Boot settings for replication lag tolerance

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -139,6 +139,17 @@ public class CentralDogmaClientAutoConfiguration {
             builder.profile(springBootProfiles);
         }
 
+        // Replication lag tolerance settings.
+        final Integer maxNumRetriesOnReplicationLag = settings.getMaxNumRetriesOnReplicationLag();
+        if (maxNumRetriesOnReplicationLag != null) {
+            builder.maxNumRetriesOnReplicationLag(maxNumRetriesOnReplicationLag);
+        }
+
+        final Long retryIntervalOnReplicationLagMillis = settings.getRetryIntervalOnReplicationLagMillis();
+        if (retryIntervalOnReplicationLagMillis != null) {
+            builder.retryIntervalOnReplicationLagMillis(retryIntervalOnReplicationLagMillis);
+        }
+
         return builder.build();
     }
 

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -91,6 +91,18 @@ public class CentralDogmaSettings {
     private Boolean useTls;
 
     /**
+     * The maximum number of retries to perform when replication lag is detected.
+     */
+    @Nullable
+    private Integer maxNumRetriesOnReplicationLag;
+
+    /**
+     * The number of milliseconds between retries which occurred due to replication lag.
+     */
+    @Nullable
+    private Long retryIntervalOnReplicationLagMillis;
+
+    /**
      * Returns the Central Dogma client profile name.
      *
      * @return {@code null} if not specified.
@@ -176,6 +188,40 @@ public class CentralDogmaSettings {
         this.useTls = useTls;
     }
 
+    /**
+     * Returns the maximum number of retries to perform when replication lag is detected.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public Integer getMaxNumRetriesOnReplicationLag() {
+        return maxNumRetriesOnReplicationLag;
+    }
+
+    /**
+     * Sets the maximum number of retries to perform when replication lag is detected.
+     */
+    public void setMaxNumRetriesOnReplicationLag(@Nullable Integer maxNumRetriesOnReplicationLag) {
+        this.maxNumRetriesOnReplicationLag = maxNumRetriesOnReplicationLag;
+    }
+
+    /**
+     * Returns the number of milliseconds between retries which occurred due to replication lag.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public Long getRetryIntervalOnReplicationLagMillis() {
+        return retryIntervalOnReplicationLagMillis;
+    }
+
+    /**
+     * Sets the number of milliseconds between retries which occurred due to replication lag.
+     */
+    public void setRetryIntervalOnReplicationLagMillis(@Nullable Long retryIntervalOnReplicationLagMillis) {
+        this.retryIntervalOnReplicationLagMillis = retryIntervalOnReplicationLagMillis;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
@@ -184,6 +230,8 @@ public class CentralDogmaSettings {
                           .add("accessToken", accessToken != null ? "********" : null)
                           .add("healthCheckIntervalMillis", healthCheckIntervalMillis)
                           .add("useTls", useTls)
+                          .add("maxNumRetriesOnReplicationLag", maxNumRetriesOnReplicationLag)
+                          .add("retryIntervalOnReplicationLagMillis", retryIntervalOnReplicationLagMillis)
                           .toString();
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
@@ -54,7 +54,9 @@ public class CentralDogmaClientAutoConfigurationOtherPropsTest {
         assertThat(settings.getHosts()).isNull();
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isTrue();
-        assertThat(settings.getHealthCheckIntervalMillis()).isEqualTo(60000);
+        assertThat(settings.getHealthCheckIntervalMillis()).isEqualTo(60000L);
         assertThat(settings.getAccessToken()).isEqualTo("my-dogma-access-token");
+        assertThat(settings.getMaxNumRetriesOnReplicationLag()).isEqualTo(42);
+        assertThat(settings.getRetryIntervalOnReplicationLagMillis()).isEqualTo(10000L);
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
@@ -55,5 +55,7 @@ public class CentralDogmaClientAutoConfigurationProfileTest {
         assertThat(settings.getProfile()).isEqualTo("myprofile");
         assertThat(settings.getUseTls()).isNull();
         assertThat(settings.getHealthCheckIntervalMillis()).isNull();
+        assertThat(settings.getMaxNumRetriesOnReplicationLag()).isNull();
+        assertThat(settings.getRetryIntervalOnReplicationLagMillis()).isNull();
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
@@ -55,5 +55,7 @@ public class CentralDogmaClientAutoConfigurationSpringProfileTest {
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isNull();
         assertThat(settings.getHealthCheckIntervalMillis()).isNull();
+        assertThat(settings.getMaxNumRetriesOnReplicationLag()).isNull();
+        assertThat(settings.getRetryIntervalOnReplicationLagMillis()).isNull();
     }
 }

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
@@ -2,3 +2,5 @@ centraldogma:
   use-tls: true
   health-check-interval-millis: 60000
   accessToken: my-dogma-access-token
+  max-num-retries-on-replication-lag: 42
+  retry-interval-on-replication-lag-millis: 10000


### PR DESCRIPTION
Motivation:

It is currently impossible for a user to configure the `CentralDogma`
client's replication lag tolerance settings via Spring Boot integration.

Modifications:

- Add two properties to `CentralDogmaSettings`.

Result:

- Fixes #449
- A user can configure the replication lag tolerance settings via Spring
  Boot integration.