### PR TITLE
Throw error that entries are not found on watching if want

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -469,7 +469,9 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                        Revision lastKnownRevision,
                                                        String pathPattern,
-                                                       long timeoutMillis) {
+                                                       long timeoutMillis,
+                                                       boolean errorOnEntryNotFound) {
+        // Legacy client does not support 'errorOnEntryNotFound'
         final CompletableFuture<WatchRepositoryResult> future = run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);
             requireNonNull(lastKnownRevision, "lastKnownRevision");
@@ -491,8 +493,8 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     @Override
     public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                      Revision lastKnownRevision, Query<T> query,
-                                                     long timeoutMillis) {
-
+                                                     long timeoutMillis, boolean errorOnEntryNotFound) {
+        // Legacy client does not support 'errorOnEntryNotFound'
         final CompletableFuture<WatchFileResult> future = run(callback -> {
             validateProjectAndRepositoryName(projectName, repositoryName);
             requireNonNull(lastKnownRevision, "lastKnownRevision");

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -885,8 +885,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         builder.set(HttpHeaderNames.IF_NONE_MATCH, lastKnownRevision.text())
                .set(HttpHeaderNames.PREFER,
                     // It is good to extract private method when this logic becomes heavier.
-                    "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L
-                    + ", notify-entry-not-found=" + errorOnEntryNotFound);
+                    "wait=" + LongMath.saturatedAdd(timeoutMillis, 999) / 1000L +
+                    ", notify-entry-not-found=" + errorOnEntryNotFound);
 
         try (SafeCloseable ignored = Clients.withContextCustomizer(ctx -> {
             final long responseTimeoutMillis = ctx.responseTimeoutMillis();

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -144,59 +144,43 @@ public abstract class AbstractCentralDogma implements CentralDogma {
     }
 
     @Override
-    public final CompletableFuture<Revision> watchRepository(
-            String projectName, String repositoryName, Revision lastKnownRevision, String pathPattern) {
-        return CentralDogma.super.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern);
-    }
-
-    @Override
-    public final <T> CompletableFuture<Entry<T>> watchFile(
-            String projectName, String repositoryName, Revision lastKnownRevision, Query<T> query) {
-        return CentralDogma.super.watchFile(projectName, repositoryName, lastKnownRevision, query);
-    }
-
-    @Override
-    public final <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
-        return CentralDogma.super.fileWatcher(projectName, repositoryName, query);
-    }
-
-    @Override
     public <T, U> Watcher<U> fileWatcher(
             String projectName, String repositoryName, Query<T> query,
             Function<? super T, ? extends U> function) {
-        return fileWatcher(projectName, repositoryName, query, function, blockingTaskExecutor);
+        return fileWatcher(projectName, repositoryName, query, function,
+                           blockingTaskExecutor,
+                           WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS,
+                           WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
     }
 
     @Override
     public <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
-                                         Function<? super T, ? extends U> function, Executor executor) {
+                                         Function<? super T, ? extends U> function, Executor executor,
+                                         long timeoutMillis, boolean errorOnEntryNotFound) {
         final FileWatcher<U> watcher =
                 new FileWatcher<>(this, blockingTaskExecutor, executor, projectName, repositoryName, query,
-                                  function);
+                                  function, timeoutMillis, errorOnEntryNotFound);
         watcher.start();
         return watcher;
-    }
-
-    @Override
-    public final Watcher<Revision> repositoryWatcher(
-            String projectName, String repositoryName, String pathPattern) {
-        return CentralDogma.super.repositoryWatcher(projectName, repositoryName, pathPattern);
     }
 
     @Override
     public <T> Watcher<T> repositoryWatcher(
             String projectName, String repositoryName, String pathPattern,
             Function<Revision, ? extends T> function) {
-        return repositoryWatcher(projectName, repositoryName, pathPattern, function, blockingTaskExecutor);
+        return repositoryWatcher(projectName, repositoryName, pathPattern, function,
+                                 blockingTaskExecutor,
+                                 WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS,
+                                 WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
     }
 
     @Override
     public <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                            Function<Revision, ? extends T> function, Executor executor) {
-
+                                            Function<Revision, ? extends T> function, Executor executor,
+                                            long timeoutMillis, boolean errorOnEntryNotFound) {
         final RepositoryWatcher<T> watcher =
-                new RepositoryWatcher<>(this, blockingTaskExecutor, executor,
-                                        projectName, repositoryName, pathPattern, function);
+                new RepositoryWatcher<>(this, blockingTaskExecutor, executor, projectName, repositoryName,
+                                        pathPattern, function, timeoutMillis, errorOnEntryNotFound);
         watcher.start();
         return watcher;
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -31,6 +31,7 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.MergeQuery;
@@ -435,7 +436,10 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for 1 minute since the invocation of this method.
+     *
+     * @deprecated Use {@link CentralDogma#watchRepository(String, String, Revision, String, long, boolean)}.
      */
+    @Deprecated
     default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                         Revision lastKnownRevision, String pathPattern) {
         return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
@@ -452,10 +456,36 @@ public interface CentralDogma {
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
      *         since the invocation of this method.
+     *
+     * @deprecated Use {@link CentralDogma#watchRepository(String, String, Revision, String, long, boolean)}.
+     */
+    @Deprecated
+    default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
+                                                        Revision lastKnownRevision, String pathPattern,
+                                                        long timeoutMillis) {
+        return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
+                               timeoutMillis, WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
+    }
+
+    /**
+     * Waits for the files matched by the specified {@code pathPattern} to be changed since the specified
+     * {@code lastKnownRevision}. If the files don't exist and {@code errorOnEntryNotFound} is ture, stops to
+     * wait files and throw {@link EntryNotFoundException} as the cause. If {@code errorOnEntryNotFound} is
+     * false and no changes were made within the specified {@code timeoutMillis}, the returned {@link
+     * CompletableFuture} will be completed with {@code null}. It is recommended to specify the largest {@code
+     * timeoutMillis} allowed by the server.
+     *
+     * <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
+     *
+     * @return the {@link Entry} which contains the latest known {@link Query} result.
+     *         thrown {@link EntryNotFoundException} if files don't exist and
+     *         {@code errorOnEntryNotFound} is ture.
+     *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
+     *         since the invocation of this method.
      */
     CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                 Revision lastKnownRevision, String pathPattern,
-                                                long timeoutMillis);
+                                                long timeoutMillis, boolean errorOnEntryNotFound);
 
     /**
      * Waits for the file matched by the specified {@link Query} to be changed since the specified
@@ -464,7 +494,10 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for 1 minute since the invocation of this method.
+     *
+     * @deprecated Use {@link CentralDogma#watchFile(String, String, Revision, Query, long, boolean)}.
      */
+    @Deprecated
     default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                       Revision lastKnownRevision, Query<T> query) {
         return watchFile(projectName, repositoryName, lastKnownRevision, query,
@@ -481,10 +514,34 @@ public interface CentralDogma {
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
      *         since the invocation of this method.
+     *
+     * @deprecated Use {@link CentralDogma#watchFile(String, String, Revision, Query, long, boolean)}.
+     */
+    @Deprecated
+    default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
+                                                      Revision lastKnownRevision, Query<T> query,
+                                                      long timeoutMillis) {
+        return watchFile(projectName, repositoryName, lastKnownRevision, query,
+                         timeoutMillis, WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
+    }
+
+    /**
+     * Waits for the file matched by the specified {@link Query} to be changed since the specified
+     * {@code lastKnownRevision}. If the file does not exist and {@code errorOnEntryNotFound} is ture, stops
+     * to wait the file and throw {@link EntryNotFoundException} as the cause. If {@code errorOnEntryNotFound}
+     * is false and no changes were made within the specified {@code timeoutMillis}, the returned
+     * {@link CompletableFuture} will be completed with {@code null}. It is recommended to specify the largest
+     * {@code timeoutMillis} allowed by the server.
+     *
+     * @return the {@link Entry} which contains the latest known {@link Query} result.
+     *         thrown {@link EntryNotFoundException} if the file does not exist and
+     *         {@code errorOnEntryNotFound} is ture.
+     *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
+     *         since the invocation of this method.
      */
     <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                               Revision lastKnownRevision, Query<T> query,
-                                              long timeoutMillis);
+                                              long timeoutMillis, boolean errorOnEntryNotFound);
 
     /**
      * Returns a {@link Watcher} which notifies its listeners when the result of the
@@ -496,7 +553,11 @@ public interface CentralDogma {
      *     assert content instanceof JsonNode;
      *     ...
      * });}</pre>
+     *
+     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
+     *             boolean)}.
      */
+    @Deprecated
     default <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
         return fileWatcher(projectName, repositoryName, query, Function.identity());
     }
@@ -516,7 +577,11 @@ public interface CentralDogma {
      *
      * <p>Note that {@link Function} by default is executed by a blocking task executor so that you can
      * safely call a blocking operation.
+     *
+     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
+     *             boolean)}.
      */
+    @Deprecated
     <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
                                   Query<T> query, Function<? super T, ? extends U> function);
 
@@ -534,9 +599,41 @@ public interface CentralDogma {
      * });}</pre>
      *
      * @param executor the {@link Executor} that executes the {@link Function}
