### PR TITLE
Update Slack shared invites and use `rel=nofollow` / Update `CON…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,15 @@
 
 First of all, thank you so much for taking your time to contribute! Central Dogma is not very different from any other open source projects you are aware of. It will be amazing if you could help us by doing any of the following:
 
+- Join [our Slack workspace](https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWFhOWU2NGZhNDk3MjBmNzczZDYyZjRmMTI1MzdiNGI3OTcwNWZlOTkyY2U3Nzk4YTM2NzQ2NGJhMjQ1NzJlNzQ) to chat with us.
 - File an issue in [the issue tracker](https://github.com/line/centraldogma/issues) to report bugs and propose new features and improvements.
 - Ask a question by creating a new issue in [the issue tracker](https://github.com/line/centraldogma/issues).
   - Browse [the list of previously answered questions](https://github.com/line/centraldogma/issues?q=label%3Aquestion-answered).
 - Contribute your work by sending [a pull request](https://github.com/line/centraldogma/pulls).
+
+### Build requirements
+
+- [OpenJDK 11 (or later)](https://adoptopenjdk.net/)
 
 ### Contributor license agreement
 
@@ -21,7 +26,7 @@ We expect contributors to follow [our code of conduct](https://github.com/line/c
 
 You can import Central Dogma into your IDE ([IntelliJ IDEA](https://www.jetbrains.com/idea/) or [Eclipse](https://www.eclipse.org/)) as a Gradle project.
 
-- IntelliJ IDEA - See [Importing Project from Gradle Model](https://www.jetbrains.com/help/idea/2016.3/importing-project-from-gradle-model.html)
+- IntelliJ IDEA - See [Importing Project from Gradle Model](https://www.jetbrains.com/help/idea/gradle.html#gradle_import_project_start)
 - Eclipse - Use [Buildship Gradle Integration](https://marketplace.eclipse.org/content/buildship-gradle-integration)
 
 After importing the project, import the IDE settings as well.
@@ -29,8 +34,10 @@ After importing the project, import the IDE settings as well.
 #### IntelliJ IDEA
 
 - [`settings.jar`](https://raw.githubusercontent.com/line/centraldogma/master/settings/intellij_idea/settings.jar) -
-  See [Importing settings from a JAR archive](https://www.jetbrains.com/help/idea/2016.3/exporting-and-importing-settings.html#d2016665e55).
+  See [Import settings from a ZIP archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#7a4f08b8).
 - Make sure to use 'LINE OSS' code style and inspection profile.
+  - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`.
+  - Go to `Preferences` > `Editors` > `Inspections` and set `Profile` option to `LINE OSS`.
 - Although optional, if you want to run Checkstyle from IDEA, install the
   [Checkstyle-IDEA plugin](https://github.com/jshiell/checkstyle-idea), import and activate
   the rule file at `settings/checkstyle/checkstyle.xml`.
@@ -51,12 +58,17 @@ After importing the project, import the IDE settings as well.
     <img src="https://raw.githubusercontent.com/line/centraldogma/master/settings/eclipse/save_actions.png">
   </details>
 - Although optional, if you want to run Checkstyle from Eclipse, install the
-  [Eclipse Checkstyle Plugin](http://eclipse-cs.sourceforge.net/), import and activate
+  [Eclipse Checkstyle Plugin](https://eclipse-cs.sourceforge.net/), import and activate
   the rule file at `settings/checkstyle/checkstyle.xml`.
   - Set the 'Type' to 'External Configuration File'.
   - Click the 'Additional properties...' button. A new dialog will show up.
   - Click the 'Find unresolved properties' button. It will find the `checkstyleConfigDir` property.
     Choose 'Yes' to add it. Set it to `<project root path>/settings/checkstyle`.
+
+### Configure `-parameters` javac option
+
+You can configure your build tool and IDE to add `-parameters` javac option.
+Please refer to [Configure `-parameters` javac option](https://line.github.io/armeria/setup.html#configure-parameters-javac-option) for more information.
 
 ### Checklist for your pull request
 
@@ -181,7 +193,7 @@ public final class MyClass {
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public boolean equals(@Nullable Object obj) {
         ... usual type check ...
         // OK
         return name.equals(((MyClass) obj).name);

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ ./gradlew build
 
 Just [create a new issue](https://github.com/line/centraldogma/issues/new) to ask a question, and browse [the list of previously answered questions](https://github.com/line/centraldogma/issues?q=label%3Aquestion-answered).
 
-We also have [a Slack workspace](https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWRlZTZmZDljNDY3OTBmN2Y1NDAwMGUzMTMzNmFlOTYzNzYyNDNmNmM5YTk3YmExM2M4NGRkOTY2NTE1MDJhODY).
+We also have [a Slack workspace](https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWFhOWU2NGZhNDk3MjBmNzczZDYyZjRmMTI1MzdiNGI3OTcwNWZlOTkyY2U3Nzk4YTM2NzQ2NGJhMjQ1NzJlNzQ).
 
 ## How to contribute
 

--- a/site/src/sphinx/_static/add_badges.js
+++ b/site/src/sphinx/_static/add_badges.js
@@ -8,7 +8,7 @@ function addBadge(parent, src, href) {
     var a = document.createElement('a');
     a.href = href;
     a.target = '_blank';
-    a.rel = 'noopener';
+    a.rel = 'nofollow noopener';
     a.appendChild(obj);
     parent.appendChild(a);
   } else {
@@ -25,7 +25,7 @@ function addBadges(parent) {
   div.className = 'project-badges';
   addBadge(div, 'https://img.shields.io/github/stars/line/centraldogma.svg?style=social');
   addBadge(div, 'https://img.shields.io/badge/chat-on%20slack-brightgreen.svg?style=social',
-    'https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWRlZTZmZDljNDY3OTBmN2Y1NDAwMGUzMTMzNmFlOTYzNzYyNDNmNmM5YTk3YmExM2M4NGRkOTY2NTE1MDJhODY');
+    'https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWFhOWU2NGZhNDk3MjBmNzczZDYyZjRmMTI1MzdiNGI3OTcwNWZlOTkyY2U3Nzk4YTM2NzQ2NGJhMjQ1NzJlNzQ');
   addBadge(div, 'https://img.shields.io/travis/line/centraldogma/master.svg?style=flat-square',
     'https://travis-ci.org/line/centraldogma');
   addBadge(div, 'https://img.shields.io/appveyor/ci/line/centraldogma/master.svg?label=appveyor&style=flat-square',

--- a/site/src/sphinx/known-issues.rst
+++ b/site/src/sphinx/known-issues.rst
@@ -31,4 +31,4 @@ Previously known issues
   - The fixed version: 0.41.0 and later.
   - Please check `CVE-2019-6002 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6002>`_ to get more information.
   - If you found security bugs, please let us know  `dl_oss_dev@linecorp.com <mailto:dl_oss_dev@linecorp.com>`_ or
-    send `Slack DM <https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWRlZTZmZDljNDY3OTBmN2Y1NDAwMGUzMTMzNmFlOTYzNzYyNDNmNmM5YTk3YmExM2M4NGRkOTY2NTE1MDJhODY>`_ to maintainer.
+    send `Slack DM <https://join.slack.com/t/central-dogma/shared_invite/enQtNjA5NDk5MTExODQzLWFhOWU2NGZhNDk3MjBmNzczZDYyZjRmMTI1MzdiNGI3OTcwNWZlOTkyY2U3Nzk4YTM2NzQ2NGJhMjQ1NzJlNzQ>`_ to maintainer.


### PR DESCRIPTION
…TING.md`

Motivation:

- Our Slack shared invite link expires sooner than expected. It may be
  because some bots are visiting the invite link following the link.
- Our `CONTRIBUTING.md` is out of date.

Modifications:

- Add `rel=nofollow` to the badge links
- Apply the changes we made for the `CONTRIBUTING.md` in Armeria to the
  Central Dogma `CONTRIBUTING.md`

Result:

- The Slack shared invite link may expire later.
- `CONTRIBUTING.md` provides up-to-date information about setting up the
  environment, etc.