### PR TITLE
Prevent access to the internal repositories from normal users

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
@@ -15,7 +15,7 @@
  */
 package com.linecorp.centraldogma.server.command;
 
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJECT_DOGMA;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -254,7 +254,7 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
     }
 
     private CompletableFuture<CommitResult> push(AbstractPushCommand<?> c, boolean normalizing) {
-        if (c.projectName().equals(INTERNAL_PROJ) || c.repositoryName().equals(Project.REPO_DOGMA) ||
+        if (c.projectName().equals(INTERNAL_PROJECT_DOGMA) || c.repositoryName().equals(Project.REPO_DOGMA) ||
             !writeQuotaEnabled()) {
             return push0(c, normalizing);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -92,6 +92,8 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                                                      "Token '%s' does not exist.", cause.getMessage()))
                .put(QueryExecutionException.class,
                     (ctx, req, cause) -> newResponse(ctx, HttpStatus.BAD_REQUEST, cause))
+               .put(UnsupportedOperationException.class,
+                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.BAD_REQUEST, cause))
                .put(TooManyRequestsException.class,
                     (ctx, req, cause) -> {
                         final TooManyRequestsException cast = (TooManyRequestsException) cause;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -94,12 +94,13 @@ public class RepositoryServiceV1 extends AbstractService {
                 }
                 return HttpApiUtil.throwResponse(
                         ctx, HttpStatus.FORBIDDEN,
-                        "You must be an owner of project '%s' to remove it.", project.name());
+                        "You must be an owner of project '%s' to retrieve removed repositories.",
+                        project.name());
             }
 
-            // Do not add internal repository to the list if the user is not an administrator.
             return project.repos().list().values().stream()
                           .filter(r -> user.isAdmin() || !Project.REPO_DOGMA.equals(r.name()))
+                          .filter(r -> hasOwnerRole || !Project.REPO_META.equals(r.name()))
                           .map(DtoConverter::convert)
                           .collect(toImmutableList());
         });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -18,7 +18,7 @@ package com.linecorp.centraldogma.server.internal.replication;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJECT_DOGMA;
 import static java.util.Objects.requireNonNull;
 
 import java.io.BufferedReader;
