### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.google.osdetector' version '1.6.2' apply false
-    id 'me.champeau.gradle.jmh' version '0.5.3' apply false
+    id 'me.champeau.jmh' version '0.6.5' apply false
 }
 
 allprojects {
@@ -33,7 +33,7 @@ apply from: "${rootDir}/gradle/scripts/build-flags.gradle"
 configure(projectsWithFlags('java')) {
 
     // Apply common plugins.
-    apply plugin: 'me.champeau.gradle.jmh'
+    apply plugin: 'me.champeau.jmh'
 
     // Common properties and functions.
     ext {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,8 +4,8 @@
 #
 boms:
 - com.fasterxml.jackson:jackson-bom:2.12.3
-- com.linecorp.armeria:armeria-bom:1.8.0
-- io.micrometer:micrometer-bom:1.7.0
+- com.linecorp.armeria:armeria-bom:1.9.0
+- io.micrometer:micrometer-bom:1.7.1
 - org.junit:junit-bom:5.7.2
 
 ch.qos.logback:
@@ -58,7 +58,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '3.0.1' }
+  gradle-node-plugin: { version: '3.1.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -111,10 +111,10 @@ com.jcraft:
 com.linecorp.armeria:
   armeria:
     javadocs:
-    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.6.0/
+    - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.9.0/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.42' }
+  checkstyle: { version: '8.43' }
 
 com.spotify:
   completable-futures:
@@ -161,11 +161,11 @@ org.junit.jupiter:
 kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.10.1' }
 
-me.champeau.gradle:
-  jmh-gradle-plugin: { version: '0.5.3' }
+me.champeau.jmh:
+  jmh-gradle-plugin: { version: '0.6.5' }
 
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.25.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.27.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
@@ -203,7 +203,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.19.0' }
+  assertj-core: { version: '3.20.2' }
 
 org.awaitility:
   awaitility: { version: '4.1.0' }
@@ -215,28 +215,28 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: &JGIT_VERSION '5.11.1.202105131744-r' }
+  org.eclipse.jgit: { version: &JGIT_VERSION '5.12.0.202106070339-r' }
   org.eclipse.jgit.ssh.jsch: { version: *JGIT_VERSION }
 
 org.hibernate.validator:
   hibernate-validator: { version: '6.1.6.Final' }
 
 org.javassist:
-  javassist: { version: '3.27.0-GA' }
+  javassist: { version: '3.28.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '3.10.0' }
+  mockito-core: { version: &MOCKITO_VERSION '3.11.2' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.31' }
+  jmh-core: { version: &JMH_VERSION '1.32' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.30' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.31' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -246,7 +246,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.4.5'
+    version: &SPRING_BOOT_VERSION '2.5.1'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -4,7 +4,7 @@
 #
 boms:
 - com.fasterxml.jackson:jackson-bom:2.12.3
-- com.linecorp.armeria:armeria-bom:1.9.0
+- com.linecorp.armeria:armeria-bom:1.9.1
 - io.micrometer:micrometer-bom:1.7.1
 - org.junit:junit-bom:5.7.2
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -79,6 +79,22 @@ task copyClientBinaries(group: 'Build',
     into "${project.ext.distDir}/bin/native"
 }
 
+task distDirWithoutClientBinaries(group: 'Build',
+        description: "Builds a distribution directory without client binaries (${project.ext.relativeDistDir})",
+        dependsOn: [tasks.copyLicenses, tasks.copyLib])
+
+// Create the tasks that copy each directory excluding client binaries under src/ into dist/
+['bin', 'conf'].each { dirName ->
+    def taskName = "copy${CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_CAMEL, dirName)}WithoutClientBinaries"
+    tasks.distDirWithoutClientBinaries.dependsOn(tasks.create(taskName, Copy) {
+        group = 'Build'
+        description = "Copies src/$dirName into ${project.ext.relativeDistDir}/$dirName"
+        from "${project.projectDir}/src/$dirName"
+        into "${project.ext.distDir}/$dirName"
+        exclude '**/dogma*'
+    })
+}
+
 task distDir(group: 'Build',
              description: "Builds a distribution directory (${project.ext.relativeDistDir})",
              dependsOn: [tasks.copyLicenses, tasks.copyLib, tasks.copyClientBinaries])


### PR DESCRIPTION
- Armeria 1.8.0 -> 1.9.0
- jGit 5.11.1.202105131744-r -> 5.12.0.202106070339-r
- Micrometer 1.7.0 -> 1.7.1
- Slf4J 1.7.30 -> 1.7.31
- Spring Boot 2.4.5 -> 2.5.1
- Build
  - AssertJ 3.19.0 -> 3.20.2
  - Checkstyle 8.42 -> 8.43
  - gradle-node-plugin 3.0.1 -> 3.1.0
  - javassist 3.27.0-GA -> 3.28.0-GA
  - jmh-core 1.31 -> 1.32
  - me.champeau.jmh 0.5.3 -> 0.6.4
  - Mockito 3.10.0 -> 3.11.2

Misc:
- Add `distDirWithoutClientBinaries` Gradle task to set up the Central Dogma server without client binaries.