### PR TITLE
Migrate unit tests to JUnit 5 (Part 1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,7 @@ configure(projectsWithFlags('java')) {
         testCompile 'org.hamcrest:hamcrest-library'
         testCompile 'org.assertj:assertj-core'
         testCompile 'org.mockito:mockito-core'
+        testCompile 'org.mockito:mockito-junit-jupiter'
         testCompile 'org.junit.jupiter:junit-jupiter-api'
         testRuntime 'org.junit.jupiter:junit-jupiter-engine'
         testRuntime 'org.junit.platform:junit-platform-launcher'

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.client.armeria.legacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,9 +30,7 @@ import java.util.Set;
 import org.apache.thrift.async.AsyncMethodCallback;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -72,7 +69,6 @@ import com.linecorp.centraldogma.internal.thrift.Repository;
 import com.linecorp.centraldogma.internal.thrift.WatchFileResult;
 import com.linecorp.centraldogma.internal.thrift.WatchRepositoryResult;
 
-@ExtendWith(MockitoExtension.class)
 class LegacyCentralDogmaTest {
 
     private static final String TIMESTAMP = "2016-01-02T03:04:05Z";

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.client.armeria.legacy;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,12 +29,11 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.thrift.async.AsyncMethodCallback;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -72,24 +72,23 @@ import com.linecorp.centraldogma.internal.thrift.Repository;
 import com.linecorp.centraldogma.internal.thrift.WatchFileResult;
 import com.linecorp.centraldogma.internal.thrift.WatchRepositoryResult;
 
-public class LegacyCentralDogmaTest {
-    private static final String TIMESTAMP = "2016-01-02T03:04:05Z";
+@ExtendWith(MockitoExtension.class)
+class LegacyCentralDogmaTest {
 
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
+    private static final String TIMESTAMP = "2016-01-02T03:04:05Z";
 
     @Mock
     private CentralDogmaService.AsyncIface iface;
 
     private CentralDogma client;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setUp() {
         client = new LegacyCentralDogma(CommonPools.workerGroup(), iface);
     }
 
     @Test
-    public void createProject() throws Exception {
+    void createProject() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
             callback.onComplete(null);
@@ -100,7 +99,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void removeProject() throws Exception {
+    void removeProject() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
             callback.onComplete(null);
@@ -111,7 +110,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void purgeProject() throws Exception {
+    void purgeProject() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
             callback.onComplete(null);
@@ -122,7 +121,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void unremoveProject() throws Exception {
+    void unremoveProject() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(1);
             callback.onComplete(null);
@@ -133,7 +132,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void listProjects() throws Exception {
+    void listProjects() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<Project>> callback = invocation.getArgument(0);
             callback.onComplete(ImmutableList.of(new Project("project")));
@@ -144,7 +143,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void listRemovedProjects() throws Exception {
+    void listRemovedProjects() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Set<String>> callback = invocation.getArgument(0);
             callback.onComplete(ImmutableSet.of("project"));
@@ -155,7 +154,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void createRepository() throws Exception {
+    void createRepository() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(2);
             callback.onComplete(null);
@@ -166,7 +165,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void removeRepository() throws Exception {
+    void removeRepository() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(2);
             callback.onComplete(null);
@@ -177,7 +176,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void purgeRepository() throws Exception {
+    void purgeRepository() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(2);
             callback.onComplete(null);
@@ -188,7 +187,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void unremoveRepository() throws Exception {
+    void unremoveRepository() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Void> callback = invocation.getArgument(2);
             callback.onComplete(null);
@@ -199,7 +198,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void listRepositories() throws Exception {
+    void listRepositories() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<Repository>> callback = invocation.getArgument(1);
             final Repository repository = new Repository("repo").setHead(
@@ -216,7 +215,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void listRemovedRepositories() throws Exception {
+    void listRemovedRepositories() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<Set<String>> callback = invocation.getArgument(1);
             callback.onComplete(ImmutableSet.of("repo"));
@@ -227,7 +226,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void normalizeRevision() throws Exception {
+    void normalizeRevision() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<TRevision> callback = invocation.getArgument(3);
             callback.onComplete(new TRevision(3));
@@ -239,7 +238,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void listFiles() throws Exception {
+    void listFiles() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<TEntry>> callback = invocation.getArgument(4);
             final TEntry entry = new TEntry("/a.txt", TEntryType.TEXT);
@@ -253,13 +252,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getFiles() throws Exception {
-        doAnswer(invocation -> {
-            final AsyncMethodCallback<com.linecorp.centraldogma.internal.thrift.Revision> callback =
-                    invocation.getArgument(3);
-            callback.onComplete(new com.linecorp.centraldogma.internal.thrift.Revision(1, 0));
-            return null;
-        }).when(iface).normalizeRevision(any(), any(), any(), any());
+    void getFiles() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<TEntry>> callback = invocation.getArgument(4);
             final TEntry entry = new TEntry("/b.txt", TEntryType.TEXT);
@@ -273,7 +266,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getHistory() throws Exception {
+    void getHistory() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<TCommit>> callback = invocation.getArgument(5);
             callback.onComplete(ImmutableList.of(new TCommit(
@@ -294,7 +287,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getDiffs() throws Exception {
+    void getDiffs() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<TChange>> callback = invocation.getArgument(5);
             final TChange change = new TChange("/a.txt", ChangeType.UPSERT_TEXT);
@@ -308,7 +301,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getPreviewDiffs() throws Exception {
+    void getPreviewDiffs() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<List<TChange>> callback = invocation.getArgument(4);
             final TChange change = new TChange("/a.txt", ChangeType.UPSERT_TEXT);
@@ -323,7 +316,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void push() throws Exception {
+    void push() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<TCommit> callback = invocation.getArgument(7);
             callback.onComplete(new TCommit(
@@ -345,13 +338,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getFile() throws Exception {
-        doAnswer(invocation -> {
-            final AsyncMethodCallback<com.linecorp.centraldogma.internal.thrift.Revision> callback =
-                    invocation.getArgument(3);
-            callback.onComplete(new com.linecorp.centraldogma.internal.thrift.Revision(1, 0));
-            return null;
-        }).when(iface).normalizeRevision(any(), any(), any(), any());
+    void getFile() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<GetFileResult> callback = invocation.getArgument(4);
             callback.onComplete(new GetFileResult(TEntryType.TEXT, "content"));
@@ -363,13 +350,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void getFile_path() throws Exception {
-        doAnswer(invocation -> {
-            final AsyncMethodCallback<com.linecorp.centraldogma.internal.thrift.Revision> callback =
-                    invocation.getArgument(3);
-            callback.onComplete(new com.linecorp.centraldogma.internal.thrift.Revision(1, 0));
-            return null;
-        }).when(iface).normalizeRevision(any(), any(), any(), any());
+    void getFile_path() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<GetFileResult> callback = invocation.getArgument(4);
             callback.onComplete(new GetFileResult(TEntryType.TEXT, "content"));
@@ -381,7 +362,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void mergeFiles() throws Exception {
+    void mergeFiles() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<MergedEntry> callback = invocation.getArgument(4);
             callback.onComplete(new MergedEntry(new TRevision(1), TEntryType.JSON, "{\"foo\": \"bar\"}",
@@ -399,7 +380,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void diffFile() throws Exception {
+    void diffFile() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<DiffFileResult> callback = invocation.getArgument(5);
             callback.onComplete(new DiffFileResult(ChangeType.UPSERT_TEXT, "some_text"));
@@ -412,7 +393,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void watchRepository() throws Exception {
+    void watchRepository() throws Exception {
         doAnswer(invocation -> {
             final AsyncMethodCallback<WatchRepositoryResult> callback = invocation.getArgument(5);
             callback.onComplete(new WatchRepositoryResult().setRevision(new TRevision(42)));
@@ -424,7 +405,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void watchRepositoryTimedOut() throws Exception {
+    void watchRepositoryTimedOut() throws Exception {
         doAnswer(invocation -> {
             AsyncMethodCallback<WatchRepositoryResult> callback = invocation.getArgument(5);
             callback.onComplete(new WatchRepositoryResult());
@@ -436,7 +417,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void watchFile() throws Exception {
+    void watchFile() throws Exception {
         doAnswer(invocation -> {
             AsyncMethodCallback<WatchFileResult> callback = invocation.getArgument(5);
             callback.onComplete(new WatchFileResult().setRevision(new TRevision(42))
@@ -450,7 +431,7 @@ public class LegacyCentralDogmaTest {
     }
 
     @Test
-    public void watchFileTimedOut() throws Exception {
+    void watchFileTimedOut() throws Exception {
         doAnswer(invocation -> {
             AsyncMethodCallback<WatchFileResult> callback = invocation.getArgument(5);
             callback.onComplete(new WatchFileResult());

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
@@ -24,9 +24,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 
@@ -39,7 +37,6 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
-@ExtendWith(MockitoExtension.class)
 class LegacyCentralDogmaTimeoutSchedulerTest {
 
     @Mock

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,12 +22,11 @@ import static org.mockito.Mockito.verify;
 
 import java.util.List;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 
@@ -40,42 +39,41 @@ import com.linecorp.armeria.common.RpcRequest;
 import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
 
-public class LegacyCentralDogmaTimeoutSchedulerTest {
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
+@ExtendWith(MockitoExtension.class)
+class LegacyCentralDogmaTimeoutSchedulerTest {
 
     @Mock
     private RpcClient client;
 
     private LegacyCentralDogmaTimeoutScheduler decorator;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setUp() {
         decorator = new LegacyCentralDogmaTimeoutScheduler(client);
     }
 
     @Test
-    public void execute() throws Exception {
+    void execute() throws Exception {
         check("listProjects", 1000L, 1L, 1L);
     }
 
     @Test
-    public void execute_watchFile() throws Exception {
+    void execute_watchFile() throws Exception {
         check("watchFile", 1000L, 1L, 1001L);
     }
 
     @Test
-    public void execute_watchRepository() throws Exception {
+    void execute_watchRepository() throws Exception {
         check("watchRepository", 1000L, 1L, 1001L);
     }
 
     @Test
-    public void execute_watch_timeoutOverflow() throws Exception {
+    void execute_watch_timeoutOverflow() throws Exception {
         check("watchRepository", Long.MAX_VALUE - 10, 100L, WatchTimeout.MAX_MILLIS);
     }
 
     @Test
-    public void execute_noTimeout() throws Exception {
+    void execute_noTimeout() throws Exception {
         check("watchFile", 1000L, 0, 0);
     }
 

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilderTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -29,7 +29,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Consumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
@@ -41,12 +41,12 @@ import com.linecorp.armeria.client.endpoint.EndpointGroupRegistry;
 import com.linecorp.armeria.client.endpoint.StaticEndpointGroup;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;
 
-public class ArmeriaCentralDogmaBuilderTest {
+class ArmeriaCentralDogmaBuilderTest {
 
     // Note: This test case relies on http://xip.io/
 
     @Test
-    public void buildingWithProfile() throws Exception {
+    void buildingWithProfile() throws Exception {
         final String groupName = "centraldogma-profile-xip";
         try {
             final ArmeriaCentralDogmaBuilder b = new ArmeriaCentralDogmaBuilder();
@@ -79,7 +79,7 @@ public class ArmeriaCentralDogmaBuilderTest {
     }
 
     @Test
-    public void buildingWithSingleResolvedHost() throws Exception {
+    void buildingWithSingleResolvedHost() throws Exception {
         final long id = AbstractArmeriaCentralDogmaBuilder.nextAnonymousGroupId.get();
         final ArmeriaCentralDogmaBuilder b = new ArmeriaCentralDogmaBuilder();
         b.host("1.2.3.4");
@@ -91,7 +91,7 @@ public class ArmeriaCentralDogmaBuilderTest {
     }
 
     @Test
-    public void buildingWithSingleUnresolvedHost() throws Exception {
+    void buildingWithSingleUnresolvedHost() throws Exception {
         final long id = AbstractArmeriaCentralDogmaBuilder.nextAnonymousGroupId.get();
         final String expectedGroupName = "centraldogma-anonymous-" + id;
 
@@ -110,7 +110,7 @@ public class ArmeriaCentralDogmaBuilderTest {
     }
 
     @Test
-    public void buildingWithMultipleHosts() throws Exception {
+    void buildingWithMultipleHosts() throws Exception {
         final long id = AbstractArmeriaCentralDogmaBuilder.nextAnonymousGroupId.get();
         final String groupName = "centraldogma-anonymous-" + id;
         try {
@@ -161,7 +161,7 @@ public class ArmeriaCentralDogmaBuilderTest {
      * </ol>
      */
     @Test
-    public void newClientBuilderCustomizationOrder() {
+    void newClientBuilderCustomizationOrder() {
         final ClientFactory cf1 = mock(ClientFactory.class);
         final ClientFactory cf2 = mock(ClientFactory.class);
         final ClientFactory cf3 = mock(ClientFactory.class);

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,16 +13,18 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.client.armeria;
 
 import static com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogma.encodePathPattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ArmeriaCentralDogmaTest {
+class ArmeriaCentralDogmaTest {
+
     @Test
-    public void testEncodePathPattern() {
+    void testEncodePathPattern() {
         assertThat(encodePathPattern("/")).isEqualTo("/");
         assertThat(encodePathPattern(" ")).isEqualTo("%20");
         assertThat(encodePathPattern("  ")).isEqualTo("%20%20");

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.client.armeria;
 
 import static com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogma.encodePathPattern;

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/JsonEndpointListDecoderTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/JsonEndpointListDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,17 +28,18 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.Endpoint;
 
-public class JsonEndpointListDecoderTest {
+class JsonEndpointListDecoderTest {
+
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    static List<String> HOST_AND_PORT_LIST = ImmutableList.of(
+    static final List<String> HOST_AND_PORT_LIST = ImmutableList.of(
             "centraldogma-sample001.com",
             "centraldogma-sample001.com:1234",
             "1.2.3.4",
             "1.2.3.4:5678"
     );
 
-    static List<Endpoint> ENDPOINT_LIST = ImmutableList.of(
+    static final List<Endpoint> ENDPOINT_LIST = ImmutableList.of(
             Endpoint.of("centraldogma-sample001.com"),
             Endpoint.of("centraldogma-sample001.com", 1234),
             Endpoint.of("1.2.3.4"),
@@ -46,9 +47,9 @@ public class JsonEndpointListDecoderTest {
     );
 
     @Test
-    public void decode() throws Exception {
-        EndpointListDecoder<JsonNode> decoder = EndpointListDecoder.JSON;
-        List<Endpoint> decoded = decoder.decode(
+    void decode() throws Exception {
+        final EndpointListDecoder<JsonNode> decoder = EndpointListDecoder.JSON;
+        final List<Endpoint> decoded = decoder.decode(
                 objectMapper.readTree(objectMapper.writeValueAsString(HOST_AND_PORT_LIST)));
 
         assertThat(decoded).hasSize(4);

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/TextEndpointListDecoderTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/TextEndpointListDecoderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,17 +21,17 @@ import static com.linecorp.centraldogma.client.armeria.JsonEndpointListDecoderTe
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.client.Endpoint;
 
-public class TextEndpointListDecoderTest {
+class TextEndpointListDecoderTest {
+
     @Test
-    public void decode() {
-        EndpointListDecoder<String> decoder = EndpointListDecoder.TEXT;
-        List<Endpoint> decoded = decoder.decode(HOST_AND_PORT_LIST.stream().collect(Collectors.joining("\n")));
+    void decode() {
+        final EndpointListDecoder<String> decoder = EndpointListDecoder.TEXT;
+        final List<Endpoint> decoded = decoder.decode(String.join("\n", HOST_AND_PORT_LIST));
 
         assertThat(decoded).hasSize(4);
         assertThat(decoded).isEqualTo(ENDPOINT_LIST);

--- a/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -20,12 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetSocketAddress;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CentralDogmaBuilderTest {
+class CentralDogmaBuilderTest {
 
     @Test
-    public void mutuallyExclusiveHostAndProfile() {
+    void mutuallyExclusiveHostAndProfile() {
         final CentralDogmaBuilder b1 = new CentralDogmaBuilder();
         b1.host("foo");
         assertThatThrownBy(() -> b1.profile("bar"))
@@ -40,7 +41,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void emptyProfile() {
+    void emptyProfile() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         assertThatThrownBy(() -> b.profile("bar"))
                 .isInstanceOf(IllegalArgumentException.class)
@@ -48,7 +49,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void mismatchingProfile() {
+    void mismatchingProfile() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
 
         assertThatThrownBy(() -> b.profile("none"))
@@ -57,7 +58,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void httpProfile() {
+    void httpProfile() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("foo");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
@@ -65,7 +66,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void httpsProfile() {
+    void httpsProfile() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.useTls();
         b.profile("foo");
@@ -74,7 +75,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void profileLoadedFromAllResources() {
+    void profileLoadedFromAllResources() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("production");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
@@ -83,7 +84,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void ipHosts() {
+    void ipHosts() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("ip_hosts");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
@@ -92,7 +93,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void profileWithHighPriorityWins() {
+    void profileWithHighPriorityWins() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("high_priority_wins");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
@@ -100,7 +101,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void profileWithLowPriorityLoses() {
+    void profileWithLowPriorityLoses() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.profile("low_priority_loses");
         assertThat(b.hosts()).containsExactlyInAnyOrder(
@@ -108,7 +109,7 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void lastProfileFirst() {
+    void lastProfileFirst() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         // The last valid profile should win, to be consistent with Spring Boot profiles.
         b.profile("foo", "qux");
@@ -119,14 +120,14 @@ public class CentralDogmaBuilderTest {
     }
 
     @Test
-    public void singleHost() {
+    void singleHost() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.host("foo");
         assertThat(b.hosts()).containsExactly(InetSocketAddress.createUnresolved("foo", 36462));
     }
 
     @Test
-    public void multipleHosts() {
+    void multipleHosts() {
         final CentralDogmaBuilder b = new CentralDogmaBuilder();
         b.host("foo", 1);
         b.host("bar", 2);

--- a/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaBuilderTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.client;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.internal.client;
 
 import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
@@ -38,9 +37,7 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -56,7 +53,6 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 
-@ExtendWith(MockitoExtension.class)
 class ReplicationLagTolerantCentralDogmaTest {
 
     private static final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();

--- a/common-legacy/src/test/java/com/linecorp/centraldogma/internal/thrift/ThriftTextCompatibilityTest.java
+++ b/common-legacy/src/test/java/com/linecorp/centraldogma/internal/thrift/ThriftTextCompatibilityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,11 +13,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.diffFile_args;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.getDiffs_args;
@@ -27,9 +28,10 @@ import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.getHistory_
  * Makes sure {@code fromRevision} and {@code toRevision} fields are renamed to {@code from} and {@code to}
  * during the build process.
  */
-public class ThriftTextCompatibilityTest {
+class ThriftTextCompatibilityTest {
+
     @Test
-    public void test() {
+    void test() {
         assertThat(getDiffs_args._Fields.findByName("fromRevision")).isNull();
         assertThat(getDiffs_args._Fields.findByName("from")).isNotNull();
         assertThat(getDiffs_args._Fields.findByName("toRevision")).isNull();

--- a/common-legacy/src/test/java/com/linecorp/centraldogma/internal/thrift/ThriftTextCompatibilityTest.java
+++ b/common-legacy/src/test/java/com/linecorp/centraldogma/internal/thrift/ThriftTextCompatibilityTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/common/src/test/java/com/linecorp/centraldogma/common/AuthorTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/AuthorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,30 +16,26 @@
 
 package com.linecorp.centraldogma.common;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 
-public class AuthorTest {
+class AuthorTest {
 
     @Test
-    public void testAuthor_invalidParameters() {
-        try {
-            new Author(null, "email@test.com");
-            fail("Expected NullPointerException");
-        } catch (NullPointerException ignored) {
-        }
-        try {
-            new Author("", "invalid mail address");
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException ignored) {
-        }
+    void testAuthor_invalidParameters() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new Author(null, "email@test.com"));
+
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new Author("", "invalid mail address"));
     }
 
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         TestUtil.assertJsonConversion(new Author("Homer Simpson", "homer@simpsonsworld.com"),
                              '{' +
                              "  \"name\": \"Homer Simpson\"," +

--- a/common/src/test/java/com/linecorp/centraldogma/common/CentralDogmaExceptionTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/CentralDogmaExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,11 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class CentralDogmaExceptionTest {
+class CentralDogmaExceptionTest {
+
     @Test
-    public void tracelessInstantiation() {
+    void tracelessInstantiation() {
         final AtomicBoolean filledInStackTrace = new AtomicBoolean();
         final CentralDogmaException e = new CentralDogmaException("foo", false) {
             private static final long serialVersionUID = -4128575947135273677L;

--- a/common/src/test/java/com/linecorp/centraldogma/common/ChangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/ChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,9 +16,9 @@
 
 package com.linecorp.centraldogma.common;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
@@ -27,10 +27,10 @@ import difflib.DiffUtils;
 import difflib.Patch;
 import difflib.PatchFailedException;
 
-public class ChangeTest {
+class ChangeTest {
 
     @Test
-    public void testTextPatches() throws PatchFailedException {
+    void testTextPatches() throws PatchFailedException {
         final String oriStr = "1\n2\n3\n4\n5\n6\n7\n8\n9";
         final String newStr = "1a\n2\n3\n4\n5\n6\n7\n8\n9a";
         final String expectedUnifiedDiff = "--- /text_file.txt\n" +
@@ -48,14 +48,14 @@ public class ChangeTest {
                                            "-9\n" +
                                            "+9a";
         final Change<String> change = Change.ofTextPatch("/text_file.txt", oriStr, newStr);
-        assertEquals(expectedUnifiedDiff, change.content());
+        assertThat(change.content()).isEqualTo(expectedUnifiedDiff);
         final Patch<String> patch = DiffUtils.parseUnifiedDiff(Util.stringToLines(change.content()));
         final String patchedStr = String.join("\n", patch.applyTo(Util.stringToLines(oriStr)));
-        assertEquals(newStr, patchedStr);
+        assertThat(patchedStr).isEqualTo(newStr);
     }
 
     @Test
-    public void testJsonConversion() throws Exception {
+    void testJsonConversion() {
         TestUtil.assertJsonConversion(Change.ofJsonUpsert("/1.json", "{ \"a\": 42 }"), Change.class,
                              '{' +
                              "  \"type\": \"UPSERT_JSON\"," +

--- a/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.common;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;

--- a/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/EntryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,28 +13,27 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.common;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.fail;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class EntryTest {
+class EntryTest {
 
     @Test
-    public void ofDirectory() throws Exception {
+    void ofDirectory() throws Exception {
         final Entry<Void> e = Entry.ofDirectory(new Revision(1), "/");
         assertThat(e.revision()).isEqualTo(new Revision(1));
         assertThat(e.hasContent()).isFalse();
-        e.ifHasContent(unused -> fail());
         assertThatThrownBy(e::content).isInstanceOf(EntryNoContentException.class);
         assertThatThrownBy(e::contentAsJson).isInstanceOf(EntryNoContentException.class);
         assertThatThrownBy(e::contentAsText).isInstanceOf(EntryNoContentException.class);
@@ -60,7 +59,7 @@ public class EntryTest {
     }
 
     @Test
-    public void ofText() throws Exception {
+    void ofText() throws Exception {
         final Entry<String> e = Entry.ofText(new Revision(1), "/a.txt", "foo");
         assertThat(e.revision()).isEqualTo(new Revision(1));
         assertThat(e.hasContent()).isTrue();
@@ -97,7 +96,7 @@ public class EntryTest {
     }
 
     @Test
-    public void ofJson() throws Exception {
+    void ofJson() throws Exception {
         final Entry<JsonNode> e = Entry.ofJson(new Revision(1), "/a.json", "{ \"foo\": \"bar\" }");
         assertThat(e.revision()).isEqualTo(new Revision(1));
         assertThat(e.hasContent()).isTrue();
@@ -128,7 +127,7 @@ public class EntryTest {
     }
 
     @Test
-    public void of() {
+    void of() {
         // Null checks
         assertThatThrownBy(() -> Entry.of(null, "/1.txt", EntryType.TEXT, "1"))
                 .isInstanceOf(NullPointerException.class);
@@ -151,7 +150,7 @@ public class EntryTest {
     }
 
     @Test
-    public void testEquals() {
+    void testEquals() {
         final Entry<Void> e = Entry.ofDirectory(new Revision(1), "/foo");
         assertThat(e).isNotEqualTo(null);
         assertThat(e).isNotEqualTo(new Object());
@@ -159,7 +158,7 @@ public class EntryTest {
     }
 
     @Test
-    public void testToString() {
+    void testToString() {
         assertThat(Entry.ofText(new Revision(1), "/a.txt", "a").toString()).isNotEmpty();
     }
 }

--- a/common/src/test/java/com/linecorp/centraldogma/common/QueryTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/QueryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,13 +16,14 @@
 
 package com.linecorp.centraldogma.common;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 
-public class QueryTest {
+class QueryTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         TestUtil.assertJsonConversion(Query.ofText("/foo.txt"), Query.class,
                              '{' +
                              "  \"type\": \"IDENTITY\"," +

--- a/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.common;
 
 import static com.linecorp.centraldogma.common.Revision.HEAD;
@@ -20,12 +21,12 @@ import static com.linecorp.centraldogma.common.Revision.INIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RevisionRangeTest {
+class RevisionRangeTest {
 
     @Test
-    public void revisionRange() {
+    void revisionRange() {
         RevisionRange range = new RevisionRange(2, 4);
 
         assertThat(range.isAscending()).isTrue();

--- a/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/RevisionRangeTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.common;
 
 import static com.linecorp.centraldogma.common.Revision.HEAD;

--- a/common/src/test/java/com/linecorp/centraldogma/common/RevisionTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/RevisionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RevisionTest {
+class RevisionTest {
 
     @Test
-    public void deserialization() throws Exception {
+    void deserialization() throws Exception {
         assertThat(toRevision("2")).isEqualTo(new Revision(2));
         assertThat(toRevision("\"3\"")).isEqualTo(new Revision(3));
         assertThat(toRevision("\"4.0\"")).isEqualTo(new Revision(4));
@@ -51,7 +51,7 @@ public class RevisionTest {
     }
 
     @Test
-    public void serialization() throws Exception {
+    void serialization() {
         assertThatJson(new Revision(9)).isEqualTo("9");
         assertThatJson(Revision.HEAD).isEqualTo("-1");
     }

--- a/common/src/test/java/com/linecorp/centraldogma/internal/JacksonTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/JacksonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,16 +22,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.centraldogma.common.QueryExecutionException;
 
-public class JacksonTest {
+class JacksonTest {
 
     @Test
-    public void nullCanBeAnyTypeWhileMerging() throws IOException {
+    void nullCanBeAnyTypeWhileMerging() throws IOException {
         final JsonNode nullNode = readTree("{\"a\": null}");
         final JsonNode numberNode = readTree("{\"a\": 1}");
         JsonNode merged = Jackson.mergeTree(nullNode, numberNode);
@@ -59,7 +59,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void rootShouldBeObjectNode() throws IOException {
+    void rootShouldBeObjectNode() throws IOException {
         final JsonNode arrayJson1 = readTree("[1, 2, 3]");
         final JsonNode arrayJson2 = readTree("[3, 4, 5]");
 
@@ -69,7 +69,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void mergeMixedJsonNodeTypes() throws IOException {
+    void mergeMixedJsonNodeTypes() throws IOException {
         final JsonNode baseJson = readTree('{' +
                                            "   \"a\": \"foo1\"," +
                                            "   \"b\": \"foo2\"," +
@@ -122,7 +122,7 @@ public class JacksonTest {
     }
 
     @Test
-    public void mismatchedValueNodeWhileMerging() throws IOException {
+    void mismatchedValueNodeWhileMerging() throws IOException {
         final JsonNode baseJson = readTree('{' +
                                            "   \"a\": {" +
                                            "      \"b\": \"foo\"" +

--- a/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,12 +22,12 @@ import static com.linecorp.centraldogma.internal.Util.validateFilePath;
 import static com.linecorp.centraldogma.internal.Util.validateJsonFilePath;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class UtilTest {
+class UtilTest {
 
     @Test
-    public void testValidateFilePath() {
+    void testValidateFilePath() {
         assertFilePathValidationSuccess("/foo.txt");
         assertFilePathValidationSuccess("/foo/bar.txt");
         assertFilePathValidationSuccess("/foo.bar/baz.json");
@@ -61,7 +61,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testValidateJsonFilePath() {
+    void testValidateJsonFilePath() {
         assertJsonFilePathValidationSuccess("/foo.json");
         assertJsonFilePathValidationSuccess("/foo/bar.json");
         assertJsonFilePathValidationSuccess("/foo.bar/baz.json");
@@ -98,7 +98,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testValidateDirPath() {
+    void testValidateDirPath() {
         assertDirPathValidationSuccess("/");
         assertDirPathValidationSuccess("/foo");
         assertDirPathValidationSuccess("/foo/");
@@ -131,7 +131,7 @@ public class UtilTest {
     }
 
     @Test
-    public void testValidEmailAddress() {
+    void testValidEmailAddress() {
         testValidEmail("dogma@github.com");
         testValidEmail("dogma@127.0.0.1");
         testValidEmail("dogma@10.1.1.1");

--- a/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.internal.api.v1;
 
 import static com.linecorp.centraldogma.internal.api.v1.WatchTimeout.MAX_MILLIS;

--- a/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/api/v1/WatchTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.internal.api.v1;
 
 import static com.linecorp.centraldogma.internal.api.v1.WatchTimeout.MAX_MILLIS;
@@ -20,12 +21,12 @@ import static com.linecorp.centraldogma.internal.api.v1.WatchTimeout.makeReasona
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class WatchTimeoutTest {
+class WatchTimeoutTest {
 
     @Test
-    public void testMakeReasonable() {
+    void testMakeReasonable() {
         assertThat(makeReasonable(1_000, 1_000)).isEqualTo(2_000);
         assertThat(makeReasonable(MAX_MILLIS, 1_000)).isEqualTo(MAX_MILLIS);
         assertThat(makeReasonable(MAX_MILLIS + 1_000, 0)).isEqualTo(MAX_MILLIS);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/AuthorConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/AuthorConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,15 +18,16 @@ package com.linecorp.centraldogma.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class AuthorConverterTest {
+class AuthorConverterTest {
+
     private static final com.linecorp.centraldogma.common.Author COMMON =
             new com.linecorp.centraldogma.common.Author("user", "user@sample.com");
     private static final Author THRIFT = new Author("user", "user@sample.com");
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(AuthorConverter.TO_DATA.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(AuthorConverter.TO_MODEL.convert(THRIFT)).isEqualTo(COMMON);
         assertThat(AuthorConverter.TO_DATA.convert(AuthorConverter.TO_MODEL.convert(THRIFT))).isEqualTo(THRIFT);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/ChangeConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/ChangeConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,9 +18,9 @@ package com.linecorp.centraldogma.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ChangeConverterTest {
+class ChangeConverterTest {
 
     private static final com.linecorp.centraldogma.common.Change<String> COMMON =
             com.linecorp.centraldogma.common.Change.ofTextUpsert("/a.txt", "hello");
@@ -30,7 +30,7 @@ public class ChangeConverterTest {
                                                      .setContent("hello");
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(ChangeConverter.TO_DATA.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(ChangeConverter.TO_MODEL.convert(THRIFT)).isEqualTo(COMMON);
         assertThat(ChangeConverter.TO_DATA.convert(ChangeConverter.TO_MODEL.convert(THRIFT))).isEqualTo(THRIFT);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/CommitConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/CommitConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,11 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
-public class CommitConverterTest {
+class CommitConverterTest {
+
     private static final String TIMESTAMP = "2016-01-02T03:04:05Z";
 
     private static final com.linecorp.centraldogma.common.Commit COMMON =
@@ -46,7 +47,7 @@ public class CommitConverterTest {
                                                     ImmutableList.of());
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(TO_DATA.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(TO_MODEL.convert(THRIFT)).isEqualTo(COMMON);
         assertThat(TO_DATA.convert(TO_MODEL.convert(THRIFT))).isEqualTo(THRIFT);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/EntryConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/EntryConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,9 +18,9 @@ package com.linecorp.centraldogma.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class EntryConverterTest {
+class EntryConverterTest {
 
     private static final com.linecorp.centraldogma.common.Revision REV =
             new com.linecorp.centraldogma.common.Revision(42);
@@ -29,7 +29,7 @@ public class EntryConverterTest {
     private static final Entry THRIFT = new Entry("/a.txt", EntryType.TEXT).setContent("hello");
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(EntryConverter.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(EntryConverter.convert(REV, THRIFT)).isEqualTo(COMMON);
         assertThat(EntryConverter.convert(EntryConverter.convert(REV, THRIFT))).isEqualTo(THRIFT);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/MarkupConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/MarkupConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,16 +20,16 @@ import static com.linecorp.centraldogma.internal.thrift.MarkupConverter.TO_DATA;
 import static com.linecorp.centraldogma.internal.thrift.MarkupConverter.TO_MODEL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class MarkupConverterTest {
+class MarkupConverterTest {
 
     private static final com.linecorp.centraldogma.common.Markup COMMON =
             com.linecorp.centraldogma.common.Markup.PLAINTEXT;
     private static final Markup THRIFT = Markup.PLAINTEXT;
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(TO_DATA.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(TO_MODEL.convert(THRIFT)).isEqualTo(COMMON);
         assertThat(TO_DATA.convert(TO_MODEL.convert(THRIFT))).isEqualTo(THRIFT);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/QueryConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/QueryConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
-public class QueryConverterTest {
+class QueryConverterTest {
 
     private static final com.linecorp.centraldogma.common.Query<String> IDENTITY_MODEL =
             com.linecorp.centraldogma.common.Query.ofText("/a.txt");
@@ -41,7 +41,7 @@ public class QueryConverterTest {
                                                            .setExpressions(ImmutableList.of("a", "b"));
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(TO_DATA.convert(IDENTITY_MODEL)).isEqualTo(IDENTITY_DATA);
         assertThat(TO_MODEL.convert(IDENTITY_DATA)).isEqualTo(IDENTITY_MODEL);
         assertThat(TO_DATA.convert(TO_MODEL.convert(IDENTITY_DATA))).isEqualTo(IDENTITY_DATA);

--- a/common/src/test/java/com/linecorp/centraldogma/internal/thrift/RevisionConverterTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/thrift/RevisionConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,16 +20,16 @@ import static com.linecorp.centraldogma.internal.thrift.RevisionConverter.TO_DAT
 import static com.linecorp.centraldogma.internal.thrift.RevisionConverter.TO_MODEL;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class RevisionConverterTest {
+class RevisionConverterTest {
 
     private static final com.linecorp.centraldogma.common.Revision COMMON =
             new com.linecorp.centraldogma.common.Revision(1);
     private static final Revision THRIFT = new Revision(1, 0);
 
     @Test
-    public void test() throws Exception {
+    void test() {
         assertThat(TO_DATA.convert(COMMON)).isEqualTo(THRIFT);
         assertThat(TO_MODEL.convert(THRIFT)).isEqualTo(COMMON);
         assertThat(TO_DATA.convert(TO_MODEL.convert(THRIFT))).isEqualTo(THRIFT);

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -228,7 +228,8 @@ org.javassist:
   javassist: { version: '3.26.0-GA' }
 
 org.mockito:
-  mockito-core: { version: '3.2.0' }
+  mockito-core: { version: &MOCKITO_VERSION '3.2.4' }
+  mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.9' }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManager.java
@@ -110,7 +110,7 @@ public final class FileBasedSessionManager implements SessionManager {
         // The scheduler can be started and stopped several times in JUnit tests, but Quartz holds
         // every scheduler instances in a singleton SchedulerRepository. So it's possible to pick up
         // the scheduler which is going to be stopped if we use the same instance name for every scheduler,
-        // because CentralDogmaRule stops the server asynchronously using another thread.
+        // because CentralDogmaExtension stops the server asynchronously using another thread.
         final String myInstanceId = String.valueOf(hashCode());
 
         final Properties cfg = new Properties();

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,7 +20,7 @@ import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpMethod;
@@ -32,7 +32,7 @@ import com.linecorp.armeria.server.Service;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.ShuttingDownException;
 
-public class CentralDogmaAuthFailureHandlerTest {
+class CentralDogmaAuthFailureHandlerTest {
 
     private final CentralDogmaAuthFailureHandler handler = new CentralDogmaAuthFailureHandler();
     @SuppressWarnings("unchecked")
@@ -41,7 +41,7 @@ public class CentralDogmaAuthFailureHandlerTest {
     private final ServiceRequestContext ctx = ServiceRequestContext.of(req);
 
     @Test
-    public void shuttingDown() throws Exception {
+    void shuttingDown() throws Exception {
         final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, new ShuttingDownException())
                                                   .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -54,7 +54,7 @@ public class CentralDogmaAuthFailureHandlerTest {
     }
 
     @Test
-    public void failure() throws Exception {
+    void failure() throws Exception {
         final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, new Exception("oops"))
                                                   .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -67,7 +67,7 @@ public class CentralDogmaAuthFailureHandlerTest {
     }
 
     @Test
-    public void incorrectToken() throws Exception {
+    void incorrectToken() throws Exception {
         final AggregatedHttpResponse res = handler.authFailed(delegate, ctx, req, null)
                                                   .aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.UNAUTHORIZED);

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server;
 
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS;
@@ -23,15 +24,15 @@ import java.net.InetAddress;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.server.ClientAddressSource;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class CentralDogmaConfigTest {
+class CentralDogmaConfigTest {
 
     @Test
-    public void trustedProxyAddress_withCustomClientAddressSources() throws Exception {
+    void trustedProxyAddress_withCustomClientAddressSources() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -58,8 +59,8 @@ public class CentralDogmaConfigTest {
                                   "  ]\n" +
                                   '}',
                                   CentralDogmaConfig.class);
-        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
-        assertThat(cfg.clientAddressSources().size()).isEqualTo(2);
+        assertThat(cfg.trustedProxyAddresses()).hasSize(2);
+        assertThat(cfg.clientAddressSources()).hasSize(2);
 
         final Predicate<InetAddress> p = cfg.trustedProxyAddressPredicate();
         assertThat(p.test(InetAddress.getByName("10.0.0.1"))).isTrue();
@@ -68,7 +69,7 @@ public class CentralDogmaConfigTest {
         assertThat(p.test(InetAddress.getByName("11.0.1.1"))).isFalse();
 
         final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
-        assertThat(sources.size()).isEqualTo(2);
+        assertThat(sources).hasSize(2);
         // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
         //                 https://github.com/line/armeria/pull/1804
         assertThat(sources.get(0).toString())
@@ -77,7 +78,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void trustedProxyAddress_withDefaultClientAddressSources() throws Exception {
+    void trustedProxyAddress_withDefaultClientAddressSources() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -100,11 +101,11 @@ public class CentralDogmaConfigTest {
                                   "  ]\n" +
                                   '}',
                                   CentralDogmaConfig.class);
-        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
+        assertThat(cfg.trustedProxyAddresses()).hasSize(2);
         assertThat(cfg.clientAddressSources()).isNull();
 
         final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
-        assertThat(sources.size()).isEqualTo(3);
+        assertThat(sources).hasSize(3);
         // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
         //                 https://github.com/line/armeria/pull/1804
         assertThat(sources.get(0).toString()).isEqualTo(ClientAddressSource.ofHeader("forwarded").toString());
@@ -114,7 +115,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void trustedProxyAddress_withDefaultClientAddressSources_withoutProxyProtocol() throws Exception {
+    void trustedProxyAddress_withDefaultClientAddressSources_withoutProxyProtocol() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -136,11 +137,11 @@ public class CentralDogmaConfigTest {
                                   "  ]\n" +
                                   '}',
                                   CentralDogmaConfig.class);
-        assertThat(cfg.trustedProxyAddresses().size()).isEqualTo(2);
+        assertThat(cfg.trustedProxyAddresses()).hasSize(2);
         assertThat(cfg.clientAddressSources()).isNull();
 
         final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
-        assertThat(sources.size()).isEqualTo(2);
+        assertThat(sources).hasSize(2);
         // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
         //                 https://github.com/line/armeria/pull/1804
         assertThat(sources.get(0).toString()).isEqualTo(ClientAddressSource.ofHeader("forwarded").toString());
@@ -149,7 +150,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void noTrustedProxyAddress() throws Exception {
+    void noTrustedProxyAddress() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -174,7 +175,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void maxRemovedRepositoryAgeMillis() throws Exception {
+    void maxRemovedRepositoryAgeMillis() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -198,7 +199,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void maxRemovedRepositoryAgeMillis_withDefault() throws Exception {
+    void maxRemovedRepositoryAgeMillis_withDefault() throws Exception {
         final CentralDogmaConfig cfg =
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +
@@ -221,7 +222,7 @@ public class CentralDogmaConfigTest {
     }
 
     @Test
-    public void maxRemovedRepositoryAgeMillis_withNegativeValue() throws Exception {
+    void maxRemovedRepositoryAgeMillis_withNegativeValue() {
         assertThatThrownBy(() ->
                 Jackson.readValue("{\n" +
                                   "  \"dataDir\": \"./data\",\n" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server;
 
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS;

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server;
 
 import static java.nio.file.Files.createTempFile;

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,28 +13,31 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server;
 
+import static java.nio.file.Files.createTempFile;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class ConfigDeserializationTest {
+class ConfigDeserializationTest {
 
-    @ClassRule
-    public static TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    static Path tempDir;
 
     @Test
-    public void tlsConfig() throws Exception {
-        final String cert = Jackson.escapeText(folder.newFile().getAbsolutePath());
-        final String key = Jackson.escapeText(folder.newFile().getAbsolutePath());
+    void tlsConfig() throws Exception {
+        final String cert = Jackson.escapeText(createTempFile(tempDir, "", "").toAbsolutePath().toString());
+        final String key = Jackson.escapeText(createTempFile(tempDir, "", "").toAbsolutePath().toString());
 
         final String jsonConfig = String.format("{\"tls\": {" +
                                                 "\"keyCertChainFile\": \"%s\", " +

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,35 +13,36 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.exporter.common.TextFormat;
 
-public class MetricsTest {
+class MetricsTest {
 
     private static final Logger logger = LoggerFactory.getLogger(MetricsTest.class);
 
-    @ClassRule
-    public static CentralDogmaRule rule = new CentralDogmaRule();
+    @RegisterExtension
+    static CentralDogmaExtension dogma = new CentralDogmaExtension();
 
     @Test
-    public void metrics() {
-        assertThat(rule.dogma().meterRegistry()).containsInstanceOf(PrometheusMeterRegistry.class);
+    void metrics() {
+        assertThat(dogma.dogma().meterRegistry()).containsInstanceOf(PrometheusMeterRegistry.class);
 
-        final AggregatedHttpResponse res = rule.httpClient().get("/monitor/metrics").aggregate().join();
+        final AggregatedHttpResponse res = dogma.httpClient().get("/monitor/metrics").aggregate().join();
         logger.debug("Prometheus metrics:\n{}", res.contentUtf8());
 
         assertThat(res.status()).isEqualTo(HttpStatus.OK);

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/NoneReplicationConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/NoneReplicationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,11 +18,12 @@ package com.linecorp.centraldogma.server;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NoneReplicationConfigTest {
+class NoneReplicationConfigTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(ReplicationConfig.NONE,
                              ReplicationConfig.class,
                              "{ \"method\": \"NONE\" }");

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin;
 import com.linecorp.centraldogma.server.internal.storage.PurgeSchedulingServicePlugin;
@@ -31,10 +32,10 @@ import com.linecorp.centraldogma.server.plugin.NoopPluginForLeader;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
 
-public class PluginGroupTest {
+class PluginGroupTest {
 
     @Test
-    public void confirmPluginsForAllReplicasLoaded() {
+    void confirmPluginsForAllReplicasLoaded() {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         final PluginGroup group = PluginGroup.loadPlugins(PluginTarget.ALL_REPLICAS, cfg);
         assertThat(group).isNotNull();
@@ -42,7 +43,7 @@ public class PluginGroupTest {
     }
 
     @Test
-    public void confirmPluginsForLeaderLoaded() {
+    void confirmPluginsForLeaderLoaded() {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         final PluginGroup group = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group).isNotNull();
@@ -54,7 +55,7 @@ public class PluginGroupTest {
      * {@link CentralDogmaConfig#isMirroringEnabled()} property is {@code true}.
      */
     @Test
-    public void confirmDefaultMirroringServiceLoadedDependingOnConfig() {
+    void confirmDefaultMirroringServiceLoadedDependingOnConfig() {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         when(cfg.isMirroringEnabled()).thenReturn(true);
         final PluginGroup group1 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
@@ -72,7 +73,7 @@ public class PluginGroupTest {
      * {@link CentralDogmaConfig#maxRemovedRepositoryAgeMillis()} property is greater then 0.
      */
     @Test
-    public void confirmScheduledPurgingServiceLoadedDependingOnConfig() {
+    void confirmScheduledPurgingServiceLoadedDependingOnConfig() {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         when(cfg.maxRemovedRepositoryAgeMillis()).thenReturn(1L);
         final PluginGroup group1 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);

--- a/server/src/test/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,15 +20,16 @@ import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConv
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class ZooKeeperReplicationConfigTest {
+class ZooKeeperReplicationConfigTest {
+
     @Test
-    public void testJsonConversion() throws Exception {
+    void testJsonConversion() {
         final ZooKeeperReplicationConfig cfg = new ZooKeeperReplicationConfig(
                 1, ImmutableMap.of(1, new ZooKeeperAddress("2", 3, 4, 5),
                                    6, new ZooKeeperAddress("7", 8, 9, 10)),
@@ -60,7 +61,7 @@ public class ZooKeeperReplicationConfigTest {
     }
 
     @Test
-    public void testJsonConversionWithoutOptionalProperties() throws Exception {
+    void testJsonConversionWithoutOptionalProperties() throws Exception {
         final ReplicationConfig defaultCfg =
                 Jackson.readValue(
                         '{' +
@@ -89,7 +90,7 @@ public class ZooKeeperReplicationConfigTest {
     }
 
     @Test
-    public void autoDetection() throws Exception {
+    void autoDetection() throws Exception {
         final ZooKeeperReplicationConfig cfg = Jackson.readValue(
                 '{' +
                 "  \"method\": \"ZOOKEEPER\"," +
@@ -111,7 +112,7 @@ public class ZooKeeperReplicationConfigTest {
     }
 
     @Test
-    public void autoDetectionFailure_TwoMatches() throws Exception {
+    void autoDetectionFailure_TwoMatches() {
         final String json =
                 '{' +
                 "  \"method\": \"ZOOKEEPER\"," +
@@ -137,7 +138,7 @@ public class ZooKeeperReplicationConfigTest {
     }
 
     @Test
-    public void autoDetectionFailure_NoMatch() throws Exception {
+    void autoDetectionFailure_NoMatch() {
         final String json =
                 '{' +
                 "  \"method\": \"ZOOKEEPER\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/CreateProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/CreateProjectCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class CreateProjectCommandTest {
+class CreateProjectCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new CreateProjectCommand(1234L, new Author("foo", "bar@baz.com"), "foo"),
                              Command.class,
                              '{' +
@@ -41,7 +42,7 @@ public class CreateProjectCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final CreateProjectCommand c = (CreateProjectCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"CREATE_PROJECT\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/CreateRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/CreateRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class CreateRepositoryCommandTest {
+class CreateRepositoryCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new CreateRepositoryCommand(1234L, new Author("foo", "bar@baz.com"), "foo", "bar"),
                              Command.class,
                              '{' +
@@ -42,7 +43,7 @@ public class CreateRepositoryCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final CreateRepositoryCommand c = (CreateRepositoryCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"CREATE_REPOSITORY\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/CreateSessionCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/CreateSessionCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,7 +24,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -32,10 +32,10 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.auth.Session;
 
-public class CreateSessionCommandTest {
+class CreateSessionCommandTest {
 
     @Test
-    public void testJsonConversion() throws Exception {
+    void testJsonConversion() throws Exception {
         final Session session =
                 new Session("session-id-12345",
                             "foo",

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class PurgeProjectCommandTest {
+class PurgeProjectCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new PurgeProjectCommand(1234L, Author.SYSTEM, "foo"),
                              Command.class,
                              '{' +
@@ -41,7 +42,7 @@ public class PurgeProjectCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final PurgeProjectCommand c = (PurgeProjectCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"PURGE_PROJECT\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,15 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class PurgeRepositoryCommandTest {
+class PurgeRepositoryCommandTest {
 
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new PurgeRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
@@ -43,7 +43,7 @@ public class PurgeRepositoryCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final PurgeRepositoryCommand c = (PurgeRepositoryCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"PURGE_REPOSITORY\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PushCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PushCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -29,10 +29,10 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class PushCommandTest {
+class PushCommandTest {
 
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(
                 new PushCommand(1234L, new Author("Marge Simpson", "marge@simpsonsworld.com"),
                                 "foo", "bar", new Revision(42), "baz", "qux", Markup.MARKDOWN,
@@ -60,7 +60,7 @@ public class PushCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final PushCommand c = (PushCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"PUSH\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveProjectCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class RemoveProjectCommandTest {
+class RemoveProjectCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new RemoveProjectCommand(1234L, Author.SYSTEM, "foo"),
                              Command.class,
                              '{' +
@@ -41,7 +42,7 @@ public class RemoveProjectCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final RemoveProjectCommand c = (RemoveProjectCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"REMOVE_PROJECT\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class RemoveRepositoryCommandTest {
+class RemoveRepositoryCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new RemoveRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
@@ -42,7 +43,7 @@ public class RemoveRepositoryCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final RemoveRepositoryCommand c = (RemoveRepositoryCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"REMOVE_REPOSITORY\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveSessionCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveSessionCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,13 +18,14 @@ package com.linecorp.centraldogma.server.command;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 
-public class RemoveSessionCommandTest {
+class RemoveSessionCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(
                 new RemoveSessionCommand(1234L, new Author("foo", "bar@baz.com"), "some-id"),
                 Command.class,

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveProjectCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class UnremoveProjectCommandTest {
+class UnremoveProjectCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new UnremoveProjectCommand(1234L, Author.SYSTEM, "foo"),
                              Command.class,
                              '{' +
@@ -41,7 +42,7 @@ public class UnremoveProjectCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final UnremoveProjectCommand c = (UnremoveProjectCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"UNREMOVE_PROJECT\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveRepositoryCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,14 +19,15 @@ package com.linecorp.centraldogma.server.command;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 
-public class UnremoveRepositoryCommandTest {
+class UnremoveRepositoryCommandTest {
+
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new UnremoveRepositoryCommand(1234L, Author.SYSTEM, "foo", "bar"),
                              Command.class,
                              '{' +
@@ -42,7 +43,7 @@ public class UnremoveRepositoryCommandTest {
     }
 
     @Test
-    public void backwardCompatibility() throws Exception {
+    void backwardCompatibility() throws Exception {
         final UnremoveRepositoryCommand c = (UnremoveRepositoryCommand) Jackson.readValue(
                 '{' +
                 "  \"type\": \"UNREMOVE_REPOSITORY\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/CachedSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/CachedSessionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +27,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -34,10 +35,10 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.linecorp.centraldogma.server.auth.Session;
 import com.linecorp.centraldogma.server.auth.SessionManager;
 
-public class CachedSessionManagerTest {
+class CachedSessionManagerTest {
 
     @Test
-    public void shouldOperateWithCache() {
+    void shouldOperateWithCache() {
         final Session session =
                 new Session("id", "username", Duration.ofHours(1));
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/CachedSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/CachedSessionManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/ExpiredSessionDeletingSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/ExpiredSessionDeletingSessionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,15 +25,15 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.server.auth.Session;
 import com.linecorp.centraldogma.server.auth.SessionManager;
 
-public class ExpiredSessionDeletingSessionManagerTest {
+class ExpiredSessionDeletingSessionManagerTest {
 
     @Test
-    public void shouldReturnNonNull() {
+    void shouldReturnNonNull() {
         final Session expiredAfterOneHour = createSession(Instant.now().plus(1, ChronoUnit.HOURS));
         final SessionManager delegate = mock(SessionManager.class);
         when(delegate.get(any())).thenReturn(CompletableFuture.completedFuture(expiredAfterOneHour));
@@ -42,7 +43,7 @@ public class ExpiredSessionDeletingSessionManagerTest {
     }
 
     @Test
-    public void shouldReturnNull() {
+    void shouldReturnNull() {
         final Session expiredSession = createSession(Instant.EPOCH);
         final SessionManager delegate = mock(SessionManager.class);
         when(delegate.get(any())).thenReturn(CompletableFuture.completedFuture(expiredSession));

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/ExpiredSessionDeletingSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/ExpiredSessionDeletingSessionManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,29 +13,32 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
+import static java.nio.file.Files.createTempDirectory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.CompletionException;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.centraldogma.server.auth.Session;
 
-public class FileBasedSessionManagerTest {
+class FileBasedSessionManagerTest {
 
-    @ClassRule
-    public static TemporaryFolder rootDir = new TemporaryFolder();
+    @TempDir
+    static Path rootDir;
 
     @Test
-    public void shouldDoBasicOperations() throws Exception {
-        final FileBasedSessionManager manager = new FileBasedSessionManager(rootDir.newFolder().toPath(), null);
+    void shouldDoBasicOperations() throws Exception {
+        final FileBasedSessionManager manager =
+                new FileBasedSessionManager(createTempDirectory(rootDir, ""), null);
         final Session session = new Session(manager.generateSessionId(), "username", Duration.ofHours(1));
         manager.create(session).join();
         assertThat(manager.get(session.id()).join())
@@ -52,9 +55,9 @@ public class FileBasedSessionManagerTest {
     }
 
     @Test
-    public void shouldDeleteExpiredSessions() throws Exception {
+    void shouldDeleteExpiredSessions() throws Exception {
         final FileBasedSessionManager manager =
-                new FileBasedSessionManager(rootDir.newFolder().toPath(), "*/2 * * ? * *");
+                new FileBasedSessionManager(createTempDirectory(rootDir, ""), "*/2 * * ? * *");
 
         final Session session =
                 new Session(manager.generateSessionId(), "username", Duration.ofSeconds(5));
@@ -64,8 +67,9 @@ public class FileBasedSessionManagerTest {
     }
 
     @Test
-    public void invalidSessionIds() throws Exception {
-        final FileBasedSessionManager manager = new FileBasedSessionManager(rootDir.newFolder().toPath(), null);
+    void invalidSessionIds() throws Exception {
+        final FileBasedSessionManager manager =
+                new FileBasedSessionManager(createTempDirectory(rootDir, ""), null);
         assertThat(manager.get("anonymous").join()).isNull();
         assertThat(manager.exists("anonymous").join()).isFalse();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/auth/FileBasedSessionManagerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.admin.auth;
 
 import static java.nio.file.Files.createTempDirectory;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,7 +24,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -38,10 +38,10 @@ import com.linecorp.centraldogma.server.metadata.Token;
 import com.linecorp.centraldogma.server.metadata.TokenRegistration;
 import com.linecorp.centraldogma.server.metadata.UserAndTimestamp;
 
-public class SerializationTest {
+class SerializationTest {
 
     @Test
-    public void testTimeSerialization() throws IOException {
+    void testTimeSerialization() throws IOException {
         final Member member =
                 new Member("armeria@dogma.org", ProjectRole.MEMBER, newCreationTag());
         assertThatJson(member).isEqualTo("{\n" +
@@ -62,7 +62,7 @@ public class SerializationTest {
     }
 
     @Test
-    public void testValidProject() throws IOException {
+    void testValidProject() throws IOException {
         final String userLogin = "armeria@dogma.org";
         final Member member = new Member(userLogin, ProjectRole.MEMBER, newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
@@ -136,7 +136,7 @@ public class SerializationTest {
     }
 
     @Test
-    public void testRemovedProject() throws IOException {
+    void testRemovedProject() throws IOException {
         final Member member = new Member("armeria@dogma.org", ProjectRole.MEMBER,
                                          newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/MergeQueryRequestConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -30,12 +30,12 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.MergeSource;
 
-public class MergeQueryRequestConverterTest {
+class MergeQueryRequestConverterTest {
 
     private static final MergeQueryRequestConverter converter = new MergeQueryRequestConverter();
 
     @Test
-    public void convert() throws Exception {
+    void convert() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final String queryString = "path=/foo.json" + '&' +
                                    "pa%22th=/foo1.json" + '&' +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/QueryRequestConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,19 +22,19 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryType;
 
-public class QueryRequestConverterTest {
+class QueryRequestConverterTest {
 
     private static final QueryRequestConverter converter = new QueryRequestConverter();
 
     @Test
-    public void convertIdentityQuery() throws Exception {
+    void convertIdentityQuery() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final String filePath = "/a.txt";
         when(ctx.pathParam("path")).thenReturn(filePath);
@@ -46,7 +46,7 @@ public class QueryRequestConverterTest {
     }
 
     @Test
-    public void invalidPath() throws Exception {
+    void invalidPath() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final String filePath = "/"; // a directory
         when(ctx.pathParam("path")).thenReturn(filePath);
@@ -56,7 +56,7 @@ public class QueryRequestConverterTest {
     }
 
     @Test
-    public void convertJsonPathQuery() throws Exception {
+    void convertJsonPathQuery() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final String jsonFilePath = "/a.json";
         when(ctx.pathParam("path")).thenReturn(jsonFilePath);
@@ -72,7 +72,7 @@ public class QueryRequestConverterTest {
     }
 
     @Test
-    public void withoutExpression() throws Exception {
+    void withoutExpression() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
 
         // even though the file is a JSON file, the converted query's type will be IDENTITY because there's no

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,7 +22,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -32,12 +32,12 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.internal.api.converter.WatchRequestConverter.WatchRequest;
 
-public class WatchRequestConverterTest {
+class WatchRequestConverterTest {
 
     private static final WatchRequestConverter converter = new WatchRequestConverter();
 
     @Test
-    public void convertWatchRequest() throws Exception {
+    void convertWatchRequest() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/",
@@ -52,7 +52,7 @@ public class WatchRequestConverterTest {
     }
 
     @Test
-    public void emptyHeader() throws Exception {
+    void emptyHeader() throws Exception {
         final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.mirror;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,7 +26,7 @@ import java.time.ZonedDateTime;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
@@ -38,13 +39,13 @@ import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
-public class MirrorTest {
+class MirrorTest {
 
     private static final Cron EVERY_MINUTE = new CronParser(
             CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("0 * * * * ?");
 
     @Test
-    public void testGitMirror() {
+    void testGitMirror() {
         // Simplest possible form
         assertMirror("git://a.com/b.git", GitMirror.class,
                      "git://a.com/b.git", "/", "master");
@@ -73,7 +74,7 @@ public class MirrorTest {
     }
 
     @Test
-    public void testCentralDogmaMirror() {
+    void testCentralDogmaMirror() {
         CentralDogmaMirror m;
 
         // Simplest possible form
@@ -120,7 +121,7 @@ public class MirrorTest {
     }
 
     @Test
-    public void testUnknownScheme() {
+    void testUnknownScheme() {
         assertThatThrownBy(() -> newMirror("magma://a.com/b.magma", Mirror.class))
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> newMirror("git+foo://a.com/b.git", Mirror.class))
@@ -128,7 +129,7 @@ public class MirrorTest {
     }
 
     @Test
-    public void jitter() {
+    void jitter() {
         final AbstractMirror mirror = newMirror("git://a.com/b.git", AbstractMirror.class);
 
         assertThat(mirror.schedule()).isSameAs(EVERY_MINUTE);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.mirror;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -25,14 +25,14 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.centraldogma.server.mirror.MirrorCredential;
 
-public class MirrorCredentialTest {
+class MirrorCredentialTest {
 
     static final Iterable<Pattern> HOSTNAME_PATTERNS = ImmutableSet.of(Pattern.compile("^foo\\.com$"));
 
@@ -42,7 +42,7 @@ public class MirrorCredentialTest {
             Pattern.compile("^bar\\.com$"));
 
     @Test
-    public void testConstruction() {
+    void testConstruction() {
         // Without ID and hostnamePatterns, i.e. effectively disabled.
         assertThat(new MirrorCredentialImpl(null, null).id()).isEmpty();
         assertThat(new MirrorCredentialImpl(null, null).hostnamePatterns()).isEmpty();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/NoneMirrorCredentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,16 +20,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.regex.Pattern;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableSet;
 
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.mirror.MirrorCredential;
 
-public class NoneMirrorCredentialTest {
+class NoneMirrorCredentialTest {
+
     @Test
-    public void testDeserialization() throws Exception {
+    void testDeserialization() throws Exception {
         // With hostnamePatterns
         assertThat(Jackson.readValue('{' +
                                      "  \"type\": \"none\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -20,15 +20,15 @@ import static com.linecorp.centraldogma.server.internal.mirror.credential.Mirror
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.mirror.MirrorCredential;
 
-public class PasswordMirrorCredentialTest {
+class PasswordMirrorCredentialTest {
 
     @Test
-    public void testConstruction() throws Exception {
+    void testConstruction() throws Exception {
         // null checks
         assertThatThrownBy(() -> new PasswordMirrorCredential(null, null, null, "sesame"))
                 .isInstanceOf(NullPointerException.class);
@@ -50,7 +50,7 @@ public class PasswordMirrorCredentialTest {
     }
 
     @Test
-    public void testDeserialization() throws Exception {
+    void testDeserialization() throws Exception {
         // With hostnamePatterns
         assertThat(Jackson.readValue('{' +
                                      "  \"type\": \"password\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredentialTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/credential/PublicKeyMirrorCredentialTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -22,12 +22,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.mirror.MirrorCredential;
 
-public class PublicKeyMirrorCredentialTest {
+class PublicKeyMirrorCredentialTest {
 
     private static final String USERNAME = "trustin";
 
@@ -61,7 +61,7 @@ public class PublicKeyMirrorCredentialTest {
     private static final String PASSPHRASE_BASE64 = "base64:c2VzYW1l"; // 'sesame'
 
     @Test
-    public void testConstruction() throws Exception {
+    void testConstruction() {
         // null checks
         assertThatThrownBy(() -> new PublicKeyMirrorCredential(
                 null, null, null, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE))
@@ -103,14 +103,14 @@ public class PublicKeyMirrorCredentialTest {
     }
 
     @Test
-    public void testBase64Passphrase() throws Exception {
+    void testBase64Passphrase() {
         final PublicKeyMirrorCredential c = new PublicKeyMirrorCredential(
                 null, null, USERNAME, PUBLIC_KEY, PRIVATE_KEY, PASSPHRASE_BASE64);
         assertThat(c.passphrase()).isEqualTo(PASSPHRASE.getBytes(StandardCharsets.UTF_8));
     }
 
     @Test
-    public void testDeserialization() throws Exception {
+    void testDeserialization() throws Exception {
         // plaintext passphrase
         assertThat(Jackson.readValue('{' +
                                      "  \"type\": \"public_key\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,7 +18,7 @@ package com.linecorp.centraldogma.server.internal.replication;
 
 import static com.linecorp.centraldogma.testing.internal.TestUtil.assertJsonConversion;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -26,12 +26,12 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.command.Command;
 
-public class ReplicationLogTest {
+class ReplicationLogTest {
 
     private static final Author AUTHOR = new Author("foo", "bar@baz.com");
 
     @Test
-    public void testJsonConversion() {
+    void testJsonConversion() {
         assertJsonConversion(new ReplicationLog<>(1, Command.createProject(1234L, AUTHOR, "foo"), null),
                              '{' +
                              "  \"replicaId\": 1," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,37 +13,35 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.replication;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.test.InstanceSpec;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.DisableOnDebug;
-import org.junit.rules.TestRule;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.ZooKeeperAddress;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 /**
  * Makes sure that we can stop a replica that's waiting for the initial quorum.
  */
-public class StartStopWithoutInitialQuorumTest {
+@Timeout(value = 1, unit = TimeUnit.MINUTES)
+class StartStopWithoutInitialQuorumTest {
 
-    @Rule
-    public final TestRule timeoutRule = new DisableOnDebug(new Timeout(1, TimeUnit.MINUTES));
-
-    @Rule
-    public final CentralDogmaRule dogma = new CentralDogmaRule() {
+    @RegisterExtension
+    final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
-        protected void before() {
+        public void before(ExtensionContext context) throws Exception {
             // Do not start yet.
         }
 
@@ -59,10 +57,15 @@ public class StartStopWithoutInitialQuorumTest {
                                                                quorumPort, electionPort, clientPort),
                                        2, new ZooKeeperAddress("127.0.0.1", 1, 1, 1))));
         }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
     };
 
     @Test
-    public void test() {
+    void test() {
         final CompletableFuture<Void> startFuture = dogma.startAsync();
         dogma.stopAsync().join();
         startFuture.join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.replication;
 
 import java.util.concurrent.CompletableFuture;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.nio.file.Files;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -149,7 +148,7 @@ public class ZooKeeperCommandExecutorTest {
                                                      Command<?> command1,
                                                      Command<?> command2) {
         final AtomicReference<Command<?>> lastCommand = new AtomicReference<>();
-        verify(replica.delegate, timeout(Duration.ofSeconds(2)).times(1)).apply(argThat(c -> {
+        verify(replica.delegate, timeout(TimeUnit.SECONDS.toMillis(2)).times(1)).apply(argThat(c -> {
             if (lastCommand.get() != null) {
                 return c.equals(lastCommand.get());
             }
@@ -163,7 +162,7 @@ public class ZooKeeperCommandExecutorTest {
         }));
 
         final Command<?> expected = lastCommand.get().equals(command1) ? command2 : command1;
-        verify(replica.delegate, timeout(Duration.ofSeconds(2)).times(1)).apply(argThat(c -> {
+        verify(replica.delegate, timeout(TimeUnit.SECONDS.toMillis(2)).times(1)).apply(argThat(c -> {
             return c.equals(expected);
         }));
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/DefaultProjectManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/DefaultProjectManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -19,12 +19,11 @@ package com.linecorp.centraldogma.server.internal.storage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
+import java.io.File;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -35,16 +34,16 @@ import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class DefaultProjectManagerTest {
+class DefaultProjectManagerTest {
 
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @TempDir
+    File tempDir;
 
     @Test
-    public void testProjectPurgeMarked() throws IOException {
+    void testProjectPurgeMarked() {
         final AtomicInteger counter = new AtomicInteger();
         final DefaultProjectManager pm = new DefaultProjectManager(
-                folder.newFolder(),
+                tempDir,
                 MoreExecutors.directExecutor(),
                 (Runnable r) -> counter.incrementAndGet(),
                 mock(MeterRegistry.class),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.storage.repository.cache;
 
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
@@ -39,9 +38,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -68,7 +65,6 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-@ExtendWith(MockitoExtension.class)
 class CachingRepositoryTest {
 
     @Mock

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,6 +13,7 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.storage.repository.cache;
 
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
@@ -37,12 +38,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
-import org.mockito.quality.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -69,17 +68,14 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
-public class CachingRepositoryTest {
-
-    @Rule
-    public final MockitoRule mockito = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+@ExtendWith(MockitoExtension.class)
+class CachingRepositoryTest {
 
     @Mock
     private Repository delegateRepo;
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void identityQuery() {
+    void identityQuery() {
         final Repository repo = setMockNames(newCachingRepo());
         final Query<String> query = Query.ofText("/baz.txt");
 
@@ -105,7 +101,7 @@ public class CachingRepositoryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void jsonPathQuery() throws JsonParseException {
+    void jsonPathQuery() throws JsonParseException {
         final Repository repo = setMockNames(newCachingRepo());
         final Query<JsonNode> query = Query.ofJsonPath("/baz.json", "$.a");
         final Entry<JsonNode> queryResult = Entry.ofJson(new Revision(10), query.path(), "{\"a\": \"b\"}");
@@ -128,8 +124,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void mergeQuery() throws JsonParseException {
+    void mergeQuery() throws JsonParseException {
         final Repository repo = setMockNames(newCachingRepo());
         final MergeQuery<JsonNode> query = MergeQuery.ofJson(MergeSource.ofRequired("/foo.json"),
                                                              MergeSource.ofRequired("/bar.json"));
@@ -161,8 +156,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void identityQueryMissingEntry() {
+    void identityQueryMissingEntry() {
         final Repository repo = setMockNames(newCachingRepo());
         final Query<String> query = Query.ofText("/baz.txt");
 
@@ -185,7 +179,7 @@ public class CachingRepositoryTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void jsonPathQueryMissingEntry() {
+    void jsonPathQueryMissingEntry() {
         final Repository repo = setMockNames(newCachingRepo());
         final Query<JsonNode> query = Query.ofJsonPath("/baz.json", "$.a");
 
@@ -207,7 +201,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void find() {
+    void find() {
         final Repository repo = setMockNames(newCachingRepo());
         final Map<String, Entry<?>> entries =
                 ImmutableMap.of("/baz.txt", Entry.ofText(new Revision(10), "/baz.txt", "qux"));
@@ -230,7 +224,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void history() {
+    void history() {
         final Repository repo = setMockNames(newCachingRepo());
         final List<Commit> commits = ImmutableList.of(
                 new Commit(new Revision(3), SYSTEM, "third", "", Markup.MARKDOWN),
@@ -259,7 +253,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void singleDiff() {
+    void singleDiff() {
         final Repository repo = setMockNames(newCachingRepo());
         final Query<String> query = Query.ofText("/foo.txt");
         final Change<String> change = Change.ofTextUpsert(query.path(), "bar");
@@ -286,7 +280,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void multiDiff() {
+    void multiDiff() {
         final Repository repo = setMockNames(newCachingRepo());
         final Map<String, Change<?>> changes = ImmutableMap.of(
                 "/foo.txt", Change.ofTextUpsert("/foo.txt", "bar"));
@@ -313,7 +307,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void findLatestRevision() {
+    void findLatestRevision() {
         final Repository repo = setMockNames(newCachingRepo());
         doReturn(new RevisionRange(INIT, new Revision(2))).when(delegateRepo).normalizeNow(INIT, HEAD);
 
@@ -331,7 +325,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void findLatestRevisionNull() {
+    void findLatestRevisionNull() {
         final Repository repo = setMockNames(newCachingRepo());
         doReturn(new RevisionRange(INIT, new Revision(2))).when(delegateRepo).normalizeNow(INIT, HEAD);
 
@@ -349,7 +343,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void finaLatestRevisionHead() {
+    void finaLatestRevisionHead() {
         final Repository repo = newCachingRepo();
         final Revision actualHeadRev = new Revision(2);
         doReturn(new RevisionRange(actualHeadRev, actualHeadRev))
@@ -361,7 +355,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void watchFastPath() {
+    void watchFastPath() {
         final Repository repo = setMockNames(newCachingRepo());
         doReturn(new RevisionRange(INIT, new Revision(2))).when(delegateRepo).normalizeNow(INIT, HEAD);
 
@@ -381,7 +375,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void watchSlowPath() {
+    void watchSlowPath() {
         final Repository repo = setMockNames(newCachingRepo());
         doReturn(new RevisionRange(INIT, new Revision(2))).when(delegateRepo).normalizeNow(INIT, HEAD);
 
@@ -402,7 +396,7 @@ public class CachingRepositoryTest {
     }
 
     @Test
-    public void metrics() {
+    void metrics() {
         final MeterRegistry meterRegistry = PrometheusMeterRegistries.newRegistry();
         final Repository repo = newCachingRepo(meterRegistry);
         final Map<String, Double> meters = MoreMeters.measureAll(meterRegistry);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TagUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TagUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,35 +16,27 @@
 
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TagUtilTest {
+class TagUtilTest {
 
     @Test
-    public void testByteHexDirName() throws Exception {
-        assertEquals("01/", TagUtil.byteHexDirName(0x00000001));
-        assertEquals("0a/0b/", TagUtil.byteHexDirName(0x00000b0a));
-        assertEquals("0a/0b/0c/", TagUtil.byteHexDirName(0x000c0b0a));
-        assertEquals("0a/0b/0c/0d/", TagUtil.byteHexDirName(0x0d0c0b0a));
+    void testByteHexDirName() {
+        assertThat(TagUtil.byteHexDirName(0x00000001)).isEqualTo("01/");
+        assertThat(TagUtil.byteHexDirName(0x00000b0a)).isEqualTo("0a/0b/");
+        assertThat(TagUtil.byteHexDirName(0x000c0b0a)).isEqualTo("0a/0b/0c/");
+        assertThat(TagUtil.byteHexDirName(0x0d0c0b0a)).isEqualTo("0a/0b/0c/0d/");
     }
 
     @Test
-    public void testByteHexDirNameException() {
-        try {
-            TagUtil.byteHexDirName(0);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-            // Expected
-        }
+    void testByteHexDirNameException() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> TagUtil.byteHexDirName(0));
 
-        try {
-            TagUtil.byteHexDirName(-1);
-            fail();
-        } catch (IllegalArgumentException ignored) {
-            // Expected
-        }
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> TagUtil.byteHexDirName(-1));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
@@ -13,7 +13,6 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-
 package com.linecorp.centraldogma.server.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,9 +33,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -48,7 +45,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.NetUtil;
 
-@ExtendWith(MockitoExtension.class)
 class TokenlessClientLoggerTest {
 
     @Mock

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/thrift/TokenlessClientLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,9 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+
 package com.linecorp.centraldogma.server.internal.thrift;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,11 +33,10 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import javax.annotation.Nullable;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -47,20 +48,20 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 
 import io.netty.util.NetUtil;
 
-@RunWith(MockitoJUnitRunner.class)
-public class TokenlessClientLoggerTest {
+@ExtendWith(MockitoExtension.class)
+class TokenlessClientLoggerTest {
 
     @Mock
-    private Clock clock; // = Mockito.mock(Clock.class);
+    private Clock clock;
     @Mock
-    private HttpService delegate; // = Mockito.mock(Service.class);
+    private HttpService delegate;
 
     @Test
-    public void testWithToken() throws Exception {
+    void testWithToken() throws Exception {
         final MockTokenlessClientLogger logger = new MockTokenlessClientLogger();
 
         // When a request with a CSRF token is received
-        final ServiceRequestContext ctx = newContext("foo", "192.168.0.1");
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         final HttpRequest req = newRequestWithToken();
         logger.serve(ctx, req);
 
@@ -74,7 +75,7 @@ public class TokenlessClientLoggerTest {
     }
 
     @Test
-    public void testWithoutToken() throws Exception {
+    void testWithoutToken() throws Exception {
         final MockTokenlessClientLogger logger = new MockTokenlessClientLogger();
 
         final Instant startTime = Instant.now();
@@ -130,7 +131,7 @@ public class TokenlessClientLoggerTest {
     }
 
     private static ServiceRequestContext newContext(String hostname, String ip) {
-        final ServiceRequestContext ctx = Mockito.mock(ServiceRequestContext.class);
+        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
         try {
             when(ctx.remoteAddress()).thenReturn(new InetSocketAddress(
                     InetAddress.getByAddress(hostname, NetUtil.createByteArrayFromIpAddressString(ip)),

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/ThriftBackwardCompatibilityTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/ThriftBackwardCompatibilityTest.java
@@ -95,7 +95,7 @@ class ThriftBackwardCompatibilityTest {
 
         res = webClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isEqualTo(2);
+        assertThat(metadata.repos()).hasSize(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();
         assertThat(metadata.repo(REPO_META)).isNotNull();
@@ -105,7 +105,7 @@ class ThriftBackwardCompatibilityTest {
 
         res = webClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isEqualTo(2);
+        assertThat(metadata.repos()).hasSize(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNotNull();
         assertThat(metadata.repo(REPO_META)).isNotNull();
@@ -115,7 +115,7 @@ class ThriftBackwardCompatibilityTest {
 
         res = webClient.get(PROJECTS_PREFIX + '/' + projectName).aggregate().join();
         metadata = Jackson.readValue(res.contentUtf8(), ProjectMetadata.class);
-        assertThat(metadata.repos().size()).isEqualTo(2);
+        assertThat(metadata.repos()).hasSize(2);
         assertThat(metadata.repo(repo1)).isNotNull();
         assertThat(metadata.repo(repo1).removal()).isNull();
         assertThat(metadata.repo(REPO_META)).isNotNull();

--- a/testing-internal/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/testing-internal/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+org.mockito.junit.jupiter.MockitoExtension

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.extensions.autodetection.enabled = true


### PR DESCRIPTION
This PR migrates part of unit tests to JUnit 5.

#### Changes:
- Migrate some tests to JUnit 5
- Use nested tests in `ProjectServiceV1Test` to reduce the number of Central Dogma instances
- Upgrade Mockito to 3.2.4 and revert an earlier change in `ZooKeeperCommandExecutorTest`
- Use `assertThat().hasSize()` where applicable