### PR TITLE
Use a blocking task executor for the watch callacks of Central Dogma client

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -94,8 +94,8 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
 
     private final CentralDogmaService.AsyncIface client;
 
-    LegacyCentralDogma(ScheduledExecutorService executor, CentralDogmaService.AsyncIface client) {
-        super(executor);
+    LegacyCentralDogma(ScheduledExecutorService blockingTaskExecutor, CentralDogmaService.AsyncIface client) {
+        super(blockingTaskExecutor);
         this.client = requireNonNull(client, "client");
     }
 

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -73,7 +73,7 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
             return dogma;
         } else {
             return new ReplicationLagTolerantCentralDogma(
-                    blockingTaskExecutor(), dogma, maxRetriesOnReplicationLag,
+                    blockingTaskExecutor, dogma, maxRetriesOnReplicationLag,
                     retryIntervalOnReplicationLagMillis(),
                     () -> {
                         // FIXME(trustin): Note that this will always return `null` due to a known limitation

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -80,7 +80,7 @@ class LegacyCentralDogmaTest {
 
     @BeforeEach
     void setUp() {
-        client = new LegacyCentralDogma(CommonPools.workerGroup(), iface);
+        client = new LegacyCentralDogma(CommonPools.blockingTaskExecutor(), iface);
     }
 
     @Test

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -118,24 +118,24 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     private static final Map<String, Function<String, CentralDogmaException>> EXCEPTION_FACTORIES =
             ImmutableMap.<String, Function<String, CentralDogmaException>>builder()
-                    .put(ProjectExistsException.class.getName(), ProjectExistsException::new)
-                    .put(ProjectNotFoundException.class.getName(), ProjectNotFoundException::new)
-                    .put(QueryExecutionException.class.getName(), QueryExecutionException::new)
-                    .put(RedundantChangeException.class.getName(), RedundantChangeException::new)
-                    .put(RevisionNotFoundException.class.getName(), RevisionNotFoundException::new)
-                    .put(EntryNotFoundException.class.getName(), EntryNotFoundException::new)
-                    .put(ChangeConflictException.class.getName(), ChangeConflictException::new)
-                    .put(RepositoryNotFoundException.class.getName(), RepositoryNotFoundException::new)
-                    .put(AuthorizationException.class.getName(), AuthorizationException::new)
-                    .put(ShuttingDownException.class.getName(), ShuttingDownException::new)
-                    .put(RepositoryExistsException.class.getName(), RepositoryExistsException::new)
-                    .build();
+                        .put(ProjectExistsException.class.getName(), ProjectExistsException::new)
+                        .put(ProjectNotFoundException.class.getName(), ProjectNotFoundException::new)
+                        .put(QueryExecutionException.class.getName(), QueryExecutionException::new)
+                        .put(RedundantChangeException.class.getName(), RedundantChangeException::new)
+                        .put(RevisionNotFoundException.class.getName(), RevisionNotFoundException::new)
+                        .put(EntryNotFoundException.class.getName(), EntryNotFoundException::new)
+                        .put(ChangeConflictException.class.getName(), ChangeConflictException::new)
+                        .put(RepositoryNotFoundException.class.getName(), RepositoryNotFoundException::new)
+                        .put(AuthorizationException.class.getName(), AuthorizationException::new)
+                        .put(ShuttingDownException.class.getName(), ShuttingDownException::new)
+                        .put(RepositoryExistsException.class.getName(), RepositoryExistsException::new)
+                        .build();
 
     private final WebClient client;
     private final String authorization;
 
-    ArmeriaCentralDogma(ScheduledExecutorService executor, WebClient client, String accessToken) {
-        super(executor);
+    ArmeriaCentralDogma(ScheduledExecutorService blockingTaskExecutor, WebClient client, String accessToken) {
+        super(blockingTaskExecutor);
         this.client = requireNonNull(client, "client");
         authorization = "Bearer " + requireNonNull(accessToken, "accessToken");
     }

--- a/client/java/build.gradle
+++ b/client/java/build.gradle
@@ -1,3 +1,3 @@
- dependencies {
-     implementation 'org.javassist:javassist'
- }
+dependencies {
+    implementation 'org.javassist:javassist'
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -41,24 +41,25 @@ import com.linecorp.centraldogma.internal.client.RepositoryWatcher;
  */
 public abstract class AbstractCentralDogma implements CentralDogma {
 
-    private final ScheduledExecutorService executor;
+    private final ScheduledExecutorService blockingTaskExecutor;
 
     /**
      * Creates a new instance.
      *
-     * @param executor the {@link ScheduledExecutorService} which will be used for scheduling the tasks
-     *                 related with automatic retries.
+     * @param blockingTaskExecutor the {@link ScheduledExecutorService} which will be used for scheduling the
+     *                             tasks related with automatic retries and invoking the callbacks for
+     *                             watched changes.
      */
-    protected AbstractCentralDogma(ScheduledExecutorService executor) {
-        this.executor = requireNonNull(executor, "executor");
+    protected AbstractCentralDogma(ScheduledExecutorService blockingTaskExecutor) {
+        this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
     }
 
     /**
      * Returns the {@link ScheduledExecutorService} which is used for scheduling the tasks related with
-     * automatic retries.
+     * automatic retries and invoking the callbacks for watched changes.
      */
     protected final ScheduledExecutorService executor() {
-        return executor;
+        return blockingTaskExecutor;
     }
 
     @Override
@@ -164,7 +165,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
             Function<? super T, ? extends U> function) {
 
         final FileWatcher<U> watcher =
-                new FileWatcher<>(this, executor, projectName, repositoryName, query, function);
+                new FileWatcher<>(this, blockingTaskExecutor, projectName, repositoryName, query, function);
         watcher.start();
         return watcher;
     }
@@ -181,7 +182,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
             Function<Revision, ? extends T> function) {
 
         final RepositoryWatcher<T> watcher =
-                new RepositoryWatcher<>(this, executor,
+                new RepositoryWatcher<>(this, blockingTaskExecutor,
                                         projectName, repositoryName, pathPattern, function);
         watcher.start();
         return watcher;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
@@ -163,9 +164,15 @@ public abstract class AbstractCentralDogma implements CentralDogma {
     public <T, U> Watcher<U> fileWatcher(
             String projectName, String repositoryName, Query<T> query,
             Function<? super T, ? extends U> function) {
+        return fileWatcher(projectName, repositoryName, query, function, blockingTaskExecutor);
+    }
 
+    @Override
+    public <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
+                                         Function<? super T, ? extends U> function, Executor executor) {
         final FileWatcher<U> watcher =
-                new FileWatcher<>(this, blockingTaskExecutor, projectName, repositoryName, query, function);
+                new FileWatcher<>(this, blockingTaskExecutor, executor, projectName, repositoryName, query,
+                                  function);
         watcher.start();
         return watcher;
     }
@@ -180,9 +187,15 @@ public abstract class AbstractCentralDogma implements CentralDogma {
     public <T> Watcher<T> repositoryWatcher(
             String projectName, String repositoryName, String pathPattern,
             Function<Revision, ? extends T> function) {
+        return repositoryWatcher(projectName, repositoryName, pathPattern, function, blockingTaskExecutor);
+    }
+
+    @Override
+    public <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
+                                            Function<Revision, ? extends T> function, Executor executor) {
 
         final RepositoryWatcher<T> watcher =
-                new RepositoryWatcher<>(this, blockingTaskExecutor,
+                new RepositoryWatcher<>(this, blockingTaskExecutor, executor,
                                         projectName, repositoryName, pathPattern, function);
         watcher.start();
         return watcher;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -526,7 +526,7 @@ public interface CentralDogma {
      * <pre>{@code
      * Watcher<MyType> watcher = client.fileWatcher(
      *         "foo", "bar", Query.ofJson("/baz.json"),
-     *         content -> new ObjectMapper().treeToValue(content, MyType.class));
+     *         content -> new ObjectMapper().treeToValue(content, MyType.class), executor);
      *
      * watcher.watch((revision, myValue) -> {
      *     assert myValue instanceof MyType;
@@ -557,7 +557,7 @@ public interface CentralDogma {
      * that contains the changes for the files matched by the given {@code pathPattern}. e.g:
      * <pre>{@code
      * Watcher<Map<String, Entry<?>> watcher = client.repositoryWatcher(
-     *         "foo", "bar", "/*.json", revision -> client.getFiles("foo", "bar", revision, "/*.json").get());
+     *         "foo", "bar", "/*.json", revision -> client.getFiles("foo", "bar", revision, "/*.json").join());
      *
      * watcher.watch((revision, contents) -> {
      *     ...
@@ -577,7 +577,8 @@ public interface CentralDogma {
      * that contains the changes for the files matched by the given {@code pathPattern}. e.g:
      * <pre>{@code
      * Watcher<Map<String, Entry<?>> watcher = client.repositoryWatcher(
-     *         "foo", "bar", "/*.json", revision -> client.getFiles("foo", "bar", revision, "/*.json").get());
+     *         "foo", "bar", "/*.json",
+     *         revision -> client.getFiles("foo", "bar", revision, "/*.json").join(), executor);
      *
      * watcher.watch((revision, contents) -> {
      *     ...

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -31,6 +32,7 @@ final class TransformingWatcher<T, U> implements Watcher<U> {
 
     private final Watcher<T> parent;
     private final Function<T, U> transformer;
+
     @Nullable
     private volatile Latest<U> transformedLatest;
     private volatile boolean closed;
@@ -64,20 +66,33 @@ final class TransformingWatcher<T, U> implements Watcher<U> {
     @Override
     public void watch(BiConsumer<? super Revision, ? super U> listener) {
         requireNonNull(listener, "listener");
-        parent.watch((rev, parentValue) -> {
+        parent.watch(transform(listener));
+    }
+
+    @Override
+    public void watch(BiConsumer<? super Revision, ? super U> listener, Executor executor) {
+        requireNonNull(listener, "listener");
+        requireNonNull(executor, "executor");
+        parent.watch(transform(listener), executor);
+    }
+
+    private BiConsumer<Revision, T> transform(BiConsumer<? super Revision, ? super U> listener) {
+        return (revision, value) -> {
             if (closed) {
                 return;
             }
-            final U transformedValue = transformer.apply(parentValue);
-            final Optional<U> unchanged = Optional
-                    .ofNullable(transformedLatest)
-                    .map(Latest::value)
-                    .filter(transformedValue::equals);
-            if (!unchanged.isPresent()) {
-                transformedLatest = new Latest<>(rev, transformedValue);
-                listener.accept(rev, transformedValue);
+            final U transformedValue = transformer.apply(value);
+            final boolean changed;
+            if (transformedLatest == null) {
+                changed = true;
+            } else {
+                changed = !transformedLatest.value().equals(transformedValue);
+            }
+            if (changed) {
+                transformedLatest = new Latest<>(revision, transformedValue);
+                listener.accept(revision, transformedValue);
             } // else, transformed value has not changed
-        });
+        };
     }
 
     @Override

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.client;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/TransformingWatcher.java
@@ -35,6 +35,7 @@ final class TransformingWatcher<T, U> implements Watcher<U> {
     @Nullable
     private volatile Latest<U> transformedLatest;
     private volatile boolean closed;
+    private volatile boolean firstWatch = true;
 
     TransformingWatcher(Watcher<T> parent, Function<T, U> transformer) {
         this.parent = parent;
@@ -82,7 +83,8 @@ final class TransformingWatcher<T, U> implements Watcher<U> {
             }
             final U transformedValue = transformer.apply(value);
             final boolean changed;
-            if (transformedLatest == null) {
+            if (firstWatch) {
+                firstWatch = false;
                 changed = true;
             } else {
                 changed = !transformedLatest.value().equals(transformedValue);
@@ -100,6 +102,7 @@ final class TransformingWatcher<T, U> implements Watcher<U> {
                 .add("parent", parent)
                 .add("transformer", transformer)
                 .add("closed", closed)
+                .add("firstWatch", firstWatch)
                 .toString();
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -203,12 +204,30 @@ public interface Watcher<T> extends AutoCloseable {
     void watch(BiConsumer<? super Revision, ? super T> listener);
 
     /**
+     * Registers a {@link BiConsumer} that will be invoked when the value of the watched entry becomes
+     * available or changes.
+     *
+     * @param executor the {@link Executor} that executes the {@link BiConsumer}
+     */
+    void watch(BiConsumer<? super Revision, ? super T> listener, Executor executor);
+
+    /**
      * Registers a {@link Consumer} that will be invoked when the value of the watched entry becomes available
      * or changes.
      */
     default void watch(Consumer<? super T> listener) {
         requireNonNull(listener, "listener");
         watch((revision, value) -> listener.accept(value));
+    }
+
+    /**
+     * Registers a {@link Consumer} that will be invoked when the value of the watched entry becomes available
+     * or changes.
+     */
+    default void watch(Consumer<? super T> listener, Executor executor) {
+        requireNonNull(listener, "listener");
+        requireNonNull(executor, "executor");
+        watch((revision, value) -> listener.accept(value), executor);
     }
 
     /**

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -19,17 +19,21 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.math.LongMath.saturatedAdd;
 import static java.util.Objects.requireNonNull;
 
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 
@@ -49,6 +53,7 @@ import com.linecorp.centraldogma.common.ShuttingDownException;
 abstract class AbstractWatcher<T> implements Watcher<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractWatcher.class);
+    private static final CompletableFuture<Void> COMPLETED_FUTURE = CompletableFuture.completedFuture(null);
 
     private static final long DELAY_ON_SUCCESS_MILLIS = TimeUnit.SECONDS.toMillis(1);
     private static final long MIN_INTERVAL_MILLIS = DELAY_ON_SUCCESS_MILLIS * 2;
@@ -102,12 +107,12 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     }
 
     private final CentralDogma client;
-    private final ScheduledExecutorService blockingTaskExecutor;
+    private final ScheduledExecutorService watchScheduler;
     private final String projectName;
     private final String repositoryName;
     private final String pathPattern;
 
-    private final List<BiConsumer<? super Revision, ? super T>> updateListeners;
+    private final List<Map.Entry<BiConsumer<? super Revision, ? super T>, Executor>> updateListeners;
     private final AtomicReference<State> state;
     private final CompletableFuture<Latest<T>> initialValueFuture;
 
@@ -115,10 +120,10 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     private volatile ScheduledFuture<?> currentScheduleFuture;
     private volatile CompletableFuture<?> currentWatchFuture;
 
-    protected AbstractWatcher(CentralDogma client, ScheduledExecutorService blockingTaskExecutor,
+    protected AbstractWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
                               String projectName, String repositoryName, String pathPattern) {
         this.client = requireNonNull(client, "client");
-        this.blockingTaskExecutor = requireNonNull(blockingTaskExecutor, "blockingTaskExecutor");
+        this.watchScheduler = requireNonNull(watchScheduler, "watchScheduler");
         this.projectName = requireNonNull(projectName, "projectName");
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
@@ -176,19 +181,24 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
 
     @Override
     public void watch(BiConsumer<? super Revision, ? super T> listener) {
+        watch(listener, watchScheduler);
+    }
+
+    @Override
+    public void watch(BiConsumer<? super Revision, ? super T> listener, Executor executor) {
         requireNonNull(listener, "listener");
         checkState(!isStopped(), "watcher closed");
-        updateListeners.add(listener);
+        updateListeners.add(new SimpleImmutableEntry<>(listener, executor));
 
         if (latest != null) {
             // Perform initial notification so that the listener always gets the initial value.
             try {
-                blockingTaskExecutor.execute(() -> {
+                executor.execute(() -> {
                     final Latest<T> latest = this.latest;
                     listener.accept(latest.revision(), latest.value());
                 });
             } catch (RejectedExecutionException e) {
-                handleBlockingTaskExecutorShutdown(e);
+                handleExecutorShutdown(executor, e);
             }
         }
     }
@@ -206,12 +216,12 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
         }
 
         try {
-            currentScheduleFuture = blockingTaskExecutor.schedule(() -> {
+            currentScheduleFuture = watchScheduler.schedule(() -> {
                 currentScheduleFuture = null;
                 doWatch(numAttemptsSoFar);
             }, delay, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
-            handleBlockingTaskExecutorShutdown(e);
+            handleExecutorShutdown(watchScheduler, e);
         }
     }
 
@@ -231,9 +241,9 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
                  latest = newLatest;
                  logger.debug("watcher noticed updated file {}/{}{}: rev={}",
                               projectName, repositoryName, pathPattern, newLatest.revision());
-                 notifyListeners();
+                 final CompletableFuture<Void> notificationFuture = notifyListeners();
                  if (oldLatest == null) {
-                     initialValueFuture.complete(newLatest);
+                     notificationFuture.thenAccept(unused -> initialValueFuture.complete(newLatest));
                  }
              }
 
@@ -280,34 +290,41 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     protected abstract CompletableFuture<Latest<T>> doWatch(
             CentralDogma client, String projectName, String repositoryName, Revision lastKnownRevision);
 
-    private void notifyListeners() {
+    private CompletableFuture<Void> notifyListeners() {
         if (isStopped()) {
             // Do not notify after stopped.
-            return;
+            return COMPLETED_FUTURE;
         }
 
+        final CompletableFuture<Void> notificationFuture = new CompletableFuture<>();
         final Latest<T> latest = this.latest;
-        for (BiConsumer<? super Revision, ? super T> listener : updateListeners) {
-            try {
-                listener.accept(latest.revision(), latest.value());
-            } catch (Exception e) {
-                logger.warn("Exception thrown for watcher ({}/{}{}): rev={}",
-                            projectName, repositoryName, pathPattern, latest.revision(), e);
-            }
+        final AtomicInteger counter = new AtomicInteger(updateListeners.size());
+        for (Map.Entry<BiConsumer<? super Revision, ? super T>, Executor> entry : updateListeners) {
+            final BiConsumer<? super Revision, ? super T> listener = entry.getKey();
+            final Executor executor = entry.getValue();
+            executor.execute(() -> {
+                try {
+                    listener.accept(latest.revision(), latest.value());
+                } catch (Exception e) {
+                    logger.warn("Exception thrown for watcher ({}/{}{}): rev={}",
+                                projectName, repositoryName, pathPattern, latest.revision(), e);
+                } finally {
+                    if (counter.decrementAndGet() == 0) {
+                        notificationFuture.complete(null);
+                    }
+                }
+            });
         }
+        return notificationFuture;
     }
 
-    private void handleBlockingTaskExecutorShutdown(RejectedExecutionException e) {
+    private void handleExecutorShutdown(Executor executor, RejectedExecutionException e) {
         if (logger.isTraceEnabled()) {
-            logger.trace("Stopping to watch since the blocking task executor is shut down:", e);
+            logger.trace("Stopping to watch since the executor is shut down. executor: {}", executor, e);
         } else {
-            logger.debug("Stopping to watch since the blocking task executor is shut down.");
+            logger.debug("Stopping to watch since the executor is shut down. executor: {}", executor);
         }
 
         close();
-    }
-
-    final ScheduledExecutorService blockingTaskExecutor() {
-        return blockingTaskExecutor;
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -83,10 +83,10 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
         }
     };
 
-    public ReplicationLagTolerantCentralDogma(ScheduledExecutorService executor, CentralDogma delegate,
-                                              int maxRetries, long retryIntervalMillis,
+    public ReplicationLagTolerantCentralDogma(ScheduledExecutorService blockingTaskExecutor,
+                                              CentralDogma delegate, int maxRetries, long retryIntervalMillis,
                                               Supplier<?> currentReplicaHintSupplier) {
-        super(executor);
+        super(blockingTaskExecutor);
 
         requireNonNull(delegate, "delegate");
         checkArgument(maxRetries > 0, "maxRetries: %s (expected: > 0)", maxRetries);

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -32,10 +32,10 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
     /**
      * Creates a new instance.
      */
-    public RepositoryWatcher(CentralDogma client, ScheduledExecutorService executor,
+    public RepositoryWatcher(CentralDogma client, ScheduledExecutorService blockingTaskExecutor,
                       String projectName, String repositoryName,
                       String pathPattern, Function<Revision, ? extends T> function) {
-        super(client, executor, projectName, repositoryName, pathPattern);
+        super(client, blockingTaskExecutor, projectName, repositoryName, pathPattern);
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
         this.function = requireNonNull(function, "function");
     }
@@ -44,11 +44,11 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
                                                    String repositoryName, Revision lastKnownRevision) {
         return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern)
-                     .thenApply(revision -> {
+                     .thenApplyAsync(revision -> {
                          if (revision == null) {
                              return null;
                          }
                          return new Latest<>(revision, function.apply(revision));
-                     });
+                     }, blockingTaskExecutor());
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.internal.client;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
@@ -28,16 +29,19 @@ import com.linecorp.centraldogma.common.Revision;
 public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
     private final String pathPattern;
     private final Function<Revision, ? extends T> function;
+    private final Executor callbackExecutor;
 
     /**
      * Creates a new instance.
      */
-    public RepositoryWatcher(CentralDogma client, ScheduledExecutorService blockingTaskExecutor,
+    public RepositoryWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
+                      Executor callbackExecutor,
                       String projectName, String repositoryName,
                       String pathPattern, Function<Revision, ? extends T> function) {
-        super(client, blockingTaskExecutor, projectName, repositoryName, pathPattern);
+        super(client, watchScheduler, projectName, repositoryName, pathPattern);
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
         this.function = requireNonNull(function, "function");
+        this.callbackExecutor = requireNonNull(callbackExecutor, "callbackExecutor");
     }
 
     @Override
@@ -49,6 +53,6 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
                              return null;
                          }
                          return new Latest<>(revision, function.apply(revision));
-                     }, blockingTaskExecutor());
+                     }, callbackExecutor);
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -35,9 +35,9 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
      * Creates a new instance.
      */
     public RepositoryWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
-                      Executor callbackExecutor,
-                      String projectName, String repositoryName,
-                      String pathPattern, Function<Revision, ? extends T> function) {
+                             Executor callbackExecutor,
+                             String projectName, String repositoryName,
+                             String pathPattern, Function<Revision, ? extends T> function) {
         super(client, watchScheduler, projectName, repositoryName, pathPattern);
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
         this.function = requireNonNull(function, "function");

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -24,12 +24,16 @@ import static org.awaitility.Awaitility.await;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -37,9 +41,12 @@ import org.junit.jupiter.params.provider.EnumSource;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
+import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
 import com.linecorp.centraldogma.client.Watcher;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.PushResult;
@@ -48,8 +55,28 @@ import com.linecorp.centraldogma.common.Revision;
 
 class WatchTest {
 
+    private static final String THREAD_NAME_PREFIX = "blocking-thread";
+    private static final ScheduledExecutorService blockingTaskExecutor =
+            Executors.newSingleThreadScheduledExecutor(
+                    ThreadFactories.newThreadFactory(THREAD_NAME_PREFIX, true));
+
     @RegisterExtension
-    static final CentralDogmaExtensionWithScaffolding dogma = new CentralDogmaExtensionWithScaffolding();
+    static final CentralDogmaExtensionWithScaffolding dogma = new CentralDogmaExtensionWithScaffolding() {
+        @Override
+        protected void configureClient(ArmeriaCentralDogmaBuilder builder) {
+            builder.blockingTaskExecutor(blockingTaskExecutor);
+        }
+
+        @Override
+        protected void configureClient(LegacyCentralDogmaBuilder builder) {
+            builder.blockingTaskExecutor(blockingTaskExecutor);
+        }
+    };
+
+    @AfterAll
+    static void shutdownExecutor() {
+        blockingTaskExecutor.shutdown();
+    }
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
@@ -354,6 +381,40 @@ class WatchTest {
         assertThat(triggeredCount.get()).isEqualTo(2);
         assertThat(heavyWatcher.latestValue().at("/a")).isEqualTo(new TextNode("apricot"));
         assertThat(heavyWatcher.latest().revision()).isEqualTo(rev3);
+    }
+
+    @ParameterizedTest
+    @EnumSource(ClientType.class)
+    void transformingThread(ClientType clientType) {
+        final CentralDogma client = clientType.client(dogma);
+        final String filePath = "/test/test.txt";
+        final Watcher<String> watcher =
+                client.fileWatcher(dogma.project(), dogma.repo1(),
+                                   Query.ofText(filePath),
+                                   text -> {
+                                       assertThat(Thread.currentThread().getName())
+                                               .startsWith(THREAD_NAME_PREFIX);
+                                       return text;
+                                   });
+
+        final AtomicReference<String> threadName = new AtomicReference<>();
+        watcher.watch(watched -> threadName.set(Thread.currentThread().getName()));
+        client.push(dogma.project(), dogma.repo1(), Revision.HEAD, "test",
+                    Change.ofTextUpsert("/test/test.txt", "foo"));
+
+        await().untilAtomic(threadName, Matchers.startsWith(THREAD_NAME_PREFIX));
+        threadName.set(null);
+
+        final Watcher<Revision> watcher2 =
+                client.repositoryWatcher(dogma.project(), dogma.repo1(),
+                                   filePath,
+                                   revision -> {
+                                       assertThat(Thread.currentThread().getName())
+                                               .startsWith(THREAD_NAME_PREFIX);
+                                       return revision;
+                                   });
+        watcher2.watch((revision1, revision2) -> threadName.set(Thread.currentThread().getName()));
+        await().untilAtomic(threadName, Matchers.startsWith(THREAD_NAME_PREFIX));
     }
 
     private static void revertTestFiles(ClientType clientType) {

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import com.google.common.util.concurrent.MoreExecutors;
 
 import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.centraldogma.client.CentralDogma;

--- a/it/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import org.awaitility.core.ConditionTimeoutException;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -185,8 +186,8 @@ class CentralDogmaBeanTest {
                                         "  \"qux\": [\"0\", \"1\"]" +
                                         '}')).join();
 
-        final TestProperty property = factory.get(new TestProperty(), TestProperty.class, update::set);
-        await().atMost(5, TimeUnit.SECONDS).until(() -> update.get() != null);
+        final TestProperty property = factory.get(new TestProperty(), TestProperty.class, x -> update.set(x));
+        await().untilAtomic(update, Matchers.notNullValue());
 
         assertThat(property.getFoo()).isEqualTo(21);
         assertThat(property.getBar()).isEqualTo("Y");

--- a/it/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
@@ -42,7 +42,6 @@ import com.linecorp.centraldogma.client.updater.CentralDogmaBean;
 import com.linecorp.centraldogma.client.updater.CentralDogmaBeanConfigBuilder;
 import com.linecorp.centraldogma.client.updater.CentralDogmaBeanFactory;
 import com.linecorp.centraldogma.common.Change;
-import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
@@ -89,13 +88,13 @@ class CentralDogmaBeanTest {
         final CentralDogma client = dogma.client();
         final TestProperty property = factory.get(new TestProperty(), TestProperty.class, listener);
 
-        final PushResult res = client.push("a", "b", Revision.HEAD, "Add c.json",
-                                           Change.ofJsonUpsert("/c.json",
-                                                               '{' +
-                                                               "  \"foo\": 20," +
-                                                               "  \"bar\": \"Y\"," +
-                                                               "  \"qux\": [\"0\", \"1\"]" +
-                                                               '}')).join();
+        client.push("a", "b", Revision.HEAD, "Add c.json",
+                    Change.ofJsonUpsert("/c.json",
+                                        '{' +
+                                        "  \"foo\": 20," +
+                                        "  \"bar\": \"Y\"," +
+                                        "  \"qux\": [\"0\", \"1\"]" +
+                                        '}')).join();
 
         // Wait until the changes are handled.
         await().atMost(5000, TimeUnit.SECONDS).until(() -> property.getFoo() == 20);
@@ -186,7 +185,7 @@ class CentralDogmaBeanTest {
                                         "  \"qux\": [\"0\", \"1\"]" +
                                         '}')).join();
 
-        final TestProperty property = factory.get(new TestProperty(), TestProperty.class, x -> update.set(x));
+        final TestProperty property = factory.get(new TestProperty(), TestProperty.class, update::set);
         await().untilAtomic(update, Matchers.notNullValue());
 
         assertThat(property.getFoo()).isEqualTo(21);


### PR DESCRIPTION
Motivation:

The callacks for watcher are synchronous APIs such as `Function<T, U>`.
Users can not compose an asynchronous API for the callback function.
They have to wait for the result and return it.
```java
dogma.repositoryWatcher("xyz", "foo", "/*.txt",
                        revision -> {
                            dogma.getFiles("xyz", "foo",
                                           revision,
                                           "/*.txt").join();
                            return "Whatever";
                        });
```

CentralDomga internally invokes the callback by an event loop which must not be blocked.
However, most users do not aware that the callback is called by an event loop.
It would be safe to call the callbacks of watcher with a blocking task executor.

Modifications:

- Replace `EventLoop` executor with a blocking task executor.

Result:

- You can now safely execute a block IO for the callbacks of watcher.
- Fixes #587