### PR TITLE
Downgrade ZooKeeper

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -174,23 +174,13 @@ com.guardsquare:
 # See: https://github.com/apache/curator/blob/master/pom.xml
 org.apache.curator:
   curator-recipes:
-    version: &CURATOR_VERSION '5.1.0'
+    version: &CURATOR_VERSION '4.3.0'
     exclusions:
     - org.apache.zookeeper:zookeeper
   curator-test:
     version: *CURATOR_VERSION
     exclusions:
     - org.apache.zookeeper:zookeeper
-
-# Ensure that we use the same Snappy version as what Curator depends on.
-# See: https://github.com/apache/curator/blob/master/pom.xml
-org.xerial.snappy:
-  snappy-java: { version: '1.1.7' }
-
-# Ensure that we use the same Dropwizard version as what Curator depends on.
-# See: https://github.com/apache/curator/blob/master/pom.xml
-io.dropwizard.metrics:
-  metrics-core: { version: '3.2.5' }
 
 org.apache.shiro:
   # Don't update `shiro` version
@@ -204,7 +194,7 @@ org.apache.thrift:
 
 org.apache.zookeeper:
   zookeeper:
-    version: '3.6.2'
+    version: '3.5.8'
     exclusions:
     - io.netty:netty-all
     - log4j:log4j

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -29,10 +29,6 @@ dependencies {
     implementation 'org.apache.zookeeper:zookeeper'
     testImplementation 'org.apache.curator:curator-test'
 
-    // Missing dependencies in ZooKeeper
-    implementation 'org.xerial.snappy:snappy-java'
-    implementation 'io.dropwizard.metrics:metrics-core'
-
     // DiffUtils
     implementation 'com.googlecode.java-diff-utils:diffutils'
 


### PR DESCRIPTION
Motivation:
We need ZooKeeper 3.6.3 or 3.7.0 to rolling upgrade from 3.5.8.
https://github.com/apache/zookeeper/commit/b1105ccc47685c64d1cca7ccb0b2bb66c194374a
However the current curator does not support ZooKeeper 3.6.3 or 3.7.0
so we should downgrade until the new curator is released.

Modifications:
- Downgrade ZooKeeper 3.6.2 -> 3.5.8
- Downgrade Curator 5.1.0 -> 4.3.0
- Remove Snappy and Dropwizard dependencies

Result:
- Downgraded ZooKeeper