### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
-        classpath 'io.spring.gradle:dependency-management-plugin:1.0.8.RELEASE'
+        classpath 'io.spring.gradle:dependency-management-plugin:1.0.9.RELEASE'
         classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
     }
 }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,9 +3,9 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.10.1
+- com.fasterxml.jackson:jackson-bom:2.10.2.20200130
 - com.linecorp.armeria:armeria-bom:0.97.0
-- io.micrometer:micrometer-bom:1.3.2
+- io.micrometer:micrometer-bom:1.3.3
 - org.junit:junit-bom:5.6.0
 
 ch.qos.logback:
@@ -22,7 +22,7 @@ com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
 
 com.bmuschko:
-  gradle-docker-plugin: { version: '6.0.0' }
+  gradle-docker-plugin: { version: '6.1.3' }
 
 com.craigburke.gradle:
   client-dependencies: { version: '1.4.1' }
@@ -48,22 +48,22 @@ com.fasterxml.jackson.core:
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.8.0'
+    version: '2.8.1'
     javadocs:
-    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.8.0/
+    - https://static.javadoc.io/com.github.ben-manes.caffeine/caffeine/2.8.1/
 
 com.github.jengelman.gradle.plugins:
   shadow: { version: '5.2.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '2.2.0' }
+  gradle-node-plugin: { version: '2.2.1' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '28.1-jre'
+    version: &GUAVA_VERSION '28.2-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -163,7 +163,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.11.1' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.13.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
@@ -199,10 +199,10 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.14.0' }
+  assertj-core: { version: '3.15.0' }
 
 org.awaitility:
-  awaitility: { version: '4.0.1' }
+  awaitility: { version: '4.0.2' }
 
 org.hamcrest:
   hamcrest-library: { version: '2.2' }
@@ -211,10 +211,10 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: '5.5.1.201910021850-r' }
+  org.eclipse.jgit: { version: '5.6.0.201912101111-r' }
 
 org.hibernate.validator:
-  hibernate-validator: { version: '6.1.0.Final' }
+  hibernate-validator: { version: '6.1.2.Final' }
 
 org.javassist:
   javassist: { version: '3.26.0-GA' }
@@ -231,17 +231,17 @@ org.openjdk.jmh:
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.29' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.30' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
     version: *SLF4J_VERSION
     javadocs:
-    - https://static.javadoc.io/org.slf4j/slf4j-api/1.7.29/
+    - https://static.javadoc.io/org.slf4j/slf4j-api/1.7.30/
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.2.1.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.2.4.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
* Caffeine 2.8.0 -> 2.8.1
* Jackson 2.10.1 -> 2.10.2.20200130
* Micrometer 1.3.2 -> 1.3.3
* SLF4J 1.7.29 -> 1.7.30
* Spring Boot 2.2.1 -> 2.2.4
* Build time
  * AssertJ 3.14.0 ->3.15.0
  * Awaitility 4.0.1 -> 4.0.2
  * dependency-management-plugin 1.0.8 -> 1.0.9
  * gradle-docker-plugin 6.0.0 -> 6.1.3
  * gradle-node-plugin 2.2.0 -> 2.2.1
  * Guava 28.1-jre -> 28.2-jre
  * Hibernate Validator 6.1.0 -> 6.1.2
  * json-unit 2.11.1 -> 2.13.0