### PR TITLE
Provide a way to configure hierarchical quorums

### DIFF
--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTimeoutSchedulerTest.java
@@ -89,8 +89,11 @@ class LegacyCentralDogmaTimeoutSchedulerTest {
                 // A response timeout is calculated from the start of the request.
                 final long responseTimeoutMillis = ctx.responseTimeoutMillis();
                 final long adjustment = expectedTimeoutMills - defaultTimeoutMills;
+
                 decorator.execute(ctx, req);
-                assertThat(ctx.responseTimeoutMillis()).isEqualTo(responseTimeoutMillis + adjustment);
+                assertThat(ctx.responseTimeoutMillis())
+                        .isEqualTo(Math.min(responseTimeoutMillis + adjustment, WatchTimeout.MAX_MILLIS));
+
                 verify(client).execute(ctx, req);
                 completed.set(true);
             } catch (Exception e) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
@@ -52,7 +52,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
     private static final String DEFAULT_SECRET = "ch4n63m3";
 
     private final int serverId;
-    private final Map<Integer, ZooKeeperAddress> servers;
+    private final Map<Integer, ZooKeeperServerConfig> servers;
     private final String secret;
     private final Map<String, String> additionalProperties;
     private final int timeoutMillis;
@@ -66,13 +66,13 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
      * @param serverId the ID of this ZooKeeper server in {@code servers}
      * @param servers the ZooKeeper server addresses, keyed by their ZooKeeper server IDs
      */
