### PR TITLE
Fix flaky test in CentralDogmaEndpointGroupTest

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
@@ -115,7 +115,8 @@ class CentralDogmaEndpointGroupTest {
                  .join();
 
             await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(latch.getCount()).isZero());
-            assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("foo.bar", 1234));
+            await().untilAsserted(() -> assertThat(endpointGroup.endpoints())
+                    .containsExactly(Endpoint.of("foo.bar", 1234)));
         }
     }
 
@@ -143,7 +144,8 @@ class CentralDogmaEndpointGroupTest {
             endpointGroup.whenReady().get(20, TimeUnit.SECONDS);
 
             await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(latch.getCount()).isZero());
-            assertThat(endpointGroup.endpoints()).containsExactly(Endpoint.of("foo.bar", 1234));
+            await().untilAsserted(() -> assertThat(endpointGroup.endpoints())
+                    .containsExactly(Endpoint.of("foo.bar", 1234)));
         }
     }
 }

--- a/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
@@ -99,10 +99,12 @@ class CentralDogmaEndpointGroupTest {
 
     @Test
     void text() throws Exception {
-        try (Watcher<String> watcher = dogma.client().fileWatcher("directory", "my-service",
-                                                                  Query.ofText("/endpoints.txt"))) {
-            final CountDownLatch latch = new CountDownLatch(2);
-            watcher.watch(unused -> latch.countDown());
+        final CountDownLatch latch = new CountDownLatch(2);
+        try (Watcher<String> watcher = dogma.client().fileWatcher(
+                "directory", "my-service", Query.ofText("/endpoints.txt"), entry -> {
+                    latch.countDown();
+                    return entry;
+                })) {
             final CentralDogmaEndpointGroup<String> endpointGroup = CentralDogmaEndpointGroup.ofWatcher(
                     watcher, EndpointListDecoder.TEXT);
             endpointGroup.whenReady().get();
@@ -114,19 +116,20 @@ class CentralDogmaEndpointGroupTest {
                                 Change.ofTextUpsert("/endpoints.txt", "foo.bar:1234"))
                  .join();
 
-            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(latch.getCount()).isZero());
             await().untilAsserted(() -> assertThat(endpointGroup.endpoints())
                     .containsExactly(Endpoint.of("foo.bar", 1234)));
+            assertThat(latch.getCount()).isZero();
         }
     }
 
     @Test
     void recoverFromNotFound() throws Exception {
-        try (Watcher<String> watcher = dogma.client().fileWatcher("directory",
-                                                                  "new-service",
-                                                                  Query.ofText("/endpoints.txt"))) {
-            final CountDownLatch latch = new CountDownLatch(1);
-            watcher.watch(unused -> latch.countDown());
+        final CountDownLatch latch = new CountDownLatch(1);
+        try (Watcher<String> watcher = dogma.client().fileWatcher(
+                "directory", "new-service", Query.ofText("/endpoints.txt"), entry -> {
+                    latch.countDown();
+                    return entry;
+                })) {
 
             final CentralDogmaEndpointGroup<String> endpointGroup = CentralDogmaEndpointGroup.ofWatcher(
                     watcher, EndpointListDecoder.TEXT);
@@ -143,9 +146,9 @@ class CentralDogmaEndpointGroupTest {
                  .join();
             endpointGroup.whenReady().get(20, TimeUnit.SECONDS);
 
-            await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(latch.getCount()).isZero());
             await().untilAsserted(() -> assertThat(endpointGroup.endpoints())
                     .containsExactly(Endpoint.of("foo.bar", 1234)));
+            assertThat(latch.getCount()).isZero();
         }
     }
 }


### PR DESCRIPTION
https://github.com/line/centraldogma/blob/centraldogma-0.52.5/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java#L105
`latch` is decremented before the `Endpoint` is set
https://github.com/line/centraldogma/blob/centraldogma-0.52.5/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java#L118
because the listener that decrements the `latch` is executed before the `endpointListDecoder` is executed.