### PR TITLE
Allow creating a new token from the input string for admin

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/NonRandomTokenTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/NonRandomTokenTest.java
@@ -59,7 +59,6 @@ class NonRandomTokenTest {
         final WebClient adminClient = WebClient.builder(client.uri())
                                                .auth(OAuth2Token.of(sessionId)).build();
 
-
         final HttpRequest request = HttpRequest.builder()
                                                .post("/api/v1/tokens")
                                                .content(MediaType.FORM_DATA,

--- a/it/src/test/java/com/linecorp/centraldogma/it/NonRandomTokenTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/NonRandomTokenTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it;
+
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.login;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.AccessToken;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class NonRandomTokenTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.administrators(TestAuthMessageUtil.USERNAME);
+            builder.authProviderFactory(new TestAuthProviderFactory());
+        }
+    };
+
+    @Test
+    void createNonRandomToken() throws Exception {
+        final WebClient client = dogma.httpClient();
+        final AggregatedHttpResponse response = login(client,
+                                                      TestAuthMessageUtil.USERNAME,
+                                                      TestAuthMessageUtil.PASSWORD);
+
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        final String sessionId = Jackson.readValue(response.content().array(), AccessToken.class)
+                                        .accessToken();
+        final WebClient adminClient = WebClient.builder(client.uri())
+                                               .auth(OAuth2Token.of(sessionId)).build();
+
+
+        final HttpRequest request = HttpRequest.builder()
+                                               .post("/api/v1/tokens")
+                                               .content(MediaType.FORM_DATA,
+                                                        "secret=appToken-secret&isAdmin=true&appId=foo")
+                                               .build();
+        AggregatedHttpResponse res = adminClient.execute(request).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.CREATED);
+        res = adminClient.get("/api/v1/tokens").aggregate().join();
+        assertThat(res.contentUtf8()).contains("\"secret\":\"appToken-secret\"");
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -107,8 +107,8 @@ public class TokenService extends AbstractService {
     @ResponseConverter(CreateApiResponseConverter.class)
     public CompletableFuture<HttpResult<Token>> createToken(@Param String appId,
                                                             @Param boolean isAdmin,
-                                                            Author author, User loginUser,
-                                                            @Nullable String secret) {
+                                                            @Param @Nullable String secret,
+                                                            Author author, User loginUser) {
         checkArgument(!isAdmin || loginUser.isAdmin(),
                       "Only administrators are allowed to create an admin-level token.");
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -46,7 +46,6 @@ class TokenServiceTest {
         }
     };
 
-
     private static final Author adminAuthor = new Author("admin@localhost.com");
     private static final Author guestAuthor = new Author("guest@localhost.com");
     private static final User admin = new User("admin@localhost.com", User.LEVEL_ADMIN);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -46,6 +46,7 @@ class TokenServiceTest {
         }
     };
 
+
     private static final Author adminAuthor = new Author("admin@localhost.com");
     private static final Author guestAuthor = new Author("guest@localhost.com");
     private static final User admin = new User("admin@localhost.com", User.LEVEL_ADMIN);
@@ -63,10 +64,10 @@ class TokenServiceTest {
 
     @Test
     void adminToken() {
-        final Token token = tokenService.createToken("forAdmin1", true, adminAuthor, admin, null).join()
+        final Token token = tokenService.createToken("forAdmin1", true, null, adminAuthor, admin).join()
                                         .content();
         assertThat(token.isActive()).isTrue();
-        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor, guest, null)
+        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, null, guestAuthor, guest)
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
 
