### PR TITLE
Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ configure(projectsWithFlags('java')) {
             verbosity = 'EXTRA'
         }
     }
-    configurations.jmh.extendsFrom configurations.testRuntime
+    configurations.jmh.extendsFrom configurations.testImplementation
 
     // Add common JVM options such as max memory and leak detection.
     tasks.withType(JavaForkOptions) {

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogmaBuilder.java
@@ -82,10 +82,10 @@ public abstract class AbstractCentralDogmaBuilder<B extends AbstractCentralDogma
     /**
      * Adds the {@link URI} of the Central Dogma server.
      *
-     * @deprecated Use {@link #host(String)} or {@link #profile(String...)}.
-     *
      * @param uri the URI of the Central Dogma server. e.g.
      *            {@code tbinary+http://example.com:36462/cd/thrift/v1}
+     *
+     * @deprecated Use {@link #host(String)} or {@link #profile(String...)}.
      */
     @Deprecated
     public final B uri(String uri) {

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,16 +3,16 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.12.3
-- com.linecorp.armeria:armeria-bom:1.9.2
-- io.micrometer:micrometer-bom:1.7.1
+- com.fasterxml.jackson:jackson-bom:2.12.4
+- com.linecorp.armeria:armeria-bom:1.10.0
+- io.micrometer:micrometer-bom:1.7.3
 - org.junit:junit-bom:5.7.2
 
 ch.qos.logback:
   logback-classic:
-    version: '1.2.3'
+    version: '1.2.5'
     javadocs:
-    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.3/
+    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.5/
 
 com.beust:
   # Please check `jcommander` version of Maven Central Repository before updating
@@ -114,11 +114,11 @@ com.linecorp.armeria:
     - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.9.0/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '8.43' }
+  checkstyle: { version: '8.45.1' }
 
 com.spotify:
   completable-futures:
-    version: '0.3.4'
+    version: '0.3.5'
     relocations:
     - from: com.spotify.futures
       to:   com.linecorp.centraldogma.internal.shaded.futures
@@ -132,10 +132,10 @@ gradle.plugin.net.davidecavestro:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.6.5/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.7.3/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.6.5/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.7.3/
 
 javax.annotation:
   javax.annotation-api: { version: '1.3.2' }
@@ -169,7 +169,7 @@ net.javacrumbs.json-unit:
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.1.0' }
+  proguard-gradle: { version: '7.1.1' }
 
 # Ensure that we use the same ZooKeeper version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
@@ -232,11 +232,11 @@ org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.32' }
+  jmh-core: { version: &JMH_VERSION '1.33' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.31' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.32' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -246,7 +246,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.5.2'
+    version: &SPRING_BOOT_VERSION '2.5.4'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
- Armeria 1.9.2 -> 1.10.0
- Completabl futures 0.3.4 -> 0.3.5
- Jackson 2.12.3 -> 2.12.4
- Logback 1.2.3 -> 1.2.5
- Micrometer 1.7.1 -> 1.7.3
- Slf4j 1.7.31 -> 1.7.32
- Spring Boot 2.5.2 -> 2.5.4
- Build
  - Checkstyle 8.43 -> 8.45.1
- Jmh 1.32 -> 1.33
  - Proguard 7.1.0 -> 7.1.1