### PR TITLE
Disallow creating a change of a JSON file using `Change.ofText{Upsert,Patch}

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/Change.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Change.java
@@ -54,11 +54,21 @@ public interface Change<T> {
     /**
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#UPSERT_TEXT}.
      *
+     * <p>Note that you should use {@link #ofJsonUpsert(String, String)} if the specified {@code path} ends with
+     * {@code ".json"}. The {@link #ofJsonUpsert(String, String)} will check that the given {@code text} is a
+     * valid JSON.
+     *
      * @param path the path of the file
      * @param text the content of the file
+     * @throws ChangeFormatException if the path ends with {@code ".json"}
      */
     static Change<String> ofTextUpsert(String path, String text) {
         requireNonNull(text, "text");
+        validateFilePath(path, "path");
+        if (EntryType.guessFromPath(path) == EntryType.JSON) {
+            throw new ChangeFormatException("invalid file type: " + path +
+                                            " (expected: a non-JSON file). Use Change.ofJsonUpsert() instead");
+        }
         return new DefaultChange<>(path, ChangeType.UPSERT_TEXT, text);
     }
 
@@ -118,13 +128,22 @@ public interface Change<T> {
     /**
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_TEXT_PATCH}.
      *
+     * <p>Note that you should use {@link #ofJsonPatch(String, String, String)} if the specified {@code path}
+     * ends with {@code ".json"}. The {@link #ofJsonUpsert(String, String)} will check that
+     * the given {@code oldText} and {@code newText} are valid JSONs.
+     *
      * @param path the path of the file
      * @param oldText the old content of the file
      * @param newText the new content of the file
+     * @throws ChangeFormatException if the path ends with {@code ".json"}
      */
     static Change<String> ofTextPatch(String path, @Nullable String oldText, String newText) {
         validateFilePath(path, "path");
         requireNonNull(newText, "newText");
+        if (EntryType.guessFromPath(path) == EntryType.JSON) {
+            throw new ChangeFormatException("invalid file type: " + path +
+                                            " (expected: a non-JSON file). Use Change.ofJsonPatch() instead");
+        }
 
         final List<String> oldLineList = oldText == null ? Collections.emptyList()
                                                          : Util.stringToLines(oldText);
@@ -139,12 +158,22 @@ public interface Change<T> {
     /**
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_TEXT_PATCH}.
      *
+     * <p>Note that you should use {@link #ofJsonPatch(String, String)} if the specified {@code path}
+     * ends with {@code ".json"}. The {@link #ofJsonUpsert(String, String)} will check that
+     * the given {@code textPatch} is a valid JSON.
+     *
      * @param path the path of the file
      * @param textPatch the patch in
      *                  <a href="https://en.wikipedia.org/wiki/Diff_utility#Unified_format">unified format</a>
+     * @throws ChangeFormatException if the path ends with {@code ".json"}
      */
     static Change<String> ofTextPatch(String path, String textPatch) {
+        validateFilePath(path, "path");
         requireNonNull(textPatch, "textPatch");
+        if (EntryType.guessFromPath(path) == EntryType.JSON) {
+            throw new ChangeFormatException("invalid file type: " + path +
+                                            " (expected: a non-JSON file). Use Change.ofJsonPatch() instead");
+        }
 
         return new DefaultChange<>(path, ChangeType.APPLY_TEXT_PATCH, textPatch);
     }

--- a/common/src/test/java/com/linecorp/centraldogma/common/ChangeTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/ChangeTest.java
@@ -17,8 +17,14 @@
 package com.linecorp.centraldogma.common;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
@@ -109,5 +115,20 @@ class ChangeTest {
                              "  \"path\": \"/6\"," +
                              "  \"content\": \"/7\"" +
                              '}');
+    }
+
+    @Test
+    void shouldNotAllowJsonFileWith_OfText() {
+
+        final List<ThrowingCallable> changes =
+                ImmutableList.of(() -> Change.ofTextUpsert("/foo.json", "abc"),
+                                 () -> Change.ofTextPatch("/foo.json", "abc"),
+                                 () -> Change.ofTextPatch("/foo.json", "foo", "bar"));
+
+        for (final ThrowingCallable change : changes) {
+            assertThatThrownBy(change)
+                    .isInstanceOf(ChangeFormatException.class)
+                    .hasMessageContaining("invalid file type: /foo.json (expected: a non-JSON file)");
+        }
     }
 }


### PR DESCRIPTION
…,Patch}`

Motivation:

When a change is created using `Change.ofTextUpsert()` with the following case:
1) The file type is json. e.g, `foo.json`
2) The content of `foo.json` is a plain text. e.g, `foo bar`

`Change.ofTextUpsert()` does not validate the text content and
Central Dogma raises an exception and returns 500 status.
```
com.linecorp.centraldogma.common.CentralDogmaException: unexpected response: [:status=500, content-type=application/json; charset=utf-8, server=Armeria/1.5.0, date=Tue, 6 Apr 2021 06:34:40 GMT, content-length=136], {"exception":"com.linecorp.centraldogma.server.storage.StorageException","message":"failed to convert list of DiffEntry to Changes map"}
java.util.concurrent.CompletionException: com.linecorp.centraldogma.common.CentralDogmaException: unexpected response: [:status=500, content-type=application/json; charset=utf-8, server=Armeria/1.5.0, date=Tue, 6 Apr 2021 06:34:40 GMT, content-length=136], {"exception":"com.linecorp.centraldogma.server.storage.StorageException","message":"failed to convert list of DiffEntry to Changes map"}
```

See #579 for detailed information.

Modifications:

- Raise `ChangeFormatException` when `Change.ofText{Upsert,Patch}()` is
  called with a path that ends with `.json'
  - The servers returns `400 Bad Request` to clients.

Result:

- You no longer see `500 Internal Server Error` when a text `Change` is created with a JSON file.
  Central Dogma server now returns `400 Bad Request` for the invalid input.
- Fixes #579