### PR TITLE
Use modern Gradle dependency API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,51 +54,51 @@ configure(projectsWithFlags('java')) {
         }
 
         // Testing utilities
-        testCompile project(':testing-internal')
+        testImplementation project(':testing-internal')
 
         // completable-futures
-        compile 'com.spotify:completable-futures'
+        implementation 'com.spotify:completable-futures'
 
         // cron-utils
-        compile 'com.cronutils:cron-utils'
+        implementation 'com.cronutils:cron-utils'
 
         // Guava
-        compile 'com.google.guava:guava'
+        implementation 'com.google.guava:guava'
 
         // Jackson
         ['annotations', 'core', 'databind'].each {
-            compile "com.fasterxml.jackson.core:jackson-$it"
+            implementation "com.fasterxml.jackson.core:jackson-$it"
         }
 
         // javax.inject
-        compile 'javax.inject:javax.inject'
+        api 'javax.inject:javax.inject'
 
         // JSR305
-        compile 'com.google.code.findbugs:jsr305'
+        implementation 'com.google.code.findbugs:jsr305'
 
         // Jetty ALPN support
         compileOnly 'org.eclipse.jetty.alpn:alpn-api'
 
         // Logging
-        compile 'org.slf4j:slf4j-api'
-        testCompile 'org.slf4j:jul-to-slf4j'
-        testRuntime 'ch.qos.logback:logback-classic'
+        implementation 'org.slf4j:slf4j-api'
+        testImplementation 'org.slf4j:jul-to-slf4j'
+        testRuntimeOnly 'ch.qos.logback:logback-classic'
         ['jcl-over-slf4j', 'log4j-over-slf4j'].each {
-            testRuntime "org.slf4j:$it"
+            testRuntimeOnly "org.slf4j:$it"
         }
 
         // Test-time dependencies
-        testCompile 'net.javacrumbs.json-unit:json-unit-fluent'
-        testCompile 'org.awaitility:awaitility'
-        testCompile 'org.hamcrest:hamcrest-library'
-        testCompile 'org.assertj:assertj-core'
-        testCompile 'org.mockito:mockito-core'
-        testCompile 'org.mockito:mockito-junit-jupiter'
-        testCompile 'org.junit.jupiter:junit-jupiter-api'
-        testCompile 'org.junit.jupiter:junit-jupiter-params'
-        testRuntime 'org.junit.jupiter:junit-jupiter-engine'
-        testRuntime 'org.junit.platform:junit-platform-launcher'
-        testRuntime 'org.junit.vintage:junit-vintage-engine'
+        testImplementation 'net.javacrumbs.json-unit:json-unit-fluent'
+        testImplementation 'org.awaitility:awaitility'
+        testImplementation 'org.hamcrest:hamcrest-library'
+        testImplementation 'org.assertj:assertj-core'
+        testImplementation 'org.mockito:mockito-core'
+        testImplementation 'org.mockito:mockito-junit-jupiter'
+        testImplementation 'org.junit.jupiter:junit-jupiter-api'
+        testImplementation 'org.junit.jupiter:junit-jupiter-params'
+        testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
     }
 
     // Target Java 8.

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ configure(projectsWithFlags('java')) {
     dependencies {
         // All projects currently require ':common' (except itself)
         if (project.name != 'common') {
-            compile project(':common')
+            api project(':common')
         }
 
         // Testing utilities

--- a/client/java-armeria-legacy/build.gradle
+++ b/client/java-armeria-legacy/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
-    compile project(':common-legacy')
-    compile project(':client:java-armeria')
+    api project(':common-legacy')
+    api project(':client:java-armeria')
 
     // Armeria
-    compile 'com.linecorp.armeria:armeria-thrift0.9'
+    implementation 'com.linecorp.armeria:armeria-thrift0.9'
 }

--- a/client/java-armeria/build.gradle
+++ b/client/java-armeria/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile project(':client:java')
+    api project(':client:java')
     // Armeria
-    compile 'com.linecorp.armeria:armeria'
+    api 'com.linecorp.armeria:armeria'
 }

