### PR TITLE
Add a lock timeout for ZooKeeperCommandExecutor

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
@@ -39,6 +39,7 @@ import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import com.linecorp.armeria.common.metric.MoreMeters;
 import com.linecorp.armeria.common.util.TextFormatter;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
@@ -50,6 +51,9 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
 import io.netty.util.concurrent.DefaultThreadFactory;
 
 public final class RepositoryGarbageCollectionPlugin implements Plugin {
@@ -63,6 +67,8 @@ public final class RepositoryGarbageCollectionPlugin implements Plugin {
     private ListeningScheduledExecutorService gcWorker;
     @Nullable
     private ListenableScheduledFuture<?> scheduledFuture;
+    @Nullable
+    private MeterRegistry meterRegistry;
 
     private volatile boolean stopping;
 
@@ -91,6 +97,7 @@ public final class RepositoryGarbageCollectionPlugin implements Plugin {
         gcConfig = context.config().repositoryGarbageCollection();
         gcWorker = MoreExecutors.listeningDecorator(Executors.newSingleThreadScheduledExecutor(
                 new DefaultThreadFactory("repository-gc-worker", true)));
+        meterRegistry = context.meterRegistry();
     }
 
     private void scheduleGc(PluginContext context) {
@@ -165,19 +172,24 @@ public final class RepositoryGarbageCollectionPlugin implements Plugin {
     }
 
     private void runGc(Project project, Repository repo, Stopwatch stopwatch) {
+        final String projectName = project.name();
+        final String repoName = repo.name();
         try {
             if (!needsGc(repo)) {
                 return;
             }
 
-            logger.info("Starting repository gc on {}/{} ..", project.name(), repo.name());
+            logger.info("Starting repository gc on {}/{} ..", projectName, repoName);
+            final Timer timer = MoreMeters.newTimer(meterRegistry, "plugins.gc.duration",
+                                                    Tags.of(projectName, repoName));
             stopwatch.reset();
             repo.gc();
             final long elapsedNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
-            logger.info("Finished repository gc on {}/{} - took {}", project.name(), repo.name(),
+            timer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+            logger.info("Finished repository gc on {}/{} - took {}", projectName, repoName,
                         TextFormatter.elapsed(elapsedNanos));
         } catch (Exception e) {
-            logger.warn("Failed to run repository gc on {}/{}", project.name(), repo.name(), e);
+            logger.warn("Failed to run repository gc on {}/{}", projectName, repoName, e);
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPlugin.java
@@ -182,7 +182,7 @@ public final class RepositoryGarbageCollectionPlugin implements Plugin {
             logger.info("Starting repository gc on {}/{} ..", projectName, repoName);
             final Timer timer = MoreMeters.newTimer(meterRegistry, "plugins.gc.duration",
                                                     Tags.of(projectName, repoName));
-            stopwatch.reset();
+            stopwatch.reset().start();
             repo.gc();
             final long elapsedNanos = stopwatch.elapsed(TimeUnit.NANOSECONDS);
             timer.record(elapsedNanos, TimeUnit.NANOSECONDS);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -46,9 +46,11 @@ import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
@@ -164,6 +166,8 @@ class GitRepository implements Repository {
     }
 
     private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+    @VisibleForTesting
+    final ReentrantLock gcLock = new ReentrantLock();
     private final Project parent;
     private final Executor repositoryWorker;
     @VisibleForTesting
@@ -886,7 +890,7 @@ class GitRepository implements Repository {
     @Override
     public CompletableFuture<CommitResult> commit(
             Revision baseRevision, long commitTimeMillis, Author author, String summary,
-            String detail, Markup markup, Iterable<Change<?>> changes, boolean normalizing) {
+            String detail, Markup markup, Iterable<Change<?>> changes, boolean directExecution) {
         requireNonNull(baseRevision, "baseRevision");
         requireNonNull(author, "author");
         requireNonNull(summary, "summary");
@@ -898,23 +902,24 @@ class GitRepository implements Repository {
         return CompletableFuture.supplyAsync(() -> {
             failFastIfTimedOut(this, logger, ctx, "commit", baseRevision, author, summary);
             return blockingCommit(baseRevision, commitTimeMillis,
-                                  author, summary, detail, markup, changes, false, normalizing);
+                                  author, summary, detail, markup, changes, false, directExecution);
         }, repositoryWorker);
     }
 
     private CommitResult blockingCommit(
             Revision baseRevision, long commitTimeMillis, Author author, String summary,
             String detail, Markup markup, Iterable<Change<?>> changes, boolean allowEmptyCommit,
-            boolean normalizing) {
+            boolean directExecution) {
 
         requireNonNull(baseRevision, "baseRevision");
 
         final RevisionAndEntries res;
         final Iterable<Change<?>> applyingChanges;
-        rwLock.writeLock().lock();
         try {
-            if (closePending.get() != null) {
-                throw closePending.get().get();
+            final boolean hasLock = writeLock(directExecution);
+            if (!hasLock) {
+                throw new StorageException(
+                        "failed to acquire a write lock for " + parent().name() + '/' + name());
             }
 
             final Revision normBaseRevision = normalizeNow(baseRevision);
@@ -925,7 +930,7 @@ class GitRepository implements Repository {
                         " or equivalent)");
             }
 
-            if (normalizing) {
+            if (directExecution) {
                 applyingChanges = blockingPreviewDiff(normBaseRevision, changes).values();
             } else {
                 applyingChanges = changes;
@@ -935,7 +940,7 @@ class GitRepository implements Repository {
 
             this.headRevision = res.revision;
         } finally {
-            rwLock.writeLock().unlock();
+            writeUnLock();
         }
 
         // Note that the notification is made while no lock is held to avoid the risk of a dead lock.
@@ -1497,14 +1502,15 @@ class GitRepository implements Repository {
 
     @Override
     public Revision gc() throws Exception {
-        rwLock.writeLock().lock();
+        // Should not acquire `writeLock()` which prevents reading commits from this repository.
+        gcLock.lock();
         try {
             garbageCollector.gc();
             final Revision headRevision = this.headRevision;
             gcRevision.write(headRevision);
             return headRevision;
         } finally {
-           rwLock.writeLock().unlock();
+            gcLock.unlock();
         }
     }
 
@@ -1588,6 +1594,44 @@ class GitRepository implements Repository {
 
     private void readUnlock() {
         rwLock.readLock().unlock();
+    }
+
+    @VisibleForTesting
+    boolean writeLock(boolean directExecution) {
+        // Should not commit changes if gc is running
+        boolean hasGcLock;
+        if (directExecution) {
+            try {
+                // Waits only 10 seconds the gc lock to prevent a command worker queue from filing up
+                // due to a long gc, if the command was directly submitted to this server.
+                hasGcLock = gcLock.tryLock() || gcLock.tryLock(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                hasGcLock = false;
+            }
+        } else {
+            // Should not fail replaying a log due to a long gc.
+            // Because if a log is failed to replay, this replica will enter read-only mode.
+            gcLock.lock();
+            hasGcLock = true;
+        }
+
+        if (hasGcLock) {
+            rwLock.writeLock().lock();
+            if (closePending.get() != null) {
+                writeUnLock();
+                throw closePending.get().get();
+            }
+        }
+
+        return hasGcLock;
+    }
+
+    private void writeUnLock() {
+        try {
+            rwLock.writeLock().unlock();
+        } finally {
+            gcLock.unlock();
+        }
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -1612,6 +1612,7 @@ class GitRepository implements Repository {
                 hasGcLock = gcLock.tryLock(10, TimeUnit.SECONDS);
             } catch (InterruptedException e) {
                 hasGcLock = false;
+                Thread.currentThread().interrupt();
             }
         } else {
             // Should not fail replaying a log due to a long gc.
@@ -1626,6 +1627,7 @@ class GitRepository implements Repository {
                 writeUnLock();
                 throw closePending.get().get();
             }
+            return true;
         }
 
         return false;

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -57,6 +57,7 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.RevisionRange;
 import com.linecorp.centraldogma.server.command.CommitResult;
+import com.linecorp.centraldogma.server.internal.replication.ReplicationLog;
 import com.linecorp.centraldogma.server.storage.StorageException;
 import com.linecorp.centraldogma.server.storage.project.Project;
 
@@ -375,11 +376,22 @@ public interface Repository {
     /**
      * Adds the specified changes to this {@link Repository}.
      *
+     * @param baseRevision the base {@link Revision} of this {@link Commit}
+     * @param commitTimeMillis the time and date of this {@link Commit}, represented as the number of
+     *                         milliseconds since the epoch (midnight, January 1, 1970 UTC)
+     * @param author the {@link Author} of this {@link Commit}
+     * @param summary the human-readable summary of this {@link Commit}
+     * @param detail the human-readable detailed description of this {@link Commit}
+     * @param markup the {@link Markup} language of {@code summary} and {@code detail}
+     * @param changes the changes to be applied
+     * @param directExecution whether this {@link Commit} is received by this server and executed directly.
+     *                        {@code false} if this commit is delivered by a {@link ReplicationLog}.
+     *
      * @return the {@link Revision} of the new {@link Commit}
      */
     CompletableFuture<CommitResult> commit(Revision baseRevision, long commitTimeMillis,
                                            Author author, String summary, String detail, Markup markup,
-                                           Iterable<Change<?>> changes, boolean normalizing);
+                                           Iterable<Change<?>> changes, boolean directExecution);
 
     /**
      * Get a list of {@link Commit} for given pathPattern.

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -423,7 +423,6 @@ class ZooKeeperCommandExecutorTest {
             }
         };
 
-
         try (Cluster cluster = Cluster.builder()
                                       .numReplicas(1)
                                       .build(mockDelegate)) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/RepositoryGarbageCollectionPluginTest.java
@@ -35,6 +35,8 @@ import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
 
+import io.micrometer.core.instrument.Metrics;
+
 class RepositoryGarbageCollectionPluginTest {
 
     @Test
@@ -51,6 +53,7 @@ class RepositoryGarbageCollectionPluginTest {
 
         when(ctx.config()).thenReturn(config);
         when(config.repositoryGarbageCollection()).thenReturn(gcConfig);
+        when(ctx.meterRegistry()).thenReturn(Metrics.globalRegistry);
 
         when(project1.name()).thenReturn("project1");
         when(project1.repos()).thenReturn(rm);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTimeoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcTimeoutTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static com.linecorp.centraldogma.common.Revision.HEAD;
+import static java.util.concurrent.ForkJoinPool.commonPool;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+
+import java.io.File;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.storage.project.Project;
+
+class GitGcTimeoutTest {
+
+    @TempDir
+    static File repoDir;
+
+    private static GitRepository repo;
+
+    @BeforeAll
+    static void init() {
+        repo = new GitRepository(mock(Project.class), new File(repoDir, "test_repo"),
+                                 commonPool(), 0L, Author.SYSTEM);
+    }
+
+    @AfterAll
+    static void destroy() {
+        if (repo != null) {
+            repo.internalClose();
+        }
+    }
+
+    @Test
+    void writeLockWithDirectExecution() {
+        repo.gcLock.lock();
+        final AtomicBoolean completed = new AtomicBoolean();
+        commonPool().execute(() -> {
+            final boolean acquired = repo.writeLock(true);
+            assertThat(acquired).isFalse();
+            completed.set(true);
+        });
+        await().timeout(Duration.ofSeconds(20)).untilTrue(completed);
+        repo.gcLock.unlock();
+    }
+
+    @Test
+    void writeLockWithReplicationLog() throws InterruptedException {
+        repo.gcLock.lock();
+        final AtomicBoolean completed = new AtomicBoolean();
+        commonPool().execute(() -> {
+            // Should wait until gcLock is released.
+            final boolean acquired = repo.writeLock(false);
+            assertThat(acquired).isTrue();
+            completed.set(true);
+        });
+
+        // Wait more than 10 seconds for testing the lock timeout.
+        Thread.sleep(20000);
+        assertThat(completed).isFalse();
+
+        repo.gcLock.unlock();
+        await().untilTrue(completed);
+    }
+
+    @Test
+    void shouldNotBlockReadWhileGc() {
+        Change<String> change = Change.ofTextUpsert("/foo.txt", "bar");
+        final Revision revision1 = repo.commit(HEAD, 0L, Author.UNKNOWN, "summary", change).join().revision();
+        change = Change.ofTextUpsert("/foo.txt", "qux");
+        final Revision revision2 = repo.commit(HEAD, 0L, Author.UNKNOWN, "summary", change).join().revision();
+        repo.gcLock.lock();
+        final Revision latestRevision = repo.findLatestRevision(revision1, "/foo.txt").join();
+        assertThat(latestRevision).isEqualTo(revision2);
+        repo.gcLock.unlock();
+    }
+}


### PR DESCRIPTION
Motivation:

A command submitted to ZooKeeperCommandExecutor could be waiting for a lock for a long time
if a command acquired the lock executes blocked by another lock.

Modifications:

- Add a timeout for ZooKeeper global locking

Result:

- A pending task in a `ZooKeeperCommandExecutor` could be fail fast when failed to get a lock.