+     *
+     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
+     *             boolean)}.
      */
-    <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
-                                  Query<T> query, Function<? super T, ? extends U> function, Executor executor);
+    @Deprecated
+    default <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
+                                          Function<? super T, ? extends U> function, Executor executor) {
+        return fileWatcher(projectName, repositoryName, query, function, executor,
+                           WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS,
+                           WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
+    }
+
+    /**
+     * Returns a {@link Watcher} which notifies its listeners after applying the specified
+     * {@link Function} when the result of the given {@link Query} becomes available or changes. e.g:
+     * <pre>{@code
+     * Watcher<MyType> watcher = client.fileWatcher(
+     *         "foo", "bar", Query.ofJson("/baz.json"),
+     *         content -> new ObjectMapper().treeToValue(content, MyType.class), executor,
+     *         60000, true);
+     *
+     * watcher.initialValueFuture().thenAccept(result -> watcher.watch((revision, myValue) -> {
+     *     assert myValue instanceof MyType;
+     *     ...
+     * }));}</pre>
+     *
+     * @param executor the {@link Executor} that executes the {@link Function}.
+     * @param errorOnEntryNotFound the {@code errorOnEntryNotFound} that is a option on watching.
+     *        if is true and the file doesn't exist, {@link Watcher#initialValueFuture()} will be completed
+     *        with {@link EntryNotFoundException}.
+     *        <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
+     */
+    <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
+                                  Function<? super T, ? extends U> function, Executor executor,
+                                  long timeoutMillis, boolean errorOnEntryNotFound);
 
     /**
      * Returns a {@link Watcher} which notifies its listeners when the specified repository has a new commit
@@ -547,7 +644,11 @@ public interface CentralDogma {
      * watcher.watch(revision -> {
      *     ...
      * });}</pre>
+     *
+     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
+     *             boolean)}.
      */
