### PR TITLE
Migrate unit tests to JUnit 5 (Part 2)

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -6,7 +6,7 @@ boms:
 - com.fasterxml.jackson:jackson-bom:2.10.1
 - com.linecorp.armeria:armeria-bom:0.97.0
 - io.micrometer:micrometer-bom:1.3.2
-
+- org.junit:junit-bom:5.6.0
 
 ch.qos.logback:
   logback-classic:
@@ -152,20 +152,9 @@ junit:
 
 org.junit.jupiter:
   junit-jupiter-api:
-    version: &JUNIT_JUPITER_VERSION '5.6.0'
     # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
       - https://junit.org/junit5/docs/5.5.2/api/
-  junit-jupiter-engine:
-    version: *JUNIT_JUPITER_VERSION
-  junit-jupiter-params:
-    version: *JUNIT_JUPITER_VERSION
-org.junit.platform:
-  junit-platform-launcher:
-    version: '1.6.0'
-org.junit.vintage:
-  junit-vintage-engine:
-    version: *JUNIT_JUPITER_VERSION
 
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.6.1' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -146,13 +146,14 @@ javax.validation:
 
 junit:
   junit:
-    version: '4.12'
+    version: '4.13'
     javadocs:
-    - https://junit.org/junit4/javadoc/4.12/
+      - https://junit.org/junit4/javadoc/4.13/
 
 org.junit.jupiter:
   junit-jupiter-api:
-    version: &JUNIT_JUPITER_VERSION '5.5.2'
+    version: &JUNIT_JUPITER_VERSION '5.6.0'
+    # ':site:javadoc' fails when we use a newer version of Javadoc.
     javadocs:
       - https://junit.org/junit5/docs/5.5.2/api/
   junit-jupiter-engine:
@@ -161,10 +162,10 @@ org.junit.jupiter:
     version: *JUNIT_JUPITER_VERSION
 org.junit.platform:
   junit-platform-launcher:
-    version: '1.5.2'
+    version: '1.6.0'
 org.junit.vintage:
   junit-vintage-engine:
-    version: '5.5.2'
+    version: *JUNIT_JUPITER_VERSION
 
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.6.1' }

--- a/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -99,7 +98,6 @@ class CentralDogmaEndpointGroupTest {
     }
 
     @Test
