### PR TITLE
Throw error when entries are not found on watching if want

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -47,6 +47,7 @@ import com.linecorp.armeria.common.thrift.ThriftFuture;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.client.WatchOptions;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Change;
@@ -469,7 +470,10 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                        Revision lastKnownRevision,
                                                        String pathPattern,
-                                                       long timeoutMillis) {
+                                                       WatchOptions watchOptions) {
+        // Legacy client only support 'timeoutMillis' in 'WatchOptions'
+        long timeoutMillis = watchOptions.getTimeoutMillis();
+
         final CompletableFuture<WatchRepositoryResult> future = run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);
             requireNonNull(lastKnownRevision, "lastKnownRevision");
@@ -491,7 +495,9 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     @Override
     public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                      Revision lastKnownRevision, Query<T> query,
-                                                     long timeoutMillis) {
+                                                     WatchOptions watchOptions) {
+        // Legacy client only support 'timeoutMillis' in 'WatchOptions'
+        long timeoutMillis = watchOptions.getTimeoutMillis();
 
         final CompletableFuture<WatchFileResult> future = run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -19,10 +19,13 @@ package com.linecorp.centraldogma.client;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
+
+import javax.annotation.Nullable;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -144,47 +147,39 @@ public abstract class AbstractCentralDogma implements CentralDogma {
     }
 
     @Override
-    public final <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
-        return CentralDogma.super.fileWatcher(projectName, repositoryName, query);
-    }
-
-    @Override
-    public <T, U> Watcher<U> fileWatcher(
-            String projectName, String repositoryName, Query<T> query,
-            Function<? super T, ? extends U> function) {
-        return fileWatcher(projectName, repositoryName, query, function, blockingTaskExecutor);
-    }
-
-    @Override
     public <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
-                                         Function<? super T, ? extends U> function, Executor executor) {
-        final FileWatcher<U> watcher =
-                new FileWatcher<>(this, blockingTaskExecutor, executor, projectName, repositoryName, query,
-                                  function);
+                                         @Nullable Function<? super T, ? extends U> function,
+                                         @Nullable Executor executor,
+                                         @Nullable WatchOptions watchOptions) {
+        final FileWatcher<U> watcher = new FileWatcher<>(
+                this,
+                blockingTaskExecutor,
+                Optional.ofNullable(executor).orElse(blockingTaskExecutor),
+                projectName,
+                repositoryName,
+                query,
+                Optional.<Function<? super T, ? extends U>>ofNullable(function)
+                        .orElse((Function<? super T, ? extends U>) Function.<T>identity()),
+                Optional.ofNullable(watchOptions).orElse(WatchOptions.defaultOptions()));
         watcher.start();
         return watcher;
     }
 
     @Override
-    public final Watcher<Revision> repositoryWatcher(
-            String projectName, String repositoryName, String pathPattern) {
-        return CentralDogma.super.repositoryWatcher(projectName, repositoryName, pathPattern);
-    }
-
-    @Override
-    public <T> Watcher<T> repositoryWatcher(
-            String projectName, String repositoryName, String pathPattern,
-            Function<Revision, ? extends T> function) {
-        return repositoryWatcher(projectName, repositoryName, pathPattern, function, blockingTaskExecutor);
-    }
-
-    @Override
     public <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                            Function<Revision, ? extends T> function, Executor executor) {
-
-        final RepositoryWatcher<T> watcher =
-                new RepositoryWatcher<>(this, blockingTaskExecutor, executor,
-                                        projectName, repositoryName, pathPattern, function);
+                                            @Nullable Function<Revision, ? extends T> function,
+                                            @Nullable Executor executor,
+                                            @Nullable WatchOptions watchOptions) {
+        final RepositoryWatcher<T> watcher = new RepositoryWatcher<>(
+                this,
+                blockingTaskExecutor,
+                Optional.ofNullable(executor).orElse(blockingTaskExecutor),
+                projectName,
+                repositoryName,
+                pathPattern,
+                Optional.<Function<Revision, ? extends T>>ofNullable(function)
+                        .orElse((Function<Revision, ? extends T>) Function.<Revision>identity()),
+                Optional.ofNullable(watchOptions).orElse(WatchOptions.defaultOptions()));
         watcher.start();
         return watcher;
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -144,18 +144,6 @@ public abstract class AbstractCentralDogma implements CentralDogma {
     }
 
     @Override
-    public final CompletableFuture<Revision> watchRepository(
-            String projectName, String repositoryName, Revision lastKnownRevision, String pathPattern) {
-        return CentralDogma.super.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern);
-    }
-
-    @Override
-    public final <T> CompletableFuture<Entry<T>> watchFile(
-            String projectName, String repositoryName, Revision lastKnownRevision, Query<T> query) {
-        return CentralDogma.super.watchFile(projectName, repositoryName, lastKnownRevision, query);
-    }
-
-    @Override
     public final <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
         return CentralDogma.super.fileWatcher(projectName, repositoryName, query);
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -148,7 +148,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
 
     @Override
     public <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
