### PR TITLE
Make client DNS query timeout configurable

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
@@ -144,10 +144,9 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
             if (addr.isUnresolved()) {
                 final DnsAddressEndpointGroupBuilder dnsAddressEndpointGroup = DnsAddressEndpointGroup
                         .builder(addr.getHostString())
-                        .eventLoop(clientFactory.eventLoopGroup().next())
-                        .port(addr.getPort());
+                        .eventLoop(clientFactory.eventLoopGroup().next());
                 dnsAddressEndpointGroupConfigurator.configure(dnsAddressEndpointGroup);
-                groups.add(dnsAddressEndpointGroup.build());
+                groups.add(dnsAddressEndpointGroup.port(addr.getPort()).build());
             } else {
                 staticEndpoints.add(toResolvedHostEndpoint(addr));
             }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
@@ -56,7 +56,7 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
     private ClientFactory clientFactory = ClientFactory.ofDefault();
     private ArmeriaClientConfigurator clientConfigurator = cb -> {};
     private Duration healthCheckInterval = Duration.ofMillis(DEFAULT_HEALTH_CHECK_INTERVAL_MILLIS);
-    private Consumer<DnsAddressEndpointGroupBuilder> dnsAddressEndpointGroupCustomizer = b -> {};
+    private DnsAddressEndpointGroupConfigurator dnsAddressEndpointGroupConfigurator = b -> {};
 
     /**
      * Returns the {@link ClientFactory} that will create an underlying
@@ -84,10 +84,14 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
         return self();
     }
 
-    public final B dnsAddressEndpointGroupCustomizer(
-            Consumer<DnsAddressEndpointGroupBuilder> dnsAddressEndpointGroupCustomizer) {
-        this.dnsAddressEndpointGroupCustomizer = requireNonNull(
-                dnsAddressEndpointGroupCustomizer, "dnsAddressEndpointGroupCustomizer");
+    /**
+     * Sets the {@link DnsAddressEndpointGroupConfigurator} that will configure the DNS lookup
+     * done by the <a href="https://line.github.io/armeria/">Armeria</a> client.
+     */
+    public final B dnsAddressEndpointGroupConfigurator(
+            DnsAddressEndpointGroupConfigurator dnsAddressEndpointGroupConfigurator) {
+        this.dnsAddressEndpointGroupConfigurator = requireNonNull(
+                dnsAddressEndpointGroupConfigurator, "dnsAddressEndpointGroupConfigurator");
         return self();
     }
 
@@ -142,7 +146,7 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
                         .builder(addr.getHostString())
                         .eventLoop(clientFactory.eventLoopGroup().next())
                         .port(addr.getPort());