-    @Timeout(10)
     void text() throws Exception {
         try (Watcher<String> watcher = dogma.client().fileWatcher("directory", "my-service",
                                                                   Query.ofText("/endpoints.txt"))) {

--- a/it/src/test/java/com/linecorp/centraldogma/it/GracefulShutdownTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/GracefulShutdownTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -34,7 +33,6 @@ import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
 
-@Timeout(20)
 class GracefulShutdownTest {
 
     @RegisterExtension

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     ['armeria', 'armeria-thrift0.9'].each {
         compile "com.linecorp.armeria:$it"
     }
-    testCompile 'com.linecorp.armeria:armeria-testing-junit4'
+    testCompile 'com.linecorp.armeria:armeria-testing-junit'
 
     // JSch
     compile 'com.jcraft:jsch'

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AdministrativeServiceTest.java
@@ -17,12 +17,10 @@
 package com.linecorp.centraldogma.server.internal.api;
 
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
+import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.net.InetSocketAddress;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -45,20 +43,10 @@ class AdministrativeServiceTest {
         }
     };
 
-    private static WebClient webClient;
-
-    @BeforeEach
-    void setUp() {
-        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
-        webClient = WebClient.builder(serverUri)
-                             .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
-                             .build();
-    }
-
     @Test
     void status() {
-        final AggregatedHttpResponse res = webClient.get(API_V1_PATH_PREFIX + "status").aggregate().join();
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.get(API_V1_PATH_PREFIX + "status").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThatJson(res.contentUtf8()).isEqualTo(
                 "{ \"writable\": true, \"replicating\": true }");
@@ -66,7 +54,8 @@ class AdministrativeServiceTest {
 
     @Test
     void updateStatus_setUnwritable() {
-        final AggregatedHttpResponse res = webClient.execute(
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }]").aggregate().join();
@@ -78,7 +67,8 @@ class AdministrativeServiceTest {
 
     @Test
     void updateStatus_setUnwritableAndNonReplicating() {
-        final AggregatedHttpResponse res = webClient.execute(
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": false }," +
@@ -91,7 +81,8 @@ class AdministrativeServiceTest {
 
     @Test
     void updateStatus_setWritableAndNonReplicating() {
-        final AggregatedHttpResponse res = webClient.execute(
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }," +
@@ -102,7 +93,8 @@ class AdministrativeServiceTest {
 
     @Test
     void redundantUpdateStatus_Writable() {
-        final AggregatedHttpResponse res = webClient.execute(
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();
@@ -112,7 +104,8 @@ class AdministrativeServiceTest {
 
     @Test
     void redundantUpdateStatus_Replicating() {
-        final AggregatedHttpResponse res = webClient.execute(
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/replicating\", \"value\": true }]").aggregate().join();
@@ -122,10 +115,11 @@ class AdministrativeServiceTest {
 
     @Test
     void updateStatus_leaveReadOnlyMode() {
+        final WebClient client = getClient(dogma);
         // Enter read-only mode.
         updateStatus_setUnwritable();
         // Try to enter writable mode.
-        final AggregatedHttpResponse res = webClient.execute(
+        final AggregatedHttpResponse res = client.execute(
                 RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "status",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON_PATCH),
                 "[{ \"op\": \"replace\", \"path\": \"/writable\", \"value\": true }]").aggregate().join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.api;
 import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -37,8 +38,8 @@ class ListCommitsAndDiffTest {
     @RegisterExtension
     static final CentralDogmaExtension dogma = new CentralDogmaExtension();
 
-    @BeforeEach
-    void setUp() {
+    @BeforeAll
+    static void setUp() {
         createProject(dogma);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ListCommitsAndDiffTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -16,13 +16,13 @@
 
 package com.linecorp.centraldogma.server.internal.api;
 
+import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 
-import java.net.InetSocketAddress;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -30,114 +30,24 @@ import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
-public class ListCommitsAndDiffTest {
+class ListCommitsAndDiffTest {
 
-    // TODO(minwoox) replace this unit test using nested structure in junit 5
-    // Rule is used instead of ClassRule because the listCommits is affected by other unit tests.
-    @Rule
-    public final CentralDogmaRule dogma = new CentralDogmaRule();
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
 
-    private static WebClient webClient;
-
-    @Before
-    public void init() {
-        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
-        webClient = WebClient.builder(serverUri)
-                             .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
-                             .build();
-
-        // the default project used for unit tests
-        RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/api/v1/projects",
-                                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        String body = "{\"name\": \"myPro\"}";
-        webClient.execute(headers, body).aggregate().join();
-
-        // the default repository used for unit tests
-        headers = RequestHeaders.of(HttpMethod.POST, "/api/v1/projects/myPro/repos",
-                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        body = "{\"name\": \"myRepo\"}";
-        webClient.execute(headers, body).aggregate().join();
-        // default files used for unit tests
-        addFooFile();
-    }
-
-    private static void addFooFile() {
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
-                                                         "/api/v1/projects/myPro/repos/myRepo/contents",
-                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        for (int i = 0; i < 2; i++) {
-            final String body =
-                    '{' +
-                    "   \"path\": \"/foo" + i + ".json\"," +
-                    "   \"type\": \"UPSERT_JSON\"," +
-                    "   \"content\" : {\"a\": \"bar" + i + "\"}," +
-                    "   \"commitMessage\" : {" +
-                    "       \"summary\" : \"Add foo" + i + ".json\"," +
-                    "       \"detail\": \"Add because we need it.\"," +
-                    "       \"markup\": \"PLAINTEXT\"" +
-                    "   }" +
-                    '}';
-            webClient.execute(headers, body).aggregate().join();
-        }
+    @BeforeEach
+    void setUp() {
+        createProject(dogma);
     }
 
     @Test
-    public void listCommits() {
-        final AggregatedHttpResponse aRes = webClient.get("/api/v1/projects/myPro/repos/myRepo/commits")
-                                                     .aggregate().join();
-        final String expectedJson =
-                '[' +
-                "   {" +
-                "       \"revision\": 3," +
-                "       \"author\": {" +
-                "           \"name\": \"${json-unit.ignore}\"," +
-                "           \"email\": \"${json-unit.ignore}\"" +
-                "       }," +
-                "       \"pushedAt\": \"${json-unit.ignore}\"," +
-                "       \"commitMessage\" : {" +
-                "           \"summary\" : \"Add foo1.json\"," +
-                "           \"detail\": \"Add because we need it.\"," +
-                "           \"markup\": \"PLAINTEXT\"" +
-                "       }" +
-                "   }," +
-                "   {" +
-                "       \"revision\": 2," +
-                "       \"author\": {" +
-                "           \"name\": \"${json-unit.ignore}\"," +
-                "           \"email\": \"${json-unit.ignore}\"" +
-                "       }," +
-                "       \"pushedAt\": \"${json-unit.ignore}\"," +
-                "       \"commitMessage\" : {" +
-                "           \"summary\" : \"Add foo0.json\"," +
-                "           \"detail\": \"Add because we need it.\"," +
-                "           \"markup\": \"PLAINTEXT\"" +
-                "       }" +
-                "   }," +
-                "   {" +
-                "       \"revision\": 1," +
-                "       \"author\": {" +
-                "           \"name\": \"admin\"," +
-                "           \"email\": \"admin@localhost.localdomain\"" +
-                "       }," +
-                "       \"pushedAt\": \"${json-unit.ignore}\"," +
-                "       \"commitMessage\" : {" +
-                "           \"summary\" : \"Create a new repository\"," +
-                "           \"detail\": \"\"," +
-                "           \"markup\": \"PLAINTEXT\"" +
-                "       }" +
-                "   }" +
-                ']';
-        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
-    }
-
-    @Test
-    public void listCommitsWithmaxCommits() {
+    void listCommitsWithMaxCommits() {
+        final WebClient client = getClient(dogma);
         final AggregatedHttpResponse aRes =
-                webClient.get("/api/v1/projects/myPro/repos/myRepo/commits/-1?to=1&maxCommits=2")
-                         .aggregate().join();
+                client.get("/api/v1/projects/myPro/repos/myRepo/commits/-1?to=1&maxCommits=2")
+                      .aggregate().join();
         final String expectedJson =
                 '[' +
                 "   {" +
@@ -171,9 +81,10 @@ public class ListCommitsAndDiffTest {
     }
 
     @Test
-    public void getOneCommit() {
-        final AggregatedHttpResponse aRes = webClient.get("/api/v1/projects/myPro/repos/myRepo/commits/2")
-                                                     .aggregate().join();
+    void getOneCommit() {
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse aRes = client.get("/api/v1/projects/myPro/repos/myRepo/commits/2")
+                                                  .aggregate().join();
         final String expectedJson =
                 '{' +
                 "   \"revision\": 2," +
@@ -192,8 +103,9 @@ public class ListCommitsAndDiffTest {
     }
 
     @Test
-    public void getCommitWithPath() {
-        final AggregatedHttpResponse aRes = webClient
+    void getCommitWithPath() {
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse aRes = client
                 .get("/api/v1/projects/myPro/repos/myRepo/commits?path=/foo0.json").aggregate().join();
         final String expectedJson =
                 '[' +
@@ -215,48 +127,10 @@ public class ListCommitsAndDiffTest {
     }
 
     @Test
-    public void listCommitsWithRevision() {
-        final AggregatedHttpResponse res1 = webClient.get("/api/v1/projects/myPro/repos/myRepo/commits?to=2")
-                                                     .aggregate().join();
-        final String expectedJson =
-                '[' +
-                "   {" +
-                "       \"revision\": 3," +
-                "       \"author\": {" +
-                "           \"name\": \"${json-unit.ignore}\"," +
-                "           \"email\": \"${json-unit.ignore}\"" +
-                "       }," +
-                "       \"pushedAt\": \"${json-unit.ignore}\"," +
-                "       \"commitMessage\" : {" +
-                "           \"summary\" : \"Add foo1.json\"," +
-                "           \"detail\": \"Add because we need it.\"," +
-                "           \"markup\": \"PLAINTEXT\"" +
-                "       }" +
-                "   }," +
-                "   {" +
-                "       \"revision\": 2," +
-                "       \"author\": {" +
-                "           \"name\": \"${json-unit.ignore}\"," +
-                "           \"email\": \"${json-unit.ignore}\"" +
-                "       }," +
-                "       \"pushedAt\": \"${json-unit.ignore}\"," +
-                "       \"commitMessage\" : {" +
-                "           \"summary\" : \"Add foo0.json\"," +
-                "           \"detail\": \"Add because we need it.\"," +
-                "           \"markup\": \"PLAINTEXT\"" +
-                "       }" +
-                "   }" +
-                ']';
-        assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
-        final AggregatedHttpResponse res2 = webClient.get("/api/v1/projects/myPro/repos/myRepo/commits/3?to=2")
-                                                     .aggregate().join();
-        assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
-    }
-
-    @Test
-    public void getDiff() {
-        editFooFile();
-        final AggregatedHttpResponse aRes = webClient
+    void getDiff() {
+        final WebClient client = getClient(dogma);
+        editFooFile(client);
+        final AggregatedHttpResponse aRes = client
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?from=3&to=5").aggregate().join();
         final String expectedJson =
                 '[' +
@@ -285,9 +159,10 @@ public class ListCommitsAndDiffTest {
     }
 
     @Test
-    public void getJsonDiff() {
-        editFooFile();
-        final AggregatedHttpResponse aRes = webClient
+    void getJsonDiff() {
+        final WebClient client = getClient(dogma);
+        editFooFile(client);
+        final AggregatedHttpResponse aRes = client
                 .get("/api/v1/projects/myPro/repos/myRepo/compare?path=/foo0.json&jsonpath=$.a&from=3&to=4")
                 .aggregate().join();
 
@@ -305,7 +180,151 @@ public class ListCommitsAndDiffTest {
         assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
     }
 
-    private static void editFooFile() {
+    @Nested
+    class ListCommitsTest {
+
+        @RegisterExtension
+        final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+            @Override
+            protected boolean runForEachTest() {
+                return true;
+            }
+        };
+
+        @BeforeEach
+        void setUp() {
+            createProject(dogma);
+        }
+
+        @Test
+        void listCommits() {
+            final WebClient client = getClient(dogma);
+            final AggregatedHttpResponse aRes = client.get("/api/v1/projects/myPro/repos/myRepo/commits")
+                                                      .aggregate().join();
+            final String expectedJson =
+                    '[' +
+                    "   {" +
+                    "       \"revision\": 3," +
+                    "       \"author\": {" +
+                    "           \"name\": \"${json-unit.ignore}\"," +
+                    "           \"email\": \"${json-unit.ignore}\"" +
+                    "       }," +
+                    "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                    "       \"commitMessage\" : {" +
+                    "           \"summary\" : \"Add foo1.json\"," +
+                    "           \"detail\": \"Add because we need it.\"," +
+                    "           \"markup\": \"PLAINTEXT\"" +
+                    "       }" +
+                    "   }," +
+                    "   {" +
+                    "       \"revision\": 2," +
+                    "       \"author\": {" +
+                    "           \"name\": \"${json-unit.ignore}\"," +
+                    "           \"email\": \"${json-unit.ignore}\"" +
+                    "       }," +
+                    "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                    "       \"commitMessage\" : {" +
+                    "           \"summary\" : \"Add foo0.json\"," +
+                    "           \"detail\": \"Add because we need it.\"," +
+                    "           \"markup\": \"PLAINTEXT\"" +
+                    "       }" +
+                    "   }," +
+                    "   {" +
+                    "       \"revision\": 1," +
+                    "       \"author\": {" +
+                    "           \"name\": \"admin\"," +
+                    "           \"email\": \"admin@localhost.localdomain\"" +
+                    "       }," +
+                    "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                    "       \"commitMessage\" : {" +
+                    "           \"summary\" : \"Create a new repository\"," +
+                    "           \"detail\": \"\"," +
+                    "           \"markup\": \"PLAINTEXT\"" +
+                    "       }" +
+                    "   }" +
+                    ']';
+            assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
+        }
+
+        @Test
+        void listCommitsWithRevision() {
+            final WebClient client = getClient(dogma);
+            final AggregatedHttpResponse res1 = client.get("/api/v1/projects/myPro/repos/myRepo/commits?to=2")
+                                                      .aggregate().join();
+            final String expectedJson =
+                    '[' +
+                    "   {" +
+                    "       \"revision\": 3," +
+                    "       \"author\": {" +
+                    "           \"name\": \"${json-unit.ignore}\"," +
+                    "           \"email\": \"${json-unit.ignore}\"" +
+                    "       }," +
+                    "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                    "       \"commitMessage\" : {" +
+                    "           \"summary\" : \"Add foo1.json\"," +
+                    "           \"detail\": \"Add because we need it.\"," +
+                    "           \"markup\": \"PLAINTEXT\"" +
+                    "       }" +
+                    "   }," +
+                    "   {" +
+                    "       \"revision\": 2," +
+                    "       \"author\": {" +
+                    "           \"name\": \"${json-unit.ignore}\"," +
+                    "           \"email\": \"${json-unit.ignore}\"" +
+                    "       }," +
+                    "       \"pushedAt\": \"${json-unit.ignore}\"," +
+                    "       \"commitMessage\" : {" +
+                    "           \"summary\" : \"Add foo0.json\"," +
+                    "           \"detail\": \"Add because we need it.\"," +
+                    "           \"markup\": \"PLAINTEXT\"" +
+                    "       }" +
+                    "   }" +
+                    ']';
+            assertThatJson(res1.contentUtf8()).isEqualTo(expectedJson);
+            final AggregatedHttpResponse res2 =
+                    client.get("/api/v1/projects/myPro/repos/myRepo/commits/3?to=2").aggregate().join();
+            assertThatJson(res2.contentUtf8()).isEqualTo(expectedJson);
+        }
+    }
+
+    private static void createProject(CentralDogmaExtension dogma) {
+        final WebClient client = getClient(dogma);
+        // the default project used for unit tests
+        RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, "/api/v1/projects",
+                                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        String body = "{\"name\": \"myPro\"}";
+        client.execute(headers, body).aggregate().join();
+
+        // the default repository used for unit tests
+        headers = RequestHeaders.of(HttpMethod.POST, "/api/v1/projects/myPro/repos",
+                                    HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        body = "{\"name\": \"myRepo\"}";
+        client.execute(headers, body).aggregate().join();
+        // default files used for unit tests
+        addFooFile(client);
+    }
+
+    private static void addFooFile(WebClient client) {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
+                                                         "/api/v1/projects/myPro/repos/myRepo/contents",
+                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        for (int i = 0; i < 2; i++) {
+            final String body =
+                    '{' +
+                    "   \"path\": \"/foo" + i + ".json\"," +
+                    "   \"type\": \"UPSERT_JSON\"," +
+                    "   \"content\" : {\"a\": \"bar" + i + "\"}," +
+                    "   \"commitMessage\" : {" +
+                    "       \"summary\" : \"Add foo" + i + ".json\"," +
+                    "       \"detail\": \"Add because we need it.\"," +
+                    "       \"markup\": \"PLAINTEXT\"" +
+                    "   }" +
+                    '}';
+            client.execute(headers, body).aggregate().join();
+        }
+    }
+
+    private static void editFooFile(WebClient client) {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
                                                          "/api/v1/projects/myPro/repos/myRepo/contents",
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
@@ -321,7 +340,7 @@ public class ListCommitsAndDiffTest {
                     "       \"markup\": \"PLAINTEXT\"" +
                     "   }" +
                     '}';
-            webClient.execute(headers, body).aggregate().join();
+            client.execute(headers, body).aggregate().join();
         }
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -17,7 +17,6 @@
 package com.linecorp.centraldogma.server.internal.api;
 
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
-import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +29,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -44,11 +44,16 @@ import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 class ProjectServiceV1Test {
 
     @RegisterExtension
-    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configureHttpClient(WebClientBuilder builder) {
+            builder.addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        }
+    };
 
     @Test
     void createProject() throws IOException {
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         final AggregatedHttpResponse aRes = createProject(client, "myPro");
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
         assertThat(headers.status()).isEqualTo(HttpStatus.CREATED);
@@ -71,7 +76,7 @@ class ProjectServiceV1Test {
 
     @Test
     void createProjectWithSameName() {
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         createProject(client, "myNewPro");
         final AggregatedHttpResponse res = createProject(client, "myNewPro");
         assertThat(ResponseHeaders.of(res.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
@@ -85,7 +90,7 @@ class ProjectServiceV1Test {
 
     @Test
     void removeProject() {
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         createProject(client, "foo");
         final AggregatedHttpResponse aRes = client.delete(PROJECTS_PREFIX + "/foo")
                                                   .aggregate().join();
@@ -95,7 +100,7 @@ class ProjectServiceV1Test {
 
     @Test
     void removeAbsentProject() {
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         final AggregatedHttpResponse aRes = client.delete(PROJECTS_PREFIX + "/foo")
                                                   .aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
@@ -105,7 +110,7 @@ class ProjectServiceV1Test {
     void purgeProject() {
         removeProject();
 
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         final AggregatedHttpResponse aRes = client.delete(PROJECTS_PREFIX + "/foo/removed")
                                                   .aggregate().join();
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
@@ -114,7 +119,7 @@ class ProjectServiceV1Test {
 
     @Test
     void unremoveProject() {
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         createProject(client, "bar");
 
         final String projectPath = PROJECTS_PREFIX + "/bar";
@@ -147,7 +152,7 @@ class ProjectServiceV1Test {
                                                          "application/json-patch+json");
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final WebClient client = getClient(dogma);
+        final WebClient client = dogma.httpClient();
         final AggregatedHttpResponse aRes = client.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
@@ -158,6 +163,11 @@ class ProjectServiceV1Test {
         @RegisterExtension
         final CentralDogmaExtension dogma = new CentralDogmaExtension() {
             @Override
+            protected void configureHttpClient(WebClientBuilder builder) {
+                builder.addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+            }
+
+            @Override
             protected boolean runForEachTest() {
                 return true;
             }
@@ -165,7 +175,7 @@ class ProjectServiceV1Test {
 
         @Test
         void listProjects() {
-            final WebClient client = getClient(dogma);
+            final WebClient client = dogma.httpClient();
             createProject(client, "trustin");
             createProject(client, "hyangtack");
             createProject(client, "minwoox");
@@ -207,7 +217,7 @@ class ProjectServiceV1Test {
 
         @Test
         void listRemovedProjects() throws IOException {
-            final WebClient client = getClient(dogma);
+            final WebClient client = dogma.httpClient();
             createProject(client, "trustin");
             createProject(client, "hyangtack");
             createProject(client, "minwoox");

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -17,11 +17,11 @@
 package com.linecorp.centraldogma.server.internal.api;
 
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -235,13 +235,5 @@ class ProjectServiceV1Test {
             // Only trustin project is left
             assertThat(jsonNode.size()).isOne();
         }
-    }
-
-    private static WebClient getClient(CentralDogmaExtension dogma) {
-        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
-        return WebClient.builder(serverUri)
-                        .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
-                        .build();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,15 +18,16 @@ package com.linecorp.centraldogma.server.internal.api;
 
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static com.linecorp.centraldogma.testing.internal.TestUtil.getClient;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -42,39 +43,24 @@ import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.storage.project.Project;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
-public class RepositoryServiceV1Test {
+class RepositoryServiceV1Test {
 
-    // TODO(minwoox) replace this unit test using nested structure in junit 5
-    // Rule is used instead of ClassRule because the listRepository and listRemovedRepository are
-    // affected by other unit tests.
-    @Rule
-    public final CentralDogmaRule dogma = new CentralDogmaRule();
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
 
     private static final String REPOS_PREFIX = PROJECTS_PREFIX + "/myPro" + REPOS;
 
-    private static WebClient webClient;
-
-    @Before
-    public void init() {
-        final InetSocketAddress serverAddress = dogma.dogma().activePort().get().localAddress();
-        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
-        webClient = WebClient.builder(serverUri)
-                             .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
-                             .build();
-
-        // the default project used for unit tests
-        final String body = "{\"name\": \"myPro\"}";
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, PROJECTS_PREFIX,
-                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-
-        webClient.execute(headers, body).aggregate().join();
+    @BeforeEach
+    void setUp() {
+        createProject(dogma);
     }
 
     @Test
-    public void createRepository() throws IOException {
-        final AggregatedHttpResponse aRes = createRepository("myRepo");
+    void createRepository() throws IOException {
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse aRes = createRepository(client, "myRepo");
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
         assertThat(headers.status()).isEqualTo(HttpStatus.CREATED);
 
@@ -87,20 +73,21 @@ public class RepositoryServiceV1Test {
         assertThat(jsonNode.get("createdAt").asText()).isNotNull();
     }
 
-    private static AggregatedHttpResponse createRepository(String repoName) {
+    private static AggregatedHttpResponse createRepository(WebClient client, String repoName) {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, REPOS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final String body = "{\"name\": \"" + repoName + "\"}";
 
-        return webClient.execute(headers, body).aggregate().join();
+        return client.execute(headers, body).aggregate().join();
     }
 
     @Test
-    public void createRepositoryWithSameName() {
-        createRepository("myRepo");
+    void createRepositoryWithSameName() {
+        final WebClient client = getClient(dogma);
+        createRepository(client, "myRepo");
 
         // create again with the same name
-        final AggregatedHttpResponse aRes = createRepository("myRepo");
+        final AggregatedHttpResponse aRes = createRepository(client, "myRepo");
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
@@ -111,12 +98,13 @@ public class RepositoryServiceV1Test {
     }
 
     @Test
-    public void createRepositoryInAbsentProject() {
+    void createRepositoryInAbsentProject() {
+        final WebClient client = getClient(dogma);
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
                                                          PROJECTS_PREFIX + "/absentProject" + REPOS,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final String body = "{\"name\": \"myRepo\"}";
-        final AggregatedHttpResponse aRes = webClient.execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse aRes = client.execute(headers, body).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
         final String expectedJson =
                 '{' +
@@ -127,107 +115,39 @@ public class RepositoryServiceV1Test {
     }
 
     @Test
-    public void listRepositories() {
-        createRepository("myRepo");
-        final AggregatedHttpResponse aRes = webClient.get(REPOS_PREFIX).aggregate().join();
-
-        assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.OK);
-        final String expectedJson =
-                '[' +
-                "   {" +
-                "       \"name\": \"dogma\"," +
-                "       \"creator\": {" +
-                "           \"name\": \"System\"," +
-                "           \"email\": \"system@localhost.localdomain\"" +
-                "       }," +
-                "       \"headRevision\": \"${json-unit.ignore}\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/dogma\"," +
-                "       \"createdAt\": \"${json-unit.ignore}\"" +
-                "   }," +
-                "   {" +
-                "       \"name\": \"meta\"," +
-                "       \"creator\": {" +
-                "           \"name\": \"System\"," +
-                "           \"email\": \"system@localhost.localdomain\"" +
-                "       }," +
-                "       \"headRevision\": \"${json-unit.ignore}\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/meta\"," +
-                "       \"createdAt\": \"${json-unit.ignore}\"" +
-                "   }," +
-                "   {" +
-                "       \"name\": \"myRepo\"," +
-                "       \"creator\": {" +
-                "           \"name\": \"admin\"," +
-                "           \"email\": \"admin@localhost.localdomain\"" +
-                "       }," +
-                "       \"headRevision\": \"${json-unit.ignore}\"," +
-                "       \"url\": \"/api/v1/projects/myPro/repos/myRepo\"," +
-                "       \"createdAt\": \"${json-unit.ignore}\"" +
-                "   }" +
-                ']';
-        assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
-    }
-
-    @Test
-    public void removeRepository() {
-        createRepository("foo");
-        final AggregatedHttpResponse aRes = webClient.delete(REPOS_PREFIX + "/foo").aggregate().join();
+    void removeRepository() {
+        final WebClient client = getClient(dogma);
+        createRepository(client,"foo");
+        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + "/foo").aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
     @Test
-    public void removeAbsentRepository() {
-        final AggregatedHttpResponse aRes = webClient.delete(REPOS_PREFIX + "/foo").aggregate().join();
+    void removeAbsentRepository() {
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + "/foo").aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
-    public void removeMetaRepository() {
-        final AggregatedHttpResponse aRes = webClient.delete(REPOS_PREFIX + '/' + Project.REPO_META)
-                                                     .aggregate().join();
+    void removeMetaRepository() {
+        final WebClient client = getClient(dogma);
+        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + '/' + Project.REPO_META)
+                                                  .aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
-    public void listRemovedRepositories() throws IOException {
-        createRepository("trustin");
-        createRepository("hyangtack");
-        createRepository("minwoox");
-        webClient.delete(REPOS_PREFIX + "/hyangtack").aggregate().join();
-        webClient.delete(REPOS_PREFIX + "/minwoox").aggregate().join();
-
-        final AggregatedHttpResponse removedRes = webClient.get(REPOS_PREFIX + "?status=removed")
-                                                           .aggregate().join();
-        assertThat(ResponseHeaders.of(removedRes.headers()).status()).isEqualTo(HttpStatus.OK);
-        final String expectedJson =
-                '[' +
-                "   {" +
-                "       \"name\": \"hyangtack\"" +
-                "   }," +
-                "   {" +
-                "       \"name\": \"minwoox\"" +
-                "   }" +
-                ']';
-        assertThatJson(removedRes.contentUtf8()).isEqualTo(expectedJson);
-
-        final AggregatedHttpResponse remainedRes = webClient.get(REPOS_PREFIX).aggregate().join();
-        final String remains = remainedRes.contentUtf8();
-        final JsonNode jsonNode = Jackson.readTree(remains);
-
-        // dogma, meta and trustin repositories are left
-        assertThat(jsonNode.size()).isEqualTo(3);
-    }
-
-    @Test
-    public void unremoveRepository() {
-        createRepository("foo");
-        webClient.delete(REPOS_PREFIX + "/foo").aggregate().join();
+    void unremoveRepository() {
+        final WebClient client = getClient(dogma);
+        createRepository(client, "foo");
+        client.delete(REPOS_PREFIX + "/foo").aggregate().join();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH, REPOS_PREFIX + "/foo",
                                                          HttpHeaderNames.CONTENT_TYPE,
                                                          "application/json-patch+json");
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final AggregatedHttpResponse aRes = webClient.execute(headers, unremovePatch).aggregate().join();
+        final AggregatedHttpResponse aRes = client.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.OK);
         final String expectedJson =
                 '{' +
@@ -244,21 +164,124 @@ public class RepositoryServiceV1Test {
     }
 
     @Test
-    public void unremoveAbsentRepository() {
+    void unremoveAbsentRepository() {
+        final WebClient client = getClient(dogma);
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH, REPOS_PREFIX + "/baz",
                                                          HttpHeaderNames.CONTENT_TYPE,
                                                          "application/json-patch+json");
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final AggregatedHttpResponse aRes = webClient.execute(headers, unremovePatch).aggregate().join();
+        final AggregatedHttpResponse aRes = client.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
-    public void normalizeRevision() {
-        createRepository("foo");
-        final AggregatedHttpResponse res = webClient.get(REPOS_PREFIX + "/foo/revision/-1")
-                                                    .aggregate().join();
+    void normalizeRevision() {
+        final WebClient client = getClient(dogma);
+        createRepository(client, "foo");
+        final AggregatedHttpResponse res = client.get(REPOS_PREFIX + "/foo/revision/-1")
+                                                 .aggregate().join();
         assertThatJson(res.contentUtf8()).isEqualTo("{\"revision\":1}");
+    }
+
+    @Nested
+    class ListRepositoriesTest {
+
+        @RegisterExtension
+        final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+            @Override
+            protected boolean runForEachTest() {
+                return true;
+            }
+        };
+
+        @BeforeEach
+        void setUp() {
+            createProject(dogma);
+        }
+
+        @Test
+        void listRepositories() {
+            final WebClient client = getClient(dogma);
+            createRepository(client, "myRepo");
+            final AggregatedHttpResponse aRes = client.get(REPOS_PREFIX).aggregate().join();
+
+            assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.OK);
+            final String expectedJson =
+                    '[' +
+                    "   {" +
+                    "       \"name\": \"dogma\"," +
+                    "       \"creator\": {" +
+                    "           \"name\": \"System\"," +
+                    "           \"email\": \"system@localhost.localdomain\"" +
+                    "       }," +
+                    "       \"headRevision\": \"${json-unit.ignore}\"," +
+                    "       \"url\": \"/api/v1/projects/myPro/repos/dogma\"," +
+                    "       \"createdAt\": \"${json-unit.ignore}\"" +
+                    "   }," +
+                    "   {" +
+                    "       \"name\": \"meta\"," +
+                    "       \"creator\": {" +
+                    "           \"name\": \"System\"," +
+                    "           \"email\": \"system@localhost.localdomain\"" +
+                    "       }," +
+                    "       \"headRevision\": \"${json-unit.ignore}\"," +
+                    "       \"url\": \"/api/v1/projects/myPro/repos/meta\"," +
+                    "       \"createdAt\": \"${json-unit.ignore}\"" +
+                    "   }," +
+                    "   {" +
+                    "       \"name\": \"myRepo\"," +
+                    "       \"creator\": {" +
+                    "           \"name\": \"admin\"," +
+                    "           \"email\": \"admin@localhost.localdomain\"" +
+                    "       }," +
+                    "       \"headRevision\": \"${json-unit.ignore}\"," +
+                    "       \"url\": \"/api/v1/projects/myPro/repos/myRepo\"," +
+                    "       \"createdAt\": \"${json-unit.ignore}\"" +
+                    "   }" +
+                    ']';
+            assertThatJson(aRes.contentUtf8()).isEqualTo(expectedJson);
+        }
+
+        @Test
+        void listRemovedRepositories() throws IOException {
+            final WebClient client = getClient(dogma);
+            createRepository(client, "trustin");
+            createRepository(client, "hyangtack");
+            createRepository(client, "minwoox");
+            client.delete(REPOS_PREFIX + "/hyangtack").aggregate().join();
+            client.delete(REPOS_PREFIX + "/minwoox").aggregate().join();
+
+            final AggregatedHttpResponse removedRes = client.get(REPOS_PREFIX + "?status=removed")
+                                                            .aggregate().join();
+            assertThat(ResponseHeaders.of(removedRes.headers()).status()).isEqualTo(HttpStatus.OK);
+            final String expectedJson =
+                    '[' +
+                    "   {" +
+                    "       \"name\": \"hyangtack\"" +
+                    "   }," +
+                    "   {" +
+                    "       \"name\": \"minwoox\"" +
+                    "   }" +
+                    ']';
+            assertThatJson(removedRes.contentUtf8()).isEqualTo(expectedJson);
+
+            final AggregatedHttpResponse remainedRes = client.get(REPOS_PREFIX).aggregate().join();
+            final String remains = remainedRes.contentUtf8();
+            final JsonNode jsonNode = Jackson.readTree(remains);
+
+            // dogma, meta and trustin repositories are left
+            assertThat(jsonNode).hasSize(3);
+        }
+    }
+
+    private static void createProject(CentralDogmaExtension dogma) {
+        // the default project used for unit tests
+        final String body = "{\"name\": \"myPro\"}";
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, PROJECTS_PREFIX,
+                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+
+        final WebClient client = getClient(dogma);
+        client.execute(headers, body).aggregate().join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -21,7 +21,6 @@ import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_
 import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
@@ -29,7 +28,6 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -64,6 +62,7 @@ import com.linecorp.centraldogma.server.metadata.PerRolePermissions;
 import com.linecorp.centraldogma.server.metadata.Permission;
 import com.linecorp.centraldogma.server.metadata.ProjectRole;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 
 class PermissionTest {
 
@@ -73,18 +72,17 @@ class PermissionTest {
     private static final String secret2 = "appToken-2";
     private static final String secret3 = "appToken-3";
 
-    @TempDir
     @Order(1)
-    static File rootDir;
+    @RegisterExtension
+    static final TemporaryFolderExtension rootDir = new TemporaryFolderExtension();
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             final ProjectManager pm = new DefaultProjectManager(
-                    rootDir, ForkJoinPool.commonPool(), MoreExecutors.directExecutor(),
-                    NoopMeterRegistry.get(), null
-            );
+                    rootDir.getRoot().toFile(), ForkJoinPool.commonPool(),
+                    MoreExecutors.directExecutor(), NoopMeterRegistry.get(), null);
             final CommandExecutor executor = new StandaloneCommandExecutor(
                     pm, ForkJoinPool.commonPool(), null, null, null);
             executor.start().join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -24,9 +24,8 @@ import java.io.File;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.CronType;
@@ -44,16 +43,16 @@ import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
-public class DefaultMirroringServiceTest {
+class DefaultMirroringServiceTest {
 
-    @ClassRule
-    public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+    @TempDir
+    static File temporaryFolder;
 
     private static final Cron EVERY_SECOND = new CronParser(
             CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("* * * * * ?");
 
     @Test
-    public void mirroringTaskShouldNeverBeRejected() throws Exception {
+    void mirroringTaskShouldNeverBeRejected() {
         final AtomicInteger taskCounter = new AtomicInteger();
         final ProjectManager pm = mock(ProjectManager.class);
         final Project p = mock(Project.class);
@@ -82,8 +81,7 @@ public class DefaultMirroringServiceTest {
 
         when(mr.mirrors()).thenReturn(ImmutableSet.of(mirror));
 
-        final DefaultMirroringService service =
-                new DefaultMirroringService(temporaryFolder.getRoot(), pm, 1, 1, 1);
+        final DefaultMirroringService service = new DefaultMirroringService(temporaryFolder, pm, 1, 1, 1);
         service.start(mock(CommandExecutor.class));
 
         try {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
@@ -16,11 +16,9 @@
 package com.linecorp.centraldogma.server.internal.replication;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.curator.test.InstanceSpec;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -34,7 +32,6 @@ import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 /**
  * Makes sure that we can stop a replica that's waiting for the initial quorum.
  */
-@Timeout(value = 1, unit = TimeUnit.MINUTES)
 class StartStopWithoutInitialQuorumTest {
 
     @RegisterExtension

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -32,7 +31,7 @@ import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
@@ -42,21 +41,23 @@ import com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepos
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
+import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 
 class RepositoryManagerWrapperTest {
-
-    @TempDir
-    static File rootDir;
 
     private static RepositoryManager m;
 
     private Executor purgeWorker;
 
+    @RegisterExtension
+    static final TemporaryFolderExtension rootDir = new TemporaryFolderExtension();
+
     @BeforeEach
     void setUp() {
         purgeWorker = mock(Executor.class);
-        m = new RepositoryManagerWrapper(new GitRepositoryManager(mock(Project.class), rootDir,
+        m = new RepositoryManagerWrapper(new GitRepositoryManager(mock(Project.class),
+                                                                  rootDir.getRoot().toFile(),
                                                                   ForkJoinPool.commonPool(),
                                                                   purgeWorker, null),
                                          RepositoryWrapper::new);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,25 +18,21 @@ package com.linecorp.centraldogma.server.internal.storage.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import java.io.IOException;
+import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
-import java.util.stream.Collectors;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
@@ -46,31 +42,29 @@ import com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepos
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
+import com.linecorp.centraldogma.testing.internal.TestUtil;
 
-public class RepositoryManagerWrapperTest {
+class RepositoryManagerWrapperTest {
 
-    @ClassRule
-    public static final TemporaryFolder rootDir = new TemporaryFolder();
+    @TempDir
+    static File rootDir;
 
     private static RepositoryManager m;
 
-    @Rule
-    public final TestName testName = new TestName();
-
     private Executor purgeWorker;
 
-    @Before
-    public void init() throws IOException {
+    @BeforeEach
+    void setUp() {
         purgeWorker = mock(Executor.class);
-        m = new RepositoryManagerWrapper(new GitRepositoryManager(mock(Project.class), rootDir.getRoot(),
+        m = new RepositoryManagerWrapper(new GitRepositoryManager(mock(Project.class), rootDir,
                                                                   ForkJoinPool.commonPool(),
                                                                   purgeWorker, null),
                                          RepositoryWrapper::new);
     }
 
     @Test
-    public void testCreate() {
-        final String name = testName.getMethodName();
+    void create(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         final Repository repo = m.create(name, Author.SYSTEM);
         assertThat(repo).isInstanceOf(RepositoryWrapper.class);
         // The cached result will be returned on the second call.
@@ -78,8 +72,8 @@ public class RepositoryManagerWrapperTest {
     }
 
     @Test
-    public void testGet() {
-        final String name = testName.getMethodName();
+    void get(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         final Repository repo = m.create(name, Author.SYSTEM);
         final Repository repo2 = m.get(name);
 
@@ -88,35 +82,33 @@ public class RepositoryManagerWrapperTest {
     }
 
     @Test
-    public void testRemove() {
-        final String name = testName.getMethodName();
+    void remove(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         m.create(name, Author.SYSTEM);
         m.remove(name);
         assertThat(m.exists(name)).isFalse();
     }
 
     @Test
-    public void testRemove_failure() {
-        final String name = testName.getMethodName();
+    void remove_failure(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         assertThatThrownBy(() -> m.remove(name)).isInstanceOf(RepositoryNotFoundException.class);
     }
 
     @Test
-    public void testUnRemove_failure() {
-        final String name = testName.getMethodName();
+    void unremove_failure(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         assertThatThrownBy(() -> m.unremove(name)).isInstanceOf(RepositoryNotFoundException.class);
     }
 
     @Test
-    public void testList() {
-        final String name = testName.getMethodName();
+    void list(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         final int numNames = 10;
         for (int i = 0; i < numNames; i++) {
             m.create(name + i, Author.SYSTEM);
         }
-        final List<String> names = m.list().entrySet().stream()
-                                    .map(Map.Entry::getKey)
-                                    .collect(Collectors.toList());
+        final List<String> names = new ArrayList<>(m.list().keySet());
 
         // Check if names is in ascending order
         for (int i = 0; i < numNames - 1; i++) {
@@ -127,8 +119,8 @@ public class RepositoryManagerWrapperTest {
     }
 
     @Test
-    public void testMarkForPurge() {
-        final String name = testName.getMethodName();
+    void markForPurge(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         m.create(name, Author.SYSTEM);
         m.remove(name);
         m.markForPurge(name);
@@ -137,27 +129,27 @@ public class RepositoryManagerWrapperTest {
     }
 
     @Test
-    public void testPurgeMarked() {
-        final String name = testName.getMethodName();
+    void purgeMarked(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         final int numNames = 10;
         for (int i = 0; i < numNames; i++) {
-            String targetName = name + i;
+            final String targetName = name + i;
             m.create(targetName, Author.SYSTEM);
             m.remove(targetName);
             m.markForPurge(targetName);
         }
         m.purgeMarked();
         for (int i = 0; i < numNames; i++) {
-            String targetName = name + i;
+            final String targetName = name + i;
             assertThatThrownBy(() -> m.get(targetName)).isInstanceOf(RepositoryNotFoundException.class);
         }
     }
 
     @Test
-    public void testClose() {
-        final String name = testName.getMethodName();
+    void close(TestInfo testInfo) {
+        final String name = TestUtil.normalizedDisplayName(testInfo);
         m.create(name, Author.SYSTEM);
-        assertTrue(m.exists(name));
+        assertThat(m.exists(name)).isTrue();
         m.close(ShuttingDownException::new);
 
         assertThatThrownBy(() -> m.get(name)).isInstanceOf(ShuttingDownException.class);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
@@ -21,13 +21,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
-import java.io.File;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -37,13 +36,19 @@ import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 
 class GitRepositoryManagerTest {
 
     private static final String TEST_REPO = "test_repo";
 
-    @TempDir
-    File rootDir;
+    @RegisterExtension
+    final TemporaryFolderExtension rootDir = new TemporaryFolderExtension() {
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
 
     @Test
     void testCreate() {
@@ -133,7 +138,8 @@ class GitRepositoryManagerTest {
     }
 
     private GitRepositoryManager newRepositoryManager() {
-        return new GitRepositoryManager(mock(Project.class), rootDir, ForkJoinPool.commonPool(),
-                                        MoreExecutors.directExecutor(), mock(RepositoryCache.class));
+        return new GitRepositoryManager(mock(Project.class), rootDir.getRoot().toFile(),
+                                        ForkJoinPool.commonPool(), MoreExecutors.directExecutor(),
+                                        mock(RepositoryCache.class));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 LINE Corporation
+ * Copyright 2020 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -18,18 +18,16 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.concurrent.ForkJoinPool;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -40,19 +38,15 @@ import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCa
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
-public class GitRepositoryManagerTest {
+class GitRepositoryManagerTest {
 
     private static final String TEST_REPO = "test_repo";
 
-    @Rule
-    public final TemporaryFolder rootDir = new TemporaryFolder();
-
-    File rootDir() {
-        return rootDir.getRoot();
-    }
+    @TempDir
+    File rootDir;
 
     @Test
-    public void testCreate() throws Exception {
+    void testCreate() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         final Repository repository = gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
         assertThat(repository).isInstanceOf(GitRepository.class);
@@ -64,7 +58,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testOpen() throws Exception {
+    void testOpen() {
         // Create a new repository and close the manager.
         GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
@@ -78,7 +72,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testGet() throws Exception {
+    void testGet() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         assertThat(gitRepositoryManager.exists(TEST_REPO)).isFalse();
 
@@ -89,7 +83,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testGetAndHas() {
+    void testGetAndHas() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         assertThat(gitRepositoryManager.exists(TEST_REPO)).isFalse();
         final Repository repo = gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
@@ -98,7 +92,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testDelete() throws Exception {
+    void testDelete() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
         assertThat(gitRepositoryManager.exists(TEST_REPO)).isTrue();
@@ -109,7 +103,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testList() {
+    void testList() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         final int numRepoFiles = 1;
         final String repoNamePattern = "repo%d";
@@ -120,7 +114,7 @@ public class GitRepositoryManagerTest {
 
         final int numDummyFiles = 1;
         for (int i = 0; i < numDummyFiles; i++) {
-            if (!Paths.get(rootDir.getRoot().toString(), String.format("dummyDir%d", i)).toFile().mkdirs()) {
+            if (!Paths.get(rootDir.toString(), String.format("dummyDir%d", i)).toFile().mkdirs()) {
                 fail("failed to test on testList");
             }
         }
@@ -130,7 +124,7 @@ public class GitRepositoryManagerTest {
     }
 
     @Test
-    public void testHas() throws IOException {
+    void testHas() {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         assertThat(gitRepositoryManager.exists(TEST_REPO)).isFalse();
         gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
@@ -139,7 +133,7 @@ public class GitRepositoryManagerTest {
     }
 
     private GitRepositoryManager newRepositoryManager() {
-        return new GitRepositoryManager(mock(Project.class), rootDir(), ForkJoinPool.commonPool(),
+        return new GitRepositoryManager(mock(Project.class), rootDir, ForkJoinPool.commonPool(),
                                         MoreExecutors.directExecutor(), mock(RepositoryCache.class));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -57,7 +57,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -1161,7 +1160,6 @@ class GitRepositoryTest {
     }
 
     @Test
-    @Timeout(10)
     void testWatchWithIdentityQuery() throws Exception {
         final Revision rev1 = repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY, textUpserts[0]).join();
 

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtension.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.testing.internal;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import com.linecorp.centraldogma.testing.junit.AbstractAllOrEachExtension;
+
+/**
+ * A JUnit {@link Extension} that creates a {@link TemporaryFolder}.
+ *
+ * <pre>{@code
+ * > class MyTest {
+ * >     @RegisterExtension
+ * >     static final TemporaryFolder folder = new TemporaryFolder();
+ * >
+ * >     @Test
+ * >     void test() throws Exception {
+ * >         Path file = folder.newFile();
+ * >         ...
+ * >     }
+ * > }
+ * }</pre>
+ */
+public class TemporaryFolderExtension extends AbstractAllOrEachExtension {
+
+    private final TemporaryFolder delegate;
+
+    public TemporaryFolderExtension() {
+        delegate = new TemporaryFolder();
+    }
+
+    @Override
+    public void before(ExtensionContext context) throws Exception {
+        delegate.create();
+    }
+
+    @Override
+    public void after(ExtensionContext context) throws Exception {
+        delegate.delete();
+    }
+
+    public void create() throws IOException {
+        delegate.create();
+    }
+
+    public boolean exists() {
+        return delegate.exists();
+    }
+
+    public Path getRoot() {
+        return delegate.getRoot();
+    }
+
+    public Path newFolder() throws IOException {
+        return delegate.newFolder();
+    }
+
+    public Path newFile() throws IOException {
+        return delegate.newFile();
+    }
+
+    public void delete() throws IOException {
+        delegate.delete();
+    }
+}

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtension.java
@@ -30,7 +30,7 @@ import com.linecorp.centraldogma.testing.junit.AbstractAllOrEachExtension;
  * <pre>{@code
  * > class MyTest {
  * >     @RegisterExtension
- * >     static final TemporaryFolder folder = new TemporaryFolder();
+ * >     static final TemporaryFolderExtension folder = new TemporaryFolderExtension();
  * >
  * >     @Test
  * >     void test() throws Exception {

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TestUtil.java
@@ -21,15 +21,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOError;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.TestInfo;
 
-import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 public final class TestUtil {
 
@@ -52,14 +48,6 @@ public final class TestUtil {
 
     public static String normalizedDisplayName(TestInfo testInfo) {
         return DISALLOWED_CHARS.matcher(testInfo.getDisplayName()).replaceAll("");
-    }
-
-    public static WebClient getClient(CentralDogmaExtension extension) {
-        final InetSocketAddress serverAddress = extension.dogma().activePort().get().localAddress();
-        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
-        return WebClient.builder(serverUri)
-                        .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
-                        .build();
     }
 
     private TestUtil() {}

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TestUtil.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/TestUtil.java
@@ -21,11 +21,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOError;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.TestInfo;
 
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 public final class TestUtil {
 
@@ -48,6 +52,14 @@ public final class TestUtil {
 
     public static String normalizedDisplayName(TestInfo testInfo) {
         return DISALLOWED_CHARS.matcher(testInfo.getDisplayName()).replaceAll("");
+    }
+
+    public static WebClient getClient(CentralDogmaExtension extension) {
+        final InetSocketAddress serverAddress = extension.dogma().activePort().get().localAddress();
+        final String serverUri = "http://127.0.0.1:" + serverAddress.getPort();
+        return WebClient.builder(serverUri)
+                        .addHttpHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
+                        .build();
     }
 
     private TestUtil() {}

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,2 +1,3 @@
+junit.jupiter.execution.timeout.default = 60s
 junit.jupiter.execution.timeout.mode = disabled_on_debug
 junit.jupiter.extensions.autodetection.enabled = true

--- a/testing-internal/src/main/resources/junit-platform.properties
+++ b/testing-internal/src/main/resources/junit-platform.properties
@@ -1,1 +1,2 @@
+junit.jupiter.execution.timeout.mode = disabled_on_debug
 junit.jupiter.extensions.autodetection.enabled = true

--- a/testing-internal/src/test/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtensionTest.java
+++ b/testing-internal/src/test/java/com/linecorp/centraldogma/testing/internal/TemporaryFolderExtensionTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.testing.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class TemporaryFolderExtensionTest {
+
+    @RegisterExtension
+    final TemporaryFolderExtension extension = new TemporaryFolderExtension() {
+        @Override
+        public void before(ExtensionContext context) throws Exception {
+            assertThat(exists()).isFalse();
+            super.before(context);
+            assertThat(exists()).isTrue();
+        }
+
+        @Override
+        public void after(ExtensionContext context) throws Exception {
+            assertThat(exists()).isTrue();
+            super.after(context);
+            assertThat(exists()).isFalse();
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    @Test
+    void recreate() throws Exception {
+        final String oldRoot = extension.getRoot().toString();
+
+        extension.delete();
+        assertThat(extension.exists()).isFalse();
+        extension.create();
+        assertThat(extension.exists()).isTrue();
+
+        assertThat(extension.getRoot().toString()).isNotEqualTo(oldRoot);
+    }
+
+    @Test
+    void newFolder() throws Exception {
+        final Path root = extension.getRoot();
+        final Path folder = extension.newFolder();
+
+        assertThat(folder.toFile().exists());
+        assertThat(Files.walk(root)).containsOnly(root, folder);
+    }
+
+    @Test
+    void newFile() throws Exception {
+        final Path root = extension.getRoot();
+        final Path file = extension.newFile();
+
+        assertThat(file.toFile().exists());
+        assertThat(Files.walk(root)).containsOnly(root, file);
+    }
+}

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServerPort;
@@ -130,8 +131,10 @@ public class CentralDogmaRuleDelegate {
                 throw new IOError(e);
             }
 
-            webClient = WebClient.of(
-                    "h2c://" + serverAddress.getHostString() + ':' + serverAddress.getPort());
+            final String uri = "h2c://" + serverAddress.getHostString() + ':' + serverAddress.getPort();
+            final WebClientBuilder webClientBuilder = WebClient.builder(uri);
+            configureHttpClient(webClientBuilder);
+            webClient = webClientBuilder.build();
         });
     }
 
@@ -244,6 +247,11 @@ public class CentralDogmaRuleDelegate {
      * Override this method to configure the Thrift-based {@link CentralDogma} client builder.
      */
     protected void configureClient(LegacyCentralDogmaBuilder builder) {}
+
+    /**
+     * Override this method to configure the {@link WebClient} builder.
+     */
+    protected void configureHttpClient(WebClientBuilder builder) {}
 
     /**
      * Override this method to perform the initial updates on the server,

--- a/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
+++ b/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
@@ -82,6 +83,11 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
             @Override
             protected void configureClient(LegacyCentralDogmaBuilder builder) {
                 CentralDogmaExtension.this.configureClient(builder);
+            }
+
+            @Override
+            protected void configureHttpClient(WebClientBuilder builder) {
+                CentralDogmaExtension.this.configureHttpClient(builder);
             }
 
             @Override
@@ -225,6 +231,11 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
      * Override this method to configure the Thrift-based {@link CentralDogma} client builder.
      */
     protected void configureClient(LegacyCentralDogmaBuilder builder) {}
+
+    /**
+     * Override this method to configure the {@link WebClient} builder.
+     */
+    protected void configureHttpClient(WebClientBuilder builder) {}
 
     /**
      * Override this method to perform the initial updates on the server,

--- a/testing/junit4/src/main/java/com/linecorp/centraldogma/testing/junit4/CentralDogmaRule.java
+++ b/testing/junit4/src/main/java/com/linecorp/centraldogma/testing/junit4/CentralDogmaRule.java
@@ -26,6 +26,7 @@ import org.junit.rules.TemporaryFolder;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
@@ -79,6 +80,11 @@ public class CentralDogmaRule extends TemporaryFolder {
             @Override
             protected void configureClient(LegacyCentralDogmaBuilder builder) {
                 CentralDogmaRule.this.configureClient(builder);
+            }
+
+            @Override
+            protected void configureHttpClient(WebClientBuilder builder) {
+                CentralDogmaRule.this.configureHttpClient(builder);
             }
 
             @Override
@@ -224,6 +230,11 @@ public class CentralDogmaRule extends TemporaryFolder {
      * Override this method to configure the Thrift-based {@link CentralDogma} client builder.
      */
     protected void configureClient(LegacyCentralDogmaBuilder builder) {}
+
+    /**
+     * Override this method to configure the {@link WebClient} builder.
+     */
+    protected void configureHttpClient(WebClientBuilder builder) {}
 
     /**
      * Override this method to perform the initial updates on the server,


### PR DESCRIPTION
This PR continues the migration of unit tests to JUnit 5.

#### Changes:
- Migrate some tests to JUnit 5
- Upgrade to JUnit 5.6.0 and 4.13
  - Enable `disabled_on_debug` for `@Timeout`
- Migrate to Armeria's `ServerExtension`
- Introduce more nested tests, similar to `ProjectServiceV1Test`
  - Extract common logic to `TestUtil.getClient()`