-                                         @Nullable Function<? super T, ? extends U> function,
+                                         Function<? super T, ? extends U> function,
                                          @Nullable Executor executor,
                                          @Nullable WatchOptions watchOptions) {
         final FileWatcher<U> watcher = new FileWatcher<>(
@@ -158,8 +158,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
                 projectName,
                 repositoryName,
                 query,
-                Optional.<Function<? super T, ? extends U>>ofNullable(function)
-                        .orElse((Function<? super T, ? extends U>) Function.<T>identity()),
+                function,
                 Optional.ofNullable(watchOptions).orElse(WatchOptions.defaultOptions()));
         watcher.start();
         return watcher;
@@ -167,7 +166,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
 
     @Override
     public <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                            @Nullable Function<Revision, ? extends T> function,
+                                            Function<Revision, ? extends T> function,
                                             @Nullable Executor executor,
                                             @Nullable WatchOptions watchOptions) {
         final RepositoryWatcher<T> watcher = new RepositoryWatcher<>(
@@ -177,8 +176,7 @@ public abstract class AbstractCentralDogma implements CentralDogma {
                 projectName,
                 repositoryName,
                 pathPattern,
-                Optional.<Function<Revision, ? extends T>>ofNullable(function)
-                        .orElse((Function<Revision, ? extends T>) Function.<Revision>identity()),
+                function,
                 Optional.ofNullable(watchOptions).orElse(WatchOptions.defaultOptions()));
         watcher.start();
         return watcher;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -24,6 +24,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import javax.annotation.Nullable;
+
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 
@@ -440,7 +442,7 @@ public interface CentralDogma {
     default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                         Revision lastKnownRevision, String pathPattern) {
         return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
-                               WatchOptions.builder().build());
+                               WatchOptions.defaultOptions());
     }
 
     /**
@@ -492,8 +494,7 @@ public interface CentralDogma {
      */
     default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                       Revision lastKnownRevision, Query<T> query) {
-        return watchFile(projectName, repositoryName, lastKnownRevision, query,
-                         WatchOptions.builder().build());
+        return watchFile(projectName, repositoryName, lastKnownRevision, query, WatchOptions.defaultOptions());
     }
 
     /**
@@ -546,7 +547,7 @@ public interface CentralDogma {
      * });}</pre>
      */
     default <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
-        return fileWatcher(projectName, repositoryName, query, Function.identity());
+        return fileWatcher(projectName, repositoryName, query, Function.identity(), null, null);
     }
 
     /**
@@ -565,8 +566,10 @@ public interface CentralDogma {
      * <p>Note that {@link Function} by default is executed by a blocking task executor so that you can
      * safely call a blocking operation.
      */
-    <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
-                                  Query<T> query, Function<? super T, ? extends U> function);
+    default <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
+                                  Query<T> query, Function<? super T, ? extends U> function) {
+        return fileWatcher(projectName, repositoryName, query, function, null, null);
+    }
 
     /**
      * Returns a {@link Watcher} which notifies its listeners after applying the specified
@@ -583,8 +586,20 @@ public interface CentralDogma {
      *
      * @param executor the {@link Executor} that executes the {@link Function}
      */
+    default <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
+                                  Query<T> query, Function<? super T, ? extends U> function, Executor executor) {
+        return fileWatcher(projectName, repositoryName, query, function, executor, null);
+    }
+
+    /**
+     * ing...
+     */
+
     <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
-                                  Query<T> query, Function<? super T, ? extends U> function, Executor executor);
+                                  Query<T> query,
+                                  @Nullable Function<? super T, ? extends U> function,
+                                  @Nullable Executor executor,
+                                  @Nullable WatchOptions watchOptions);
 
     /**
      * Returns a {@link Watcher} which notifies its listeners when the specified repository has a new commit
@@ -597,7 +612,7 @@ public interface CentralDogma {
      * });}</pre>
      */
     default Watcher<Revision> repositoryWatcher(String projectName, String repositoryName, String pathPattern) {
-        return repositoryWatcher(projectName, repositoryName, pathPattern, Function.identity());
+        return repositoryWatcher(projectName, repositoryName, pathPattern, Function.identity(), null, null);
     }
 
     /**
@@ -617,8 +632,10 @@ public interface CentralDogma {
      * may have to retry in the above example due to
      * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
      */
