### PR TITLE
Add Snappy and Dropwizard metric dependency.

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -182,6 +182,16 @@ org.apache.curator:
     exclusions:
     - org.apache.zookeeper:zookeeper
 
+# Ensure that we use the same Snappy version as what Curator depends on.
+# See: https://github.com/apache/curator/blob/master/pom.xml
+org.xerial.snappy:
+  snappy-java: { version: '1.1.7' }
+
+# Ensure that we use the same Dropwizard version as what Curator depends on.
+# See: https://github.com/apache/curator/blob/master/pom.xml
+io.dropwizard.metrics:
+  metrics-core: { version: '3.2.5' }
+
 org.apache.shiro:
   # Don't update `shiro` version
   shiro-core:

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     implementation 'org.apache.zookeeper:zookeeper'
     testImplementation 'org.apache.curator:curator-test'
 
+    // Missing dependencies in ZooKeeper
+    implementation 'org.xerial.snappy:snappy-java'
+    implementation 'io.dropwizard.metrics:metrics-core'
+
     // DiffUtils
     implementation 'com.googlecode.java-diff-utils:diffutils'
 


### PR DESCRIPTION
Motivation:
Snappy and Dropwizard dependencies are removed from ZooKeeper 3.6.0
https://github.com/apache/zookeeper/commit/b787770b9920a7ae99f9ed2dbe583ece1b2665cc#diff-237e154d86dc584115184b6d4b8bfda7ef88fe934a67ae796c6856badc0cacbf
The test didn't fail because curator-test has the dependencies.

Modifications:
- Add Snappy 1.1.7
- Add Dropwizard metric 3.2.5

Result:
- No more `ClassNotFoundException`