### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     dependencies {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
         classpath 'io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE'
-        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.4.8'
+        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
     }
 }
 

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,7 +4,7 @@
 #
 boms:
 - com.fasterxml.jackson:jackson-bom:2.10.0
-- com.linecorp.armeria:armeria-bom:0.94.0
+- com.linecorp.armeria:armeria-bom:0.95.0
 
 ch.qos.logback:
   logback-classic:
@@ -20,7 +20,7 @@ com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
 
 com.bmuschko:
-  gradle-docker-plugin: { version: '5.1.0' }
+  gradle-docker-plugin: { version: '5.3.0' }
 
 com.craigburke.gradle:
   client-dependencies: { version: '1.4.1' }
@@ -36,13 +36,13 @@ com.cronutils:
 com.fasterxml.jackson.core:
   jackson-annotations:
     javadocs:
-    - https://fasterxml.github.io/jackson-annotations/javadoc/2.9/
+    - https://fasterxml.github.io/jackson-annotations/javadoc/2.10/
   jackson-core:
     javadocs:
-    - https://fasterxml.github.io/jackson-core/javadoc/2.9/
+    - https://fasterxml.github.io/jackson-core/javadoc/2.10/
   jackson-databind:
     javadocs:
-    - https://fasterxml.github.io/jackson-databind/javadoc/2.9/
+    - https://fasterxml.github.io/jackson-databind/javadoc/2.10/
 
 com.github.ben-manes.caffeine:
   caffeine:
@@ -107,7 +107,7 @@ com.linecorp.armeria:
     - https://line.github.io/armeria/apidocs/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.25' }
+  checkstyle: { version: '8.26' }
 
 com.spotify:
   completable-futures:
@@ -151,14 +151,14 @@ kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.6.1' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.4.8' }
+  jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.8.1' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.11.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
-  proguard-gradle: { version: '6.1.1' }
+  proguard-gradle: { version: '6.2.0' }
 
 org.apache.curator:
   curator-recipes:
@@ -182,7 +182,7 @@ org.apache.thrift:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.5.5'
+    version: '3.5.6'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j
@@ -190,22 +190,22 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.13.2' }
+  assertj-core: { version: '3.14.0' }
 
 org.awaitility:
   awaitility: { version: '4.0.1' }
 
 org.hamcrest:
-  hamcrest-library: { version: '2.1' }
+  hamcrest-library: { version: '2.2' }
 
 org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: '5.5.0.201909110433-r' }
+  org.eclipse.jgit: { version: '5.5.1.201910021850-r' }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.0.17.Final' }
+  hibernate-validator: { version: '6.1.0.Final' }
 
 org.javassist:
   javassist: { version: '3.26.0-GA' }
@@ -221,7 +221,7 @@ org.openjdk.jmh:
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.28' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.29' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -239,7 +239,7 @@ org.springframework.boot:
   spring-boot-gradle-plugin: { version: *SPRING_BOOT_VERSION }
 
 org.quartz-scheduler:
-  quartz: { version: '2.3.1' }
+  quartz: { version: '2.3.2' }
 
 org.testng:
   testng: { version: '7.0.0' }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Armeria 0.94.0 -> 0.95.0
- AssertJ 3.13.2 -> 3.14.0
- Checkstyle 8.25 -> 8.26
- Gradle 5.6.2 -> 5.6.3
- gradle-docker-plugin 5.1.0 -> 5.3.0
- Hamcrest 2.1 -> 2.2
- hibernate-validator 6.0.17.Final -> 6.1.0.Final
- jGit 5.5.0.201909110433-r -> 5.5.1.201910021850-r
- jmh-gradle-plugin 0.4.8 -> 0.5.0
- json-unit 2.8.1 -> 2.11.0
- Proguard 6.1.1 -> 6.2.0
- Quartz 2.3.1 -> 2.3.2
- Slf4j 1.7.28 -> 1.7.29
- ZooKeeper 3.5.5 -> 3.5.6