### PR TITLE
Migrate ProjectManagerRule to JUnit 5

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.api;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,9 +22,9 @@ import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
 
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.ServiceRequestContext;
@@ -32,14 +33,14 @@ import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.MigrationUtil;
 import com.linecorp.centraldogma.server.metadata.Token;
 import com.linecorp.centraldogma.server.metadata.User;
-import com.linecorp.centraldogma.testing.internal.ProjectManagerRule;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 import io.netty.util.internal.StringUtil;
 
-public class TokenServiceTest {
+class TokenServiceTest {
 
-    @ClassRule
-    public static final ProjectManagerRule rule = new ProjectManagerRule() {
+    @RegisterExtension
+    static final ProjectManagerExtension manager = new ProjectManagerExtension() {
         @Override
         protected void afterExecutorStarted() {
             MigrationUtil.migrate(projectManager(), executor());
@@ -55,14 +56,14 @@ public class TokenServiceTest {
 
     private final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
 
-    @BeforeClass
-    public static void beforeClass() {
-        tokenService = new TokenService(rule.projectManager(), rule.executor(),
-                                        new MetadataService(rule.projectManager(), rule.executor()));
+    @BeforeAll
+    static void setUp() {
+        tokenService = new TokenService(manager.projectManager(), manager.executor(),
+                                        new MetadataService(manager.projectManager(), manager.executor()));
     }
 
     @Test
-    public void adminToken() {
+    void adminToken() {
         final Token token = tokenService.createToken("forAdmin1", true, adminAuthor, admin).join()
                                         .content().get();
         assertThat(token.isActive()).isTrue();
@@ -86,7 +87,7 @@ public class TokenServiceTest {
     }
 
     @Test
-    public void userToken() {
+    void userToken() {
         final Token userToken1 = tokenService.createToken("forUser1", false, adminAuthor, admin)
                                              .join().content().get();
         final Token userToken2 = tokenService.createToken("forUser2", false, guestAuthor, guest)

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,8 +19,8 @@ package com.linecorp.centraldogma.server.metadata;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
@@ -28,21 +28,26 @@ import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
-import com.linecorp.centraldogma.testing.internal.ProjectManagerRule;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 /**
  * Makes sure {@link MetadataService} adds the default metadata of a repository when the {@code metadata.json}
  * does not contain the repository metadata.
  */
-public class MissingRepositoryMetadataTest {
+class MissingRepositoryMetadataTest {
 
-    @Rule
-    public final ProjectManagerRule rule = new ProjectManagerRule() {
+    @RegisterExtension
+    final ProjectManagerExtension manager = new ProjectManagerExtension() {
         @Override
         protected void afterExecutorStarted() {
             MigrationUtil.migrate(projectManager(), executor());
             // Create a project and its metadata here.
             executor().execute(Command.createProject(AUTHOR, PROJ)).join();
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
         }
     };
 
@@ -50,10 +55,10 @@ public class MissingRepositoryMetadataTest {
     private static final String PROJ = "proj";
 
     @Test
-    public void missingRepositoryMetadata() throws Exception {
-        final ProjectManager pm = rule.projectManager();
+    void missingRepositoryMetadata() {
+        final ProjectManager pm = manager.projectManager();
         final RepositoryManager rm = pm.get(PROJ).repos();
-        final CommandExecutor executor = rule.executor();
+        final CommandExecutor executor = manager.executor();
 
         // Create a new repository without adding metadata.
         rm.create("repo", AUTHOR);

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolder.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.testing.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+
+import javax.annotation.Nullable;
+
+/**
+ * A helper class to handle temporary folders in JUnit {@code Extension}s.
+ */
+public class TemporaryFolder {
+
+    @Nullable
+    private Path root;
+
+    public void create() throws IOException {
+        root = Files.createTempDirectory("centraldogma");
+    }
+
+    public boolean exists() {
+        return root != null;
+    }
+
+    public Path getRoot() {
+        if (root == null) {
+            throw new IllegalStateException("The temporary folder has not been created yet");
+        }
+
+        return root;
+    }
+
+    public Path newFolder() throws IOException {
+        return Files.createTempDirectory(getRoot(), "");
+    }
+
+    public Path newFile() throws IOException {
+        return Files.createTempFile(getRoot(), "", "");
+    }
+
+    public void delete() throws IOException {
+        if (root == null) {
+            return;
+        }
+
+        Files.walk(root)
+             .sorted(Comparator.reverseOrder())
+             .map(Path::toFile)
+             .forEach(File::delete);
+
+        root = null;
+    }
+}

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolder.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolder.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -61,10 +62,11 @@ public class TemporaryFolder {
             return;
         }
 
-        Files.walk(root)
-             .sorted(Comparator.reverseOrder())
-             .map(Path::toFile)
-             .forEach(File::delete);
+        try (Stream<Path> walk = Files.walk(root)) {
+            walk.sorted(Comparator.reverseOrder())
+                .map(Path::toFile)
+                .forEach(File::delete);
+        }
 
         root = null;
     }

--- a/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
+++ b/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.testing.junit;
 
 import java.io.IOException;

--- a/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
+++ b/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
@@ -13,18 +13,13 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.testing.junit;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Comparator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
-
-import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -38,6 +33,7 @@ import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+import com.linecorp.centraldogma.testing.internal.TemporaryFolder;
 
 /**
  * A JUnit {@link Extension} that starts an embedded Central Dogma server.
@@ -59,8 +55,8 @@ import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
 public class CentralDogmaExtension extends AbstractAllOrEachExtension {
 
     private final CentralDogmaRuleDelegate delegate;
-    @Nullable
-    private File dataDir;
+
+    private final TemporaryFolder dataDir = new TemporaryFolder();
 
     /**
      * Creates a new instance with TLS disabled.
@@ -98,16 +94,15 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
 
     @Override
     public void before(ExtensionContext context) throws Exception {
-        createDataDir();
-        assert dataDir != null;
-        delegate.setUp(dataDir);
+        dataDir.create();
+        delegate.setUp(dataDir.getRoot().toFile());
     }
 
     @Override
     public void after(ExtensionContext context) throws Exception {
         stopAsync().whenComplete((unused1, unused2) -> {
             try {
-                deleteDataDir();
+                dataDir.delete();
             } catch (IOException e) {
                 throw new CompletionException(e);
             }
@@ -129,15 +124,15 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
      */
     public final CompletableFuture<Void> startAsync() {
         // Create the root folder first if it doesn't exist.
-        if (dataDir == null) {
+        if (!dataDir.exists()) {
             try {
-                createDataDir();
+                dataDir.create();
             } catch (IOException e) {
                 return CompletableFutures.exceptionallyCompletedFuture(e);
             }
         }
 
-        return delegate.startAsync(dataDir);
+        return delegate.startAsync(dataDir.getRoot().toFile());
     }
 
     /**
@@ -237,21 +232,4 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
      * such as creating a repository and populating sample data.
      */
     protected void scaffold(CentralDogma client) {}
-
-    private void createDataDir() throws IOException {
-        dataDir = Files.createTempDirectory("centraldogma").toFile();
-    }
-
-    private void deleteDataDir() throws IOException {
-        if (dataDir == null) {
-            return;
-        }
-
-        Files.walk(dataDir.toPath())
-             .sorted(Comparator.reverseOrder())
-             .map(Path::toFile)
-             .forEach(File::delete);
-
-        dataDir = null;
-    }
 }


### PR DESCRIPTION
This PR migrates internal `ProjectManagerRule` to JUnit 5.

#### Changes:
- Replace `ProjectManagerRule` with `ProjectManagerExtension`
- Migrate tests using the extension
- Extract common extension logic to `TemporaryFolder`