### PR TITLE
Disallow to create non-reserved files in internal repositories

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -87,6 +87,7 @@ import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.MergedEntry;
@@ -98,7 +99,6 @@ import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.QueryType;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
-import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
@@ -130,7 +130,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
                         .put(AuthorizationException.class.getName(), AuthorizationException::new)
                         .put(ShuttingDownException.class.getName(), ShuttingDownException::new)
                         .put(RepositoryExistsException.class.getName(), RepositoryExistsException::new)
-                        .put(RepositoryNotAllowedException.class.getName(), RepositoryNotAllowedException::new)
+                        .put(InvalidPushException.class.getName(), InvalidPushException::new)
                         .build();
 
     private final WebClient client;
@@ -193,7 +193,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         try {
             validateProjectName(projectName);
             return client.execute(
-                    headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
+                                 headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
                          .aggregate()
                          .thenApply(ArmeriaCentralDogma::handlePurgeResult);
         } catch (Exception e) {

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -193,7 +193,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         try {
             validateProjectName(projectName);
             return client.execute(
-                                 headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
+                    headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
                          .aggregate()
                          .thenApply(ArmeriaCentralDogma::handlePurgeResult);
         } catch (Exception e) {

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -98,6 +98,7 @@ import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.QueryType;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
@@ -129,6 +130,7 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
                         .put(AuthorizationException.class.getName(), AuthorizationException::new)
                         .put(ShuttingDownException.class.getName(), ShuttingDownException::new)
                         .put(RepositoryExistsException.class.getName(), RepositoryExistsException::new)
+                        .put(RepositoryNotAllowedException.class.getName(), RepositoryNotAllowedException::new)
                         .build();
 
     private final WebClient client;

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -24,8 +24,6 @@ import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
@@ -58,15 +56,14 @@ class ArmeriaCentralDogmaTest {
                 .isSameAs(pathPatternThatDoesNotNeedEscaping);
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "dogma", "meta" })
-    void pushFileToInternalRepositoryShouldFail(String repoName) throws UnknownHostException {
+    @Test
+    void pushFileToMetaRepositoryShouldFail() throws UnknownHostException {
         final CentralDogma client = new ArmeriaCentralDogmaBuilder()
                 .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
                 .build();
 
         assertThatThrownBy(() -> client.push("foo",
-                                             repoName,
+                                             "meta",
                                              Revision.HEAD,
                                              "summary",
                                              Change.ofJsonUpsert("/bar.json", "{ \"a\": \"b\" }"))

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -29,8 +29,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.PushResult;
-import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
@@ -72,7 +72,7 @@ class ArmeriaCentralDogmaTest {
                                              Change.ofJsonUpsert("/bar.json", "{ \"a\": \"b\" }"))
                                        .join())
                 .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(RepositoryNotAllowedException.class);
+                .hasCauseInstanceOf(InvalidPushException.class);
     }
 
     @Test

--- a/common/src/main/java/com/linecorp/centraldogma/common/InvalidPushException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/InvalidPushException.java
@@ -17,38 +17,37 @@
 package com.linecorp.centraldogma.common;
 
 /**
- * A {@link CentralDogmaException} that is raised when attempted to create a file in the repository which is
- * not allowed.
+ * A {@link CentralDogmaException} that is raised when a push is invalid.
  */
-public class RepositoryNotAllowedException extends CentralDogmaException {
+public class InvalidPushException extends CentralDogmaException {
 
     private static final long serialVersionUID = -8681517517157384962L;
 
     /**
      * Creates a new instance.
      */
-    public RepositoryNotAllowedException() {
+    public InvalidPushException() {
         super();
     }
 
     /**
      * Creates a new instance.
      */
-    public RepositoryNotAllowedException(String message) {
+    public InvalidPushException(String message) {
         super(message);
     }
 
     /**
      * Creates a new instance.
      */
-    public RepositoryNotAllowedException(String message, Throwable cause) {
+    public InvalidPushException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
      * Creates a new instance.
      */
-    public RepositoryNotAllowedException(Throwable cause) {
+    public InvalidPushException(Throwable cause) {
         super(cause);
     }
 
@@ -58,15 +57,15 @@ public class RepositoryNotAllowedException extends CentralDogmaException {
      * @param message the detail message
      * @param writableStackTrace whether or not the stack trace should be writable
      */
-    public RepositoryNotAllowedException(String message, boolean writableStackTrace) {
+    public InvalidPushException(String message, boolean writableStackTrace) {
         super(message, writableStackTrace);
     }
 
     /**
      * Creates a new instance.
      */
-    protected RepositoryNotAllowedException(String message, Throwable cause, boolean enableSuppression,
-                                            boolean writableStackTrace) {
+    protected InvalidPushException(String message, Throwable cause, boolean enableSuppression,
+                                   boolean writableStackTrace) {
         super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/common/src/main/java/com/linecorp/centraldogma/common/InvalidPushException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/InvalidPushException.java
@@ -19,16 +19,14 @@ package com.linecorp.centraldogma.common;
 /**
  * A {@link CentralDogmaException} that is raised when a push is invalid.
  */
-public class InvalidPushException extends CentralDogmaException {
+public final class InvalidPushException extends CentralDogmaException {
 
     private static final long serialVersionUID = -8681517517157384962L;
 
     /**
      * Creates a new instance.
      */
-    public InvalidPushException() {
-        super();
-    }
+    public InvalidPushException() {}
 
     /**
      * Creates a new instance.
@@ -59,13 +57,5 @@ public class InvalidPushException extends CentralDogmaException {
      */
     public InvalidPushException(String message, boolean writableStackTrace) {
         super(message, writableStackTrace);
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    protected InvalidPushException(String message, Throwable cause, boolean enableSuppression,
-                                   boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
     }
 }

--- a/common/src/main/java/com/linecorp/centraldogma/common/RepositoryNotAllowedException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RepositoryNotAllowedException.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.common;
+
+/**
+ * A {@link CentralDogmaException} that is raised when attempted to create a file in the repository which is
+ * not allowed.
+ */
+public class RepositoryNotAllowedException extends CentralDogmaException {
+
+    private static final long serialVersionUID = -8681517517157384962L;
+
+    /**
+     * Creates a new instance.
+     */
+    public RepositoryNotAllowedException() {
+        super();
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public RepositoryNotAllowedException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public RepositoryNotAllowedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    public RepositoryNotAllowedException(Throwable cause) {
+        super(cause);
+    }
+
+    /**
+     * Creates a new instance.
+     *
+     * @param message the detail message
+     * @param writableStackTrace whether or not the stack trace should be writable
+     */
+    public RepositoryNotAllowedException(String message, boolean writableStackTrace) {
+        super(message, writableStackTrace);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    protected RepositoryNotAllowedException(String message, Throwable cause, boolean enableSuppression,
+                                            boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -417,17 +417,16 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         if (Project.REPO_META.equals(repoName)) {
-            final boolean hasChangesWithoutMirroring =
+            final boolean hasChangesOtherThanMirroring =
                     Streams.stream(changes)
                            .anyMatch(change -> !DefaultMetaRepository.PATH_MIRRORS.equals(change.path()));
-            if (hasChangesWithoutMirroring) {
+            if (hasChangesOtherThanMirroring) {
                 throw new InvalidPushException(
                         "The " + Project.REPO_META + " repository is reserved for internal usage.");
             }
 
             final Optional<String> notAllowedLocalRepo =
                     Streams.stream(changes)
-                           .filter(change -> DefaultMetaRepository.PATH_MIRRORS.equals(change.path()))
                            .filter(change -> change.content() != null)
                            .map(change -> {
                                final Object content = change.content();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -411,11 +411,6 @@ public class ContentServiceV1 extends AbstractService {
      * given {@code repoName} field is one of {@code meta} and {@code dogma} which are internal repositories.
      */
     public static void checkPush(String repoName, Iterable<Change<?>> changes) {
-        if (Project.REPO_DOGMA.equals(repoName)) {
-            throw new InvalidPushException(
-                    "The " + Project.REPO_DOGMA + " repository is reserved for internal usage.");
-        }
-
         if (Project.REPO_META.equals(repoName)) {
             final boolean hasChangesOtherThanMirroring =
                     Streams.stream(changes)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -38,6 +38,7 @@ import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.TooManyRequestsException;
@@ -100,7 +101,9 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                         final Object type = firstNonNull(cast.type(), "requests");
                         return newResponse(ctx, HttpStatus.TOO_MANY_REQUESTS, cast,
                                            "Too many %s are sent to %s", type, cause.getMessage());
-                    });
+                    })
+               .put(RepositoryNotAllowedException.class,
+                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.FORBIDDEN, cause));
 
         exceptionHandlers = builder.build();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -33,12 +33,12 @@ import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction;
 import com.linecorp.centraldogma.common.ChangeConflictException;
 import com.linecorp.centraldogma.common.EntryNoContentException;
 import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
-import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.TooManyRequestsException;
@@ -102,8 +102,8 @@ public final class HttpApiExceptionHandler implements ExceptionHandlerFunction {
                         return newResponse(ctx, HttpStatus.TOO_MANY_REQUESTS, cast,
                                            "Too many %s are sent to %s", type, cause.getMessage());
                     })
-               .put(RepositoryNotAllowedException.class,
-                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.FORBIDDEN, cause));
+               .put(InvalidPushException.class,
+                    (ctx, req, cause) -> newResponse(ctx, HttpStatus.BAD_REQUEST, cause));
 
         exceptionHandlers = builder.build();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -44,7 +44,6 @@ import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -60,8 +59,7 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepository {
 
-    @VisibleForTesting
-    static final String PATH_CREDENTIALS = "/credentials.json";
+    public static final String PATH_CREDENTIALS = "/credentials.json";
 
     public static final String PATH_MIRRORS = "/mirrors.json";
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -63,6 +63,8 @@ public class DefaultMetaRepository extends RepositoryWrapper implements MetaRepo
 
     public static final String PATH_MIRRORS = "/mirrors.json";
 
+    public static final Set<String> metaRepoFiles = ImmutableSet.of(PATH_CREDENTIALS, PATH_MIRRORS);
+
     private static final String PATH_CREDENTIALS_AND_MIRRORS = PATH_CREDENTIALS + ',' + PATH_MIRRORS;
 
     private final Lock mirrorLock = new ReentrantLock();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -17,8 +17,7 @@ package com.linecorp.centraldogma.server.internal.thrift;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
-import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkMirrorLocalRepo;
-import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkPushLocalRepo;
+import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkPush;
 import static com.linecorp.centraldogma.server.internal.thrift.Converter.convert;
 import static com.linecorp.centraldogma.server.storage.project.Project.isReservedRepoName;
 import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FIND_ALL_WITHOUT_CONTENT;
@@ -293,8 +292,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
         final List<com.linecorp.centraldogma.common.Change<?>> convertedChanges =
                 convert(changes, Converter::convert);
         try {
-            checkMirrorLocalRepo(repositoryName, convertedChanges);
-            checkPushLocalRepo(repositoryName, convertedChanges);
+            checkPush(repositoryName, convertedChanges);
         } catch (Exception e) {
             resultHandler.onError(e);
             return;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.thrift;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
 import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkMirrorLocalRepo;
+import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkPushLocalRepo;
 import static com.linecorp.centraldogma.server.internal.thrift.Converter.convert;
 import static com.linecorp.centraldogma.server.storage.project.Project.isReservedRepoName;
 import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FIND_ALL_WITHOUT_CONTENT;
@@ -293,6 +294,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                 convert(changes, Converter::convert);
         try {
             checkMirrorLocalRepo(repositoryName, convertedChanges);
+            checkPushLocalRepo(repositoryName, convertedChanges);
         } catch (Exception e) {
             resultHandler.onError(e);
             return;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
@@ -32,6 +32,7 @@ import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
@@ -188,7 +189,7 @@ final class Converter {
         }
 
         ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
-        if (t instanceof IllegalArgumentException) {
+        if (t instanceof IllegalArgumentException || t instanceof RepositoryNotAllowedException) {
             code = ErrorCode.BAD_REQUEST;
         } else if (t instanceof EntryNotFoundException) {
             code = ErrorCode.ENTRY_NOT_FOUND;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
@@ -169,7 +169,7 @@ final class Converter {
                 com.linecorp.centraldogma.common.Revision.HEAD,
                 com.linecorp.centraldogma.common.Revision.HEAD,
                 com.linecorp.centraldogma.server.storage.repository.Repository.ALL_PATH, 1).thenApply(
-                history -> new Repository(name).setHead(convert(history.get(0))));
+                        history -> new Repository(name).setHead(convert(history.get(0))));
     }
 
     static Commit convert(com.linecorp.centraldogma.common.Commit commit) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/Converter.java
@@ -27,12 +27,12 @@ import javax.annotation.Nullable;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.ChangeConflictException;
 import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.ProjectNotFoundException;
 import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
-import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
@@ -169,7 +169,7 @@ final class Converter {
                 com.linecorp.centraldogma.common.Revision.HEAD,
                 com.linecorp.centraldogma.common.Revision.HEAD,
                 com.linecorp.centraldogma.server.storage.repository.Repository.ALL_PATH, 1).thenApply(
-                        history -> new Repository(name).setHead(convert(history.get(0))));
+                history -> new Repository(name).setHead(convert(history.get(0))));
     }
 
     static Commit convert(com.linecorp.centraldogma.common.Commit commit) {
@@ -189,7 +189,7 @@ final class Converter {
         }
 
         ErrorCode code = ErrorCode.INTERNAL_SERVER_ERROR;
-        if (t instanceof IllegalArgumentException || t instanceof RepositoryNotAllowedException) {
+        if (t instanceof IllegalArgumentException || t instanceof InvalidPushException) {
             code = ErrorCode.BAD_REQUEST;
         } else if (t instanceof EntryNotFoundException) {
             code = ErrorCode.ENTRY_NOT_FOUND;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -153,7 +153,7 @@ class ContentServiceV1Test {
                 RequestHeaders.of(HttpMethod.POST, "/api/v1/projects/myPro/repos/" + repoName + "/contents",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final AggregatedHttpResponse res = client.execute(headers, body).aggregate().join();
-        assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(res.contentUtf8()).contains(InvalidPushException.class.getName());
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -46,8 +46,8 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.RedundantChangeException;
-import com.linecorp.centraldogma.common.RepositoryNotAllowedException;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -154,7 +154,7 @@ class ContentServiceV1Test {
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final AggregatedHttpResponse res = client.execute(headers, body).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
-        assertThat(res.contentUtf8()).contains(RepositoryNotAllowedException.class.getName());
+        assertThat(res.contentUtf8()).contains(InvalidPushException.class.getName());
     }
 
     @Nested

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -133,9 +131,8 @@ class ContentServiceV1Test {
                 '}');
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = { "dogma", "meta" })
-    void pushFileToInternalRepositoryShouldFail(String repoName) {
+    @Test
+    void pushFileToMetaRepositoryShouldFail() {
         final WebClient client = dogma.httpClient();
 
         final String body =
@@ -150,7 +147,7 @@ class ContentServiceV1Test {
                 "   }" +
                 '}';
         final RequestHeaders headers =
-                RequestHeaders.of(HttpMethod.POST, "/api/v1/projects/myPro/repos/" + repoName + "/contents",
+                RequestHeaders.of(HttpMethod.POST, "/api/v1/projects/myPro/repos/meta/contents",
                                   HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final AggregatedHttpResponse res = client.execute(headers, body).aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -130,6 +130,28 @@ class ContentServiceV1Test {
                 '}');
     }
 
+    @Test
+    void pushAFileToMetaRepositoryShouldBeForbidden() {
+        final WebClient client = dogma.httpClient();
+
+        final String body =
+                '{' +
+                "   \"path\" : \"/meta/foo.json\"," +
+                "   \"type\" : \"UPSERT_JSON\"," +
+                "   \"content\" : {\"a\": \"bar\"}," +
+                "   \"commitMessage\" : {" +
+                "       \"summary\" : \"Add foo.json\"," +
+                "       \"detail\": \"Add because we need it.\"," +
+                "       \"markup\": \"PLAINTEXT\"" +
+                "   }" +
+                '}';
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET,
+                                                         "/api/v1/projects/myPro/repos/meta/contents",
+                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final AggregatedHttpResponse res = client.execute(headers, body).aggregate().join();
+        assertThat(res.status()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
     @Nested
     class FilesTest {
 


### PR DESCRIPTION
### Motivation

 - #633

### Modifications

 - Checks a commit not to create non-reserved files in internal repositories (`dogma` and `meta`).
 - Create `RepositoryNotAllowedException` which is raised in this case.

### Results

 - Close #633
 - Users can't create a file except for `mirrors.json` in the internal repositories.
 - The HTTP API will respond `403 Forbidden` with the `RepositoryNotAllowedException` in this case.
 - The Thrift API will respond `BAD_REQUEST` in this case due to backward compatibility.