-    public ZooKeeperReplicationConfig(int serverId, Map<Integer, ZooKeeperAddress> servers) {
+    public ZooKeeperReplicationConfig(int serverId, Map<Integer, ZooKeeperServerConfig> servers) {
         this(serverId, servers, null, null, null, null, null, null);
     }
 
     @VisibleForTesting
     ZooKeeperReplicationConfig(
-            int serverId, Map<Integer, ZooKeeperAddress> servers, String secret,
+            int serverId, Map<Integer, ZooKeeperServerConfig> servers, String secret,
             Map<String, String> additionalProperties,
             int timeoutMillis, int numWorkers, int maxLogCount, long minLogAgeMillis) {
         this(Integer.valueOf(serverId), servers, secret, additionalProperties, Integer.valueOf(timeoutMillis),
@@ -82,8 +82,8 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
     @JsonCreator
     ZooKeeperReplicationConfig(@JsonProperty("serverId") @Nullable Integer serverId,
                                @JsonProperty(value = "servers", required = true)
-                               @JsonDeserialize(keyAs = Integer.class, contentAs = ZooKeeperAddress.class)
-                               Map<Integer, ZooKeeperAddress> servers,
+                               @JsonDeserialize(keyAs = Integer.class, contentAs = ZooKeeperServerConfig.class)
+                               Map<Integer, ZooKeeperServerConfig> servers,
                                @JsonProperty("secret") @Nullable String secret,
                                @JsonProperty("additionalProperties")
                                @JsonDeserialize(keyAs = String.class, contentAs = String.class)
@@ -124,7 +124,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
                 minLogAgeMillis == null || minLogAgeMillis <= 0 ? DEFAULT_MIN_LOG_AGE_MILLIS : minLogAgeMillis;
     }
 
-    private static int findServerId(Map<Integer, ZooKeeperAddress> servers) {
+    private static int findServerId(Map<Integer, ZooKeeperServerConfig> servers) {
         int serverId = -1;
         try {
             for (final Enumeration<NetworkInterface> e = NetworkInterface.getNetworkInterfaces();
@@ -143,7 +143,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
         return serverId;
     }
 
-    private static int findServerId(Map<Integer, ZooKeeperAddress> servers, int currentServerId,
+    private static int findServerId(Map<Integer, ZooKeeperServerConfig> servers, int currentServerId,
                                     NetworkInterface iface) {
         for (final Enumeration<InetAddress> ea = iface.getInetAddresses(); ea.hasMoreElements();) {
             currentServerId = findServerId(servers, currentServerId, ea.nextElement());
@@ -151,10 +151,10 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
         return currentServerId;
     }
 
-    private static int findServerId(Map<Integer, ZooKeeperAddress> servers, int currentServerId,
+    private static int findServerId(Map<Integer, ZooKeeperServerConfig> servers, int currentServerId,
                                     InetAddress addr) {
         final String ip = NetUtil.toAddressString(addr, true);
-        for (Entry<Integer, ZooKeeperAddress> entry : servers.entrySet()) {
+        for (Entry<Integer, ZooKeeperServerConfig> entry : servers.entrySet()) {
             final String zkAddr;
             try {
                 zkAddr = NetUtil.toAddressString(InetAddress.getByName(entry.getValue().host()), true);
@@ -192,17 +192,17 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
     }
 
     /**
-     * Returns the address of this ZooKeeper server in {@link #servers()}.
+     * Returns the configuration of this ZooKeeper server in {@link #servers()}.
      */
-    public ZooKeeperAddress serverAddress() {
+    public ZooKeeperServerConfig serverConfig() {
         return servers.get(serverId);
     }
 
     /**
-     * Returns the addresses of all ZooKeeper servers, keyed by their server IDs.
+     * Returns the configuration of all ZooKeeper servers, keyed by their server IDs.
      */
     @JsonProperty
-    public Map<Integer, ZooKeeperAddress> servers() {
+    public Map<Integer, ZooKeeperServerConfig> servers() {
         return servers;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
@@ -65,7 +65,11 @@ public final class ZooKeeperServerConfig {
                       "clientPort: %s (expected: 0-65535)", clientPort);
         this.clientPort = clientPort;
         this.groupId = groupId;
-        this.weight = weight == null ? 1 : weight;
+        if (weight == null) {
+            weight = 1;
+        }
+        checkArgument(weight >= 0, "weight: %s (expected: >= 0)", weight);
+        this.weight = weight;
     }
 
     private static int validatePort(int port, String name) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.centraldogma.server;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -53,7 +54,7 @@ public final class ZooKeeperServerConfig {
     public ZooKeeperServerConfig(@JsonProperty(value = "host", required = true) String host,
                                  @JsonProperty(value = "quorumPort", required = true) int quorumPort,
                                  @JsonProperty(value = "electionPort", required = true) int electionPort,
-                                 @JsonProperty(value = "clientPort", defaultValue = "0") int clientPort,
+                                 @JsonProperty(value = "clientPort", defaultValue = "0") Integer clientPort,
                                  @JsonProperty("groupId") @Nullable Integer groupId,
                                  @JsonProperty(value = "weight", defaultValue = "1") Integer weight) {
 
@@ -61,6 +62,9 @@ public final class ZooKeeperServerConfig {
         this.quorumPort = validatePort(quorumPort, "quorumPort");
         this.electionPort = validatePort(electionPort, "electionPort");
 
+        if (clientPort == null) {
+            clientPort = 0;
+        }
         checkArgument(clientPort >= 0 && clientPort <= 65535,
                       "clientPort: %s (expected: 0-65535)", clientPort);
         this.clientPort = clientPort;

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
@@ -55,7 +55,7 @@ public final class ZooKeeperServerConfig {
                                  @JsonProperty(value = "electionPort", required = true) int electionPort,
                                  @JsonProperty(value = "clientPort", defaultValue = "0") int clientPort,
                                  @JsonProperty("groupId") @Nullable Integer groupId,
-                                 @JsonProperty(value = "weight", defaultValue = "1") int weight) {
+                                 @JsonProperty(value = "weight", defaultValue = "1") Integer weight) {
 
         this.host = requireNonNull(host, "host");
         this.quorumPort = validatePort(quorumPort, "quorumPort");
@@ -65,7 +65,7 @@ public final class ZooKeeperServerConfig {
                       "clientPort: %s (expected: 0-65535)", clientPort);
         this.clientPort = clientPort;
         this.groupId = groupId;
-        this.weight = weight;
+        this.weight = weight == null ? 1 : weight;
     }
 
     private static int validatePort(int port, String name) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.centraldogma.server;
 
-import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
@@ -47,16 +46,17 @@ public final class ZooKeeperServerConfig {
      * @param quorumPort the quorum port number
      * @param electionPort the election port number
      * @param clientPort the client port number (0-65535)
-     * @param groupId the group ID to use hierarchical quorums
+     * @param groupId the group ID to use for hierarchical quorums
      * @param weight the weight of the Zookeeper server
      */
     @JsonCreator
-    public ZooKeeperServerConfig(@JsonProperty(value = "host", required = true) String host,
-                                 @JsonProperty(value = "quorumPort", required = true) int quorumPort,
-                                 @JsonProperty(value = "electionPort", required = true) int electionPort,
-                                 @JsonProperty(value = "clientPort", defaultValue = "0") Integer clientPort,
-                                 @JsonProperty("groupId") @Nullable Integer groupId,
-                                 @JsonProperty(value = "weight", defaultValue = "1") Integer weight) {
+    public ZooKeeperServerConfig(
+            @JsonProperty(value = "host", required = true) String host,
+            @JsonProperty(value = "quorumPort", required = true) int quorumPort,
+            @JsonProperty(value = "electionPort", required = true) int electionPort,
+            @JsonProperty(value = "clientPort", defaultValue = "0") @Nullable Integer clientPort,
+            @JsonProperty("groupId") @Nullable Integer groupId,
+            @JsonProperty(value = "weight", defaultValue = "1") @Nullable Integer weight) {
 
         this.host = requireNonNull(host, "host");
         this.quorumPort = validatePort(quorumPort, "quorumPort");

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperServerConfig.java
@@ -20,6 +20,8 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -27,12 +29,15 @@ import com.google.common.base.MoreObjects;
 /**
  * Represents the address and port numbers of a ZooKeeper node.
  */
-public final class ZooKeeperAddress {
+public final class ZooKeeperServerConfig {
 
     private final String host;
     private final int quorumPort;
     private final int electionPort;
     private final int clientPort;
+    @Nullable
+    private final Integer groupId;
+    private final int weight;
 
     /**
      * Creates a new instance.
@@ -41,12 +46,16 @@ public final class ZooKeeperAddress {
      * @param quorumPort the quorum port number
      * @param electionPort the election port number
      * @param clientPort the client port number (0-65535)
+     * @param groupId the group ID to use hierarchical quorums
+     * @param weight the weight of the Zookeeper server
      */
     @JsonCreator
-    public ZooKeeperAddress(@JsonProperty(value = "host", required = true) String host,
-                            @JsonProperty(value = "quorumPort", required = true) int quorumPort,
-                            @JsonProperty(value = "electionPort", required = true) int electionPort,
-                            @JsonProperty(value = "clientPort", defaultValue = "0") int clientPort) {
+    public ZooKeeperServerConfig(@JsonProperty(value = "host", required = true) String host,
+                                 @JsonProperty(value = "quorumPort", required = true) int quorumPort,
+                                 @JsonProperty(value = "electionPort", required = true) int electionPort,
+                                 @JsonProperty(value = "clientPort", defaultValue = "0") int clientPort,
+                                 @JsonProperty("groupId") @Nullable Integer groupId,
+                                 @JsonProperty(value = "weight", defaultValue = "1") int weight) {
 
         this.host = requireNonNull(host, "host");
         this.quorumPort = validatePort(quorumPort, "quorumPort");
@@ -55,6 +64,8 @@ public final class ZooKeeperAddress {
         checkArgument(clientPort >= 0 && clientPort <= 65535,
                       "clientPort: %s (expected: 0-65535)", clientPort);
         this.clientPort = clientPort;
+        this.groupId = groupId;
+        this.weight = weight;
     }
 
     private static int validatePort(int port, String name) {
@@ -94,9 +105,26 @@ public final class ZooKeeperAddress {
         return clientPort;
     }
 
+    /**
+     * Returns the group ID to use hierarchical quorums.
+     */
+    @Nullable
+    @JsonProperty
+    public Integer groupId() {
+        return groupId;
+    }
+
+    /**
+     * Returns the weight of the ZooKeeper server.
+     */
+    @JsonProperty
+    public int weight() {
+        return weight;
+    }
+
     @Override
     public int hashCode() {
-        return Objects.hash(host, quorumPort, electionPort, clientPort);
+        return Objects.hash(host, quorumPort, electionPort, clientPort, groupId, weight);
     }
 
     @Override
@@ -109,11 +137,13 @@ public final class ZooKeeperAddress {
             return false;
         }
 
-        final ZooKeeperAddress that = (ZooKeeperAddress) o;
+        final ZooKeeperServerConfig that = (ZooKeeperServerConfig) o;
         return host.equals(that.host) &&
                quorumPort == that.quorumPort &&
                electionPort == that.electionPort &&
-               clientPort == that.clientPort;
+               clientPort == that.clientPort &&
+               Objects.equals(groupId, that.groupId) &&
+               weight == that.weight;
     }
 
     @Override
@@ -123,6 +153,8 @@ public final class ZooKeeperAddress {
                           .add("quorumPort", quorumPort)
                           .add("electionPort", electionPort)
                           .add("clientPort", clientPort)
+                          .add("groupId", groupId)
+                          .add("weight", weight)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -466,11 +466,11 @@ public final class ZooKeeperCommandExecutor
                 }
                 if (isHierarchical) {
                     groupBuilder.build().asMap().forEach((groupId, serverIds) -> {
-                        // group.1=1:2:3
+                        // e.g. group.1=1:2:3
                         zkProps.setProperty("group." + groupId, colonJoiner.join(serverIds));
                     });
                     servers.forEach((serverId, serverConfig) -> {
-                        // weight.1=1
+                        // e.g. weight.1=1
                         zkProps.setProperty("weight." + serverId, String.valueOf(serverConfig.weight()));
                     });
                 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -457,7 +457,7 @@ public final class ZooKeeperCommandExecutor
                                 servers.values().stream()
                                        .filter(serverConfig -> serverConfig.groupId() == null)
                                        .collect(toImmutableList());
-                        logger.warn("Hierarchical quorums are disabled. 'groupId' are missed in {}",
+                        logger.warn("Hierarchical quorums are disabled. 'groupId' are missing in {}",
                                     noGroupIds);
                         break;
                     } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -778,9 +778,12 @@ public final class ZooKeeperCommandExecutor
 
         @JsonCreator
         LogMeta(@JsonProperty(value = "replicaId", required = true) int replicaId,
-                @JsonProperty(value = "timestamp", defaultValue = "0") long timestamp,
+                @JsonProperty(value = "timestamp", defaultValue = "0") Long timestamp,
                 @JsonProperty("size") int size) {
             this.replicaId = replicaId;
+            if (timestamp == null) {
+                timestamp = 0L;
+            }
             this.timestamp = timestamp;
             this.size = size;
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.replication;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
@@ -30,6 +31,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
@@ -71,13 +74,16 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
+import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.command.AbstractCommandExecutor;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -93,6 +99,7 @@ public final class ZooKeeperCommandExecutor
     private static final Logger logger = LoggerFactory.getLogger(ZooKeeperCommandExecutor.class);
     private static final Escaper jaasValueEscaper =
             Escapers.builder().addEscape('\"', "\\\"").addEscape('\\', "\\\\").build();
+    private static final Joiner colonJoiner = Joiner.on(':');
 
     private static final String PATH_PREFIX = "/dogma";
     private static final int MAX_BYTES = 1024 * 1023; // Max size in document is 1M. but safety.
@@ -269,6 +276,10 @@ public final class ZooKeeperCommandExecutor
 
         // Register the metrics which are accessible even before started.
         Gauge.builder("replica.id", this, self -> replicaId()).register(meterRegistry);
+        Gauge.builder("replica.groupId", this, self -> {
+            final Integer groupId = self.cfg.serverConfig().groupId();
+            return groupId != null ? groupId : -1;
+        }).register(meterRegistry);
         Gauge.builder("replica.read.only", this, self -> self.isWritable() ? 0 : 1).register(meterRegistry);
         Gauge.builder("replica.replicating", this, self -> self.isStarted() ? 1 : 0).register(meterRegistry);
         Gauge.builder("replica.has.leadership", this,
@@ -417,14 +428,53 @@ public final class ZooKeeperCommandExecutor
             System.setProperty("zookeeper.authProvider.1", SASLAuthenticationProvider.class.getName());
 
             // Set the client port, which is unused.
-            zkProps.setProperty("clientPort", String.valueOf(cfg.serverAddress().clientPort()));
+            zkProps.setProperty("clientPort", String.valueOf(cfg.serverConfig().clientPort()));
 
+            final Map<Integer, ZooKeeperServerConfig> servers = cfg.servers();
             // Add replicas.
-            cfg.servers().forEach((id, addr) -> {
+            boolean hasGroupId = false;
+            for (Entry<Integer, ZooKeeperServerConfig> entry : servers.entrySet()) {
+                final ZooKeeperServerConfig serverConfig = entry.getValue();
                 zkProps.setProperty(
-                        "server." + id,
-                        addr.host() + ':' + addr.quorumPort() + ':' + addr.electionPort() + ":participant");
-            });
+                        "server." + entry.getKey(),
+                        serverConfig.host() + ':' + serverConfig.quorumPort() + ':' +
+                        serverConfig.electionPort() + ":participant");
+
+                if (!hasGroupId && serverConfig.groupId() != null) {
+                    hasGroupId = true;
+                }
+            }
+
+            // Add groups if exists
+            if (hasGroupId) {
+                final ImmutableMultimap.Builder<Integer, Integer> groupBuilder = ImmutableMultimap.builder();
+                boolean hierarchicalQuorumsEnabled = true;
+                for (Entry<Integer, ZooKeeperServerConfig> entry : servers.entrySet()) {
+                    final Integer groupId = entry.getValue().groupId();
+                    if (groupId == null) {
+                        hierarchicalQuorumsEnabled = false;
+                        final List<ZooKeeperServerConfig> noGroupIds =
+                                servers.values().stream()
+                                       .filter(serverConfig -> serverConfig.groupId() == null)
+                                       .collect(toImmutableList());
+                        logger.warn("Hierarchical quorums are disabled. 'groupId' are missed in {}",
+                                    noGroupIds);
+                        break;
+                    } else {
+                        groupBuilder.put(groupId, entry.getKey());
+                    }
+                }
+                if (hierarchicalQuorumsEnabled) {
+                    groupBuilder.build().asMap().forEach((groupId, serverIds) -> {
+                        // group.1=1:2:3
+                        zkProps.setProperty("group." + groupId, colonJoiner.join(serverIds));
+                    });
+                    servers.forEach((serverId, serverConfig) -> {
+                        // weight.1=1
+                        zkProps.setProperty("weight." + serverId, String.valueOf(serverConfig.weight()));
+                    });
+                }
+            }
 
             // Disable Jetty-based admin server.
             zkProps.setProperty("admin.enableServer", "false");

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -141,11 +141,8 @@ class CentralDogmaConfigTest {
 
         final List<ClientAddressSource> sources = cfg.clientAddressSourceList();
         assertThat(sources).hasSize(2);
-        // TODO(hyangtack) Need to add equals/hashCode to ClientAddressSource class.
-        //                 https://github.com/line/armeria/pull/1804
-        assertThat(sources.get(0).toString()).isEqualTo(ClientAddressSource.ofHeader("forwarded").toString());
-        assertThat(sources.get(1).toString()).isEqualTo(
-                ClientAddressSource.ofHeader("x-forwarded-for").toString());
+        assertThat(sources.get(0)).isEqualTo(ClientAddressSource.ofHeader("forwarded"));
+        assertThat(sources.get(1)).isEqualTo(ClientAddressSource.ofHeader("x-forwarded-for"));
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfigTest.java
@@ -45,13 +45,17 @@ class ZooKeeperReplicationConfigTest {
                              "      \"host\": \"2\"," +
                              "      \"quorumPort\": 3," +
                              "      \"electionPort\": 4," +
-                             "      \"clientPort\": 5" +
+                             "      \"clientPort\": 5," +
+                             "      \"groupId\": null," +
+                             "      \"weight\": 1" +
                              "    }," +
                              "    \"6\": {" +
                              "      \"host\": \"7\"," +
                              "      \"quorumPort\": 8," +
                              "      \"electionPort\": 9," +
-                             "      \"clientPort\": 10" +
+                             "      \"clientPort\": 10," +
+                             "      \"groupId\": null," +
+                             "      \"weight\": 1" +
                              "    }" +
                              "  }," + // NB: secret is not serialized.
                              "  \"additionalProperties\": { \"12\": \"13\", \"14\": \"15\" }," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -52,8 +52,8 @@ import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
-import com.linecorp.centraldogma.server.ZooKeeperAddress;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
+import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 
@@ -82,9 +82,11 @@ class ReplicatedLoginAndLogoutTest {
         final int zkElectionPort2 = InstanceSpec.getRandomPort();
         final int zkClientPort2 = InstanceSpec.getRandomPort();
 
-        final Map<Integer, ZooKeeperAddress> servers = ImmutableMap.of(
-                1, new ZooKeeperAddress("127.0.0.1", zkQuorumPort1, zkElectionPort1, zkClientPort1),
-                2, new ZooKeeperAddress("127.0.0.1", zkQuorumPort2, zkElectionPort2, zkClientPort2));
+        final Map<Integer, ZooKeeperServerConfig> servers = ImmutableMap.of(
+                1, new ZooKeeperServerConfig("127.0.0.1", zkQuorumPort1, zkElectionPort1,
+                                             zkClientPort1, /* groupId */ null, /* weight */ 1),
+                2, new ZooKeeperServerConfig("127.0.0.1", zkQuorumPort2, zkElectionPort2,
+                                             zkClientPort2, /* groupId */ null, /* weight */ 1));
 
         final AuthProviderFactory factory = new TestAuthProviderFactory();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/StartStopWithoutInitialQuorumTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.centraldogma.server.internal.replication;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.curator.test.InstanceSpec;
@@ -25,8 +26,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
-import com.linecorp.centraldogma.server.ZooKeeperAddress;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
+import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 /**
@@ -48,10 +49,14 @@ class StartStopWithoutInitialQuorumTest {
             final int electionPort = InstanceSpec.getRandomPort();
             final int clientPort = InstanceSpec.getRandomPort();
 
-            builder.replication(new ZooKeeperReplicationConfig(
-                    1, ImmutableMap.of(1, new ZooKeeperAddress("127.0.0.1",
-                                                               quorumPort, electionPort, clientPort),
-                                       2, new ZooKeeperAddress("127.0.0.1", 1, 1, 1))));
+            final Map<Integer, ZooKeeperServerConfig> servers =
+                    ImmutableMap.of(1,
+                                    new ZooKeeperServerConfig("127.0.0.1", quorumPort, electionPort,
+                                                              clientPort, /* groupId */ null, /* weight */ 1),
+                                    2,
+                                    new ZooKeeperServerConfig("127.0.0.1", 1, 1,
+                                                              1, /* groupId */ null, /* weight */ 1));
+            builder.replication(new ZooKeeperReplicationConfig(1, servers));
         }
 
         @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -415,7 +415,6 @@ class ZooKeeperCommandExecutorTest {
         return buildCluster(numReplicas, start, 1, delegateSupplier, null);
     }
 
-
     private List<Replica> buildCluster(
             int numReplicas, boolean start, int numGroup,
             Supplier<Function<Command<?>, CompletableFuture<?>>> delegateSupplier,

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -92,8 +92,8 @@ class ZooKeeperCommandExecutorTest {
     @Test
     void testLogWatch() throws Exception {
         // The 5th replica is used for ensuring the quorum.
-        final List<Replica> cluster = buildCluster(5, true /* start */, 1,
-                                                   ZooKeeperCommandExecutorTest::newMockDelegate, null);
+        final List<Replica> cluster = buildCluster(5, true /* start */,
+                                                   ZooKeeperCommandExecutorTest::newMockDelegate);
         final Replica replica1 = cluster.get(0);
         final Replica replica2 = cluster.get(1);
         final Replica replica3 = cluster.get(2);
@@ -201,10 +201,10 @@ class ZooKeeperCommandExecutorTest {
     void testRace() throws Exception {
         // Each replica has its own AtomicInteger which counts the number of commands
         // it executed/replayed so far.
-        final List<Replica> replicas = buildCluster(NUM_REPLICAS, true /* start */, 1, () -> {
+        final List<Replica> replicas = buildCluster(NUM_REPLICAS, true /* start */, () -> {
             final AtomicInteger counter = new AtomicInteger();
             return command -> completedFuture(new Revision(counter.incrementAndGet()));
-        }, null);
+        });
 
         try {
             final Command<Revision> command =

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -239,17 +239,23 @@ example shows the configuration of the first replica in a 3-replica cluster:
           "1": {
             "host": "replica1.example.com",
             "quorumPort": 36463,
-            "electionPort": 36464
+            "electionPort": 36464,
+            "groupId": null,
+            "weight": null,
           },
           "2": {
             "host": "replica2.example.com",
             "quorumPort": 36463,
-            "electionPort": 36464
+            "electionPort": 36464,
+            "groupId": null,
+            "weight": null,
           },
           "3": {
             "host": "replica3.example.com",
             "quorumPort": 36463,
-            "electionPort": 36464
+            "electionPort": 36464,
+            "groupId": null,
+            "weight": null,
           }
         },
         "secret": "JqJAkZ!oZ6MNx4rBpIH8M*yuVWXDULgR",
@@ -292,6 +298,18 @@ example shows the configuration of the first replica in a 3-replica cluster:
     - ``electionPort`` (integer)
 
       - the TCP/IP port number which is used by ZooKeeper for leader election
+
+    - ``groupId`` (integer)
+
+      - the group ID which is used by ZooKeeper for
+        `hierarchical quorums https://zookeeper.apache.org/doc/r3.5.8/zookeeperHierarchicalQuorums.html`_
+         If ``null`` or unspecified, hierarchical quorums are disabled.
+
+    - ``weight`` (integer)
+
+      - the weight of the replica which is used by ZooKeeper for hierarchical quorums
+        If ``null`` or unspecified, ``1`` is used by default.
+        If ``groupId`` is ``null``, this value will be ignored.
 
   - It is highly recommended to have more than 3, preferably odd number of, replicas because the consensus
     algorithm requires more than half of all replicas to agree with each other to function correctly.


### PR DESCRIPTION
Motivation:

For multi-data center replication, hierarchical quorums could reduce total
write transaction time than a single quorum.

See #534

Modifications:

- Add `groupId` and `weight` to Zookeeper replication config

Result:

- You can now use hierarchical quorums for the embedded Zookeeper of Central Dogma
- Closes #534