### PR TITLE
Replace some usages of TemporaryFolderExtension

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
@@ -140,6 +141,11 @@ class PermissionTest {
             }, decorator, new HttpApiExceptionHandler());
         }
     };
+
+    @AfterAll
+    static void tearDown() {
+        server.stop().join();
+    }
 
     @ParameterizedTest
     @MethodSource("arguments")

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -21,6 +21,7 @@ import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_
 import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.file.Path;
 import java.util.Set;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
@@ -28,6 +29,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -62,7 +64,6 @@ import com.linecorp.centraldogma.server.metadata.PerRolePermissions;
 import com.linecorp.centraldogma.server.metadata.Permission;
 import com.linecorp.centraldogma.server.metadata.ProjectRole;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
-import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 
 class PermissionTest {
 
@@ -73,15 +74,15 @@ class PermissionTest {
     private static final String secret3 = "appToken-3";
 
     @Order(1)
-    @RegisterExtension
-    static final TemporaryFolderExtension rootDir = new TemporaryFolderExtension();
+    @TempDir
+    static Path tempDir;
 
     @RegisterExtension
     static final ServerExtension server = new ServerExtension() {
         @Override
         protected void configure(ServerBuilder sb) throws Exception {
             final ProjectManager pm = new DefaultProjectManager(
-                    rootDir.getRoot().toFile(), ForkJoinPool.commonPool(),
+                    tempDir.toFile(), ForkJoinPool.commonPool(),
                     MoreExecutors.directExecutor(), NoopMeterRegistry.get(), null);
             final CommandExecutor executor = new StandaloneCommandExecutor(
                     pm, ForkJoinPool.commonPool(), null, null, null);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -29,12 +29,14 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
@@ -61,6 +63,16 @@ class RepositoryManagerWrapperTest {
                                                                   ForkJoinPool.commonPool(),
                                                                   purgeWorker, null),
                                          RepositoryWrapper::new);
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            m.list().keySet().forEach(name -> m.remove(name));
+            m.purgeMarked();
+        } catch (CentralDogmaException e) {
+            // Manager has already been closed.
+        }
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapperTest.java
@@ -23,6 +23,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
@@ -31,7 +32,7 @@ import java.util.concurrent.ForkJoinPool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
@@ -41,7 +42,6 @@ import com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepos
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
-import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 
 class RepositoryManagerWrapperTest {
@@ -50,14 +50,14 @@ class RepositoryManagerWrapperTest {
 
     private Executor purgeWorker;
 
-    @RegisterExtension
-    static final TemporaryFolderExtension rootDir = new TemporaryFolderExtension();
+    @TempDir
+    static Path tempDir;
 
     @BeforeEach
     void setUp() {
         purgeWorker = mock(Executor.class);
         m = new RepositoryManagerWrapper(new GitRepositoryManager(mock(Project.class),
-                                                                  rootDir.getRoot().toFile(),
+                                                                  tempDir.toFile(),
                                                                   ForkJoinPool.commonPool(),
                                                                   purgeWorker, null),
                                          RepositoryWrapper::new);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcRevisionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitGcRevisionTest.java
@@ -18,28 +18,31 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 
 public class GitGcRevisionTest {
 
-    @RegisterExtension
-    final TemporaryFolderExtension rootDir = new TemporaryFolderExtension() {
-        @Override
-        protected boolean runForEachTest() {
-            return true;
-        }
-    };
+    private Path tempDir;
+
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) {
+        this.tempDir = tempDir;
+    }
 
     @Test
     void readAndWrite() throws IOException {
-        try (GitGcRevision gitGcRevision = new GitGcRevision(rootDir.newFolder().toFile())) {
+        final File rootDir = Files.createTempDirectory(tempDir, null).toFile();
 
+        try (GitGcRevision gitGcRevision = new GitGcRevision(rootDir)) {
             assertThat(gitGcRevision.lastRevision()).isNull();
             final Revision revision = new Revision(10);
             gitGcRevision.write(revision);


### PR DESCRIPTION
#### Motivation
- Try to use `@TempDir` in some tests to see if file deletion logic on Windows has been improved

#### Modifications
- Replace some usages of `TemporaryFolderExtension` with JUnit's `@TempDir`