### PR TITLE
Unwrap CompletionException to check actual thrown exception

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -39,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.spotify.futures.CompletableFutures;
 
@@ -681,6 +683,9 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
             String projectName, String repositoryName, Revision revision, Throwable cause) {
 
         requireNonNull(cause, "cause");
+        if (cause instanceof CompletionException) {
+            cause = Throwables.getRootCause(cause);
+        }
 
         if (!(cause instanceof RevisionNotFoundException)) {
             return false;

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -27,6 +27,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
@@ -40,7 +41,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.spotify.futures.CompletableFutures;
 
@@ -630,10 +630,10 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                 } else if (logger.isDebugEnabled()) {
                     if (currentReplicaHint != null) {
                         logger.debug("[{}] Retrieved the up-to-date data after {} retries: {} => {}",
-                                    currentReplicaHint, attemptsSoFar, taskRunner, resultOrCause(res, cause));
+                                     currentReplicaHint, attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     } else {
                         logger.debug("Retrieved the up-to-date data after {} retries: {} => {}",
-                                    attemptsSoFar, taskRunner, resultOrCause(res, cause));
+                                     attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     }
                 }
 
@@ -676,17 +676,27 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     }
 
     /**
+     * Returns the cause of the specified {@code throwable} peeling it recursively, if it is one of the
+     * {@link CompletionException}, {@link ExecutionException}. Otherwise returns the {@code throwable}.
+     */
+    private static Throwable peel(Throwable throwable) {
+        Throwable cause = throwable.getCause();
+        while (cause != null && cause != throwable &&
+               (throwable instanceof CompletionException || throwable instanceof ExecutionException)) {
+            throwable = cause;
+            cause = throwable.getCause();
+        }
+        return throwable;
+    }
+
+    /**
      * Returns {@code true} to indicate that the request must be retried if {@code cause} is
      * a {@link RevisionNotFoundException} and the specified {@link Revision} is supposed to exist.
      */
     private boolean handleRevisionNotFound(
             String projectName, String repositoryName, Revision revision, Throwable cause) {
-
         requireNonNull(cause, "cause");
-        if (cause instanceof CompletionException) {
-            cause = Throwables.getRootCause(cause);
-        }
-
+        cause = peel(cause);
         if (!(cause instanceof RevisionNotFoundException)) {
             return false;
         }

--- a/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
@@ -30,11 +30,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.junit.AfterClass;


### PR DESCRIPTION
Motivation:
- An exception which is thrown at `CompletableFuture` callback handler will be wrapped with `CompletionException`.
- `ReplicationLagTolerantCentralDogma` does not retry when `CompletionException`-wrapped `RevisionNotFoundException` is thrown

Changes:
- Unwrap `CompletionException`

Results:
- Handle replication lag correctly