### PR TITLE
Fix that `mergeFiles` API modifies the content of the merge sources

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/MergeQuery.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/MergeQuery.java
@@ -78,7 +78,7 @@ public interface MergeQuery<T> {
      */
     static MergeQuery<JsonNode> ofJsonPath(Iterable<MergeSource> mergeSources,
                                            Iterable<String> jsonPaths) {
-        if (Iterables.isEmpty(jsonPaths)) {
+        if (Iterables.isEmpty(requireNonNull(jsonPaths, "jsonPaths"))) {
             return ofJson(mergeSources);
         }
         return new JsonMergeQuery(JSON_PATH, mergeSources, jsonPaths);

--- a/common/src/main/java/com/linecorp/centraldogma/common/MergeQuery.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/MergeQuery.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 
 /**
  * A merge query on files.
@@ -77,6 +78,9 @@ public interface MergeQuery<T> {
      */
     static MergeQuery<JsonNode> ofJsonPath(Iterable<MergeSource> mergeSources,
                                            Iterable<String> jsonPaths) {
+        if (Iterables.isEmpty(jsonPaths)) {
+            return ofJson(mergeSources);
+        }
         return new JsonMergeQuery(JSON_PATH, mergeSources, jsonPaths);
     }
 

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Jackson.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Jackson.java
@@ -346,8 +346,11 @@ public final class Jackson {
                 // Append the filed name and traverse the child.
                 fieldNameAppender.append(fieldName);
                 fieldNameAppender.append('/');
-                baseObject.set(fieldName,
-                               traverse(baseValue, updateValue, fieldNameAppender, isMerging, false));
+                final JsonNode traversed =
+                        traverse(baseValue, updateValue, fieldNameAppender, isMerging, false);
+                if (isMerging) {
+                    baseObject.set(fieldName, traversed);
+                }
                 // Remove the appended filed name above.
                 fieldNameAppender.delete(length, fieldNameAppender.length());
             }

--- a/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
@@ -34,6 +34,7 @@ import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.MergeSource;
 import com.linecorp.centraldogma.common.MergedEntry;
+import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -71,6 +72,20 @@ class MergeFileTest  {
         assertThat(merged.paths()).containsExactly("/foo.json", "/foo1.json","/foo2.json");
         assertThat(merged.revision()).isEqualTo(new Revision(2));
         assertThatJson(merged.content()).isEqualTo("{ \"a\": \"new_bar\", \"b\": \"baz\" }");
+
+        // Check again to see if the original files are changed.
+        assertThatJson(client.getFile("myPro", "myRepo", Revision.HEAD, Query.ofJson("/foo.json"))
+                             .join()
+                             .content())
+                .isEqualTo("{ \"a\": \"bar\" }");
+        assertThatJson(client.getFile("myPro", "myRepo", Revision.HEAD, Query.ofJson("/foo1.json"))
+                             .join()
+                             .content())
+                .isEqualTo("{ \"b\": \"baz\" }");
+        assertThatJson(client.getFile("myPro", "myRepo", Revision.HEAD, Query.ofJson("/foo2.json"))
+                             .join()
+                             .content())
+                .isEqualTo("{ \"a\": \"new_bar\" }");
 
         assertThatThrownBy(() -> client.mergeFiles("myPro", "myRepo", Revision.HEAD,
                                                    MergeSource.ofRequired("/foo.json"),


### PR DESCRIPTION
Motivation:
`mergeFiles` API should not modify the content of the merge sources

Modifications:
- Fix a bug where the `mergeFiles` API modifies the content of the first file of the merge sources

Result:
- You no longer see that the `mergeFiles` API does not modify the content of the merge sources.