@@ -87,9 +88,9 @@ class TokenServiceTest {
 
     @Test
     void userToken() {
-        final Token userToken1 = tokenService.createToken("forUser1", false, adminAuthor, admin, null)
+        final Token userToken1 = tokenService.createToken("forUser1", false, null, adminAuthor, admin)
                                              .join().content();
-        final Token userToken2 = tokenService.createToken("forUser2", false, guestAuthor, guest, null)
+        final Token userToken2 = tokenService.createToken("forUser2", false, null, guestAuthor, guest)
                                              .join().content();
         assertThat(userToken1.isActive()).isTrue();
         assertThat(userToken2.isActive()).isTrue();
@@ -114,16 +115,16 @@ class TokenServiceTest {
 
     @Test
     void nonRandomToken() {
-        final Token token = tokenService.createToken("forAdmin1", true, adminAuthor,
-                                                     admin, "appToken-secret")
+        final Token token = tokenService.createToken("forAdmin1", true, "appToken-secret", adminAuthor,
+                                                     admin)
                                         .join().content();
         assertThat(token.isActive()).isTrue();
 
         final Collection<Token> tokens = tokenService.listTokens(admin).join();
         assertThat(tokens.stream().filter(t -> !StringUtil.isNullOrEmpty(t.secret()))).hasSize(1);
 
-        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor,
-                                                          guest, "appToken-secret")
+        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, "appToken-secret", guestAuthor,
+                                                          guest)
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -63,10 +63,10 @@ class TokenServiceTest {
 
     @Test
     void adminToken() {
-        final Token token = tokenService.createToken("forAdmin1", true, adminAuthor, admin).join()
+        final Token token = tokenService.createToken("forAdmin1", true, adminAuthor, admin, null).join()
                                         .content();
         assertThat(token.isActive()).isTrue();
-        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor, guest)
+        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor, guest, null)
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
 
@@ -87,9 +87,9 @@ class TokenServiceTest {
 
     @Test
     void userToken() {
-        final Token userToken1 = tokenService.createToken("forUser1", false, adminAuthor, admin)
+        final Token userToken1 = tokenService.createToken("forUser1", false, adminAuthor, admin, null)
                                              .join().content();
-        final Token userToken2 = tokenService.createToken("forUser2", false, guestAuthor, guest)
+        final Token userToken2 = tokenService.createToken("forUser2", false, guestAuthor, guest, null)
                                              .join().content();
         assertThat(userToken1.isActive()).isTrue();
         assertThat(userToken2.isActive()).isTrue();
@@ -110,5 +110,21 @@ class TokenServiceTest {
             assertThat(t.creation()).isEqualTo(userToken2.creation());
             assertThat(t.deactivation()).isEqualTo(userToken2.deactivation());
         });
+    }
+
+    @Test
+    void nonRandomToken() {
+        final Token token = tokenService.createToken("forAdmin1", true, adminAuthor,
+                                                     admin, "appToken-secret")
+                                        .join().content();
+        assertThat(token.isActive()).isTrue();
+
+        final Collection<Token> tokens = tokenService.listTokens(admin).join();
+        assertThat(tokens.stream().filter(t -> !StringUtil.isNullOrEmpty(t.secret()))).hasSize(1);
+
+        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, guestAuthor,
+                                                          guest, "appToken-secret")
+                                             .join())
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -122,9 +122,10 @@ class TokenServiceTest {
         final Collection<Token> tokens = tokenService.listTokens(admin).join();
         assertThat(tokens.stream().filter(t -> !StringUtil.isNullOrEmpty(t.secret()))).hasSize(1);
 
-        assertThatThrownBy(() -> tokenService.createToken("forAdmin2", true, "appToken-secret", guestAuthor,
+        assertThatThrownBy(() -> tokenService.createToken("forUser1", true, "appToken-secret", guestAuthor,
                                                           guest)
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
+        tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -42,6 +42,7 @@ import java.util.function.Function;
 
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreV2;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.ThrowingConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -254,6 +255,7 @@ class ZooKeeperCommandExecutorTest {
     }
 
     @Test
+    @Timeout(120)
     void hierarchicalQuorumsWithFailOver() throws Throwable {
         try (Cluster cluster = Cluster.builder()
                                       .numReplicas(9)


### PR DESCRIPTION
Motivation:

When migrating a Central Dogma into anther Central Domga, a repository could be easily migrated by copying its file folder under `/data`.
However it is difficult to merge the tokens of two systems because all tokens are managed by `tokens` repository.

Modifications:

- Allow to create a new token from `sceret` parameter for admin
- Increase timeout of `ZooKeeperCommandExecutorTest.hierarchicalQuorumsWithFailOver()` for receiving flakyness
- 
Result:

- You can now create a new token with non-random string starting with `appToken-` for admin
- Fixes #550