### PR TITLE
Downgrade JMH to 0.5.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
-    id 'me.champeau.jmh' version '0.6.4' apply false
+    id 'me.champeau.gradle.jmh' version '0.5.3' apply false
 }
 
 allprojects {
@@ -33,7 +33,7 @@ apply from: "${rootDir}/gradle/scripts/build-flags.gradle"
 configure(projectsWithFlags('java')) {
 
     // Apply common plugins.
-    apply plugin: 'me.champeau.jmh'
+    apply plugin: 'me.champeau.gradle.jmh'
 
     // Common properties and functions.
     ext {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -161,8 +161,8 @@ org.junit.jupiter:
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.10.1' }
 
-me.champeau.jmh:
-  jmh-gradle-plugin: { version: '0.6.4' }
+me.champeau.gradle:
+  jmh-gradle-plugin: { version: '0.5.3' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.25.0' }


### PR DESCRIPTION
Motivation:
me.champeau.jmh 0.6.X is compatible with Gradle 6.8+
However, we have an issue with the Gradle 6.8+
https://discuss.gradle.org/t/unable-to-exclude-task-after-upgrading-from-6-6-1-to-6-8-or-later/40098
So let me just revert it temporarily before I solve the problem.

Modification:
- Downgrade JMH to 0.5.3

Result:
- N/A