### PR TITLE
Fix performance issue with GitRepository.history & startup issues

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -459,7 +459,7 @@ class GitRepository implements Repository {
         readLock();
         try (ObjectReader reader = jGitRepository.newObjectReader();
              TreeWalk treeWalk = new TreeWalk(reader);
-             RevWalk revWalk = new RevWalk(reader)) {
+             RevWalk revWalk = newRevWalk(reader)) {
 
             // Query on a non-exist revision will return empty result.
             final Revision headRevision = cachedHeadRevision();
@@ -566,13 +566,14 @@ class GitRepository implements Repository {
 
         // At this point, we are sure: from.major >= to.major
         readLock();
-        try (RevWalk revWalk = new RevWalk(jGitRepository)) {
+        try (RevWalk revWalk = newRevWalk()) {
             final ObjectId fromCommitId = commitIdDatabase.get(descendingRange.from());
             final ObjectId toCommitId = commitIdDatabase.get(descendingRange.to());
 
             // Walk through the commit tree to get the corresponding commit information by given filters
             revWalk.setTreeFilter(AndTreeFilter.create(TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
-
+            // Disable rewriteParents because otherwise `RevWalk` will load every commit into memory.
+            revWalk.setRewriteParents(false);
             revWalk.markStart(revWalk.parseCommit(fromCommitId));
             final RevCommit toCommit = revWalk.parseCommit(toCommitId);
             if (toCommit.getParentCount() != 0) {
@@ -599,7 +600,7 @@ class GitRepository implements Repository {
             // If the pathPattern does not contain "/**", the caller wants commits only with the specific path,
             // so skip the empty commit.
             if (needsLastCommit && pathPattern.contains(ALL_PATH)) {
-                try (RevWalk tmpRevWalk = new RevWalk(jGitRepository)) {
+                try (RevWalk tmpRevWalk = newRevWalk()) {
                     final RevCommit lastRevCommit = tmpRevWalk.parseCommit(toCommitId);
                     final Revision lastCommitRevision =
                             CommitUtil.extractRevision(lastRevCommit.getFullMessage());
@@ -665,7 +666,7 @@ class GitRepository implements Repository {
 
             final RevisionRange range = normalizeNow(from, to).toAscending();
             readLock();
-            try (RevWalk rw = new RevWalk(jGitRepository)) {
+            try (RevWalk rw = newRevWalk()) {
                 final RevTree treeA = rw.parseTree(commitIdDatabase.get(range.from()));
                 final RevTree treeB = rw.parseTree(commitIdDatabase.get(range.to()));
 
@@ -709,7 +710,7 @@ class GitRepository implements Repository {
 
         readLock();
         try (ObjectReader reader = jGitRepository.newObjectReader();
-             RevWalk revWalk = new RevWalk(reader);
+             RevWalk revWalk = newRevWalk(reader);
              DiffFormatter diffFormatter = new DiffFormatter(null)) {
 
             final ObjectId baseTreeId = toTree(revWalk, baseRevision);
@@ -882,7 +883,7 @@ class GitRepository implements Repository {
 
         try (ObjectInserter inserter = jGitRepository.newObjectInserter();
              ObjectReader reader = jGitRepository.newObjectReader();
-             RevWalk revWalk = new RevWalk(reader)) {
+             RevWalk revWalk = newRevWalk(reader)) {
 
             final ObjectId prevTreeId = prevRevision != null ? toTree(revWalk, prevRevision) : null;
 
@@ -1025,8 +1026,8 @@ class GitRepository implements Repository {
                         }
                         break;
                     case RENAME: {
-                        final String newPath = ((String) change.content()).substring(
-                                1); // Strip the leading '/'.
+                        final String newPath =
+                                ((String) change.content()).substring(1); // Strip the leading '/'.
 
                         if (dirCache.getEntry(newPath) != null) {
                             throw new ChangeConflictException("a file exists at the target path: " + change);
@@ -1299,7 +1300,7 @@ class GitRepository implements Repository {
         // Convert the revisions to Git trees.
         final List<DiffEntry> diffEntries;
         readLock();
-        try (RevWalk revWalk = new RevWalk(jGitRepository)) {
+        try (RevWalk revWalk = newRevWalk()) {
             final RevTree treeA = toTree(revWalk, range.from());
             final RevTree treeB = toTree(revWalk, range.to());
             diffEntries = blockingCompareTrees(treeA, treeB);
@@ -1442,7 +1443,7 @@ class GitRepository implements Repository {
      * Returns the current revision.
      */
     private Revision uncachedHeadRevision() {
-        try (RevWalk revWalk = new RevWalk(jGitRepository)) {
+        try (RevWalk revWalk = newRevWalk()) {
             final ObjectId headRevisionId = jGitRepository.resolve(R_HEADS_MASTER);
             if (headRevisionId != null) {
                 final RevCommit revCommit = revWalk.parseCommit(headRevisionId);
@@ -1464,6 +1465,22 @@ class GitRepository implements Repository {
         } catch (IOException e) {
             throw new StorageException("failed to parse a commit: " + commitId, e);
         }
+    }
+
+    private RevWalk newRevWalk() {
+        final RevWalk revWalk = new RevWalk(jGitRepository);
+        configureRevWalk(revWalk);
+        return revWalk;
+    }
+
+    private static RevWalk newRevWalk(ObjectReader reader) {
+        final RevWalk revWalk = new RevWalk(reader);
+        configureRevWalk(revWalk);
+        return revWalk;
+    }
+
+    private static void configureRevWalk(RevWalk revWalk) {
+        revWalk.setRewriteParents(false);
     }
 
     private void readLock() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -572,8 +572,6 @@ class GitRepository implements Repository {
 
             // Walk through the commit tree to get the corresponding commit information by given filters
             revWalk.setTreeFilter(AndTreeFilter.create(TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
-            // Disable rewriteParents because otherwise `RevWalk` will load every commit into memory.
-            revWalk.setRewriteParents(false);
             revWalk.markStart(revWalk.parseCommit(fromCommitId));
             final RevCommit toCommit = revWalk.parseCommit(toCommitId);
             if (toCommit.getParentCount() != 0) {
@@ -1480,6 +1478,7 @@ class GitRepository implements Repository {
     }
 
     private static void configureRevWalk(RevWalk revWalk) {
+        // Disable rewriteParents because otherwise `RevWalk` will load every commit into memory.
         revWalk.setRewriteParents(false);
     }
 


### PR DESCRIPTION
Motivation:

- In a certain case, jGit's `RevWalk` can load the entire repository
  history, even including those unused, into memory, which may take a
  lot of time for a repository with a large number of commits.
- Central Dogma server can delete the PID file it did not create.
- Central Dogma server's default PID file path is usually unwritable by
  a non-super user.

Modifications:

- Set `false` to `RevWalk.rewriteParents` so that the excessive amount
  of commits are loaded into memory.
- Do not delete the PID file if not created by the current process.
- Change the default PID file path to less restrictive one.

Result:

- Fixes #472
- Central Dogma server does not delete the existing server's PID file
  anymore.
- Central Dogma server can be launched without an explicit `-pidfile`
  option even if a user is not a super user.