### PR TITLE
Fix the method name for bean creation of CentralDogma client

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -83,7 +83,7 @@ public class CentralDogmaClientAutoConfiguration {
      * Returns a newly created {@link CentralDogma} client.
      */
     @Bean
-    public CentralDogma client(
+    public CentralDogma dogmaClient(
             Environment env,
             CentralDogmaSettings settings,
             @ForCentralDogma ClientFactory clientFactory,


### PR DESCRIPTION
This PR fixes the method name for bean creation of CentralDogma client.
As the default strategy, Spring uses the method name annotated by `@Bean` as a bean name.
Refer to: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/context/annotation/Bean.html

The existing name `client` is so common that there could be conflicts between user-defined beans and/or beans in the other libraries. 

I adopted `dogmaClient` as a new method name because `dogmaClientFactory` method is already defined in the same class.