### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,16 +3,16 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.12.4
-- com.linecorp.armeria:armeria-bom:1.11.0
-- io.micrometer:micrometer-bom:1.7.3
+- com.fasterxml.jackson:jackson-bom:2.13.0
+- com.linecorp.armeria:armeria-bom:1.12.0
+- io.micrometer:micrometer-bom:1.7.4
 - org.junit:junit-bom:5.7.2
 
 ch.qos.logback:
   logback-classic:
-    version: '1.2.5'
+    version: '1.2.6'
     javadocs:
-    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.5/
+    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.6/
 
 com.beust:
   # Please check `jcommander` version of Maven Central Repository before updating
@@ -58,14 +58,14 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '3.1.0' }
+  gradle-node-plugin: { version: '3.1.1' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
 
 com.google.guava:
   guava:
-    version: &GUAVA_VERSION '30.1.1-jre'
+    version: &GUAVA_VERSION '31.0.1-jre'
     exclusions:
     - com.google.errorprone:error_prone_annotations
     - com.google.j2objc:j2objc-annotations
@@ -162,7 +162,7 @@ kr.motd.gradle:
   sphinx-gradle-plugin: { version: '2.10.1' }
 
 me.champeau.jmh:
-  jmh-gradle-plugin: { version: '0.6.5' }
+  jmh-gradle-plugin: { version: '0.6.6' }
 
 net.javacrumbs.json-unit:
   json-unit: { version: &JSON_UNIT_VERSION '2.28.0' }
@@ -203,7 +203,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.20.2' }
+  assertj-core: { version: '3.21.0' }
 
 org.awaitility:
   awaitility: { version: '4.1.0' }
@@ -215,7 +215,7 @@ org.eclipse.jetty.alpn:
   alpn-api: { version: '1.1.3.v20160715' }
 
 org.eclipse.jgit:
-  org.eclipse.jgit: { version: &JGIT_VERSION '5.12.0.202106070339-r' }
+  org.eclipse.jgit: { version: &JGIT_VERSION '5.13.0.202109080827-r' }
   org.eclipse.jgit.ssh.jsch: { version: *JGIT_VERSION }
 
 org.hibernate.validator:
@@ -246,7 +246,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.5.4'
+    version: &SPRING_BOOT_VERSION '2.5.5'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
- Armeria 1.11.0 -> 1.12.0
- Jackson 2.12.4 -> 2.13.0
- JGit 5.12.0 -> 5.13.0
- Logback 1.2.5 -> 1.2.6
- Micrometer 1.7.3 -> 1.7.4
- Spring Boot 2.5.4 -> 2.5.5
- Build
  - gradle-node-plugin 3.1.0 -> 3.1.1
  - Guava 30.1.1 -> 31.0.1
  - AssertJ 3.20.2 -> 3.21.0