### PR TITLE
Update broken link for armeria parameters javac option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ After importing the project, import the IDE settings as well.
 ### Configure `-parameters` javac option
 
 You can configure your build tool and IDE to add `-parameters` javac option.
-Please refer to [Configure `-parameters` javac option](https://line.github.io/armeria/setup.html#configure-parameters-javac-option) for more information.
+Please refer to [Configure `-parameters` javac option](https://line.github.io/armeria/docs/setup#configure--parameters-javac-option) for more information.
 
 ### Checklist for your pull request
 


### PR DESCRIPTION
As an fyi, I also found the same broken link in armeria project (under `examples/README.md`)
