### PR TITLE
Add a GitHub Action for building and publishing Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,66 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Restore Gradle cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/wrapper/dists
+            ~/.gradle/caches/jars-3
+            ~/.gradle/caches/modules-2
+            ~/.gradle/caches/package-lists
+            ~/.gradle/caches/sphinx-binary
+            ~/.gradle/go/binary
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Build Docker image
+        run: ./gradlew :dist:docker
+        shell: bash
+
+      - name: Extract release version
+        id: release-version
+        uses: actions/github-script@v4
+        with:
+          # Extract a release version from 'refs/tags/centraldogma-x.y.z' tag.
+          script: |
+            const version = context.ref.replace(/.*centraldogma-/, '')
+            console.log('Release version: ' + version)
+            return version
+          result-encoding: string
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Push Docker image
+        run: |
+          docker push line/centraldogma:${{ steps.release-version.outputs.result }}
+          docker push line/centraldogma:latest
+        shell: bash
+
+      - name: Clean up Gradle cache
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties
+        shell: bash

--- a/.post-release-msg
+++ b/.post-release-msg
@@ -15,14 +15,7 @@
 
    https://github.com/line/centraldogma/releases/tag/${tag}
 
-5. Build a docker image and push it into docker hub
-
-   ./gradlew :dist:docker
-   docker login
-   docker push line/centraldogma:${releaseVersion}
-   docker push line/centraldogma:latest
-
-6. Copy the web site generated to the 'gh-pages' branch. e.g.
+5. Copy the web site generated to the 'gh-pages' branch. e.g.
 
    cd ../site-centraldogma
    rm -fr .buildinfo .doctrees .gradle *


### PR DESCRIPTION
Motivation:

As a part of automation, it would be nice to automatically push Docker
image when a new version is released.

Modifications:

- Add docker.yml for a new GitHub Action job

Result:

Use GitHub Actions to push Docker image