### PR TITLE
Do not log warnings about closed connections and streams

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -50,6 +50,8 @@ import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.Jackson;
 
+import io.netty.handler.codec.http2.Http2Exception;
+
 /**
  * A utility class which provides common functions for HTTP API.
  */
@@ -180,8 +182,9 @@ public final class HttpApiUtil {
             if (cause != null) {
                 if (!(Exceptions.isStreamCancelling(cause) ||
                       cause instanceof ShuttingDownException ||
-                      // TODO(trustin): Remove this condition after upgrading to 0.98.3+.
-                      cause instanceof ClosedStreamException)) {
+                      // TODO(trustin): Remove the following 2 conditions after upgrading to 0.98.3+.
+                      cause instanceof ClosedStreamException ||
+                      cause instanceof Http2Exception.StreamException)) {
                     logger.warn("{} Returning an internal server error: {}", ctx, m, cause);
                 }
             } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -38,17 +38,21 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.common.ClosedSessionException;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.stream.AbortedStreamException;
+import com.linecorp.armeria.common.stream.ClosedStreamException;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.Jackson;
+
+import io.netty.handler.codec.http2.Http2Exception;
 
 /**
  * A utility class which provides common functions for HTTP API.
@@ -178,8 +182,11 @@ public final class HttpApiUtil {
         //                 the stack trace of the cause to the trusted client.
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
             if (cause != null) {
-                if (!(cause instanceof ShuttingDownException ||
-                      cause instanceof AbortedStreamException)) {
+                if (!(cause instanceof AbortedStreamException ||
+                      cause instanceof ClosedStreamException ||
+                      cause instanceof Http2Exception ||
+                      cause instanceof ClosedSessionException ||
+                      cause instanceof ShuttingDownException)) {
                     logger.warn("{} Returning an internal server error: {}", ctx, m, cause);
                 }
             } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -179,9 +179,9 @@ public final class HttpApiUtil {
         if (status == HttpStatus.INTERNAL_SERVER_ERROR) {
             if (cause != null) {
                 if (!(Exceptions.isStreamCancelling(cause) ||
-                      // TODO(trustin): Remove this after upgrading to 0.98.3+.
-                      cause instanceof ClosedStreamException ||
-                      cause instanceof ShuttingDownException)) {
+                      cause instanceof ShuttingDownException ||
+                      // TODO(trustin): Remove this condition after upgrading to 0.98.3+.
+                      cause instanceof ClosedStreamException)) {
                     logger.warn("{} Returning an internal server error: {}", ctx, m, cause);
                 }
             } else {


### PR DESCRIPTION
Motivation:

The disconnection between Central Dogma client and server can happen
very often due to various reasons, such as application shutdown. It's of
dubious value to log them.

Modifications:

- Do not log the exceptions related with unexpected disconnections and
  stream resets at WARN level.
  - Note that they will still be recorded in `RequestLog`s.

Result:

- Less noisy log file