+    @Deprecated
     default Watcher<Revision> repositoryWatcher(String projectName, String repositoryName, String pathPattern) {
         return repositoryWatcher(projectName, repositoryName, pathPattern, Function.identity());
     }
@@ -568,7 +669,11 @@ public interface CentralDogma {
      * <p>Note that you may get {@link RevisionNotFoundException} during the {@code getFiles()} call and
      * may have to retry in the above example due to
      * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
+     *
+     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
+     *             boolean)}.
      */
+    @Deprecated
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
                                      Function<Revision, ? extends T> function);
 
@@ -588,7 +693,38 @@ public interface CentralDogma {
      * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
      *
      * @param executor the {@link Executor} that executes the {@link Function}
+     *
+     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
+     *             boolean)}.
+     */
+    @Deprecated
+    default <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
+                                             Function<Revision, ? extends T> function, Executor executor) {
+        return repositoryWatcher(projectName, repositoryName, pathPattern, function, executor,
+                                 WatchConstants.DEFAULT_WATCH_TIMEOUT_MILLIS,
+                                 WatchConstants.DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND);
+    }
+
+    /**
+     * Returns a {@link Watcher} which notifies its listeners after applying the specified
+     * {@link Function} when the result of the given {@link Query} becomes available or changes. e.g:
+     * <pre>{@code
+     * Watcher<MyType> watcher = client.repositoryWatcher(
+     *         "foo", "bar", "/*.json",
+     *         revision -> client.getFiles("foo", "bar", revision, "/*.json").join(), executor,
+     *         60000, true);
+     *
+     * watcher.initialValueFuture().thenAccept(result -> watcher.watch((revision, contents) -> {
+     *     ...
+     * }));}</pre>
+     *
+     * @param executor the {@link Executor} that executes the {@link Function}.
+     * @param errorOnEntryNotFound the {@code errorOnEntryNotFound} that is a option on watching.
+     *        if is true and the files don't exist, {@link Watcher#initialValueFuture()} will be completed
+     *        with {@link EntryNotFoundException}.
+     *        <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
      */
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
-                                     Function<Revision, ? extends T> function, Executor executor);
+                                     Function<Revision, ? extends T> function, Executor executor,
+                                     long timeoutMillis, boolean errorOnEntryNotFound);
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -436,10 +436,7 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for 1 minute since the invocation of this method.
-     *
-     * @deprecated Use {@link CentralDogma#watchRepository(String, String, Revision, String, long, boolean)}.
      */
-    @Deprecated
     default CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                         Revision lastKnownRevision, String pathPattern) {
         return watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
@@ -493,10 +490,7 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for 1 minute since the invocation of this method.
-     *
-     * @deprecated Use {@link CentralDogma#watchFile(String, String, Revision, Query, long, boolean)}.
      */
-    @Deprecated
     default <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                       Revision lastKnownRevision, Query<T> query) {
         return watchFile(projectName, repositoryName, lastKnownRevision, query,
@@ -551,11 +545,7 @@ public interface CentralDogma {
      *     assert content instanceof JsonNode;
      *     ...
      * });}</pre>
-     *
-     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     default <T> Watcher<T> fileWatcher(String projectName, String repositoryName, Query<T> query) {
         return fileWatcher(projectName, repositoryName, query, Function.identity());
     }
@@ -575,11 +565,7 @@ public interface CentralDogma {
      *
      * <p>Note that {@link Function} by default is executed by a blocking task executor so that you can
      * safely call a blocking operation.
-     *
-     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName,
                                   Query<T> query, Function<? super T, ? extends U> function);
 
@@ -595,13 +581,7 @@ public interface CentralDogma {
      *     assert myValue instanceof MyType;
      *     ...
      * });}</pre>