--- a/client/java-spring-boot-autoconfigure/build.gradle
+++ b/client/java-spring-boot-autoconfigure/build.gradle
@@ -1,11 +1,11 @@
 dependencies {
-    compile project(':client:java-armeria-legacy')
+    api project(':client:java-armeria-legacy')
     compileOnly 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter'
+    api 'org.springframework.boot:spring-boot-starter'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 
-    testCompile project(':client:java-armeria')
-    testCompile 'junit:junit'
-    testCompile 'org.springframework.boot:spring-boot-starter-test'
-    testRuntime 'org.hibernate.validator:hibernate-validator'
+    testImplementation project(':client:java-armeria')
+    testImplementation 'junit:junit'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
 }

--- a/client/java-spring-boot-starter/build.gradle
+++ b/client/java-spring-boot-starter/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile project(':client:java-spring-boot-autoconfigure')
+    api project(':client:java-spring-boot-autoconfigure')
 }

--- a/client/java-spring-boot1-autoconfigure/build.gradle
+++ b/client/java-spring-boot1-autoconfigure/build.gradle
@@ -1,12 +1,12 @@
 dependencies {
-    compile project(':client:java-armeria-legacy')
-    compile 'javax.validation:validation-api'
-    compile 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'
+    api project(':client:java-armeria-legacy')
+    api 'javax.validation:validation-api'
+    api 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'
 
-    testCompile project(':client:java-armeria')
-    testCompile 'junit:junit'
-    testCompile 'org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE'
-    testRuntime 'org.hibernate.validator:hibernate-validator'
+    testImplementation project(':client:java-armeria')
+    testImplementation 'junit:junit'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE'
+    testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
 }
 
 // Use the sources from 'client-spring-boot-autoconfigure'.

--- a/client/java-spring-boot1-starter/build.gradle
+++ b/client/java-spring-boot1-starter/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile project(':client:java-spring-boot1-autoconfigure')
+    api project(':client:java-spring-boot1-autoconfigure')
 }

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -1,3 +1,3 @@
  dependencies {
-     compile 'org.javassist:javassist'
+     implementation 'org.javassist:javassist'
  }

