### PR TITLE
Install java.util.logging-to-SLF4J bridge on startup

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     jmh 'org.mockito:mockito-core'
     // Logging
     optionalImplementation 'ch.qos.logback:logback-classic'
+    optionalImplementation 'org.slf4j:jul-to-slf4j'
 }
 
 clientDependencies {

--- a/server/src/main/java/com/linecorp/centraldogma/server/Main.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/Main.java
@@ -40,6 +40,21 @@ import com.linecorp.armeria.common.util.SystemInfo;
  */
 public final class Main {
 
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
+    static {
+        try {
+            // Install the java.util.logging to SLF4J bridge.
+            final Class<?> bridgeHandler =
+                    Class.forName("org.slf4j.bridge.SLF4JBridgeHandler", true, Main.class.getClassLoader());
+            bridgeHandler.getMethod("removeHandlersForRootLogger").invoke(null);
+            bridgeHandler.getMethod("install").invoke(null);
+            logger.debug("Installed the java.util.logging-to-SLF4J bridge.");
+        } catch (Throwable cause) {
+            logger.debug("Failed to install the java.util.logging-to-SLF4J bridge:", cause);
+        }
+    }
+
     enum State {
         NONE,
         INITIALIZED,
@@ -47,8 +62,6 @@ public final class Main {
         STOPPED,
         DESTROYED
     }
-
-    private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     private static final File DEFAULT_DATA_DIR =
             new File(System.getProperty("user.dir", ".") + File.separatorChar + "data");


### PR DESCRIPTION
Related: #496
Motivation:

Caffeine logs its error messages to STDOUT, because we did not install
the `java.util.logging`-to-SLF4J bridge on startup.

Modifications:

- Add `jul-to-slf4j` as an optional dependency.
- Install the bridge when `Main` class is loaded.

Result:

- Caffeine doesn't pollute STDOUT.
- Fixes #496