### PR TITLE
Add a path from a project page to a metadata page on UI

### DIFF
--- a/server/src/main/resources/webapp/i18n/en.main.json
+++ b/server/src/main/resources/webapp/i18n/en.main.json
@@ -40,6 +40,7 @@
     "button_delete": "Delete",
     "button_edit": "Edit",
     "button_fetch_again": "Fetch again",
+    "button_go_to_metadata": "Go to metadata",
     "button_history": "History",
     "button_query": "Query",
     "button_restore": "Restore",

--- a/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
@@ -3,6 +3,14 @@
 
   <hr />
 
+  <div class="row" style="margin-bottom: 10px">
+    <div class="pull-right" has-role="LEVEL_USER">
+      <a type="button" class="btn btn-primary" ng-href="#/metadata/{{project.name}}">
+        <span class="glyphicon glyphicon-cog"></span> {{ 'entities.button_go_to_metadata' | translate }}
+      </a>
+    </div>
+  </div >
+
   <table class="table table-hover table-responsive">
     <tbody>
     <tr ng-repeat="repository in repositories">

--- a/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
+++ b/server/src/main/resources/webapp/scripts/app/entities/projects/project.html
@@ -3,14 +3,6 @@
 
   <hr />
 
-  <div class="row" style="margin-bottom: 10px">
-    <div class="pull-right" has-role="LEVEL_USER">
-      <a type="button" class="btn btn-primary" ng-href="#/metadata/{{project.name}}">
-        <span class="glyphicon glyphicon-cog"></span> {{ 'entities.button_go_to_metadata' | translate }}
-      </a>
-    </div>
-  </div >
-
   <table class="table table-hover table-responsive">
     <tbody>
     <tr ng-repeat="repository in repositories">
@@ -22,9 +14,15 @@
   <hr />
 
   <div class="row">
-    <div class="pull-right" has-role="LEVEL_USER">
+    <div class="pull-right" has-role="LEVEL_USER" style="margin-left: 5px">
       <a type="button" class="btn btn-primary" ng-href="#/projects/{{project.name}}/new_repo">
         <span class="glyphicon glyphicon-plus"></span> {{ 'entities.button_create_repository' | translate }}
+      </a>
+    </div>
+
+    <div class="pull-right" has-role="LEVEL_USER" style="margin-left: 5px">
+      <a type="button" class="btn btn-primary" ng-href="#/metadata/{{project.name}}">
+        <span class="glyphicon glyphicon-cog"></span> {{ 'entities.button_go_to_metadata' | translate }}
       </a>
     </div>
   </div>


### PR DESCRIPTION
It seems nice in practice to me if there is a path from a project page (`#/projects/xxx`) to a metadata page (`#/metadata/xxx`) on the UI.

Here is a screenshot:
<img width="1207" alt="Screen Shot 2021-06-04 at 15 45 49" src="https://user-images.githubusercontent.com/8002872/120757844-0a8aff80-c54c-11eb-8d36-8880a26648a3.png">
