### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,10 +3,10 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.12.1
-- com.linecorp.armeria:armeria-bom:1.5.0
-- io.micrometer:micrometer-bom:1.6.3
-- org.junit:junit-bom:5.7.0
+- com.fasterxml.jackson:jackson-bom:2.12.2
+- com.linecorp.armeria:armeria-bom:1.6.0
+- io.micrometer:micrometer-bom:1.6.5
+- org.junit:junit-bom:5.7.1
 
 ch.qos.logback:
   logback-classic:
@@ -57,14 +57,14 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '2.2.4' }
+  gradle-node-plugin: { version: '3.0.1' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '30.1-jre'
+    version: &GUAVA_VERSION '30.1.1-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -110,10 +110,10 @@ com.jcraft:
 com.linecorp.armeria:
   armeria:
     javadocs:
-    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.1.0/
+    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.6.0/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.40' }
+  checkstyle: { version: '8.41.1' }
 
 com.spotify:
   completable-futures:
@@ -131,10 +131,10 @@ gradle.plugin.net.davidecavestro:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.6.3/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.6.5/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.6.3/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.6.5/
 
 javax.annotation:
   javax.annotation-api: { version: '1.3.2' }
@@ -147,9 +147,9 @@ javax.validation:
 
 junit:
   junit:
-    version: '4.13.1'
+    version: '4.13.2'
     javadocs:
-      - https://junit.org/junit4/javadoc/4.13.1/
+      - https://junit.org/junit4/javadoc/4.13.2/
 
 org.junit.jupiter:
   junit-jupiter-api:
@@ -158,13 +158,13 @@ org.junit.jupiter:
       - https://junit.org/junit5/docs/5.5.2/api/
 
 kr.motd.gradle:
-  sphinx-gradle-plugin: { version: '2.9.0' }
+  sphinx-gradle-plugin: { version: '2.10.1' }
 
 me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.2' }
+  jmh-gradle-plugin: { version: '0.5.3' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.24.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.25.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
@@ -174,7 +174,7 @@ com.guardsquare:
 # See: https://github.com/apache/curator/blob/master/pom.xml
 org.apache.curator:
   curator-recipes:
-    version: &CURATOR_VERSION '4.3.0'
+    version: &CURATOR_VERSION '5.1.0'
     exclusions:
     - org.apache.zookeeper:zookeeper
   curator-test:
@@ -194,7 +194,7 @@ org.apache.thrift:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.5.8'
+    version: '3.6.2'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j
@@ -214,7 +214,7 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: &JGIT_VERSION '5.10.0.202012080955-r' }
+  org.eclipse.jgit: { version: &JGIT_VERSION '5.11.0.202103091610-r' }
   org.eclipse.jgit.ssh.jsch: { version: *JGIT_VERSION }
 
 org.hibernate.validator:
@@ -224,14 +224,14 @@ org.javassist:
   javassist: { version: '3.27.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.7.7' }
+  mockito-core: { version: &MOCKITO_VERSION '3.8.0' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.27' }
+  jmh-core: { version: &JMH_VERSION '1.29' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
@@ -245,7 +245,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.4.2'
+    version: &SPRING_BOOT_VERSION '2.4.4'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
@@ -166,6 +166,7 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
                     future.completeExceptionally(cause);
                 }
             }, threadName);
+            thread.setContextClassLoader(CommandExecutorStartStop.class.getClassLoader());
             thread.start();
             return future;
         }


### PR DESCRIPTION
- Armeria 1.5.0 -> 1.6.0
- Curator 4.3.0 -> 5.1.0
- Jackson 2.12.1 -> 2.12.2
- jGit 5.10.0.202012080955-r -> 5.11.0.202103091610-r
- Micrometer 1.6.3 -> 1.6.5
- Spring Boot 2.4.2 -> 2.4.4
- ZooKeeper 3.5.8 -> 3.6.2
- Shaded
  - Guava 30.1-jre -> 30.1.1-jre
- Build
  - Checkstyle 8.40 -> 8.40.1
  - Gradle 6.8.1 -> 6.8.3
  - gradle-node-plugin 2.2.4 -> 3.0.1
  - jmh-core 1.27 -> 1.29
  - jmh-gradle-plugin 0.5.2 -> 0.5.3
  - json-unit 2.24.0 -> 2.25.0
  - Junit5 5.7.0 -> 5.7.1
    - Junit4 4.13.1 -> 4.13.2
  - Mockito 3.7.7 -> 3.8.0
  - sphinx-gradle-plugin 2.9.0 -> 2.10.1