### PR TITLE
Update dependencies

### DIFF
--- a/common-legacy/build.gradle
+++ b/common-legacy/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     // Thrift
     implementation 'org.apache.thrift:libthrift'
-    compileOnly 'jakarta.annotation:jakarta.annotation-api'
+    compileOnly 'javax.annotation:javax.annotation-api'
 }
 
 tasks.compileThrift.doLast {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,9 +3,9 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.11.3
-- com.linecorp.armeria:armeria-bom:1.2.0
-- io.micrometer:micrometer-bom:1.5.5
+- com.fasterxml.jackson:jackson-bom:2.12.0
+- com.linecorp.armeria:armeria-bom:1.3.0
+- io.micrometer:micrometer-bom:1.6.1
 - org.junit:junit-bom:5.7.0
 
 ch.qos.logback:
@@ -113,11 +113,11 @@ com.linecorp.armeria:
     - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.1.0/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.36.2' }
+  checkstyle: { version: '8.38' }
 
 com.spotify:
   completable-futures:
-    version: '0.3.3'
+    version: '0.3.4'
     relocations:
     - from: com.spotify.futures
       to:   com.linecorp.centraldogma.internal.shaded.futures
@@ -136,8 +136,8 @@ io.micrometer:
     javadocs:
     - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.5.5/
 
-jakarta.annotation:
-  jakarta.annotation-api: { version: '1.3.5' }
+javax.annotation:
+  javax.annotation-api: { version: '1.3.2' }
 
 javax.inject:
   javax.inject: { version: '1' }
@@ -164,7 +164,7 @@ me.champeau.gradle:
   jmh-gradle-plugin: { version: '0.5.2' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.19.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.22.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
@@ -202,7 +202,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.17.2' }
+  assertj-core: { version: '3.18.1' }
 
 org.awaitility:
   awaitility: { version: '4.0.3' }
@@ -224,7 +224,7 @@ org.javassist:
   javassist: { version: '3.27.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.5.15' }
+  mockito-core: { version: &MOCKITO_VERSION '3.6.28' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
@@ -245,7 +245,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.3.4.RELEASE'
+    version: &SPRING_BOOT_VERSION '2.4.0'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Armeria 1.2.0 -> 1.3.0
- AssertJ 3.17.2 -> 3.18.1
- completable-futures 0.3.3 -> 0.3.4
- Jackson 2.11.3 -> 2.12.0
- jakatra.annotation 1.3.5 -> javax.annotation 1.3.2
- json-unit 2.19.0 -> 2.22.0
- Micrometer 1.5.5 -> 1.6.1
- Mockito 3.5.15 -> 3.6.28
- Spring Boot 2.3.4.RELEASE -> 2.4.0
- Build
  - Checkstyle 8.36.2 -> 8.38
  - Gradle 6.7 -> 6.7.1