### PR TITLE
Downgrade ZooKeeper

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,7 +4,7 @@
 #
 boms:
 - com.fasterxml.jackson:jackson-bom:2.10.3
-- com.linecorp.armeria:armeria-bom:0.99.1
+- com.linecorp.armeria:armeria-bom:0.99.2
 - io.micrometer:micrometer-bom:1.3.6
 - org.junit:junit-bom:5.6.1
 
@@ -163,12 +163,14 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.5.0' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.16.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.16.2' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 net.sf.proguard:
   proguard-gradle: { version: '6.2.2' }
 
+# Ensure that we use the same ZooKeeper version as what Curator depends on.
+# See: https://github.com/apache/curator/blob/master/pom.xml
 org.apache.curator:
   curator-recipes:
     version: &CURATOR_VERSION '4.3.0'
@@ -191,7 +193,7 @@ org.apache.thrift:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.6.0'
+    version: '3.5.7'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j
@@ -250,7 +252,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.2.5.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.2.6.RELEASE'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
Curator 4.3.0 depends on ZooKeeper 3.5.7.
So we should align the version.

Modifications:
- Zookeeper 3.6.0 -> 3.5.7
- Armeria 0.99.1 -> 0.99.2
- json-unit 2.16.0 -> 2.16.2
- Spring Boot 2.2.5.RELEASE -> 2.2.6.RELEASE