### PR TITLE
Simplified checking of empty content http-status.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -160,7 +160,8 @@ public final class HttpApiUtil {
 
     private static HttpResponse newResponse0(RequestContext ctx, HttpStatus status,
                                              @Nullable Throwable cause, @Nullable String message) {
-        checkArgument(!status.isContentAlwaysEmpty(), "invalid status code. status: %s", status.code());
+        checkArgument(!status.isContentAlwaysEmpty(),
+                      "status: %s (expected: a status with non-empty content)", status);
 
         final ObjectNode node = JsonNodeFactory.instance.objectNode();
         if (cause != null) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.HttpStatusClass;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
@@ -161,16 +160,7 @@ public final class HttpApiUtil {
 
     private static HttpResponse newResponse0(RequestContext ctx, HttpStatus status,
                                              @Nullable Throwable cause, @Nullable String message) {
-        // TODO(trustin): Use HttpStatus.isContentEmpty().
-        //                https://github.com/line/armeria/pull/2058
-        checkArgument(!HttpStatusClass.INFORMATIONAL.contains(status.code()),
-                      "invalid status code. status: %d", status.code());
-        switch (status.code()) {
-            case /* NO_CONTENT */ 204:
-            case /* RESET_CONTENT */ 205:
-            case /* NOT_MODIFIED */ 304:
-                throw new IllegalArgumentException("Can't create a response with content for: " + status);
-        }
+        checkArgument(!status.isContentAlwaysEmpty(), "invalid status code. status: %s", status.code());
 
         final ObjectNode node = JsonNodeFactory.instance.objectNode();
         if (cause != null) {


### PR DESCRIPTION
Hi, I did a simple modify related to the work that I've done before.
(It wasn't my name's `TODO`, but I kept thinking. 😅)

Motivation:
- Dependency-version has been updated `(Armeria : 0.91.0 -> 0.92.0)`, 
and I thought now we can use the `HttpStatus.isContentAlwaysEmpty()` in checking of http-status.

Modifications:
- Simplified the checking of http-status of empty-content.

Related-Links:
- https://github.com/line/centraldogma/pull/442
- https://github.com/line/armeria/pull/2058
