### PR TITLE
Remove a write lock from git gc

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
@@ -171,7 +171,7 @@ public final class RepositoryGarbageCollectionPlugin implements Plugin {
             }
 
             logger.info("Starting repository gc on {}/{} ..", project.name(), repo.name());
-            stopwatch.reset();
+            stopwatch.reset().start();
             repo.gc();
             final long elapsedNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
             logger.info("Finished repository gc on {}/{} - took {}", project.name(), repo.name(),

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -1497,15 +1497,11 @@ class GitRepository implements Repository {
 
     @Override
     public Revision gc() throws Exception {
-        rwLock.writeLock().lock();
-        try {
-            garbageCollector.gc();
-            final Revision headRevision = this.headRevision;
-            gcRevision.write(headRevision);
-            return headRevision;
-        } finally {
-           rwLock.writeLock().unlock();
-        }
+        // A git gc can run without a write lock.
+        garbageCollector.gc();
+        final Revision headRevision = this.headRevision;
+        gcRevision.write(headRevision);
+        return headRevision;
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTest.java
@@ -18,9 +18,11 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
 import static java.util.concurrent.ForkJoinPool.commonPool;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -94,5 +96,7 @@ class GitGcTest {
         // Make sure that a gc is still running.
         // This is flaky. But a gc for 10k commits usually takes about more than 15 seconds.
         assertThat(completed).isFalse();
+
+        await().timeout(Duration.ofMinutes(3)).untilTrue(completed);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static java.util.concurrent.ForkJoinPool.commonPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.util.Base64;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.storage.project.Project;
+
+class GitGcTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(GitGcTest.class);
+
+    @TempDir
+    static File repoDir;
+
+    private static GitRepository repo;
+
+    @BeforeAll
+    static void init() {
+        repo = new GitRepository(mock(Project.class), new File(repoDir, "test_repo"),
+                                 commonPool(), 0L, Author.SYSTEM);
+    }
+
+    private static String randString() {
+        final byte[] bytes = new byte[1000];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    @Timeout(value = 3, unit = TimeUnit.MINUTES)
+    @Test
+    void parallelRunGcWithCommit() throws Exception {
+        // Generate huge commits for long gc time.
+        for (int i = 0; i < 10_000; i++) {
+            final Change<String> change = Change.ofTextUpsert("/foo", randString());
+            repo.commit(Revision.HEAD, 0L, Author.UNKNOWN, "summary", change).join();
+        }
+
+        final ExecutorService gcExecutor = Executors.newSingleThreadExecutor();
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final AtomicBoolean completed = new AtomicBoolean();
+
+        // Execute gc in a separate thread.
+        gcExecutor.execute(() -> {
+            try {
+                startLatch.countDown();
+                repo.gc();
+                completed.set(true);
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        });
+
+        startLatch.await();
+        for (int i = 0; i < 10; i++) {
+            final Change<String> change = Change.ofTextUpsert("/foo", randString());
+            repo.commit(Revision.HEAD, 0L, Author.UNKNOWN, "summary", change).join();
+        }
+        // Make sure that a gc is still running.
+        // This is flaky. But a gc for 10k commits usually takes about more than 15 seconds.
+        assertThat(completed).isFalse();
+    }
+}


### PR DESCRIPTION
Motivation:

A git gc can run while commiting new revisions.
We don't need to use a write lock for git gc.

Futhermore, a gc takes about 15 seconds for 10k commits.
It is a huge block. So the long locking time could make `repositoryWorker` exhausted

Modifications:

- Remove a write lock from `GitRepository.gc()`
- Call `start()` if a stopwatch is reset in `RepositoryGarbageCollectionPlugin`

Result:

- A git gc no longer blocks git commits.