-     *
-     * @param executor the {@link Executor} that executes the {@link Function}
-     *
-     * @deprecated Use {@link CentralDogma#fileWatcher(String, String, Query, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     default <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
                                           Function<? super T, ? extends U> function, Executor executor) {
         return fileWatcher(projectName, repositoryName, query, function, executor,
@@ -642,11 +622,7 @@ public interface CentralDogma {
      * watcher.watch(revision -> {
      *     ...
      * });}</pre>
-     *
-     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     default Watcher<Revision> repositoryWatcher(String projectName, String repositoryName, String pathPattern) {
         return repositoryWatcher(projectName, repositoryName, pathPattern, Function.identity());
     }
@@ -667,11 +643,7 @@ public interface CentralDogma {
      * <p>Note that you may get {@link RevisionNotFoundException} during the {@code getFiles()} call and
      * may have to retry in the above example due to
      * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
-     *
-     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
                                      Function<Revision, ? extends T> function);
 
@@ -691,11 +663,7 @@ public interface CentralDogma {
      * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
      *
      * @param executor the {@link Executor} that executes the {@link Function}
-     *
-     * @deprecated Use {@link CentralDogma#repositoryWatcher(String, String, String, Function, Executor, long,
-     *             boolean)}.
      */
-    @Deprecated
     default <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
                                              Function<Revision, ? extends T> function, Executor executor) {
         return repositoryWatcher(projectName, repositoryName, pathPattern, function, executor,
@@ -704,8 +672,8 @@ public interface CentralDogma {
     }
 
     /**
-     * Returns a {@link Watcher} which notifies its listeners after applying the specified
-     * {@link Function} when the result of the given {@link Query} becomes available or changes. e.g:
+     * Returns a {@link Watcher} which notifies its listeners when the specified repository has a new commit
+     * that contains the changes for the files matched by the given {@code pathPattern}. e.g:
      * <pre>{@code
      * Watcher<MyType> watcher = client.repositoryWatcher(
      *         "foo", "bar", "/*.json",
@@ -715,6 +683,9 @@ public interface CentralDogma {
      * watcher.initialValueFuture().thenAccept(result -> watcher.watch((revision, contents) -> {
      *     ...
      * }));}</pre>
+     * Note that you may get {@link RevisionNotFoundException} during the {@code getFiles()} call and
+     * may have to retry in the above example due to
+     * <a href="https://github.com/line/centraldogma/issues/40">a known issue</a>.
      *
      * @param executor the {@link Executor} that executes the {@link Function}.
      * @param errorOnEntryNotFound the {@code errorOnEntryNotFound} that is a option on watching.

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -469,19 +469,18 @@ public interface CentralDogma {
 
     /**
      * Waits for the files matched by the specified {@code pathPattern} to be changed since the specified
-     * {@code lastKnownRevision}. If the files don't exist and {@code errorOnEntryNotFound} is ture, stops to
-     * wait files and throw {@link EntryNotFoundException} as the cause. If {@code errorOnEntryNotFound} is
-     * false and no changes were made within the specified {@code timeoutMillis}, the returned {@link
-     * CompletableFuture} will be completed with {@code null}. It is recommended to specify the largest {@code
-     * timeoutMillis} allowed by the server.
+     * {@code lastKnownRevision}. If the files don't exist and {@code errorOnEntryNotFound} is {@code true},
+     * the returned {@link CompletableFuture} will be completed exceptionally with
+     * {@link EntryNotFoundException}. If no changes were made within the specified {@code timeoutMillis},
+     * the returned {@link CompletableFuture} will be completed with {@code null}.
+     * It is recommended to specify the largest {@code timeoutMillis} allowed by the server.
      *
      * <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
      *
-     * @return the {@link Entry} which contains the latest known {@link Query} result.
-     *         thrown {@link EntryNotFoundException} if files don't exist and
-     *         {@code errorOnEntryNotFound} is ture.
-     *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method.
+     * @return the latest known {@link Revision} which contains the changes for the matched files.
+     *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
+     *         since the invocation of this method. {@link EntryNotFoundException} is raised if the
+     *         target does not exist.
      */
     CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                 Revision lastKnownRevision, String pathPattern,
@@ -527,17 +526,16 @@ public interface CentralDogma {
 
     /**
      * Waits for the file matched by the specified {@link Query} to be changed since the specified
-     * {@code lastKnownRevision}. If the file does not exist and {@code errorOnEntryNotFound} is ture, stops
-     * to wait the file and throw {@link EntryNotFoundException} as the cause. If {@code errorOnEntryNotFound}
-     * is false and no changes were made within the specified {@code timeoutMillis}, the returned
-     * {@link CompletableFuture} will be completed with {@code null}. It is recommended to specify the largest
-     * {@code timeoutMillis} allowed by the server.
+     * {@code lastKnownRevision}. If the file does not exist and {@code errorOnEntryNotFound} is {@code true},
+     * the returned {@link CompletableFuture} will be completed exceptionally with
+     * {@link EntryNotFoundException}. If no changes were made within the specified {@code timeoutMillis},
+     * the returned {@link CompletableFuture} will be completed with {@code null}.
+     * It is recommended to specify the largest {@code timeoutMillis} allowed by the server.
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
-     *         thrown {@link EntryNotFoundException} if the file does not exist and
-     *         {@code errorOnEntryNotFound} is ture.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method.
+     *         since the invocation of this method. {@link EntryNotFoundException} is raised if the
+     *         target does not exist.
      */
     <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                               Revision lastKnownRevision, Query<T> query,
@@ -627,8 +625,8 @@ public interface CentralDogma {
      *
      * @param executor the {@link Executor} that executes the {@link Function}.
      * @param errorOnEntryNotFound the {@code errorOnEntryNotFound} that is a option on watching.
-     *        if is true and the file doesn't exist, {@link Watcher#initialValueFuture()} will be completed
-     *        with {@link EntryNotFoundException}.
+     *        if is {@code true} and the file doesn't exist, {@link Watcher#initialValueFuture()} will be
+     *        completed with {@link EntryNotFoundException}.
      *        <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
      */
     <T, U> Watcher<U> fileWatcher(String projectName, String repositoryName, Query<T> query,
@@ -720,8 +718,8 @@ public interface CentralDogma {
      *
      * @param executor the {@link Executor} that executes the {@link Function}.
      * @param errorOnEntryNotFound the {@code errorOnEntryNotFound} that is a option on watching.
-     *        if is true and the files don't exist, {@link Watcher#initialValueFuture()} will be completed
-     *        with {@link EntryNotFoundException}.
+     *        if is {@code true} and the files don't exist, {@link Watcher#initialValueFuture()} will be
+     *        completed with {@link EntryNotFoundException}.
      *        <p>Note: Legacy client does not support {@code errorOnEntryNotFound}</p>
      */
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/WatchConstants.java
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit;
 final class WatchConstants {
 
     static final long DEFAULT_WATCH_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(1);
+    static final boolean DEFAULT_WATCH_ERROR_ON_ENTRY_NOT_FOUND = false;
     static final int RECOMMENDED_AWAIT_TIMEOUT_SECONDS = 20;
 
     private WatchConstants() {}

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -192,13 +192,6 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     public void watch(BiConsumer<? super Revision, ? super T> listener, Executor executor) {
         requireNonNull(listener, "listener");
         checkState(!isStopped(), "watcher closed");
-        if (!initialValueFuture.isDone() && errorOnEntryNotFound) {
-            logger.warn("If entry doesn't not exist, this watch is not working. "
-                        + "Please check 'initialValueFuture()' is completed without any exception. "
-                        + "Recommend to handle this method using 'initialValueFuture()', "
-                        + "if you to need the error that entry doesn't exist.");
-        }
-
         updateListeners.add(new SimpleImmutableEntry<>(listener, executor));
 
         if (latest != null) {

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -110,6 +110,8 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     private final String projectName;
     private final String repositoryName;
     private final String pathPattern;
+    private final long timeoutMillis;
+    private final boolean errorOnEntryNotFound;
 
     private final List<Map.Entry<BiConsumer<? super Revision, ? super T>, Executor>> updateListeners;
     private final AtomicReference<State> state;
@@ -120,12 +122,15 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     private volatile CompletableFuture<?> currentWatchFuture;
 
     protected AbstractWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
-                              String projectName, String repositoryName, String pathPattern) {
+                              String projectName, String repositoryName, String pathPattern,
+                              long timeoutMillis, boolean errorOnEntryNotFound) {
         this.client = requireNonNull(client, "client");
         this.watchScheduler = requireNonNull(watchScheduler, "watchScheduler");
         this.projectName = requireNonNull(projectName, "projectName");
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
+        this.timeoutMillis = timeoutMillis;
+        this.errorOnEntryNotFound = errorOnEntryNotFound;
 
         updateListeners = new CopyOnWriteArrayList<>();
         state = new AtomicReference<>(State.INIT);
@@ -187,6 +192,13 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     public void watch(BiConsumer<? super Revision, ? super T> listener, Executor executor) {
         requireNonNull(listener, "listener");
         checkState(!isStopped(), "watcher closed");
+        if (!initialValueFuture.isDone() && errorOnEntryNotFound) {
+            logger.warn("If entry doesn't not exist, this watch is not working. "
+                        + "Please check 'initialValueFuture()' is completed without any exception. "
+                        + "Recommend to handle this method using 'initialValueFuture()', "
+                        + "if you to need the error that entry doesn't exist.");
+        }
+
         updateListeners.add(new SimpleImmutableEntry<>(listener, executor));
 
         if (latest != null) {
@@ -230,18 +242,19 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
         }
 
         final Revision lastKnownRevision = latest != null ? latest.revision() : Revision.INIT;
-        final CompletableFuture<Latest<T>> f = doWatch(client, projectName, repositoryName, lastKnownRevision);
+        final CompletableFuture<Latest<T>> f = doWatch(
+                client, projectName, repositoryName, lastKnownRevision, timeoutMillis,
+                !initialValueFuture.isDone() ? errorOnEntryNotFound : false);
 
         currentWatchFuture = f;
         f.whenComplete((result, cause) -> currentWatchFuture = null)
          .thenAccept(newLatest -> {
              if (newLatest != null) {
-                 final Latest<T> oldLatest = latest;
                  latest = newLatest;
                  logger.debug("watcher noticed updated file {}/{}{}: rev={}",
                               projectName, repositoryName, pathPattern, newLatest.revision());
                  notifyListeners();
-                 if (oldLatest == null) {
+                 if (!initialValueFuture.isDone()) {
                      initialValueFuture.complete(newLatest);
                  }
              }
@@ -255,6 +268,11 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
                  boolean logged = false;
                  if (cause instanceof CentralDogmaException) {
                      if (cause instanceof EntryNotFoundException) {
+                         if (!initialValueFuture.isDone() && errorOnEntryNotFound) {
+                             initialValueFuture.completeExceptionally(thrown);
+                             close();
+                             return null;
+                         }
                          logger.info("{}/{}{} does not exist yet; trying again",
                                      projectName, repositoryName, pathPattern);
                          logged = true;
@@ -287,7 +305,8 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
     }
 
     protected abstract CompletableFuture<Latest<T>> doWatch(
-            CentralDogma client, String projectName, String repositoryName, Revision lastKnownRevision);
+            CentralDogma client, String projectName, String repositoryName, Revision lastKnownRevision,
+            long timeoutMillis, boolean errorOnEntryNotFound);
 
     private void notifyListeners() {
         if (isStopped()) {

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/FileWatcher.java
@@ -39,9 +39,11 @@ public final class FileWatcher<T> extends AbstractWatcher<T> {
     public <U> FileWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
                            Executor callbackExecutor,
                            String projectName, String repositoryName,
-                           Query<U> query, Function<? super U, ? extends T> function) {
+                           Query<U> query, Function<? super U, ? extends T> function,
+                           long timeoutMillis, boolean errorOnEntryNotFound) {
 
-        super(client, watchScheduler, projectName, repositoryName, requireNonNull(query, "query").path());
+        super(client, watchScheduler, projectName, repositoryName, requireNonNull(query, "query").path(),
+              timeoutMillis, errorOnEntryNotFound);
         this.query = query;
         this.function = unsafeCast(requireNonNull(function, "function"));
         this.callbackExecutor = requireNonNull(callbackExecutor, "callbackExecutor");
@@ -49,8 +51,10 @@ public final class FileWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision) {
-        return client.watchFile(projectName, repositoryName, lastKnownRevision, query)
+                                                   String repositoryName, Revision lastKnownRevision,
+                                                   long timeoutMillis, boolean errorOnEntryNotFound) {
+        return client.watchFile(projectName, repositoryName, lastKnownRevision, query, timeoutMillis,
+                                errorOnEntryNotFound)
                      .thenApplyAsync(result -> {
                          if (result == null) {
                              return null;

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -429,7 +429,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     @Override
     public CompletableFuture<Revision> watchRepository(
             String projectName, String repositoryName, Revision lastKnownRevision,
-            String pathPattern, long timeoutMillis) {
+            String pathPattern, long timeoutMillis, boolean errorOnEntryNotFound) {
 
         return normalizeRevisionAndExecuteWithRetries(
                 projectName, repositoryName, lastKnownRevision,
@@ -437,7 +437,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public CompletableFuture<Revision> apply(Revision normLastKnownRevision) {
                         return delegate.watchRepository(projectName, repositoryName, normLastKnownRevision,
-                                                        pathPattern, timeoutMillis)
+                                                        pathPattern, timeoutMillis, errorOnEntryNotFound)
                                        .thenApply(newLastKnownRevision -> {
                                            if (newLastKnownRevision != null) {
                                                updateLatestKnownRevision(projectName, repositoryName,
@@ -450,7 +450,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchRepository(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + pathPattern + ", " + timeoutMillis + ')';
+                               lastKnownRevision + ", " + pathPattern + ", " + timeoutMillis + ", "
+                               + errorOnEntryNotFound + ')';
                     }
                 });
     }
@@ -458,7 +459,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     @Override
     public <T> CompletableFuture<Entry<T>> watchFile(
             String projectName, String repositoryName, Revision lastKnownRevision,
-            Query<T> query, long timeoutMillis) {
+            Query<T> query, long timeoutMillis, boolean errorOnEntryNotFound) {
 
         return normalizeRevisionAndExecuteWithRetries(
                 projectName, repositoryName, lastKnownRevision,
@@ -466,7 +467,7 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public CompletableFuture<Entry<T>> apply(Revision normLastKnownRevision) {
                         return delegate.watchFile(projectName, repositoryName, normLastKnownRevision,
-                                                  query, timeoutMillis)
+                                                  query, timeoutMillis, errorOnEntryNotFound)
                                        .thenApply(entry -> {
                                            if (entry != null) {
                                                updateLatestKnownRevision(projectName, repositoryName,
@@ -479,7 +480,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchFile(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + query + ", " + timeoutMillis + ')';
+                               lastKnownRevision + ", " + query + ", " + timeoutMillis + ", "
+                               + errorOnEntryNotFound + ')';
                     }
                 });
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -450,8 +450,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchRepository(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + pathPattern + ", " + timeoutMillis + ", "
-                               + errorOnEntryNotFound + ')';
+                               lastKnownRevision + ", " + pathPattern + ", " + timeoutMillis + ", " +
+                               errorOnEntryNotFound + ')';
                     }
                 });
     }
@@ -480,8 +480,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                     @Override
                     public String toString() {
                         return "watchFile(" + projectName + ", " + repositoryName + ", " +
-                               lastKnownRevision + ", " + query + ", " + timeoutMillis + ", "
-                               + errorOnEntryNotFound + ')';
+                               lastKnownRevision + ", " + query + ", " + timeoutMillis + ", " +
+                               errorOnEntryNotFound + ')';
                     }
                 });
     }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
+import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Revision;
 
 public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
@@ -37,8 +38,10 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
     public RepositoryWatcher(CentralDogma client, ScheduledExecutorService watchScheduler,
                              Executor callbackExecutor,
                              String projectName, String repositoryName,
-                             String pathPattern, Function<Revision, ? extends T> function) {
-        super(client, watchScheduler, projectName, repositoryName, pathPattern);
+                             String pathPattern, Function<Revision, ? extends T> function,
+                             long timeoutMillis, boolean errorOnEntryNotFound) {
+        super(client, watchScheduler, projectName, repositoryName, pathPattern, timeoutMillis,
+              errorOnEntryNotFound);
         this.pathPattern = requireNonNull(pathPattern, "pathPattern");
         this.function = requireNonNull(function, "function");
         this.callbackExecutor = requireNonNull(callbackExecutor, "callbackExecutor");
@@ -46,8 +49,10 @@ public final class RepositoryWatcher<T> extends AbstractWatcher<T> {
 
     @Override
     protected CompletableFuture<Latest<T>> doWatch(CentralDogma client, String projectName,
-                                                   String repositoryName, Revision lastKnownRevision) {
-        return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern)
+                                                   String repositoryName, Revision lastKnownRevision,
+                                                   long timeoutMillis, boolean errorOnEntryNotFound) {
+        return client.watchRepository(projectName, repositoryName, lastKnownRevision, pathPattern,
+                                      timeoutMillis, errorOnEntryNotFound)
                      .thenApplyAsync(revision -> {
                          if (revision == null) {
                              return null;

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/RepositoryWatcher.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
-import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Revision;
 
 public final class RepositoryWatcher<T> extends AbstractWatcher<T> {

--- a/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogmaTest.java
@@ -20,6 +20,7 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
@@ -323,16 +324,16 @@ class ReplicationLagTolerantCentralDogmaTest {
         final Revision latestRevision = new Revision(3);
         when(delegate.normalizeRevision(any(), any(), any()))
                 .thenReturn(completedFuture(Revision.INIT));
-        when(delegate.watchRepository(any(), any(), any(), any(), anyLong()))
+        when(delegate.watchRepository(any(), any(), any(), any(), anyLong(), anyBoolean()))
                 .thenReturn(completedFuture(latestRevision));
 
-        assertThat(dogma.watchRepository("foo", "bar", Revision.INIT, "/**", 10000L).join())
+        assertThat(dogma.watchRepository("foo", "bar", Revision.INIT, "/**", 10000L, false).join())
                 .isEqualTo(latestRevision);
 
         assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
 
         verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.INIT);
-        verify(delegate, times(1)).watchRepository("foo", "bar", Revision.INIT, "/**", 10000L);
+        verify(delegate, times(1)).watchRepository("foo", "bar", Revision.INIT, "/**", 10000L, false);
         verifyNoMoreInteractions(delegate);
         reset(delegate);
 
@@ -358,16 +359,17 @@ class ReplicationLagTolerantCentralDogmaTest {
         final Entry<String> latestEntry = Entry.ofText(latestRevision, "/a.txt", "a");
         when(delegate.normalizeRevision(any(), any(), any()))
                 .thenReturn(completedFuture(Revision.INIT));
-        when(delegate.watchFile(any(), any(), any(), (Query<String>) any(), anyLong()))
+        when(delegate.watchFile(any(), any(), any(), (Query<String>) any(), anyLong(), anyBoolean()))
                 .thenReturn(completedFuture(latestEntry));
 
-        assertThat(dogma.watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L).join())
+        assertThat(dogma.watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L, false).join())
                 .isEqualTo(latestEntry);
 
         assertThat(dogma.latestKnownRevision("foo", "bar")).isEqualTo(latestRevision);
 
         verify(delegate, times(1)).normalizeRevision("foo", "bar", Revision.INIT);
-        verify(delegate, times(1)).watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L);
+        verify(delegate, times(1)).watchFile("foo", "bar", Revision.INIT, Query.ofText("/a.txt"), 10000L,
+                                             false);
         verifyNoMoreInteractions(delegate);
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -290,11 +290,9 @@ class WatchTest {
     void watchFileWithNotExistFile(ClientType clientType) {
         final CentralDogma client = clientType.client(dogma);
 
-        CompletableFuture<Entry<JsonNode>> future1 = client.watchFile(dogma.project(), dogma.repo1(),
-                                                                      Revision.HEAD,
-                                                                      Query.ofJson("/test/not_exist.json"),
-                                                                      1000, false);
-
+        final CompletableFuture<Entry<JsonNode>> future1 = client.watchFile(
+                dogma.project(), dogma.repo1(), Revision.HEAD, Query.ofJson("/test/not_exist.json"),
+                1000, false);
         assertThat(future1.join()).isNull();
 
         // Legacy client doesn't support this feature.
@@ -302,10 +300,9 @@ class WatchTest {
             return;
         }
 
-        CompletableFuture<Entry<JsonNode>> future2 = client.watchFile(dogma.project(), dogma.repo1(),
-                                                                      Revision.HEAD,
-                                                                      Query.ofJson("/test/not_exist.json"),
-                                                                      1000, true);
+        final CompletableFuture<Entry<JsonNode>> future2 = client.watchFile(
+                dogma.project(), dogma.repo1(), Revision.HEAD, Query.ofJson("/test/not_exist.json"),
+                1000, true);
         assertThatThrownBy(() -> future2.join()).getCause().isInstanceOf(EntryNotFoundException.class);
     }
 
@@ -514,8 +511,7 @@ class WatchTest {
 
         // prepare test
         final CentralDogma client = clientType.client(dogma);
-
-        String filePath = "/test/not_exist.json";
+        final String filePath = "/test/not_exist.json";
 
         // create watcher
         final Watcher<JsonNode> watcher = client.fileWatcher(dogma.project(), dogma.repo1(),
@@ -546,9 +542,8 @@ class WatchTest {
 
         // prepare test
         revertTestFiles(clientType);
-
         final CentralDogma client = clientType.client(dogma);
-        String filePath = "/test/not_exist.json";
+        final String filePath = "/test/not_exist.json";
 
         // create watcher
         final Watcher<JsonNode> watcher = client.fileWatcher(dogma.project(), dogma.repo1(),
@@ -591,7 +586,7 @@ class WatchTest {
         // prepare test
         revertTestFiles(clientType);
         final CentralDogma client = clientType.client(dogma);
-        String filePath = "/test/test2.json";
+        final String filePath = "/test/test2.json";
 
         // create watcher
         final Watcher<JsonNode> watcher = client.fileWatcher(dogma.project(), dogma.repo1(),

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -24,8 +24,6 @@ import static org.awaitility.Awaitility.await;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -41,13 +39,10 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 import com.linecorp.armeria.common.util.ThreadFactories;
-import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
 import com.linecorp.centraldogma.client.Watcher;
@@ -188,7 +183,7 @@ class WatchTest {
                                                                            1000, false);
         assertThat(future1.join()).isNull();
 
-        //Legacy client don't support this feature
+        // Legacy client doesn't support this feature.
         if (clientType == ClientType.LEGACY) {
             return;
         }
@@ -302,7 +297,7 @@ class WatchTest {
 
         assertThat(future1.join()).isNull();
 
-        //Legacy client don't support this feature
+        // Legacy client doesn't support this feature.
         if (clientType == ClientType.LEGACY) {
             return;
         }
@@ -508,9 +503,9 @@ class WatchTest {
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
-    void fileWatcher_entry_not_exist_error(ClientType clientType)
+    void fileWatcher_errorOnEntryNotFound(ClientType clientType)
             throws Exception {
-        //Legacy client don't support this feature
+        // Legacy client doesn't support this feature.
         if (clientType == ClientType.LEGACY) {
             return;
         }
@@ -528,8 +523,12 @@ class WatchTest {
                                                              blockingTaskExecutor, 100, true);
 
         // check entry does not exist when to get initial value
-        assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(
-                EntryNotFoundException.class);
+        assertThatThrownBy(watcher::awaitInitialValue)
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+        assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS))
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+        assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS, new TextNode("test")))
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
         assertThatThrownBy(() -> watcher.watch((rev, node) -> {
@@ -538,7 +537,7 @@ class WatchTest {
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
-    void fileWatcher_entry_not_exist_error_and_watch_is_not_working_if_initialValue_completed_with_exception(
+    void fileWatcher_errorOnEntryNotFound_watch_method_is_not_working(
             ClientType clientType) throws Exception {
         // Legacy client don't support this feature
         if (clientType == ClientType.LEGACY) {
@@ -582,7 +581,7 @@ class WatchTest {
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
-    void fileWatcher_entry_not_exist_error_and_file_is_removed_on_watching(ClientType clientType)
+    void fileWatcher_errorOnEntryNotFound_file_is_removed_on_watching(ClientType clientType)
             throws InterruptedException {
         // Legacy client don't support this feature
         if (clientType == ClientType.LEGACY) {
@@ -643,9 +642,9 @@ class WatchTest {
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
-    void repositoryWatcher_entry_not_exist_error(
+    void repositoryWatcher_errorOnEntryNotFound(
             ClientType clientType) {
-        //Legacy client don't support this feature
+        // Legacy client doesn't support this feature.
         if (clientType == ClientType.LEGACY) {
             return;
         }
@@ -662,8 +661,12 @@ class WatchTest {
                                                                    blockingTaskExecutor, 100, true);
 
         // check entry does not exist when to get initial value
-        assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(
-                EntryNotFoundException.class);
+        assertThatThrownBy(watcher::awaitInitialValue)
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+        assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS))
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+        assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS, Revision.INIT))
+                .getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
         assertThatThrownBy(() -> watcher.watch((rev, node) -> {
@@ -672,10 +675,8 @@ class WatchTest {
 
     @ParameterizedTest
     @EnumSource(ClientType.class)
-    void
-    repositoryWatcher_entry_not_exist_error_and_watch_not_working_if_initialVal_completed_with_exception
-            (
-                    ClientType clientType) throws Exception {
+    void repositoryWatcher_errorOnEntryNotFound_watch_method_is_not_working(ClientType clientType)
+            throws Exception {
         // Legacy client don't support this feature
         if (clientType == ClientType.LEGACY) {
             return;


### PR DESCRIPTION
### Motivation
- https://github.com/line/centraldogma/issues/532
- To-Do of https://github.com/line/centraldogma/pull/610

### Modifications
- Put value of `notify-entry-not-found` on `Prefer` request header to get error that entries are not found on watching file/repository
- Propagate error that entries are not found into `Watcher#initialValueFuture`

### Result
- You can get error on watching file/repository if the entry doesn't exist.