### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -109,7 +109,7 @@ com.jcraft:
 com.linecorp.armeria:
   armeria:
     javadocs:
-    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/0.99.6/
+    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/0.99.8/
 
 com.puppycrawl.tools:
   checkstyle: { version: '8.34' }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,9 +3,9 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.11.0
-- com.linecorp.armeria:armeria-bom:0.99.7
-- io.micrometer:micrometer-bom:1.5.1
+- com.fasterxml.jackson:jackson-bom:2.11.1
+- com.linecorp.armeria:armeria-bom:0.99.8
+- io.micrometer:micrometer-bom:1.5.2
 - org.junit:junit-bom:5.6.2
 
 ch.qos.logback:
@@ -38,19 +38,19 @@ com.cronutils:
 com.fasterxml.jackson.core:
   jackson-annotations:
     javadocs:
-    - https://fasterxml.github.io/jackson-annotations/javadoc/2.10/
+    - https://fasterxml.github.io/jackson-annotations/javadoc/2.11/
   jackson-core:
     javadocs:
-    - https://fasterxml.github.io/jackson-core/javadoc/2.10/
+    - https://fasterxml.github.io/jackson-core/javadoc/2.11/
   jackson-databind:
     javadocs:
-    - https://fasterxml.github.io/jackson-databind/javadoc/2.10/
+    - https://fasterxml.github.io/jackson-databind/javadoc/2.11/
 
 com.github.ben-manes.caffeine:
   caffeine:
-    version: '2.8.4'
+    version: '2.8.5'
     javadocs:
-    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.8.1/
+    - https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.8.5/
 
 com.github.jengelman.gradle.plugins:
   shadow: { version: '6.0.0' }
@@ -112,7 +112,7 @@ com.linecorp.armeria:
     - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/0.99.6/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.33' }
+  checkstyle: { version: '8.34' }
 
 com.spotify:
   completable-futures:
@@ -130,10 +130,10 @@ gradle.plugin.net.davidecavestro:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.3.2/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.5.2/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.3.2/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.5.2/
 
 jakarta.annotation:
   jakarta.annotation-api: { version: '1.3.5' }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     ['armeria', 'armeria-thrift0.9'].each {
         api "com.linecorp.armeria:$it"
     }
-    testImplementation 'com.linecorp.armeria:armeria-testing-junit'
+    testImplementation 'com.linecorp.armeria:armeria-junit5'
 
     // JSch
     implementation 'com.jcraft:jsch'

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -47,7 +47,7 @@ import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.auth.AuthService;
-import com.linecorp.armeria.testing.junit.server.ServerExtension;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;


### PR DESCRIPTION
- Armeria 0.99.7 -> 0.99.8
- Jackson 2.11.0 -> 2.11.1
- Micrometer 1.5.1 -> 1.5.2
- Server
  - Caffeine 2.8.4 -> 2.8.5
- Build
  - Checkstyle 8.33 -> 8.34
  - Gradle 6.5 -> 6.5.1