### PR TITLE
Prohibit mirroring to internal repositories

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -227,8 +227,7 @@ public class ContentServiceV1 extends AbstractService {
                                        final JsonNode localRepoNode = jsonNode.get(MIRROR_LOCAL_REPO);
                                        if (localRepoNode != null) {
                                            final String localRepo = localRepoNode.textValue();
-                                           if (Project.REPO_META.equals(localRepo) ||
-                                               Project.REPO_DOGMA.equals(localRepo)) {
+                                           if (Project.isReservedRepoName(localRepo)) {
                                                return localRepo;
                                            }
                                        }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -63,8 +63,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
     @VisibleForTesting
     static final String PATH_CREDENTIALS = "/credentials.json";
 
-    @VisibleForTesting
-    static final String PATH_MIRRORS = "/mirrors.json";
+    public static final String PATH_MIRRORS = "/mirrors.json";
 
     private static final String PATH_CREDENTIALS_AND_MIRRORS = PATH_CREDENTIALS + ',' + PATH_MIRRORS;
 


### PR DESCRIPTION
Motivation:
We should prohibit mirroring to internal repositories which can cause a security incident.

Modification:
- Raise an exception if the `localRepo` of mirroring setting is one of `meta` and `dogma` which are internal repositories.

Result:
- You cannot set up mirroring to internal repositories anymore.