-    <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                     Function<Revision, ? extends T> function);
+    default <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
+                                     Function<Revision, ? extends T> function){
+        return repositoryWatcher(projectName, repositoryName, pathPattern, function, null, null);
+    }
 
     /**
      * Returns a {@link Watcher} which notifies its listeners when the specified repository has a new commit
@@ -637,6 +654,17 @@ public interface CentralDogma {
      *
      * @param executor the {@link Executor} that executes the {@link Function}
      */
+    default <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
+                                     Function<Revision, ? extends T> function, Executor executor) {
+        return repositoryWatcher(projectName, repositoryName, pathPattern, function, executor, null);
+    }
+
+    /**
+     * ing...
+     */
+
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                     Function<Revision, ? extends T> function, Executor executor);
+                                     @Nullable Function<Revision, ? extends T> function,
+                                     @Nullable Executor executor,
+                                     @Nullable WatchOptions watchOptions);
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 final class WatchConstants {
 
     static final long DEFAULT_WATCH_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    static final boolean DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND = false;
     static final int RECOMMENDED_AWAIT_TIMEOUT_SECONDS = 20;
 
     private WatchConstants() {}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/WatchOptions.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/WatchOptions.java
@@ -17,6 +17,10 @@ public final class WatchOptions {
         this.errorOnEntryNotFound = errorOnEntryNotFound;
     }
 
+    public static WatchOptions defaultOptions() {
+        return new Builder().build();
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/WatchOptions.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/WatchOptions.java
@@ -1,0 +1,42 @@
+package com.linecorp.centraldogma.client;
+
+public final class WatchOptions {
+    private final long timeoutMillis;
+    private final boolean errorOnEntryNotFound;
+
+    public long getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    public boolean isErrorOnEntryNotFound() {
+        return errorOnEntryNotFound;
+    }
+
+    private WatchOptions(long timeoutMillis, boolean errorOnEntryNotFound) {
+        this.timeoutMillis = timeoutMillis;
+        this.errorOnEntryNotFound = errorOnEntryNotFound;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private long timeoutMillis = WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS;
+        private boolean errorOnEntryNotFound = WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND;
+
+        public Builder timeoutMillis(long timeoutMillis) {
+            this.timeoutMillis = timeoutMillis;
+            return this;
+        }
+
+        public Builder errorOnEntryNotFound(boolean errorOnEntryNotFound) {
+            this.errorOnEntryNotFound = errorOnEntryNotFound;
+            return this;
+        }
+
+        public WatchOptions build() {
+            return new WatchOptions(timeoutMillis, errorOnEntryNotFound);
+        }
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
+import com.linecorp.centraldogma.client.WatchOptions;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 
@@ -39,9 +40,10 @@ public final class FileWatcher<T> extends AbstractWatcher<T> {
     public <U> FileWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
                            Executor callbackExecutor,
                            String projectName, String repositoryName,
-                           Query<U> query, Function<? super U, ? extends T> function) {
+                           Query<U> query, Function<? super U, ? extends T> function,
+                           WatchOptions watchOptions) {
 
-        super(client, watchScheduler, projectName, repositoryName, requireNonNull(query, "query").path());
+        super(client, watchScheduler, projectName, repositoryName, requireNonNull(query, "query").path(), watchOptions);
         this.query = query;
         this.function = unsafeCast(requireNonNull(function, "function"));
         this.callbackExecutor = requireNonNull(callbackExecutor, "callbackExecutor");
@@ -49,8 +51,9 @@ public final class FileWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision) {
-        return client.watchFile(projectName, repositoryName, lastKnownRevision, query)
+                                                   String repositoryName, Revision lastKnownRevision,
+                                                   WatchOptions watchOptions) {
+        return client.watchFile(projectName, repositoryName, lastKnownRevision, query, watchOptions)
                      .thenApplyAsync(result -> {
                          if (result == null) {
                              return null;

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -47,6 +47,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.client.WatchOptions;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Commit;
@@ -429,7 +430,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     @Override
     public CompletableFuture<Revision> watchRepository(
             String projectName, String repositoryName, Revision lastKnownRevision,
-            String pathPattern, long timeoutMillis) {
+            String pathPattern, WatchOptions watchOptions) {
 
         return normalizeRevisionAndExecuteWithRetries(
                 projectName, repositoryName, lastKnownRevision,
@@ -437,7 +438,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public CompletableFuture<Revision> apply(Revision normLastKnownRevision) {
                         return delegate.watchRepository(projectName, repositoryName, normLastKnownRevision,
-                                                        pathPattern, timeoutMillis)
+                                                        pathPattern, watchOptions)
                                        .thenApply(newLastKnownRevision -> {
                                            if (newLastKnownRevision != null) {
                                                updateLatestKnownRevision(projectName, repositoryName,
@@ -450,23 +451,23 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchRepository(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + pathPattern + ", " + timeoutMillis + ')';
+                               lastKnownRevision + ", " + pathPattern + ", " + watchOptions.getTimeoutMillis()
+                               + ", " + watchOptions.isErrorOnEntryNotFound() + ')';
                     }
                 });
     }
 
     @Override
-    public <T> CompletableFuture<Entry<T>> watchFile(
-            String projectName, String repositoryName, Revision lastKnownRevision,
-            Query<T> query, long timeoutMillis) {
-
+    public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
+                                                     Revision lastKnownRevision, Query<T> query,
+                                                     WatchOptions watchOptions) {
         return normalizeRevisionAndExecuteWithRetries(
                 projectName, repositoryName, lastKnownRevision,
                 new Function<Revision, CompletableFuture<Entry<T>>>() {
                     @Override
                     public CompletableFuture<Entry<T>> apply(Revision normLastKnownRevision) {
                         return delegate.watchFile(projectName, repositoryName, normLastKnownRevision,
-                                                  query, timeoutMillis)
+                                                  query, watchOptions)
                                        .thenApply(entry -> {
                                            if (entry != null) {
                                                updateLatestKnownRevision(projectName, repositoryName,
@@ -479,7 +480,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchFile(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + query + ", " + timeoutMillis + ')';
+                               lastKnownRevision + ", " + query + ", " + watchOptions.getTimeoutMillis() + ", "
+                               + watchOptions.isErrorOnEntryNotFound() + ')';
                     }
                 });
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
+import com.linecorp.centraldogma.client.WatchOptions;
 import com.linecorp.centraldogma.common.Revision;
 
 public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
@@ -37,8 +38,9 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
     public RepositoryWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
                              Executor callbackExecutor,
                              String projectName, String repositoryName,
-                             String pathPattern, Function<Revision, ? extends T> function) {
-        super(client, watchScheduler, projectName, repositoryName, pathPattern);
+                             String pathPattern, Function<Revision, ? extends T> function,
+                             WatchOptions watchOptions) {
+        super(client, watchScheduler, projectName, repositoryName, pathPattern, watchOptions);
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
         this.function = requireNonNull(function, "function");
         this.callbackExecutor = requireNonNull(callbackExecutor, "callbackExecutor");
@@ -46,8 +48,9 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision) {
-        return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern)
+                                                   String repositoryName, Revision lastKnownRevision,
+                                                   WatchOptions watchOptions) {
+        return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern, watchOptions)
                      .thenApplyAsync(revision -> {
                          if (revision == null) {
                              return null;

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -522,7 +522,7 @@ class WatchTest {
                 null, null,
                 WatchOptions.builder().timeoutMillis(100).errorOnEntryNotFound(true).build());
 
-        // check entry is not exist when to get initial value
+        // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(EntryNotFoundException.class);
     }
 
@@ -557,7 +557,7 @@ class WatchTest {
             triggeredCount.incrementAndGet();
         });
 
-        // check entry is not exist when to get initial value
+        // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // watch added file
@@ -677,7 +677,7 @@ class WatchTest {
                 null, null,
                 WatchOptions.builder().timeoutMillis(100).errorOnEntryNotFound(true).build());
 
-        // check entry is not exist when to get initial value
+        // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(EntryNotFoundException.class);
     }
 
@@ -710,7 +710,7 @@ class WatchTest {
             triggeredCount.incrementAndGet();
         });
 
-        // check entry is not exist when to get initial value
+        // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // watch added file


### PR DESCRIPTION
### Motivation
- https://github.com/line/centraldogma/issues/532
- To-Do of https://github.com/line/centraldogma/pull/610

### Modifications
- Add `WatchOptions` object to put additional options on watching file/repository
- Put value of `notify-entry-not-found` on `Prefer` request header using `WatchOptions#errorOnEntryNotFound`
- Propagate error that entries are not found to `Watcher#initialValueFuture` if `WatchOptions#errorOnEntryNotFound` is true

### Result
- You can get error on watching file/repository when the entry doesn't exist.