### PR TITLE
Clean node_modules folder while performing Gradle clean task

### DIFF
--- a/server-auth/webapp/build.gradle
+++ b/server-auth/webapp/build.gradle
@@ -44,7 +44,13 @@ task buildWebApp(type: YarnTask) {
     args = ['run', 'build']
 }
 
+task cleanNodeModules(type: Delete) {
+    delete 'node_modules'
+    followSymlinks = true
+}
+
 tasks.assemble.dependsOn tasks.buildWebApp
+tasks.clean.dependsOn tasks.cleanNodeModules
 
 node {
     version = '10.19.0'


### PR DESCRIPTION
Motivation:

When broken js files are cached to a local file system due to network disruption,
There is no task to remove the broken files.

Modifications:

- Remove `node_modules` folder when `clean` task is triggered

Result:

You can now remove `node_modules` folder by executing `gradle clean`.