### PR TITLE
Move down the GitHub corner on mobile view

### DIFF
--- a/site/src/sphinx/_static/overrides.css
+++ b/site/src/sphinx/_static/overrides.css
@@ -80,20 +80,6 @@ html, body, .wy-grid-for-nav {
   height: 1.45em;
 }
 
-/* Hide the Github fork ribbon on mobile view. */
-@media screen and (max-width: 768px) {
-  .github-fork-ribbon {
-    display: none;
-  }
-}
-
-/* Move the right-side breadcrumb a little bit left so that it does not overlap with the Github fork ribbon. */
-@media screen and (min-width: 769px) {
-  .wy-breadcrumbs-aside {
-    padding-right: 64px;
-  }
-}
-
 .wy-breadcrumbs-aside {
   margin-top: 0.225em;
 }
@@ -318,6 +304,12 @@ td.hljs-ln-code {
   }
   .github-corner .octo-arm {
     animation: octocat-wave 560ms ease-in-out
+  }
+}
+
+@media screen and (max-width: 768px) {
+  .github-corner > svg {
+    top: 50px;
   }
 }
 /* GitHub Corners style ends */


### PR DESCRIPTION
Motivation:

On mobile view, the GitHub corner covers the hamburger button when the
menu is open.

Modification:

Move down the GitHub corner so that it never overlaps with the hamburger
button regardless whether the menu is open or not.

Result:

Better mobile web site experience