### PR TITLE
More efficient history operation

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -326,8 +326,7 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         final RevisionRange range = repository.normalizeNow(fromRevision, toRevision).toDescending();
-        final int maxCommits0 = maxCommits.map(integer -> Math.min(integer, Repository.MAX_MAX_COMMITS))
-                                          .orElse(Repository.DEFAULT_MAX_COMMITS);
+        final int maxCommits0 = maxCommits.orElse(Repository.DEFAULT_MAX_COMMITS);
         return repository
                 .history(range.from(), range.to(), normalizePath(path), maxCommits0)
                 .thenApply(commits -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -326,7 +326,7 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         final RevisionRange range = repository.normalizeNow(fromRevision, toRevision).toDescending();
-        final int maxCommits0 = maxCommits.map(integer -> Math.min(integer, Repository.DEFAULT_MAX_COMMITS))
+        final int maxCommits0 = maxCommits.map(integer -> Math.min(integer, Repository.MAX_MAX_COMMITS))
                                           .orElse(Repository.DEFAULT_MAX_COMMITS);
         return repository
                 .history(range.from(), range.to(), normalizePath(path), maxCommits0)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -85,7 +85,6 @@ import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevTree;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.revwalk.TreeRevFilter;
-import org.eclipse.jgit.revwalk.filter.AndRevFilter;
 import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -99,8 +99,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
-import com.google.common.math.IntMath;
-import com.google.common.primitives.Ints;
 
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Author;
@@ -612,8 +610,11 @@ class GitRepository implements Repository {
             final RevFilter filter = new TreeRevFilter(revWalk, AndTreeFilter.create(
                     TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
 
-            final List<Commit> commitList = new ArrayList<>();
+            // Search up to 1000 commits when maxCommits <= 100.
+            // Search up to (maxCommits * 10) commits when maxCommits > 100.
             final int maxNumProcessedCommits = Math.max(maxCommits * 10, MAX_MAX_COMMITS);
+
+            final List<Commit> commitList = new ArrayList<>();
             int numProcessedCommits = 0;
             for (RevCommit revCommit : revWalk) {
                 numProcessedCommits++;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -611,7 +611,7 @@ class GitRepository implements Repository {
                     TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
 
             // Search up to 1000 commits when maxCommits <= 100.
-            // Search up to (maxCommits * 10) commits when maxCommits > 100.
+            // Search up to (maxCommits * 10) commits when 100 < maxCommits <= 1000.
             final int maxNumProcessedCommits = Math.max(maxCommits * 10, MAX_MAX_COMMITS);
 
             final List<Commit> commitList = new ArrayList<>();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -589,6 +589,9 @@ class GitRepository implements Repository {
         // At this point, we are sure: from.major >= to.major
         readLock();
         try (RevWalk revWalk = newRevWalk()) {
+            final ObjectIdOwnerMap<?> revWalkInternalMap =
+                    (ObjectIdOwnerMap<?>) revWalkObjectsField.get(revWalk);
+
             final ObjectId fromCommitId = commitIdDatabase.get(descendingRange.from());
             final ObjectId toCommitId = commitIdDatabase.get(descendingRange.to());
             final int minRevision = descendingRange.to().major();
@@ -619,7 +622,7 @@ class GitRepository implements Repository {
                 // Clear the internal lookup table of RevWalk to reduce the memory usage.
                 // This is safe because we have linear history and traverse in one direction.
                 if (commitList.size() % 16 == 0) {
-                    ((ObjectIdOwnerMap<?>) revWalkObjectsField.get(revWalk)).clear();
+                    revWalkInternalMap.clear();
                 }
             }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -609,7 +609,6 @@ class GitRepository implements Repository {
                     TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
 
             final List<Commit> commitList = new ArrayList<>();
-            boolean needsLastCommit = true;
             int numProcessedCommits = 0;
             for (RevCommit revCommit : revWalk) {
                 if (filter.include(revWalk, revCommit)) {
@@ -619,7 +618,6 @@ class GitRepository implements Repository {
                 }
 
                 if (revCommit.getId().equals(toCommitId) || commitList.size() >= maxCommits) {
-                    needsLastCommit = false;
                     break;
                 }
 
@@ -635,7 +633,7 @@ class GitRepository implements Repository {
             // when a new repository is created.
             // If the pathPattern does not contain "/**", the caller wants commits only with the specific path,
             // so skip the empty commit.
-            if (needsLastCommit && pathPattern.contains(ALL_PATH)) {
+            if (commitList.isEmpty() && pathPattern.contains(ALL_PATH)) {
                 try (RevWalk tmpRevWalk = newRevWalk()) {
                     final RevCommit lastRevCommit = tmpRevWalk.parseCommit(toCommitId);
                     final Revision lastCommitRevision =

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -611,19 +611,24 @@ class GitRepository implements Repository {
             final List<Commit> commitList = new ArrayList<>();
             int numProcessedCommits = 0;
             for (RevCommit revCommit : revWalk) {
+                numProcessedCommits++;
+
                 if (filter.include(revWalk, revCommit)) {
                     revWalk.parseBody(revCommit);
                     commitList.add(toCommit(revCommit));
                     revCommit.disposeBody();
                 }
 
-                if (revCommit.getId().equals(toCommitId) || commitList.size() >= maxCommits) {
+                if (revCommit.getId().equals(toCommitId) ||
+                    commitList.size() >= maxCommits ||
+                    // Prevent from iterating for too long.
+                    numProcessedCommits >= MAX_MAX_COMMITS * 10) {
                     break;
                 }
 
                 // Clear the internal lookup table of RevWalk to reduce the memory usage.
                 // This is safe because we have linear history and traverse in one direction.
-                if (++numProcessedCommits % 16 == 0) {
+                if (numProcessedCommits % 16 == 0) {
                     revWalkInternalMap.clear();
                 }
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -628,9 +628,11 @@ class GitRepository implements Repository {
                 }
             }
 
-            // Include the initial empty commit only when the pathPattern contains '/**' and
-            // the caller specified the initial revision (1) in the range.
-            if (descendingRange.to().major() == 1 && pathPattern.contains(ALL_PATH)) {
+            // Include the initial empty commit only when the caller specified
+            // the initial revision (1) in the range and the pathPattern contains '/**'.
+            if (commitList.size() < maxCommits &&
+                descendingRange.to().major() == 1 &&
+                pathPattern.contains(ALL_PATH)) {
                 try (RevWalk tmpRevWalk = newRevWalk()) {
                     final RevCommit lastRevCommit = tmpRevWalk.parseCommit(toCommitId);
                     commitList.add(toCommit(lastRevCommit));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -569,7 +569,7 @@ class GitRepository implements Repository {
         try (RevWalk revWalk = newRevWalk()) {
             final ObjectId fromCommitId = commitIdDatabase.get(descendingRange.from());
             final ObjectId toCommitId = commitIdDatabase.get(descendingRange.to());
-            final int lastRevision = descendingRange.to().major();
+            final int minRevision = descendingRange.to().major();
 
             // Walk through the commit tree to get the corresponding commit information by given filters
             revWalk.setTreeFilter(AndTreeFilter.create(TreeFilter.ANY_DIFF, PathPatternFilter.of(pathPattern)));
@@ -580,13 +580,13 @@ class GitRepository implements Repository {
             for (RevCommit revCommit : revWalk) {
                 final Commit commit = toCommit(revCommit);
                 final int revision = commit.revision().major();
-                if (revision < lastRevision) {
+                if (revision < minRevision) {
                     // Went beyond the last commit.
                     needsLastCommit = false;
                     break;
                 }
                 commitList.add(commit);
-                if (revision == lastRevision || commitList.size() == maxCommits) {
+                if (revision == minRevision || commitList.size() == maxCommits) {
                     // Visited the last commit or can't retrieve beyond maxCommits
                     needsLastCommit = false;
                     break;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -628,19 +628,12 @@ class GitRepository implements Repository {
                 }
             }
 
-            // Handle the case where the last commit was not visited by the RevWalk,
-            // which can happen when the commit is empty.  In our repository, an empty commit can only be made
-            // when a new repository is created.
-            // If the pathPattern does not contain "/**", the caller wants commits only with the specific path,
-            // so skip the empty commit.
-            if (commitList.isEmpty() && pathPattern.contains(ALL_PATH)) {
+            // Include the initial empty commit only when the pathPattern contains '/**' and
+            // the caller specified the initial revision (1) in the range.
+            if (descendingRange.to().major() == 1 && pathPattern.contains(ALL_PATH)) {
                 try (RevWalk tmpRevWalk = newRevWalk()) {
                     final RevCommit lastRevCommit = tmpRevWalk.parseCommit(toCommitId);
-                    final Revision lastCommitRevision =
-                            CommitUtil.extractRevision(lastRevCommit.getFullMessage());
-                    if (lastCommitRevision.major() == 1) {
-                        commitList.add(toCommit(lastRevCommit));
-                    }
+                    commitList.add(toCommit(lastRevCommit));
                 }
             }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -61,7 +61,8 @@ import com.linecorp.centraldogma.server.storage.project.Project;
  */
 public interface Repository {
 
-    int DEFAULT_MAX_COMMITS = 1024;
+    int DEFAULT_MAX_COMMITS = 100;
+    int MAX_MAX_COMMITS = 1000;
 
     String ALL_PATH = "/**";
 


### PR DESCRIPTION
Motivation:

- `GitRepository.blockingHistory()` uses `RevWalk.markUninteresting()`
  to filter out old revisions, but we don't really need it because our
  repository always has linear history. Use of `markUninteresting()`
  causes an additional overhead since it involves `DelayRevQueue` and
  `FixUninterestingGenerator`.
- When `blockingHistory()` iterates over a `RevWalk`, it breaks the loop
  when `revCommit.getId().equals(toCommitId)`. This may not be enough
  for breaking out of the loop because `toCommitId` may not be yielded
  by the `RevWalk` if it does not contain any entris that match
  `pathPattern`.
- `RevWalk` keeps `ObjectIdOwnerMap` internally as a cache, but we don't
  really need this at all because our repository always has linear
  history. It only increases memory usage during iteration.

Modifications:

- Do not use `RevWalk.markUninteresting()`.
- Do not specify any filter for `RevWalk`. Retrieve all commits in range
  and filter by ourselves.
  - This also prevents `RevWalk` from spending long time handling many
    commits for single `Iterator.next()` call.
- Clear the `ObjectIdOwnerMap` every 16 commits to reduce memory pressure.
- Clamp `maxCommits` at 1000 and Search up to `max(maxCommits * 10, 1000)`
  commits.
- Change the default maxCommits from 1000 to 100.

Result:

- Efficiency
- Closes #508