### PR TITLE
Allow colon for json path

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -42,10 +42,10 @@ public final class Util {
     private static final Pattern FILE_PATH_PATTERN = Pattern.compile(
             "^(?:/[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)+$");
     private static final Pattern JSON_FILE_PATH_PATTERN = Pattern.compile(
-            "^(?:/[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)+\\.(?i)json$");
+            "^(?:/[-_0-9a-zA-Z](?:[-_.:0-9a-zA-Z]*[-_:0-9a-zA-Z])?)+\\.(?i)json$");
     private static final Pattern DIR_PATH_PATTERN = Pattern.compile(
             "^(?:/[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)*/?$");
-    private static final Pattern PATH_PATTERN_PATTERN = Pattern.compile("^[- /*_.,0-9a-zA-Z]+$");
+    private static final Pattern PATH_PATTERN_PATTERN = Pattern.compile("^[- /*_.,:0-9a-zA-Z]+$");
     private static final Pattern EMAIL_PATTERN = Pattern.compile(
             "^[_A-Za-z0-9-+]+(?:\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(?:\\.[A-Za-z0-9]+)*(?:\\.[A-Za-z]{2,})$");
     private static final Pattern GENERAL_EMAIL_PATTERN = Pattern.compile(


### PR DESCRIPTION
This is a PR for accepting colons for path names. (specifically, our use case is to create json files like `localhost:8080.json`)

Let me know if this is something you be open to accepting, and I will make this a serious PR w/ test cases, etc :)