### PR TITLE
Fix version constraints in Spring Boot 1 modules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ build:
   verbosity: detailed
 
 build_script:
-  - gradlew.bat --no-daemon --stacktrace --warning-mode=all checkstyle test build
+  - gradlew.bat --no-daemon --stacktrace checkstyle test build
 
 test: off
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'me.champeau.gradle.jmh' version '0.5.0' apply false
 }
 
-
 allprojects {
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,8 @@
-buildscript {
-    repositories {
-        gradlePluginPortal()
-        mavenCentral()
-    }
-    dependencies {
-        classpath 'com.google.gradle:osdetector-gradle-plugin:1.6.2'
-        classpath 'io.spring.gradle:dependency-management-plugin:1.0.9.RELEASE'
-        classpath 'me.champeau.gradle:jmh-gradle-plugin:0.5.0'
-    }
+plugins {
+    id 'com.google.osdetector' version '1.6.2' apply false
+    id 'me.champeau.gradle.jmh' version '0.5.0' apply false
 }
+
 
 allprojects {
     repositories {

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationHostsTest.java
@@ -33,10 +33,10 @@ import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurati
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "useHosts", "confTest" })
-public class CentralDogmaClientAutoConfigurationHostsTest {
+class CentralDogmaClientAutoConfigurationHostsTest {
     @Configuration
     @Import(CentralDogmaClientAutoConfiguration.class)
-    public static class TestConfiguration {}
+    static class TestConfiguration {}
 
     @Inject
     private CentralDogma client;
@@ -45,12 +45,12 @@ public class CentralDogmaClientAutoConfigurationHostsTest {
     private CentralDogmaSettings settings;
 
     @Test
-    public void centralDogmaClient() throws Exception {
+    void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
     }
 
     @Test
-    public void settings() {
+    void settings() {
         assertThat(settings.getHosts()).containsExactly("alice.com", "bob.com:8080", "charlie.com:36462");
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isNull();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationOtherPropsTest.java
@@ -33,10 +33,10 @@ import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurati
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "otherProps", "confTest" })
-public class CentralDogmaClientAutoConfigurationOtherPropsTest {
+class CentralDogmaClientAutoConfigurationOtherPropsTest {
     @Configuration
     @Import(CentralDogmaClientAutoConfiguration.class)
-    public static class TestConfiguration {}
+    static class TestConfiguration {}
 
     @Inject
     private CentralDogma client;
@@ -45,12 +45,12 @@ public class CentralDogmaClientAutoConfigurationOtherPropsTest {
     private CentralDogmaSettings settings;
 
     @Test
-    public void centralDogmaClient() throws Exception {
+    void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
     }
 
     @Test
-    public void settings() {
+    void settings() {
         assertThat(settings.getHosts()).isNull();
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isTrue();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationProfileTest.java
@@ -33,10 +33,10 @@ import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurati
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "useProfile", "confTest" })
-public class CentralDogmaClientAutoConfigurationProfileTest {
+class CentralDogmaClientAutoConfigurationProfileTest {
     @Configuration
     @Import(CentralDogmaClientAutoConfiguration.class)
-    public static class TestConfiguration {}
+    static class TestConfiguration {}
 
     @Inject
     private CentralDogma client;
@@ -45,12 +45,12 @@ public class CentralDogmaClientAutoConfigurationProfileTest {
     private CentralDogmaSettings settings;
 
     @Test
-    public void centralDogmaClient() throws Exception {
+    void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
     }
 
     @Test
-    public void settings() {
+    void settings() {
         assertThat(settings.getHosts()).isNull();
         assertThat(settings.getProfile()).isEqualTo("myprofile");
         assertThat(settings.getUseTls()).isNull();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationSpringProfileTest.java
@@ -33,10 +33,10 @@ import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurati
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "confTest" })
-public class CentralDogmaClientAutoConfigurationSpringProfileTest {
+class CentralDogmaClientAutoConfigurationSpringProfileTest {
     @Configuration
     @Import(CentralDogmaClientAutoConfiguration.class)
-    public static class TestConfiguration {}
+    static class TestConfiguration {}
 
     @Inject
     private CentralDogma client;
@@ -45,12 +45,12 @@ public class CentralDogmaClientAutoConfigurationSpringProfileTest {
     private CentralDogmaSettings settings;
 
     @Test
-    public void centralDogmaClient() throws Exception {
+    void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
     }
 
     @Test
-    public void settings() {
+    void settings() {
         assertThat(settings.getHosts()).isNull();
         assertThat(settings.getProfile()).isNull();
         assertThat(settings.getUseTls()).isNull();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithClientFactoryTest.java
@@ -36,9 +36,9 @@ import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurati
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "confTest" })
-public class CentralDogmaClientAutoConfigurationWithClientFactoryTest {
+class CentralDogmaClientAutoConfigurationWithClientFactoryTest {
     @SpringBootApplication
-    public static class TestConfiguration {
+    static class TestConfiguration {
         private static final ClientFactory dogmaClientFactory = ClientFactory.builder().build();
         private static final ClientFactory otherClientFactory = ClientFactory.builder().build();
 
@@ -77,7 +77,7 @@ public class CentralDogmaClientAutoConfigurationWithClientFactoryTest {
     private ClientFactory clientFactoryForCentralDogma;
 
     @Test
-    public void centralDogmaClient() throws Exception {
+    void centralDogmaClient() throws Exception {
         assertThat(client).isNotNull();
         assertThat(clientFactoryForCentralDogma).isNotSameAs(ClientFactory.ofDefault());
         assertThat(clientFactoryForCentralDogma).isSameAs(TestConfiguration.dogmaClientFactory);

--- a/client/java-spring-boot1-autoconfigure/build.gradle
+++ b/client/java-spring-boot1-autoconfigure/build.gradle
@@ -1,9 +1,27 @@
+final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
+
+repositories {
+    mavenCentral()
+    maven { url 'https://jitpack.io' }
+}
+
 dependencies {
     api project(':client:java-armeria')
     api 'javax.validation:validation-api'
-    api 'org.springframework.boot:spring-boot-starter:1.5.22.RELEASE'
+    api('org.springframework.boot:spring-boot-starter') {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly SPRING_BOOT_VERSION
+        }
+    }
 
-    testImplementation 'org.springframework.boot:spring-boot-starter-test:1.5.22.RELEASE'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        version {
+            // Will fail the build if the override doesn't work
+            strictly SPRING_BOOT_VERSION
+        }
+    }
+    testImplementation 'com.github.sbrannen:spring-test-junit5:1.5.0'
     testRuntimeOnly 'org.hibernate.validator:hibernate-validator'
 }
 
@@ -21,5 +39,6 @@ tasks.sourcesJar.from "${autoconfigureProjectDir}/src/main/resources"
 tasks.javadoc.source "${autoconfigureProjectDir}/src/main/java"
 
 // Disable checkstyle because it's checked by 'client-spring-boot-autoconfigure'
-tasks.checkstyleMain.onlyIf { false }
-tasks.checkstyleTest.onlyIf { false }
+tasks.withType(Checkstyle) {
+    onlyIf { false }
+}

--- a/client/java-spring-boot1-starter/build.gradle
+++ b/client/java-spring-boot1-starter/build.gradle
@@ -1,3 +1,14 @@
+final def SPRING_BOOT_VERSION = '1.5.22.RELEASE'
+
 dependencies {
     api project(':client:java-spring-boot1-autoconfigure')
+
+    constraints {
+        api("org.springframework.boot:spring-boot-starter") {
+            version {
+                strictly SPRING_BOOT_VERSION
+            }
+            because 'boot1-autoconfigure downgrades this version'
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

We forgot to migrate the build scripts of `:client:java-spring-boot1-*`
when we migrate from Spring's dependency management plugin to Gradle's
version constraint API.

Modifications:

- Fix dependencies.
- Add `sbrannen/spring-test-junit5` for testing with Spring Boot 1.x.
  - Work around the bug which pulls in a bean from other tests.

Result:

- `armeria-client-spring-boot1-*` modules now have correct dependencies.