-                dnsAddressEndpointGroupCustomizer.accept(dnsAddressEndpointGroup);
+                dnsAddressEndpointGroupConfigurator.configure(dnsAddressEndpointGroup);
                 groups.add(dnsAddressEndpointGroup.build());
             } else {
                 staticEndpoints.add(toResolvedHostEndpoint(addr));

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/DnsAddressEndpointGroupConfigurator.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/DnsAddressEndpointGroupConfigurator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.armeria;
+
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
+import com.linecorp.centraldogma.client.CentralDogma;
+
+/**
+ * Configures the DNS resolution of the <a href="https://line.github.io/armeria/">Armeria</a> client of
+ * {@link CentralDogma}.
+ */
+@FunctionalInterface
+public interface DnsAddressEndpointGroupConfigurator {
+    /**
+     * Configures the DNS lookup of the {@link ArmeriaCentralDogma} client.
+     */
+    void configure(DnsAddressEndpointGroupBuilder dnsAddressEndpointGroupBuilder);
+}

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import javax.inject.Qualifier;
 
@@ -46,6 +47,7 @@ import org.springframework.core.type.MethodMetadata;
 import com.google.common.net.HostAndPort;
 
 import com.linecorp.armeria.client.ClientFactory;
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.ArmeriaClientConfigurator;
@@ -87,13 +89,15 @@ public class CentralDogmaClientAutoConfiguration {
             Environment env,
             CentralDogmaSettings settings,
             @ForCentralDogma ClientFactory clientFactory,
-            Optional<ArmeriaClientConfigurator> armeriaClientConfigurator) throws UnknownHostException {
+            Optional<ArmeriaClientConfigurator> armeriaClientConfigurator,
+            Optional<Consumer<DnsAddressEndpointGroupBuilder>> dnsAddressEndpointGroupCustomizer) throws UnknownHostException {
 
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
 
         builder.clientFactory(clientFactory);
         builder.clientConfigurator(cb -> armeriaClientConfigurator.ifPresent(
                 configurator -> configurator.configure(cb)));
+        dnsAddressEndpointGroupCustomizer.ifPresent(builder::dnsAddressEndpointGroupCustomizer);
 
         // Set health check interval.
         final Long healthCheckIntervalMillis = settings.getHealthCheckIntervalMillis();

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -89,7 +89,8 @@ public class CentralDogmaClientAutoConfiguration {
             CentralDogmaSettings settings,
             @ForCentralDogma ClientFactory clientFactory,
             Optional<ArmeriaClientConfigurator> armeriaClientConfigurator,
-            Optional<DnsAddressEndpointGroupConfigurator> dnsAddressEndpointGroupConfigurator) throws UnknownHostException {
+            Optional<DnsAddressEndpointGroupConfigurator> dnsAddressEndpointGroupConfigurator)
+            throws UnknownHostException {
 
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
 

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -20,7 +20,6 @@ import java.lang.annotation.RetentionPolicy;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Consumer;
 
 import javax.inject.Qualifier;
 
@@ -47,10 +46,10 @@ import org.springframework.core.type.MethodMetadata;
 import com.google.common.net.HostAndPort;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.ArmeriaClientConfigurator;
+import com.linecorp.centraldogma.client.armeria.DnsAddressEndpointGroupConfigurator;
 
 /**
  * Spring bean configuration for {@link CentralDogma} client.
@@ -90,14 +89,14 @@ public class CentralDogmaClientAutoConfiguration {
             CentralDogmaSettings settings,
             @ForCentralDogma ClientFactory clientFactory,
             Optional<ArmeriaClientConfigurator> armeriaClientConfigurator,
-            Optional<Consumer<DnsAddressEndpointGroupBuilder>> dnsAddressEndpointGroupCustomizer) throws UnknownHostException {
+            Optional<DnsAddressEndpointGroupConfigurator> dnsAddressEndpointGroupConfigurator) throws UnknownHostException {
 
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
 
         builder.clientFactory(clientFactory);
         builder.clientConfigurator(cb -> armeriaClientConfigurator.ifPresent(
                 configurator -> configurator.configure(cb)));
-        dnsAddressEndpointGroupCustomizer.ifPresent(builder::dnsAddressEndpointGroupCustomizer);
+        dnsAddressEndpointGroupConfigurator.ifPresent(builder::dnsAddressEndpointGroupConfigurator);
 
         // Set health check interval.
         final Long healthCheckIntervalMillis = settings.getHealthCheckIntervalMillis();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 
 import javax.inject.Inject;
 
@@ -31,14 +30,14 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest.TestConfiguration;
+import com.linecorp.centraldogma.client.armeria.DnsAddressEndpointGroupConfigurator;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest.TestConfiguration;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = TestConfiguration.class)
 @ActiveProfiles({ "local", "confTest" })
-class CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest {
+class CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest {
     @SpringBootApplication
     static class TestConfiguration {
         @Bean
@@ -47,7 +46,7 @@ class CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest {
         }
 
         @Bean
-        Consumer<DnsAddressEndpointGroupBuilder> dnsAddressEndpointGroupCustomizer(
+        DnsAddressEndpointGroupConfigurator dnsAddressEndpointGroupConfigurator(
                 AtomicBoolean customizationDone) {
             return b -> customizationDone.set(true);
         }

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroupBuilder;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest.TestConfiguration;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "confTest" })
+class CentralDogmaClientAutoConfigurationWithDnsEndpointGroupCustomizerTest {
+    @SpringBootApplication
+    static class TestConfiguration {
+        @Bean
+        AtomicBoolean customizationDone() {
+            return new AtomicBoolean();
+        }
+
+        @Bean
+        Consumer<DnsAddressEndpointGroupBuilder> dnsAddressEndpointGroupCustomizer(
+                AtomicBoolean customizationDone) {
+            return b -> customizationDone.set(true);
+        }
+    }
+
+    @Inject
+    private CentralDogma client;
+
+    @Inject
+    private AtomicBoolean customizationDone;
+
+    @Test
+    void centralDogmaClient() throws Exception {
+        assertThat(client).isNotNull();
+        // client has been instantiated
+        assertTrue(customizationDone.get());
+    }
+}


### PR DESCRIPTION
Motivation:
Central Dogma client (based on Armeria) currently uses a non-configurable default of 5s.
We want to be able to configure it based on our network situation.

Modifications:
- Add `DnsAddressEndpointGroupConfigurator` to configure `DnsAddressEndpointGroup`.

Result:
- You can now customize `DnsAddressEndpointGroup` in `ArmeriaCentralDogmaBuilder`.