### PR TITLE
Add file exclusion rule for mirroring

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -213,8 +213,8 @@ class GitMirrorTest {
     }
 
     @Test
-    void remoteToLocal_remoteExcludePath() throws Exception {
-        pushMirrorSettings(null, null, "second");
+    void remoteToLocal_remoteExclude() throws Exception {
+        pushMirrorSettings(null, null, "/first/ex*" + "\\n" + "second");
 
         final Revision rev0 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
 
@@ -243,6 +243,7 @@ class GitMirrorTest {
         //// This file should not be mirrored because it does not conform to CD's file naming rule.
         addToGitIndex(".gitkeep", "");
         addToGitIndex("first/light.txt", "26-Aug-2014");
+        addToGitIndex("first/exclude.txt", "26-Aug-2014");
         addToGitIndex("second/son.json", "{\"release_date\": \"21-Mar-2014\"}");
         git.commit().setMessage("Add the release dates of the 'Infamous' series").call();
 
@@ -452,12 +453,12 @@ class GitMirrorTest {
     }
 
     private void pushMirrorSettings(@Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String remoteExcludePath) {
-        pushMirrorSettings(REPO_FOO, localPath, remotePath, remoteExcludePath);
+                                    @Nullable String remoteExclude) {
+        pushMirrorSettings(REPO_FOO, localPath, remotePath, remoteExclude);
     }
 
     private void pushMirrorSettings(String localRepo, @Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String remoteExcludePath) {
+                                    @Nullable String remoteExclude) {
         client.push(projName, Project.REPO_META, Revision.HEAD, "Add /mirrors.json",
                     Change.ofJsonUpsert("/mirrors.json",
                                         "[{" +
@@ -466,9 +467,7 @@ class GitMirrorTest {
                                         "  \"localRepo\": \"" + localRepo + "\"," +
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
-                                        (remoteExcludePath != null ?
-                                         ",\"remoteExcludePath\": \"" + firstNonNull(remoteExcludePath, "") +
-                                         '"' : "") +
+                                        ",\"remoteExclude\": \"" + firstNonNull(remoteExclude, "") + "\"" +
                                         "}]")).join();
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -467,8 +467,8 @@ class GitMirrorTest {
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
                                         (remoteExcludePath != null ?
-                                         ",\"remoteExcludePath\": \"" + firstNonNull(remoteExcludePath, "")
-                                         + '"' : "") +
+                                         ",\"remoteExcludePath\": \"" + firstNonNull(remoteExcludePath, "") +
+                                         '"' : "") +
                                         "}]")).join();
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -213,7 +213,7 @@ class GitMirrorTest {
     }
 
     @Test
-    void remoteToLocal_remoteExclude() throws Exception {
+    void remoteToLocal_gitIgnore() throws Exception {
         pushMirrorSettings(null, null, "/first/ex*" + "\\n" + "second");
 
         final Revision rev0 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
@@ -453,12 +453,12 @@ class GitMirrorTest {
     }
 
     private void pushMirrorSettings(@Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String remoteExclude) {
-        pushMirrorSettings(REPO_FOO, localPath, remotePath, remoteExclude);
+                                    @Nullable String gitIgnore) {
+        pushMirrorSettings(REPO_FOO, localPath, remotePath, gitIgnore);
     }
 
     private void pushMirrorSettings(String localRepo, @Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String remoteExclude) {
+                                    @Nullable String gitIgnore) {
         client.push(projName, Project.REPO_META, Revision.HEAD, "Add /mirrors.json",
                     Change.ofJsonUpsert("/mirrors.json",
                                         "[{" +
@@ -467,7 +467,7 @@ class GitMirrorTest {
                                         "  \"localRepo\": \"" + localRepo + "\"," +
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
-                                        ",\"remoteExclude\": \"" + firstNonNull(remoteExclude, "") + "\"" +
+                                        ",\"gitIgnore\": \"" + firstNonNull(gitIgnore, "") + "\"" +
                                         "}]")).join();
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -213,7 +213,7 @@ class GitMirrorTest {
     }
 
     @Test
-    void remoteToLocal_gitIgnore() throws Exception {
+    void remoteToLocal_gitignore() throws Exception {
         pushMirrorSettings(null, "/first", "/exclude_if_root.txt" + "\\n" + "exclude_dir");
 
         final Revision rev0 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
@@ -477,12 +477,12 @@ class GitMirrorTest {
     }
 
     private void pushMirrorSettings(@Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String gitIgnore) {
-        pushMirrorSettings(REPO_FOO, localPath, remotePath, gitIgnore);
+                                    @Nullable String gitignore) {
+        pushMirrorSettings(REPO_FOO, localPath, remotePath, gitignore);
     }
 
     private void pushMirrorSettings(String localRepo, @Nullable String localPath, @Nullable String remotePath,
-                                    @Nullable String gitIgnore) {
+                                    @Nullable String gitignore) {
         client.push(projName, Project.REPO_META, Revision.HEAD, "Add /mirrors.json",
                     Change.ofJsonUpsert("/mirrors.json",
                                         "[{" +
@@ -491,7 +491,7 @@ class GitMirrorTest {
                                         "  \"localRepo\": \"" + localRepo + "\"," +
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
-                                        ",\"gitIgnore\": \"" + firstNonNull(gitIgnore, "") + '"' +
+                                        ",\"gitignore\": \"" + firstNonNull(gitignore, "") + '"' +
                                         "}]")).join();
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -214,7 +214,7 @@ class GitMirrorTest {
 
     @Test
     void remoteToLocal_gitignore() throws Exception {
-        pushMirrorSettings(null, "/first", "/exclude_if_root.txt" + "\\n" + "exclude_dir");
+        pushMirrorSettings(null, "/first", "\"/exclude_if_root.txt\\nexclude_dir\"");
 
         final Revision rev0 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
 
@@ -283,6 +283,62 @@ class GitMirrorTest {
                                            Entry.ofText(rev4, "/light.txt", "26-Aug-2014\n"),
                                            Entry.ofDirectory(rev4, "/subdir"),
                                            Entry.ofText(rev4, "/subdir/exclude_if_root.txt", "26-Aug-2014\n"));
+    }
+
+    @Test
+    void remoteToLocal_gitignore_with_array() throws Exception {
+        pushMirrorSettings(null, "/first", "[\"/exclude_if_root.txt\", \"exclude_dir\"]");
+
+        final Revision rev0 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
+
+        // Mirror an empty git repository, which will;
+        // - Create /mirror_state.json
+        // - Remove the sample files created by createProject().
+        mirroringService.mirror().join();
+
+        //// Make sure a new commit is added.
+        final Revision rev1 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
+        assertThat(rev1).isEqualTo(rev0.forward(1));
+
+        //// Make sure /mirror_state.json exists (and nothing else.)
+        final Entry<JsonNode> expectedInitialMirrorState = expectedMirrorState(rev1, "/");
+        assertThat(client.getFiles(projName, REPO_FOO, rev1, "/**").join().values())
+                .containsExactly(expectedInitialMirrorState);
+
+        // Try to mirror again with no changes in the git repository.
+        mirroringService.mirror().join();
+
+        //// Make sure it does not try to produce an empty commit.
+        final Revision rev2 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
+        assertThat(rev2).isEqualTo(rev1);
+
+        // Now, add some files to the git repository and mirror.
+        addToGitIndex(".gitkeep", "");
+        addToGitIndex("first/light.txt", "26-Aug-2014");
+
+        /// This file is excluded from mirroring by pattern "/exclude_if_root.txt"
+        addToGitIndex("first/exclude_if_root.txt", "26-Aug-2014");
+
+        addToGitIndex("first/subdir/exclude_if_root.txt", "26-Aug-2014");
+
+        /// This file is excluded from mirroring by pattern "exclude_dir"
+        addToGitIndex("first/subdir/exclude_dir/cascaded_exclude.txt", "26-Aug-2014");
+
+        git.commit().setMessage("Add the release dates of the 'Infamous' series").call();
+
+        mirroringService.mirror().join();
+
+        //// Make sure a new commit is added.
+        final Revision rev3 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
+        assertThat(rev3).isEqualTo(rev2.forward(1));
+
+        //// Make sure the file that match gitignore are not mirrored.
+        final Entry<JsonNode> expectedSecondMirrorState = expectedMirrorState(rev3, "/");
+        assertThat(client.getFiles(projName, REPO_FOO, rev3, "/**").join().values())
+                .containsExactlyInAnyOrder(expectedSecondMirrorState,
+                                           Entry.ofText(rev3, "/light.txt", "26-Aug-2014\n"),
+                                           Entry.ofDirectory(rev3, "/subdir"),
+                                           Entry.ofText(rev3, "/subdir/exclude_if_root.txt", "26-Aug-2014\n"));
     }
 
     @Test
@@ -491,7 +547,7 @@ class GitMirrorTest {
                                         "  \"localRepo\": \"" + localRepo + "\"," +
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
-                                        ",\"gitignore\": \"" + firstNonNull(gitignore, "") + '"' +
+                                        ",\"gitignore\": " + firstNonNull(gitignore, "\"\"") +
                                         "}]")).join();
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -266,6 +266,23 @@ class GitMirrorTest {
                                            Entry.ofText(rev3, "/light.txt", "26-Aug-2014\n"),
                                            Entry.ofDirectory(rev3, "/subdir"),
                                            Entry.ofText(rev3, "/subdir/exclude_if_root.txt", "26-Aug-2014\n"));
+
+        /// Add new file, but it is not mirrored because its parent directory is excluded
+        addToGitIndex("first/subdir/exclude_dir/new2.txt", "26-Aug-2014");
+
+        git.commit().setMessage("Add new file in excluded directory").call();
+
+        mirroringService.mirror().join();
+
+        final Revision rev4 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
+        assertThat(rev4).isEqualTo(rev2.forward(2));
+
+        //// Make sure the file that there's no change in mirrored file list
+        assertThat(client.getFiles(projName, REPO_FOO, rev4, "/**").join().values())
+                .containsExactlyInAnyOrder(expectedMirrorState(rev4, "/"),
+                                           Entry.ofText(rev4, "/light.txt", "26-Aug-2014\n"),
+                                           Entry.ofDirectory(rev4, "/subdir"),
+                                           Entry.ofText(rev4, "/subdir/exclude_if_root.txt", "26-Aug-2014\n"));
     }
 
     @Test

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -253,7 +253,7 @@ class GitMirrorTest {
         final Revision rev3 = client.normalizeRevision(projName, REPO_FOO, Revision.HEAD).join();
         assertThat(rev3).isEqualTo(rev2.forward(1));
 
-        //// Make sure only the file under '/first' is there, because '/second' was excluded.
+        //// Make sure only the file '/first/light.txt' is there, because other files were excluded.
         final Entry<JsonNode> expectedSecondMirrorState = expectedMirrorState(rev3, "/");
         assertThat(client.getFiles(projName, REPO_FOO, rev3, "/**").join().values())
                 .containsExactlyInAnyOrder(expectedSecondMirrorState,

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -491,7 +491,7 @@ class GitMirrorTest {
                                         "  \"localRepo\": \"" + localRepo + "\"," +
                                         (localPath != null ? "\"localPath\": \"" + localPath + "\"," : "") +
                                         "  \"remoteUri\": \"" + gitUri + firstNonNull(remotePath, "") + '"' +
-                                        ",\"gitIgnore\": \"" + firstNonNull(gitIgnore, "") + "\"" +
+                                        ",\"gitIgnore\": \"" + firstNonNull(gitIgnore, "") + '"' +
                                         "}]")).join();
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -53,7 +53,9 @@ public abstract class AbstractMirror implements Mirror {
     private final String localPath;
     private final URI remoteRepoUri;
     private final String remotePath;
+    @Nullable
     private final String remoteBranch;
+    @Nullable
     private final String gitIgnore;
     private final ExecutionTime executionTime;
     private final long jitterMillis;
@@ -171,6 +173,7 @@ public abstract class AbstractMirror implements Mirror {
     @Override
     public String toString() {
         final ToStringHelper helper = MoreObjects.toStringHelper("")
+                                                 .omitNullValues()
                                                  .add("schedule", CronDescriptor.instance().describe(schedule))
                                                  .add("direction", direction)
                                                  .add("localProj", localRepo.parent().name())

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -181,12 +181,9 @@ public abstract class AbstractMirror implements Mirror {
                                                  .add("localPath", localPath)
                                                  .add("remoteRepo", remoteRepoUri)
                                                  .add("remotePath", remotePath)
-                                                 .add("gitIgnore", gitIgnore);
-        if (remoteBranch != null) {
-            helper.add("remoteBranch", remoteBranch);
-        }
-
-        helper.add("credential", credential);
+                                                 .add("remoteBranch", remoteBranch)
+                                                 .add("gitIgnore", gitIgnore)
+                                                 .add("credential", credential);
 
         return helper.toString();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -54,12 +54,14 @@ public abstract class AbstractMirror implements Mirror {
     private final URI remoteRepoUri;
     private final String remotePath;
     private final String remoteBranch;
+    private final String remoteExcludePath;
     private final ExecutionTime executionTime;
     private final long jitterMillis;
 
     protected AbstractMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                              Repository localRepo, String localPath,
-                             URI remoteRepoUri, String remotePath, @Nullable String remoteBranch) {
+                             URI remoteRepoUri, String remotePath, @Nullable String remoteBranch,
+                             @Nullable String remoteExcludePath) {
 
         this.schedule = requireNonNull(schedule, "schedule");
         this.direction = requireNonNull(direction, "direction");
@@ -69,6 +71,7 @@ public abstract class AbstractMirror implements Mirror {
         this.remoteRepoUri = requireNonNull(remoteRepoUri, "remoteRepoUri");
         this.remotePath = normalizePath(requireNonNull(remotePath, "remotePath"));
         this.remoteBranch = remoteBranch;
+        this.remoteExcludePath = remoteExcludePath;
 
         executionTime = ExecutionTime.forCron(this.schedule);
 
@@ -131,6 +134,11 @@ public abstract class AbstractMirror implements Mirror {
     @Override
     public final String remoteBranch() {
         return remoteBranch;
+    }
+
+    @Override
+    public final String remoteExcludePath() {
+        return remoteExcludePath;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -54,14 +54,14 @@ public abstract class AbstractMirror implements Mirror {
     private final URI remoteRepoUri;
     private final String remotePath;
     private final String remoteBranch;
-    private final String remoteExcludePath;
+    private final String remoteExclude;
     private final ExecutionTime executionTime;
     private final long jitterMillis;
 
     protected AbstractMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                              Repository localRepo, String localPath,
                              URI remoteRepoUri, String remotePath, @Nullable String remoteBranch,
-                             @Nullable String remoteExcludePath) {
+                             @Nullable String remoteExclude) {
 
         this.schedule = requireNonNull(schedule, "schedule");
         this.direction = requireNonNull(direction, "direction");
@@ -71,7 +71,7 @@ public abstract class AbstractMirror implements Mirror {
         this.remoteRepoUri = requireNonNull(remoteRepoUri, "remoteRepoUri");
         this.remotePath = normalizePath(requireNonNull(remotePath, "remotePath"));
         this.remoteBranch = remoteBranch;
-        this.remoteExcludePath = remoteExcludePath;
+        this.remoteExclude = remoteExclude;
 
         executionTime = ExecutionTime.forCron(this.schedule);
 
@@ -137,8 +137,8 @@ public abstract class AbstractMirror implements Mirror {
     }
 
     @Override
-    public final String remoteExcludePath() {
-        return remoteExcludePath;
+    public final String remoteExclude() {
+        return remoteExclude;
     }
 
     @Override
@@ -177,7 +177,8 @@ public abstract class AbstractMirror implements Mirror {
                                                  .add("localRepo", localRepo.name())
                                                  .add("localPath", localPath)
                                                  .add("remoteRepo", remoteRepoUri)
-                                                 .add("remotePath", remotePath);
+                                                 .add("remotePath", remotePath)
+                                                 .add("remoteExclude", remoteExclude);
         if (remoteBranch != null) {
             helper.add("remoteBranch", remoteBranch);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -54,14 +54,14 @@ public abstract class AbstractMirror implements Mirror {
     private final URI remoteRepoUri;
     private final String remotePath;
     private final String remoteBranch;
-    private final String remoteExclude;
+    private final String gitIgnore;
     private final ExecutionTime executionTime;
     private final long jitterMillis;
 
     protected AbstractMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                              Repository localRepo, String localPath,
                              URI remoteRepoUri, String remotePath, @Nullable String remoteBranch,
-                             @Nullable String remoteExclude) {
+                             @Nullable String gitIgnore) {
 
         this.schedule = requireNonNull(schedule, "schedule");
         this.direction = requireNonNull(direction, "direction");
@@ -71,7 +71,7 @@ public abstract class AbstractMirror implements Mirror {
         this.remoteRepoUri = requireNonNull(remoteRepoUri, "remoteRepoUri");
         this.remotePath = normalizePath(requireNonNull(remotePath, "remotePath"));
         this.remoteBranch = remoteBranch;
-        this.remoteExclude = remoteExclude;
+        this.gitIgnore = gitIgnore;
 
         executionTime = ExecutionTime.forCron(this.schedule);
 
@@ -137,8 +137,8 @@ public abstract class AbstractMirror implements Mirror {
     }
 
     @Override
-    public final String remoteExclude() {
-        return remoteExclude;
+    public final String gitIgnore() {
+        return gitIgnore;
     }
 
     @Override
@@ -178,7 +178,7 @@ public abstract class AbstractMirror implements Mirror {
                                                  .add("localPath", localPath)
                                                  .add("remoteRepo", remoteRepoUri)
                                                  .add("remotePath", remotePath)
-                                                 .add("remoteExclude", remoteExclude);
+                                                 .add("gitIgnore", gitIgnore);
         if (remoteBranch != null) {
             helper.add("remoteBranch", remoteBranch);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -56,14 +56,14 @@ public abstract class AbstractMirror implements Mirror {
     @Nullable
     private final String remoteBranch;
     @Nullable
-    private final String gitIgnore;
+    private final String gitignore;
     private final ExecutionTime executionTime;
     private final long jitterMillis;
 
     protected AbstractMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                              Repository localRepo, String localPath,
                              URI remoteRepoUri, String remotePath, @Nullable String remoteBranch,
-                             @Nullable String gitIgnore) {
+                             @Nullable String gitignore) {
 
         this.schedule = requireNonNull(schedule, "schedule");
         this.direction = requireNonNull(direction, "direction");
@@ -73,7 +73,7 @@ public abstract class AbstractMirror implements Mirror {
         this.remoteRepoUri = requireNonNull(remoteRepoUri, "remoteRepoUri");
         this.remotePath = normalizePath(requireNonNull(remotePath, "remotePath"));
         this.remoteBranch = remoteBranch;
-        this.gitIgnore = gitIgnore;
+        this.gitignore = gitignore;
 
         executionTime = ExecutionTime.forCron(this.schedule);
 
@@ -139,8 +139,8 @@ public abstract class AbstractMirror implements Mirror {
     }
 
     @Override
-    public final String gitIgnore() {
-        return gitIgnore;
+    public final String gitignore() {
+        return gitignore;
     }
 
     @Override
@@ -182,7 +182,7 @@ public abstract class AbstractMirror implements Mirror {
                                                  .add("remoteRepo", remoteRepoUri)
                                                  .add("remotePath", remotePath)
                                                  .add("remoteBranch", remoteBranch)
-                                                 .add("gitIgnore", gitIgnore)
+                                                 .add("gitignore", gitignore)
                                                  .add("credential", credential);
 
         return helper.toString();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -21,8 +21,6 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.net.URI;
 
-import javax.annotation.Nullable;
-
 import com.cronutils.model.Cron;
 
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -38,10 +36,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
     public CentralDogmaMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                               Repository localRepo, String localPath,
                               URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
-                              @Nullable String remoteExcludePath) {
+                              String remoteExclude) {
         // Central Dogma has no notion of 'branch', so we just pass null as a placeholder.
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null,
-              remoteExcludePath);
+              remoteExclude);
 
         this.remoteProject = requireNonNull(remoteProject, "remoteProject");
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.net.URI;
 
+import javax.annotation.Nullable;
+
 import com.cronutils.model.Cron;
 
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -35,9 +37,11 @@ public final class CentralDogmaMirror extends AbstractMirror {
 
     public CentralDogmaMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                               Repository localRepo, String localPath,
-                              URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath) {
+                              URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
+                              @Nullable String remoteExcludePath) {
         // Central Dogma has no notion of 'branch', so we just pass null as a placeholder.
-        super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null);
+        super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null,
+              remoteExcludePath);
 
         this.remoteProject = requireNonNull(remoteProject, "remoteProject");
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -36,10 +36,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
     public CentralDogmaMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                               Repository localRepo, String localPath,
                               URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
-                              String gitIgnore) {
+                              String gitignore) {
         // Central Dogma has no notion of 'branch', so we just pass null as a placeholder.
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null,
-              gitIgnore);
+              gitignore);
 
         this.remoteProject = requireNonNull(remoteProject, "remoteProject");
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -36,10 +36,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
     public CentralDogmaMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                               Repository localRepo, String localPath,
                               URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
-                              String remoteExclude) {
+                              String gitIgnore) {
         // Central Dogma has no notion of 'branch', so we just pass null as a placeholder.
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null,
-              remoteExclude);
+              gitIgnore);
 
         this.remoteProject = requireNonNull(remoteProject, "remoteProject");
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -21,6 +21,8 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.net.URI;
 
+import javax.annotation.Nullable;
+
 import com.cronutils.model.Cron;
 
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -36,7 +38,7 @@ public final class CentralDogmaMirror extends AbstractMirror {
     public CentralDogmaMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                               Repository localRepo, String localPath,
                               URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
-                              String gitignore) {
+                              @Nullable String gitignore) {
         // Central Dogma has no notion of 'branch', so we just pass null as a placeholder.
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, null,
               gitignore);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -26,6 +26,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.RemoteSetUrlCommand;
@@ -75,8 +77,10 @@ public final class GitMirror extends AbstractMirror {
 
     public GitMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath,
-                     URI remoteRepoUri, String remotePath, String remoteBranch) {
-        super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, remoteBranch);
+                     URI remoteRepoUri, String remotePath, String remoteBranch,
+                     @Nullable String remoteExcludePath) {
+        super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, remoteBranch,
+              remoteExcludePath);
     }
 
     @Override
@@ -147,6 +151,10 @@ public final class GitMirror extends AbstractMirror {
                 while (treeWalk.next()) {
                     final FileMode fileMode = treeWalk.getFileMode();
                     final String path = '/' + treeWalk.getPathString();
+
+                    if (path.startsWith(remotePath() + remoteExcludePath())) {
+                        continue;
+                    }
 
                     // Recurse into a directory if necessary.
                     if (fileMode == FileMode.TREE) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -79,7 +79,8 @@ public final class GitMirror extends AbstractMirror {
 
     private static final int GIT_TIMEOUT_SECS = 10;
 
-    private final IgnoreNode ignoreNode = new IgnoreNode();
+    @Nullable
+    private IgnoreNode ignoreNode;
 
     public GitMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath,
@@ -89,6 +90,7 @@ public final class GitMirror extends AbstractMirror {
               gitIgnore);
 
         if (gitIgnore != null) {
+            ignoreNode = new IgnoreNode();
             try {
                 ignoreNode.parse(new ByteArrayInputStream(gitIgnore.getBytes()));
             } catch (IOException e) {
@@ -166,7 +168,10 @@ public final class GitMirror extends AbstractMirror {
                     final FileMode fileMode = treeWalk.getFileMode();
                     final String path = '/' + treeWalk.getPathString();
 
-                    if (ignoreNode.isIgnored(path, fileMode == FileMode.TREE) == MatchResult.IGNORED) {
+                    if (ignoreNode != null &&
+                        path.startsWith(remotePath()) &&
+                        ignoreNode.isIgnored('/' + path.substring(remotePath().length()),
+                                                fileMode == FileMode.TREE) == MatchResult.IGNORED) {
                         continue;
                     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -85,16 +85,16 @@ public final class GitMirror extends AbstractMirror {
     public GitMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath,
                      URI remoteRepoUri, String remotePath, String remoteBranch,
-                     @Nullable String gitIgnore) {
+                     @Nullable String gitignore) {
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, remoteBranch,
-              gitIgnore);
+              gitignore);
 
-        if (gitIgnore != null) {
+        if (gitignore != null) {
             ignoreNode = new IgnoreNode();
             try {
-                ignoreNode.parse(new ByteArrayInputStream(gitIgnore.getBytes()));
+                ignoreNode.parse(new ByteArrayInputStream(gitignore.getBytes()));
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to read gitIgnore: " + gitIgnore, e);
+                throw new IllegalArgumentException("Failed to read gitignore: " + gitignore, e);
             }
         }
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -171,19 +171,25 @@ public final class GitMirror extends AbstractMirror {
                     if (ignoreNode != null &&
                         path.startsWith(remotePath()) &&
                         ignoreNode.isIgnored('/' + path.substring(remotePath().length()),
-                                                fileMode == FileMode.TREE) == MatchResult.IGNORED) {
+                                             fileMode == FileMode.TREE) == MatchResult.IGNORED) {
                         continue;
                     }
 
                     // Recurse into a directory if necessary.
                     if (fileMode == FileMode.TREE) {
                         // Enter if the directory is under remotePath.
+                        // e.g.
+                        // path == /foo/bar
+                        // remotePath == /foo/
                         if (path.startsWith(remotePath())) {
                             treeWalk.enterSubtree();
                             continue;
                         }
 
                         // Enter if the directory is equal to remotePath.
+                        // e.g.
+                        // path == /foo
+                        // remotePath == /foo/
                         final int pathLen = path.length() + 1; // Include the trailing '/'.
                         if (pathLen == remotePath().length() && remotePath().startsWith(path)) {
                             treeWalk.enterSubtree();
@@ -191,6 +197,9 @@ public final class GitMirror extends AbstractMirror {
                         }
 
                         // Enter if the directory is parent of remotePath.
+                        // e.g.
+                        // path == /foo
+                        // remotePath == /foo/bar/
                         if (pathLen < remotePath().length() && remotePath().startsWith(path + '/')) {
                             treeWalk.enterSubtree();
                             continue;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -84,15 +84,15 @@ public final class GitMirror extends AbstractMirror {
     public GitMirror(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath,
                      URI remoteRepoUri, String remotePath, String remoteBranch,
-                     @Nullable String remoteExclude) {
+                     @Nullable String gitIgnore) {
         super(schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath, remoteBranch,
-              remoteExclude);
+              gitIgnore);
 
-        if (remoteExclude != null) {
+        if (gitIgnore != null) {
             try {
-                ignoreNode.parse(new ByteArrayInputStream(remoteExclude.getBytes()));
+                ignoreNode.parse(new ByteArrayInputStream(gitIgnore.getBytes()));
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to read remoteExclude pattern: " + remoteExclude);
+                throw new IllegalArgumentException("Failed to read gitIgnore: " + gitIgnore);
             }
         }
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -94,7 +94,7 @@ public final class GitMirror extends AbstractMirror {
             try {
                 ignoreNode.parse(new ByteArrayInputStream(gitIgnore.getBytes()));
             } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to read gitIgnore: " + gitIgnore);
+                throw new IllegalArgumentException("Failed to read gitIgnore: " + gitIgnore, e);
             }
         }
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -219,7 +219,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         final String localRepo;
         final String localPath;
         final URI remoteUri;
-        final String remoteExclude;
+        final String gitIgnore;
         @Nullable
         final String credentialId;
         final Cron schedule;
@@ -231,7 +231,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                            @JsonProperty(value = "localRepo", required = true) String localRepo,
                            @JsonProperty("localPath") @Nullable String localPath,
                            @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
-                           @JsonProperty("remoteExclude") @Nullable String remoteExclude,
+                           @JsonProperty("gitIgnore") @Nullable String gitIgnore,
                            @JsonProperty("credentialId") @Nullable String credentialId) {
 
             super(firstNonNull(enabled, true));
@@ -240,7 +240,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localRepo = requireNonNull(localRepo, "localRepo");
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
-            this.remoteExclude = remoteExclude;
+            this.gitIgnore = gitIgnore;
             this.credentialId = credentialId;
         }
 
@@ -252,7 +252,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
 
             return Collections.singletonList(Mirror.of(
                     schedule, direction, findCredential(credentials, remoteUri, credentialId),
-                    parent.repos().get(localRepo), localPath, remoteUri, remoteExclude));
+                    parent.repos().get(localRepo), localPath, remoteUri, gitIgnore));
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -220,6 +220,8 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         final String localPath;
         final URI remoteUri;
         @Nullable
+        final String remoteExcludePath;
+        @Nullable
         final String credentialId;
         final Cron schedule;
 
@@ -230,6 +232,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                            @JsonProperty(value = "localRepo", required = true) String localRepo,
                            @JsonProperty("localPath") @Nullable String localPath,
                            @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
+                           @JsonProperty("remoteExcludePath") @Nullable String remoteExcludePath,
                            @JsonProperty("credentialId") @Nullable String credentialId) {
 
             super(firstNonNull(enabled, true));
@@ -238,6 +241,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localRepo = requireNonNull(localRepo, "localRepo");
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
+            this.remoteExcludePath = remoteExcludePath;
             this.credentialId = credentialId;
         }
 
@@ -249,7 +253,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
 
             return Collections.singletonList(Mirror.of(
                     schedule, direction, findCredential(credentials, remoteUri, credentialId),
-                    parent.repos().get(localRepo), localPath, remoteUri));
+                    parent.repos().get(localRepo), localPath, remoteUri, remoteExcludePath));
         }
     }
 
@@ -316,7 +320,8 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                                                                                 : defaultCredentialId),
                                           repo,
                                           firstNonNull(i.localPath, defaultLocalPath),
-                                          remoteUri));
+                                          remoteUri,
+                                          null));
                 }
             });
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -219,6 +219,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         final String localRepo;
         final String localPath;
         final URI remoteUri;
+        @Nullable
         final String gitIgnore;
         @Nullable
         final String credentialId;
@@ -231,7 +232,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                            @JsonProperty(value = "localRepo", required = true) String localRepo,
                            @JsonProperty("localPath") @Nullable String localPath,
                            @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
-                           @JsonProperty("gitIgnore") @Nullable String gitIgnore,
+                           @JsonProperty("gitIgnore") @Nullable Object gitIgnore,
                            @JsonProperty("credentialId") @Nullable String credentialId) {
 
             super(firstNonNull(enabled, true));
@@ -240,7 +241,18 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localRepo = requireNonNull(localRepo, "localRepo");
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
-            this.gitIgnore = gitIgnore;
+            if (gitIgnore != null) {
+                if (gitIgnore instanceof Iterable) {
+                    this.gitIgnore = String.join("\n", (Iterable<String>) gitIgnore);
+                } else if (gitIgnore instanceof String) {
+                    this.gitIgnore = (String) gitIgnore;
+                } else {
+                    throw new IllegalArgumentException(
+                            "gitIgnore: " + gitIgnore + " (expected: either a string or array of strings)");
+                }
+            } else {
+                this.gitIgnore = null;
+            }
             this.credentialId = credentialId;
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -30,7 +30,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -48,6 +47,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Streams;
 
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Revision;
@@ -244,8 +244,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
             if (gitignore != null) {
                 if (gitignore instanceof Iterable &&
-                    StreamSupport.stream(((Iterable<?>) gitignore).spliterator(), false)
-                                 .allMatch(String.class::isInstance)) {
+                    Streams.stream((Iterable<?>) gitignore).allMatch(String.class::isInstance)) {
                     this.gitignore = String.join("\n", (Iterable<String>) gitignore);
                 } else if (gitignore instanceof String) {
                     this.gitignore = (String) gitignore;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -219,8 +219,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         final String localRepo;
         final String localPath;
         final URI remoteUri;
-        @Nullable
-        final String remoteExcludePath;
+        final String remoteExclude;
         @Nullable
         final String credentialId;
         final Cron schedule;
@@ -232,7 +231,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                            @JsonProperty(value = "localRepo", required = true) String localRepo,
                            @JsonProperty("localPath") @Nullable String localPath,
                            @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
-                           @JsonProperty("remoteExcludePath") @Nullable String remoteExcludePath,
+                           @JsonProperty("remoteExclude") @Nullable String remoteExclude,
                            @JsonProperty("credentialId") @Nullable String credentialId) {
 
             super(firstNonNull(enabled, true));
@@ -241,7 +240,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localRepo = requireNonNull(localRepo, "localRepo");
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
-            this.remoteExcludePath = remoteExcludePath;
+            this.remoteExclude = remoteExclude;
             this.credentialId = credentialId;
         }
 
@@ -253,7 +252,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
 
             return Collections.singletonList(Mirror.of(
                     schedule, direction, findCredential(credentials, remoteUri, credentialId),
-                    parent.repos().get(localRepo), localPath, remoteUri, remoteExcludePath));
+                    parent.repos().get(localRepo), localPath, remoteUri, remoteExclude));
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -220,7 +220,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
         final String localPath;
         final URI remoteUri;
         @Nullable
-        final String gitIgnore;
+        final String gitignore;
         @Nullable
         final String credentialId;
         final Cron schedule;
@@ -232,7 +232,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                            @JsonProperty(value = "localRepo", required = true) String localRepo,
                            @JsonProperty("localPath") @Nullable String localPath,
                            @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
-                           @JsonProperty("gitIgnore") @Nullable Object gitIgnore,
+                           @JsonProperty("gitignore") @Nullable Object gitignore,
                            @JsonProperty("credentialId") @Nullable String credentialId) {
 
             super(firstNonNull(enabled, true));
@@ -241,17 +241,17 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localRepo = requireNonNull(localRepo, "localRepo");
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
-            if (gitIgnore != null) {
-                if (gitIgnore instanceof Iterable) {
-                    this.gitIgnore = String.join("\n", (Iterable<String>) gitIgnore);
-                } else if (gitIgnore instanceof String) {
-                    this.gitIgnore = (String) gitIgnore;
+            if (gitignore != null) {
+                if (gitignore instanceof Iterable) {
+                    this.gitignore = String.join("\n", (Iterable<String>) gitignore);
+                } else if (gitignore instanceof String) {
+                    this.gitignore = (String) gitignore;
                 } else {
                     throw new IllegalArgumentException(
-                            "gitIgnore: " + gitIgnore + " (expected: either a string or array of strings)");
+                            "gitignore: " + gitignore + " (expected: either a string or array of strings)");
                 }
             } else {
-                this.gitIgnore = null;
+                this.gitignore = null;
             }
             this.credentialId = credentialId;
         }
@@ -264,7 +264,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
 
             return Collections.singletonList(Mirror.of(
                     schedule, direction, findCredential(credentials, remoteUri, credentialId),
-                    parent.repos().get(localRepo), localPath, remoteUri, gitIgnore));
+                    parent.repos().get(localRepo), localPath, remoteUri, gitignore));
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.StreamSupport;
 
 import javax.annotation.Nullable;
 
@@ -242,7 +243,9 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
             this.localPath = firstNonNull(localPath, "/");
             this.remoteUri = requireNonNull(remoteUri, "remoteUri");
             if (gitignore != null) {
-                if (gitignore instanceof Iterable) {
+                if (gitignore instanceof Iterable &&
+                    StreamSupport.stream(((Iterable<?>) gitignore).spliterator(), false)
+                                 .allMatch(String.class::isInstance)) {
                     this.gitignore = String.join("\n", (Iterable<String>) gitignore);
                 } else if (gitignore instanceof String) {
                     this.gitignore = (String) gitignore;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -250,7 +250,7 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
                     this.gitignore = (String) gitignore;
                 } else {
                     throw new IllegalArgumentException(
-                            "gitignore: " + gitignore + " (expected: either a string or array of strings)");
+                            "gitignore: " + gitignore + " (expected: either a string or an array of strings)");
                 }
             } else {
                 this.gitignore = null;

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -55,8 +55,8 @@ public interface Mirror {
      * @param localRepo the Central Dogma repository name
      * @param localPath the directory path in the {@code localRepo}
      * @param remoteUri the URI of the Git repository which will be mirrored from
-     * @param gitIgnore the file pattern for the files in {@code remoteUri} which will not be mirrored
-     *                      It follows the same format to gitignore
+     * @param gitIgnore the file pattern for the files in {@code remoteUri} which will not be mirrored.
+     *                  It follows the same format to <a href="https://git-scm.com/docs/gitignore">gitignore</a>
      */
     static Mirror of(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath, URI remoteUri,
@@ -151,12 +151,12 @@ public interface Mirror {
     /**
      * Returns the name of the branch in the Git repository where is supposed to be mirrored.
      */
-    String remoteBranch();
+    @Nullable String remoteBranch();
 
     /**
-     * Returns the file pattern for the files which won't be mirrored.
+     * Returns a <a href="https://git-scm.com/docs/gitignore">gitignore</a> pattern for the files which won't be mirrored.
      */
-    String gitIgnore();
+    @Nullable String gitIgnore();
 
     /**
      * Performs the mirroring task.

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -55,11 +55,12 @@ public interface Mirror {
      * @param localRepo the Central Dogma repository name
      * @param localPath the directory path in the {@code localRepo}
      * @param remoteUri the URI of the Git repository which will be mirrored from
-     * @param remoteExcludePath the relative path to {@code remoteUri} which will not be mirrored
+     * @param remoteExclude the file pattern for the files in {@code remoteUri} which will not be mirrored
+     *                      It follows the same format to gitignore
      */
     static Mirror of(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath, URI remoteUri,
-                     @Nullable String remoteExcludePath) {
+                     @Nullable String remoteExclude) {
         requireNonNull(schedule, "schedule");
         requireNonNull(direction, "direction");
         requireNonNull(credential, "credential");
@@ -88,7 +89,7 @@ public interface Mirror {
 
                 return new CentralDogmaMirror(schedule, direction, credential, localRepo, localPath,
                                               remoteRepoUri, remoteProject, remoteRepo, components[1],
-                                              remoteExcludePath);
+                                              remoteExclude);
             }
             case SCHEME_GIT:
             case SCHEME_GIT_SSH:
@@ -98,7 +99,7 @@ public interface Mirror {
                 final String[] components = split(remoteUri, "git", "master");
                 return new GitMirror(schedule, direction, credential, localRepo, localPath,
                                      URI.create(components[0]), components[1], components[2],
-                                     remoteExcludePath);
+                                     remoteExclude);
             }
         }
 
@@ -153,9 +154,9 @@ public interface Mirror {
     String remoteBranch();
 
     /**
-     * Returns the relative path to {@code remotePath} where isn't supposed to be mirrored.
+     * Returns the file pattern for the files which won't be mirrored.
      */
-    String remoteExcludePath();
+    String remoteExclude();
 
     /**
      * Performs the mirroring task.

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -155,7 +155,8 @@ public interface Mirror {
     String remoteBranch();
 
     /**
-     * Returns a <a href="https://git-scm.com/docs/gitignore">gitignore</a> pattern for the files which won't be mirrored.
+     * Returns a <a href="https://git-scm.com/docs/gitignore">gitignore</a> pattern for the files
+     * which won't be mirrored.
      */
     @Nullable
     String gitIgnore();

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -55,12 +55,12 @@ public interface Mirror {
      * @param localRepo the Central Dogma repository name
      * @param localPath the directory path in the {@code localRepo}
      * @param remoteUri the URI of the Git repository which will be mirrored from
-     * @param gitIgnore the file pattern for the files in {@code remoteUri} which will not be mirrored.
+     * @param gitignore the file pattern for the files in {@code remoteUri} which will not be mirrored.
      *                  It follows the same format to <a href="https://git-scm.com/docs/gitignore">gitignore</a>
      */
     static Mirror of(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath, URI remoteUri,
-                     @Nullable String gitIgnore) {
+                     @Nullable String gitignore) {
         requireNonNull(schedule, "schedule");
         requireNonNull(direction, "direction");
         requireNonNull(credential, "credential");
@@ -89,7 +89,7 @@ public interface Mirror {
 
                 return new CentralDogmaMirror(schedule, direction, credential, localRepo, localPath,
                                               remoteRepoUri, remoteProject, remoteRepo, components[1],
-                                              gitIgnore);
+                                              gitignore);
             }
             case SCHEME_GIT:
             case SCHEME_GIT_SSH:
@@ -99,7 +99,7 @@ public interface Mirror {
                 final String[] components = split(remoteUri, "git", "master");
                 return new GitMirror(schedule, direction, credential, localRepo, localPath,
                                      URI.create(components[0]), components[1], components[2],
-                                     gitIgnore);
+                                     gitignore);
             }
         }
 
@@ -159,7 +159,7 @@ public interface Mirror {
      * which won't be mirrored.
      */
     @Nullable
-    String gitIgnore();
+    String gitignore();
 
     /**
      * Performs the mirroring task.

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -55,12 +55,12 @@ public interface Mirror {
      * @param localRepo the Central Dogma repository name
      * @param localPath the directory path in the {@code localRepo}
      * @param remoteUri the URI of the Git repository which will be mirrored from
-     * @param remoteExclude the file pattern for the files in {@code remoteUri} which will not be mirrored
+     * @param gitIgnore the file pattern for the files in {@code remoteUri} which will not be mirrored
      *                      It follows the same format to gitignore
      */
     static Mirror of(Cron schedule, MirrorDirection direction, MirrorCredential credential,
                      Repository localRepo, String localPath, URI remoteUri,
-                     @Nullable String remoteExclude) {
+                     @Nullable String gitIgnore) {
         requireNonNull(schedule, "schedule");
         requireNonNull(direction, "direction");
         requireNonNull(credential, "credential");
@@ -89,7 +89,7 @@ public interface Mirror {
 
                 return new CentralDogmaMirror(schedule, direction, credential, localRepo, localPath,
                                               remoteRepoUri, remoteProject, remoteRepo, components[1],
-                                              remoteExclude);
+                                              gitIgnore);
             }
             case SCHEME_GIT:
             case SCHEME_GIT_SSH:
@@ -99,7 +99,7 @@ public interface Mirror {
                 final String[] components = split(remoteUri, "git", "master");
                 return new GitMirror(schedule, direction, credential, localRepo, localPath,
                                      URI.create(components[0]), components[1], components[2],
-                                     remoteExclude);
+                                     gitIgnore);
             }
         }
 
@@ -156,7 +156,7 @@ public interface Mirror {
     /**
      * Returns the file pattern for the files which won't be mirrored.
      */
-    String remoteExclude();
+    String gitIgnore();
 
     /**
      * Performs the mirroring task.

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -151,12 +151,14 @@ public interface Mirror {
     /**
      * Returns the name of the branch in the Git repository where is supposed to be mirrored.
      */
-    @Nullable String remoteBranch();
+    @Nullable
+    String remoteBranch();
 
     /**
      * Returns a <a href="https://git-scm.com/docs/gitignore">gitignore</a> pattern for the files which won't be mirrored.
      */
-    @Nullable String gitIgnore();
+    @Nullable
+    String gitIgnore();
 
     /**
      * Performs the mirroring task.

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
@@ -66,7 +66,7 @@ class DefaultMirroringServiceTest {
 
         final Mirror mirror = new AbstractMirror(EVERY_SECOND, MirrorDirection.REMOTE_TO_LOCAL,
                                                  MirrorCredential.FALLBACK, r, "/",
-                                                 URI.create("unused://uri"), "/", null) {
+                                                 URI.create("unused://uri"), "/", null, null) {
             @Override
             protected void mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes) {}
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
@@ -178,7 +178,7 @@ class MirrorTest {
                                                   Repository repository, Class<T> mirrorType) {
         final MirrorCredential credential = mock(MirrorCredential.class);
         final Mirror mirror = Mirror.of(schedule, MirrorDirection.LOCAL_TO_REMOTE,
-                                        credential, repository, "/", URI.create(remoteUri));
+                                        credential, repository, "/", URI.create(remoteUri), null);
 
         assertThat(mirror).isInstanceOf(mirrorType);
         assertThat(mirror.direction()).isEqualTo(MirrorDirection.LOCAL_TO_REMOTE);

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -110,9 +110,9 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
 
 - ``gitignore`` (string or array of strings, optional)
 
-  - a `gitignore <https://git-scm.com/docs/gitignore>`_ pattern for the files excluded from mirroring.
-    The type of gitignore can be a full string of gitignore (e.g. ``/filename.txt\ndirectory``) or an array of
-    strings which consists of each line of gitignore. The file path expressed in gitignore is relative to the
+  - a `gitignore <https://git-scm.com/docs/gitignore>` specifies files that should be excluded from mirroring.
+    The type of gitignore can either be a string containing the entire file (e.g. ``/filename.txt\ndirectory``) or an array 
+    of strings where each line represents a single pattern. The file pattern expressed in gitignore is relative to the
     path of ``remoteUri``.
 
 ``/credentials.json`` contains the authentication credentials which are required when accessing the Git

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -108,7 +108,7 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
     the credential whose ``hostnamePattern`` is matched by the host name part of the ``remoteUri`` value will
     be selected automatically.
 
-- ``gitignore`` (string or array of string, optional)
+- ``gitignore`` (string or array of strings, optional)
 
   - a `gitignore <https://git-scm.com/docs/gitignore>`_ pattern for the files excluded from mirroring.
     The type of gitignore can be a full string of gitignore (e.g. ``/filename.txt\ndirectory``) or an array of

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -50,7 +50,11 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
         "localRepo": "foo",
         "localPath": "/",
         "remoteUri": "git+ssh://git.example.com/foo.git/settings#release",
-        "credentialId": "my_private_key"
+        "credentialId": "my_private_key",
+        "gitIgnore": [
+            "/credential.txt",
+            "private_dir"
+        ]
       }
     ]
 
@@ -103,6 +107,13 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
   - the ID of the credential to use for authentication, as defined in ``/credentials.json``. If unspecified,
     the credential whose ``hostnamePattern`` is matched by the host name part of the ``remoteUri`` value will
     be selected automatically.
+
+- ``gitIgnore`` (string or array of string, optional)
+
+  - a `gitIgnore <https://git-scm.com/docs/gitignore>`_ pattern for the files excluded from mirroring.
+    The type of gitIgnore can be a full string of gitIgnore (e.g. ``/filename.txt\ndirectory``) or an array of
+    strings which consists of each line of gitIgnore. The file path expressed in gitIgnore is relative to the
+    path of ``remoteUri``.
 
 ``/credentials.json`` contains the authentication credentials which are required when accessing the Git
 repositories defined in ``/mirrors.json``:

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -51,7 +51,7 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
         "localPath": "/",
         "remoteUri": "git+ssh://git.example.com/foo.git/settings#release",
         "credentialId": "my_private_key",
-        "gitIgnore": [
+        "gitignore": [
             "/credential.txt",
             "private_dir"
         ]
@@ -108,11 +108,11 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
     the credential whose ``hostnamePattern`` is matched by the host name part of the ``remoteUri`` value will
     be selected automatically.
 
-- ``gitIgnore`` (string or array of string, optional)
+- ``gitignore`` (string or array of string, optional)
 
-  - a `gitIgnore <https://git-scm.com/docs/gitignore>`_ pattern for the files excluded from mirroring.
-    The type of gitIgnore can be a full string of gitIgnore (e.g. ``/filename.txt\ndirectory``) or an array of
-    strings which consists of each line of gitIgnore. The file path expressed in gitIgnore is relative to the
+  - a `gitignore <https://git-scm.com/docs/gitignore>`_ pattern for the files excluded from mirroring.
+    The type of gitignore can be a full string of gitignore (e.g. ``/filename.txt\ndirectory``) or an array of
+    strings which consists of each line of gitignore. The file path expressed in gitignore is relative to the
     path of ``remoteUri``.
 
 ``/credentials.json`` contains the authentication credentials which are required when accessing the Git


### PR DESCRIPTION
**Motivation**
Related to https://github.com/line/centraldogma/issues/38

**Modifications**

- Add `remoteExclude` property to `SingleMirrorConfig`.
  - It takes string of `gitignore` format
