### PR TITLE
Downgrade Node.js to 10.19.0

### DIFF
--- a/server-auth/webapp/build.gradle
+++ b/server-auth/webapp/build.gradle
@@ -47,7 +47,7 @@ task buildWebApp(type: YarnTask) {
 tasks.assemble.dependsOn tasks.buildWebApp
 
 node {
-    version = '12.15.0'
+    version = '10.19.0'
     yarnVersion = '1.22.0'
     download = true
 }


### PR DESCRIPTION
.. because some users build Central Dogma in the OS with a lower GLIBC
version.