### PR TITLE
Add metadata only once for a repository

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -123,9 +123,10 @@ public class MetadataService {
                     continue;
                 }
 
+                final String projectAndRepositoryName = projectName + '/' + repo;
                 final CompletableFuture<Revision> future = new CompletableFuture<>();
                 final CompletableFuture<Revision> futureInMap =
-                        reposInAddingMetadata.computeIfAbsent(repo, key -> future);
+                        reposInAddingMetadata.computeIfAbsent(projectAndRepositoryName, key -> future);
                 if (futureInMap != future) { // The metadata is already in adding.
                     builder.add(futureInMap);
                     continue;
@@ -139,7 +140,7 @@ public class MetadataService {
                     } else {
                         future.complete(revision);
                     }
-                    reposInAddingMetadata.remove(repo);
+                    reposInAddingMetadata.remove(projectAndRepositoryName);
                     return null;
                 });
                 builder.add(future);


### PR DESCRIPTION
Motivation:
CentralDogma currently adds metadata information of a repository into metadata.json if it doesn't exist.
However, if `MetadataService.getProject(...) is called multiple times before the metadata is added, there can be multiple commits of adding operation.
(We have watched over 1000 times for the same repository.)

Modifications:
- Fix to commit only once for the metadata of a repository.

Result:
- You no longer see multiple `Adding missing repository metadata` for the same repository.

Todo:
- Change to add metadata after `CreateRepository` is called.