### PR TITLE
Use `com.bmuschko.docker-remote-api` plugin again

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -14,6 +14,7 @@ buildscript {
 }
 
 apply plugin: 'com.boazj.log'
+apply plugin: 'com.bmuschko.docker-remote-api'
 
 evaluationDependsOn(':cli')
 evaluationDependsOn(':server')


### PR DESCRIPTION
Motivation:
I removed the plugin in #448 because I thought that was the problem while I was deploying Central Dogma.
But it was not a problem. It seems like that `gradle-docker-plugin` 5.1.0 requires higher Gradle version we used.
After I upgraded the Gradle version from 5.5.1 to 5.6.2, the problem is gone.
So I put this plugin back.