### PR TITLE
Add `Central Dogma` to client's warn, error messages

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -106,11 +106,11 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
                 }
                 setEndpoints(newEndpoints);
             } catch (Exception e) {
-                logger.warn("Failed to refresh the endpoint list at Central Dogma.", e);
+                logger.warn("Failed to re-retrieve the endpoint list from Central Dogma.", e);
             }
         });
         instanceListWatcher.initialValueFuture().exceptionally(e -> {
-            logger.warn("Failed to initialize instance list at Central Dogma.", e);
+            logger.warn("Failed to retrieve the initial instance list from Central Dogma.", e);
             return null;
         });
     }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -106,11 +106,11 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
                 }
                 setEndpoints(newEndpoints);
             } catch (Exception e) {
-                logger.warn("Failed to refresh the endpoint list.", e);
+                logger.warn("Failed to refresh the endpoint list at Central Dogma.", e);
             }
         });
         instanceListWatcher.initialValueFuture().exceptionally(e -> {
-            logger.warn("Failed to initialize instance list.", e);
+            logger.warn("Failed to initialize instance list at Central Dogma.", e);
             return null;
         });
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -265,13 +265,13 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
                  }
 
                  if (!logged) {
-                     logger.warn("Failed to watch a file ({}/{}{}); trying again",
+                     logger.warn("Failed to watch a file ({}/{}{}) at Central Dogma; trying again",
                                  projectName, repositoryName, pathPattern, cause);
                  }
 
                  scheduleWatch(numAttemptsSoFar + 1);
              } catch (Throwable t) {
-                 logger.error("Unexpected exception while watching a file:", t);
+                 logger.error("Unexpected exception while watching a file at Central Dogma:", t);
              }
              return null;
          });

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -621,10 +621,10 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
             if (!retryRequired || nextAttemptsSoFar > maxRetries) {
                 if (retryRequired) {
                     if (currentReplicaHint != null) {
-                        logger.warn("[{}] Failed to retrieve the up-to-date data after {} retries: {} => {}",
+                        logger.warn("[{}] Failed to retrieve the up-to-date data at Central Dogma after {} retries: {} => {}",
                                     currentReplicaHint, attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     } else {
-                        logger.warn("Failed to retrieve the up-to-date data after {} retries: {} => {}",
+                        logger.warn("Failed to retrieve the up-to-date data at Central Dogma after {} retries: {} => {}",
                                     attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     }
                 } else if (logger.isDebugEnabled()) {

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -621,10 +621,12 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
             if (!retryRequired || nextAttemptsSoFar > maxRetries) {
                 if (retryRequired) {
                     if (currentReplicaHint != null) {
-                        logger.warn("[{}] Failed to retrieve the up-to-date data at Central Dogma after {} retries: {} => {}",
+                        logger.warn("[{}] Failed to retrieve the up-to-date data from Central Dogma " +
+                                    "after {} retries: {} => {}",
                                     currentReplicaHint, attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     } else {
-                        logger.warn("Failed to retrieve the up-to-date data at Central Dogma after {} retries: {} => {}",
+                        logger.warn("Failed to retrieve the up-to-date data from Central Dogma " +
+                                    "after {} retries: {} => {}",
                                     attemptsSoFar, taskRunner, resultOrCause(res, cause));
                     }
                 } else if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Motivation:
We have been informed that Central Dogma message itself is indistinguishable from other messages.

```
Failed to watch a file (/path/to/file); trying again
```

Modification:
* Add `Central Dogma` to client warn and error messages

Result:
A user can easily distinguish Central Dogma client warn and error log messages from other messages.

/cc: @tokuhirom 