--- a/common-legacy/build.gradle
+++ b/common-legacy/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     // Thrift
-    compile 'org.apache.thrift:libthrift'
+    implementation 'org.apache.thrift:libthrift'
     compileOnly 'jakarta.annotation:jakarta.annotation-api'
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -9,21 +9,21 @@ buildscript {
 
 dependencies {
     // DiffUtils
-    compile 'com.googlecode.java-diff-utils:diffutils'
+    implementation 'com.googlecode.java-diff-utils:diffutils'
 
     // Jackson JSR310
-    compile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // Guava
-    compile 'com.google.guava:guava'
+    implementation 'com.google.guava:guava'
 
     // Jackson
     [ 'core', 'annotations', 'databind' ].each {
-        compile "com.fasterxml.jackson.core:jackson-$it"
+        implementation "com.fasterxml.jackson.core:jackson-$it"
     }
 
     // JSON-path
-    compile 'com.jayway.jsonpath:json-path'
+    implementation 'com.jayway.jsonpath:json-path'
 }
 
 if (tasks.findByName('trimShadedJar')) {

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -28,10 +28,10 @@ ext {
 
 dependencies {
     // Logging
-    runtime 'ch.qos.logback:logback-classic'
-    runtime 'com.linecorp.armeria:armeria-logback'
+    runtimeOnly 'ch.qos.logback:logback-classic'
+    runtimeOnly 'com.linecorp.armeria:armeria-logback'
     ['jcl-over-slf4j', 'jul-to-slf4j', 'log4j-over-slf4j'].each {
-        runtime "org.slf4j:$it"
+        runtimeOnly "org.slf4j:$it"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -1,3 +1,8 @@
 dependencies {
-    testCompile project(':testing-internal')
+    // jGit
+    testImplementation 'org.eclipse.jgit:org.eclipse.jgit'
+    // JSch
+    testImplementation 'com.jcraft:jsch'
+
+    testImplementation project(':testing-internal')
 }

--- a/server-auth/saml/build.gradle
+++ b/server-auth/saml/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    compile project(':server')
-    compile 'com.linecorp.armeria:armeria-saml'
+    implementation project(':server')
+    implementation 'com.linecorp.armeria:armeria-saml'
 
-    testCompile project(':testing-internal')
+    testImplementation project(':testing-internal')
 }

--- a/server-auth/shiro/build.gradle
+++ b/server-auth/shiro/build.gradle
@@ -1,7 +1,10 @@
 dependencies {
-    compile project(':server')
-    testCompile project(':testing-internal')
+    api project(':server')
+    testImplementation project(':testing-internal')
+
+    // Caffeine
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // Shiro
-    compile 'org.apache.shiro:shiro-core'
+    implementation 'org.apache.shiro:shiro-core'
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -10,46 +10,45 @@ buildscript {
 apply plugin: 'com.craigburke.client-dependencies'
 
 dependencies {
-    compile project(':common-legacy')
+    implementation project(':common-legacy')
 
     // Armeria
     ['armeria', 'armeria-thrift0.9'].each {
-        compile "com.linecorp.armeria:$it"
+        api "com.linecorp.armeria:$it"
     }
-    testCompile 'com.linecorp.armeria:armeria-testing-junit'
+    testImplementation 'com.linecorp.armeria:armeria-testing-junit'
 
     // JSch
-    compile 'com.jcraft:jsch'
+    implementation 'com.jcraft:jsch'
 
     // Caffeine
-    compile 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
 
     // Curator & ZooKeeper
-    compile 'org.apache.curator:curator-recipes'
-    compile 'org.apache.zookeeper:zookeeper'
-    testCompile 'org.apache.curator:curator-test'
+    implementation 'org.apache.curator:curator-recipes'
+    implementation 'org.apache.zookeeper:zookeeper'
+    testImplementation 'org.apache.curator:curator-test'
+
+    // DiffUtils
+    implementation 'com.googlecode.java-diff-utils:diffutils'
 
     // jCommander
-    compile('com.beust:jcommander') {
-        ext.optional = true
-    }
+    optionalImplementation 'com.beust:jcommander'
 
     // jGit
-    compile 'org.eclipse.jgit:org.eclipse.jgit'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit'
 
     // Micrometer
-    compile 'io.micrometer:micrometer-core'
-    compile 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'io.micrometer:micrometer-core'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // Quartz
-    compile 'org.quartz-scheduler:quartz'
+    implementation 'org.quartz-scheduler:quartz'
 
     // Mockito for mocking a Project
     jmh 'org.mockito:mockito-core'
     // Logging
-    runtime('ch.qos.logback:logback-classic') {
-        ext.optional = true
-    }
+    optionalImplementation 'ch.qos.logback:logback-classic'
 }
 
 clientDependencies {

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
-    compile project(':testing:junit')
-    compile project(':testing:junit4')
+    api project(':testing:junit')
+    api project(':testing:junit4')
 
-    compile 'org.assertj:assertj-core'
-    compile 'net.javacrumbs.json-unit:json-unit-fluent'
-    compile 'ch.qos.logback:logback-classic'
+    api 'org.assertj:assertj-core'
+    api 'net.javacrumbs.json-unit:json-unit-fluent'
+    api 'ch.qos.logback:logback-classic'
 }

--- a/testing/common/build.gradle
+++ b/testing/common/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile project(':client:java-armeria-legacy')
-    compile project(':server')
+    api project(':client:java-armeria-legacy')
+    api project(':server')
 }

--- a/testing/junit/build.gradle
+++ b/testing/junit/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile project(':testing:testing-common')
-    compile 'org.junit.jupiter:junit-jupiter-api'
+    api project(':testing:testing-common')
+    api 'org.junit.jupiter:junit-jupiter-api'
 }

--- a/testing/junit4/build.gradle
+++ b/testing/junit4/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    compile project(':testing:testing-common')
-    compile 'junit:junit'
+    api project(':testing:testing-common')
+    api 'junit:junit'
 }


### PR DESCRIPTION
Motivation:
Gradle introduced a new API for dependencies.

Modifications:
* Change `compile` to `api` or `implmentation`
* Change 'testCompile` to `testImplementation`
* Change optional compile dependency to `optionalImplementation`

Result:
* Maybe faster incremental compile time
* Easy to control the exposed API