### PR TITLE
Exception thrown by watcher listeners should not affect other listeners

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -288,7 +288,12 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
 
         final Latest<T> latest = this.latest;
         for (BiConsumer<? super Revision, ? super T> listener : updateListeners) {
-            listener.accept(latest.revision(), latest.value());
+            try {
+                listener.accept(latest.revision(), latest.value());
+            } catch (Exception e) {
+                logger.warn("Exception thrown for watcher ({}/{}{}) on ({}), ",
+                            projectName, repositoryName, pathPattern, latest, e);
+            }
         }
     }
 

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -291,8 +291,8 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
             try {
                 listener.accept(latest.revision(), latest.value());
             } catch (Exception e) {
-                logger.warn("Exception thrown for watcher ({}/{}{}) on ({}), ",
-                            projectName, repositoryName, pathPattern, latest, e);
+                logger.warn("Exception thrown for watcher ({}/{}{}): rev={}",
+                            projectName, repositoryName, pathPattern, latest.revision(), e);
             }
         }
     }

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -280,8 +280,7 @@ class WatchTest {
         final Change<JsonNode> update = Change.ofJsonUpsert(
                 filePath, "{ \"a\": \"air\" }");
         client.push(dogma.project(), dogma.repo1(), rev0, "Modify /a", update)
-              .join()
-              .revision();
+              .join();
 
         // the updated json should be reflected in the second watcher
         await().untilTrue(atomicBoolean);


### PR DESCRIPTION
**Motivation**

Not sure if this is intentional behavior, but it seems odd to me that an exception thrown by one watcher affects other watcher callbacks