@@ -824,7 +824,7 @@ public final class ZooKeeperCommandExecutor
 
     @Nullable
     private WriteLock acquireWriteLock(NormalizingPushCommand command) throws Exception {
-        if (command.projectName().equals(INTERNAL_PROJ) ||
+        if (command.projectName().equals(INTERNAL_PROJECT_DOGMA) ||
             command.repositoryName().equals(Project.REPO_DOGMA)) {
             // Do not check quota for internal project and repository.
             return null;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.project;
 
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJECT_DOGMA;
 import static com.linecorp.centraldogma.server.metadata.MetadataService.METADATA_JSON;
 import static java.util.Objects.requireNonNull;
 
@@ -144,7 +144,7 @@ public class DefaultProject implements Project {
 
     private void initializeMetadata(long creationTimeMillis, Author author) {
         // Do not generate a metadata file for internal projects.
-        if (name.equals(INTERNAL_PROJ)) {
+        if (name.equals(INTERNAL_PROJECT_DOGMA)) {
             return;
         }
 
@@ -155,7 +155,7 @@ public class DefaultProject implements Project {
 
             final UserAndTimestamp userAndTimestamp = UserAndTimestamp.of(author);
             final RepositoryMetadata repo = new RepositoryMetadata(REPO_META, userAndTimestamp,
-                                                                   PerRolePermissions.DEFAULT);
+                                                                   PerRolePermissions.ofInternal());
             final Member member = new Member(author, ProjectRole.OWNER, userAndTimestamp);
             final ProjectMetadata metadata = new ProjectMetadata(name,
                                                                  ImmutableMap.of(repo.id(), repo),

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/ProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/ProjectInitializer.java
@@ -38,7 +38,7 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 
 public final class ProjectInitializer {
 
-    public static final String INTERNAL_PROJ = "dogma";
+    public static final String INTERNAL_PROJECT_DOGMA = "dogma";
 
     /**
      * Creates an internal project and repositories such as a token storage.
@@ -46,7 +46,7 @@ public final class ProjectInitializer {
     public static void initializeInternalProject(CommandExecutor executor) {
         final long creationTimeMillis = System.currentTimeMillis();
         try {
-            executor.execute(createProject(creationTimeMillis, Author.SYSTEM, INTERNAL_PROJ))
+            executor.execute(createProject(creationTimeMillis, Author.SYSTEM, INTERNAL_PROJECT_DOGMA))
                     .get();
         } catch (Throwable cause) {
             cause = Exceptions.peel(cause);
@@ -57,9 +57,10 @@ public final class ProjectInitializer {
 
         // These repositories might be created when creating an internal project, but we try to create them
         // again here in order to make sure them exist because sometimes their names are changed.
-        for (final String repo : ImmutableList.of(Project.REPO_META, Project.REPO_DOGMA)) {
+        for (final String repo : Project.internalRepos()) {
             try {
-                executor.execute(createRepository(creationTimeMillis, Author.SYSTEM, INTERNAL_PROJ, repo))
+                executor.execute(createRepository(creationTimeMillis, Author.SYSTEM,
+                                                  INTERNAL_PROJECT_DOGMA, repo))
                         .get();
             } catch (Throwable cause) {
                 cause = Exceptions.peel(cause);
@@ -72,9 +73,9 @@ public final class ProjectInitializer {
         try {
             final Change<?> change = Change.ofJsonPatch(MetadataService.TOKEN_JSON,
                                                         null, Jackson.valueToTree(new Tokens()));
-            final String commitSummary = "Initialize the token list file: /" + INTERNAL_PROJ + '/' +
+            final String commitSummary = "Initialize the token list file: /" + INTERNAL_PROJECT_DOGMA + '/' +
                                          Project.REPO_DOGMA + MetadataService.TOKEN_JSON;
-            executor.execute(push(Author.SYSTEM, INTERNAL_PROJ, Project.REPO_DOGMA, Revision.HEAD,
+            executor.execute(push(Author.SYSTEM, INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, Revision.HEAD,
                                   commitSummary, "", Markup.PLAINTEXT, ImmutableList.of(change)))
                     .get();
         } catch (Throwable cause) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/SafeProjectManager.java
@@ -16,7 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.storage.project;
 
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJECT_DOGMA;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Instant;
@@ -122,6 +122,6 @@ public class SafeProjectManager implements ProjectManager {
 
     protected static boolean isValidProjectName(String name) {
         return name != null &&
-               !INTERNAL_PROJ.equals(name);
+               !INTERNAL_PROJECT_DOGMA.equals(name);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -405,11 +405,9 @@ public class MetadataService {
         requireNonNull(repoName, "repoName");
         requireNonNull(perRolePermissions, "perRolePermissions");
 
-        for (final String internalRepo : Project.internalRepos()) {
-            if (internalRepo.equals(repoName)) {
-                throw new UnsupportedOperationException(
-                        "can't update the per role permission for internal repository: " + repoName);
-            }
+        if (Project.isReservedRepoName(repoName)) {
+            throw new UnsupportedOperationException(
+                    "can't update the per role permission for internal repository: " + repoName);
         }
 
         final JsonPointer path = JsonPointer.compile("/repos" + encodeSegment(repoName) +

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -19,7 +19,7 @@ package com.linecorp.centraldogma.server.metadata;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation.asJsonArray;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchUtil.encodeSegment;
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJ;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectInitializer.INTERNAL_PROJECT_DOGMA;
 import static com.linecorp.centraldogma.server.metadata.RepositorySupport.convertWithJackson;
 import static com.linecorp.centraldogma.server.metadata.Tokens.SECRET_PREFIX;
 import static com.linecorp.centraldogma.server.metadata.Tokens.validateSecret;
@@ -300,7 +300,7 @@ public class MetadataService {
      * with a default {@link PerRolePermissions}.
      */
     public CompletableFuture<Revision> addRepo(Author author, String projectName, String repoName) {
-        return addRepo(author, projectName, repoName, PerRolePermissions.DEFAULT);
+        return addRepo(author, projectName, repoName, PerRolePermissions.ofDefault());
     }
 
     /**
@@ -404,6 +404,13 @@ public class MetadataService {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(perRolePermissions, "perRolePermissions");
+
+        for (final String internalRepo : Project.internalRepos()) {
+            if (internalRepo.equals(repoName)) {
+                throw new UnsupportedOperationException(
+                        "can't update the per role permission for internal repository: " + repoName);
+            }
+        }
 
         final JsonPointer path = JsonPointer.compile("/repos" + encodeSegment(repoName) +
                                                      "/perRolePermissions");
@@ -801,7 +808,7 @@ public class MetadataService {
      * Returns a {@link Tokens}.
      */
     public CompletableFuture<Tokens> getTokens() {
-        return tokenRepo.fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                         .thenApply(HolderWithRevision::object);
     }
 
@@ -851,7 +858,7 @@ public class MetadataService {
                                                new AddOperation(appIdPath, Jackson.valueToTree(newToken)),
                                                new AddOperation(secretPath,
                                                                 Jackson.valueToTree(newToken.id()))));
-        return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
+        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                               "Add a token: " + newToken.id(), change);
     }
 
@@ -870,8 +877,8 @@ public class MetadataService {
             futures[i++] = removeToken(p.name(), author, appId, true).toCompletableFuture();
         }
         return CompletableFuture.allOf(futures).thenCompose(unused -> tokenRepo.push(
-                INTERNAL_PROJ, Project.REPO_DOGMA, author, "Remove the token: " + appId,
-                () -> tokenRepo.fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+                INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author, "Remove the token: " + appId,
+                () -> tokenRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                                .thenApply(tokens -> {
                                    final Token token = tokens.object().get(appId);
                                    final JsonPointer appIdPath =
@@ -896,10 +903,10 @@ public class MetadataService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
+        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                               "Enable the token: " + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -927,10 +934,10 @@ public class MetadataService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        return tokenRepo.push(INTERNAL_PROJ, Project.REPO_DOGMA, author,
+        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                               "Disable the token: " + appId,
                               () -> tokenRepo
-                                      .fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                                       .thenApply(tokens -> {
                                           final Token token = tokens.object().get(appId);
                                           final JsonPointer removalPath =
@@ -956,7 +963,7 @@ public class MetadataService {
      */
     public CompletableFuture<Token> findTokenByAppId(String appId) {
         requireNonNull(appId, "appId");
-        return tokenRepo.fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().get(appId));
     }
 
@@ -966,7 +973,7 @@ public class MetadataService {
     public CompletableFuture<Token> findTokenBySecret(String secret) {
         requireNonNull(secret, "secret");
         validateSecret(secret);
-        return tokenRepo.fetch(INTERNAL_PROJ, Project.REPO_DOGMA, TOKEN_JSON)
+        return tokenRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                         .thenApply(tokens -> tokens.object().findBySecret(secret));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/PerRolePermissions.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/PerRolePermissions.java
@@ -44,7 +44,30 @@ public class PerRolePermissions {
     public static final Collection<Permission> READ_ONLY = EnumSet.of(Permission.READ);
     public static final Collection<Permission> NO_PERMISSION = EnumSet.noneOf(Permission.class);
 
-    public static final PerRolePermissions DEFAULT = new PerRolePermissions(READ_WRITE, READ_WRITE, READ_WRITE);
+    /**
+     * The default permission.
+     *
+     * @deprecated Use {@link #ofDefault()}.
+     */
+    @Deprecated
+    public static final PerRolePermissions DEFAULT =
+            new PerRolePermissions(READ_WRITE, READ_WRITE, NO_PERMISSION);
+    private static final PerRolePermissions internalPermissions =
+            new PerRolePermissions(READ_WRITE, NO_PERMISSION, NO_PERMISSION);
+
+    /**
+     * Creates a {@link PerRolePermissions} which allows read/write a repository from a owner.
+     */
+    public static PerRolePermissions ofInternal() {
+        return internalPermissions;
+    }
+
+    /**
+     * Creates a {@link PerRolePermissions} which allows read/write to owners and members.
+     */
+    public static PerRolePermissions ofDefault() {
+        return DEFAULT;
+    }
 
     /**
      * Creates a {@link PerRolePermissions} which allows accessing a repository from everyone.

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/Project.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/Project.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.centraldogma.server.storage.project;
 
+import static com.linecorp.centraldogma.server.storage.project.ProjectUtil.internalRepos;
 import static java.util.Objects.requireNonNull;
+
+import java.util.List;
 
 import com.google.common.base.Ascii;
 
@@ -70,11 +73,18 @@ public interface Project {
     RepositoryManager repos();
 
     /**
+     * Returns the list of internal repositories which are {@link #REPO_DOGMA} and {@link #REPO_META}.
+     */
+    static List<String> internalRepos() {
+        return internalRepos;
+    }
+
+    /**
      * Returns {@code true} if the specified repository name is reserved by Central Dogma.
      */
     static boolean isReservedRepoName(String repoName) {
         requireNonNull(repoName, "repoName");
         repoName = Ascii.toLowerCase(repoName);
-        return REPO_META.equals(repoName) || REPO_DOGMA.equals(repoName);
+        return internalRepos().contains(repoName);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/ProjectUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/ProjectUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.storage.project;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+final class ProjectUtil {
+
+    static final List<String> internalRepos = ImmutableList.of(Project.REPO_DOGMA, Project.REPO_META);
+
+    private ProjectUtil() {}
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -66,7 +66,7 @@ class SerializationTest {
         final String userLogin = "armeria@dogma.org";
         final Member member = new Member(userLogin, ProjectRole.MEMBER, newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
-                                                                             PerRolePermissions.DEFAULT);
+                                                                             PerRolePermissions.ofDefault());
         final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
@@ -86,7 +86,7 @@ class SerializationTest {
                                            "      \"perRolePermissions\" : {\n" +
                                            "        \"owner\" : [ \"READ\", \"WRITE\" ],\n" +
                                            "        \"member\" : [ \"READ\", \"WRITE\" ],\n" +
-                                           "        \"guest\" : [ \"READ\", \"WRITE\" ]\n" +
+                                           "        \"guest\" : []\n" +
                                            "      },\n" +
                                            "      \"perUserPermissions\" : { },\n" +
                                            "      \"perTokenPermissions\" : { },\n" +
@@ -140,7 +140,7 @@ class SerializationTest {
         final Member member = new Member("armeria@dogma.org", ProjectRole.MEMBER,
                                          newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
-                                                                             PerRolePermissions.DEFAULT);
+                                                                             PerRolePermissions.ofDefault());
         final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
@@ -161,7 +161,7 @@ class SerializationTest {
                                            "      \"perRolePermissions\" : {\n" +
                                            "        \"owner\" : [ \"READ\", \"WRITE\" ],\n" +
                                            "        \"member\" : [ \"READ\", \"WRITE\" ],\n" +
-                                           "        \"guest\" : [ \"READ\", \"WRITE\" ]\n" +
+                                           "        \"guest\" : []\n" +
                                            "      },\n" +
                                            "      \"perUserPermissions\" : { },\n" +
                                            "      \"perTokenPermissions\" : { },\n" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
@@ -112,7 +112,7 @@ final class Replica {
     private static MetadataService mockMetaService() {
         final MetadataService mds = mock(MetadataService.class);
         final RepositoryMetadata repoMeta =
-                new RepositoryMetadata("", UserAndTimestamp.of(Author.SYSTEM), PerRolePermissions.DEFAULT);
+                new RepositoryMetadata("", UserAndTimestamp.of(Author.SYSTEM), PerRolePermissions.ofDefault());
         lenient().when(mds.getRepo(anyString(), anyString()))
                  .thenReturn(CompletableFuture.completedFuture(repoMeta));
         return mds;

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -39,6 +39,7 @@ import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.server.QuotaConfig;
 import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 class MetadataServiceTest {
@@ -194,6 +195,12 @@ class MetadataServiceTest {
                 .containsExactly(Permission.READ, Permission.WRITE);
         assertThat(mds.findPermissions(project1, repo1, guest).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
+
+        for (String internalRepo : Project.internalRepos()) {
+            assertThatThrownBy(() -> mds.updatePerRolePermissions(
+                    author, project1, internalRepo, PerRolePermissions.ofDefault()).join())
+                    .isInstanceOf(UnsupportedOperationException.class);
+        }
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MissingRepositoryMetadataTest.java
@@ -68,7 +68,7 @@ class MissingRepositoryMetadataTest {
         final RepositoryMetadata metadata = mds.getRepo(PROJ, "repo").join();
         assertThat(metadata.id()).isEqualTo("repo");
         assertThat(metadata.name()).isEqualTo("repo");
-        assertThat(metadata.perRolePermissions()).isEqualTo(PerRolePermissions.DEFAULT);
+        assertThat(metadata.perRolePermissions()).isEqualTo(PerRolePermissions.ofDefault());
         assertThat(metadata.perTokenPermissions()).isEmpty();
         assertThat(metadata.perUserPermissions()).isEmpty();
 


### PR DESCRIPTION
Motivation:
We have to prevent access to the internal repositories from users other than owners and admins.

Modifications:
- Prohibit to access the internal `meta` repository other than admin and owner.
  - Internal repositories are now created with `PerRolePermissions.ofInternal()` that only the owner has read/write permissions.
- Change the guest permission of `PerRolePermissions.ofDefault()` which is `NO_PERMISSION`
  - TODO Provide a way to specify permission when a repository is created.

Result:
- Only owners can access the internal `meta` repository.
- Guests do not have the read permission by default when a repository is created.