### PR TITLE
Fix to accept valid ETag values for watch API

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -60,9 +60,15 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
             @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
 
-        final String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
+        String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
         if (isNullOrEmpty(ifNoneMatch)) {
             return null;
+        }
+
+        if (ifNoneMatch.startsWith("\"") && ifNoneMatch.endsWith("\"")) {
+            ifNoneMatch = ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
+        } else if (ifNoneMatch.startsWith("W/\"") && ifNoneMatch.endsWith("\"")) {
+            ifNoneMatch = ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
         }
 
         final Revision lastKnownRevision = new Revision(ifNoneMatch);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -82,12 +82,12 @@ public final class WatchRequestConverter implements RequestConverterFunction {
         return new WatchRequest(lastKnownRevision, timeoutMillis, notifyEntryNotFound);
     }
 
-    // Three below cases are valid:
-    // - <revision> (for backward compatibility)
-    // - "<revision>"
-    // - W/"<revision>"
     @VisibleForTesting
     String extractRevision(String ifNoneMatch) {
+        // Three below cases are valid:
+        // - <revision> (for backward compatibility)
+        // - "<revision>"
+        // - W/"<revision>"
         if (ifNoneMatch.startsWith("\"") && ifNoneMatch.endsWith("\"") && !ifNoneMatch.equals("\"")) {
             ifNoneMatch = ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
         } else if (ifNoneMatch.startsWith("W/\"") && ifNoneMatch.endsWith("\"")

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -86,11 +86,14 @@ public final class WatchRequestConverter implements RequestConverterFunction {
         // - <revision> (for backward compatibility)
         // - "<revision>"
         // - W/"<revision>"
-        if (ifNoneMatch.startsWith("\"") && ifNoneMatch.endsWith("\"") && !ifNoneMatch.equals("\"")) {
-            ifNoneMatch = ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
-        } else if (ifNoneMatch.startsWith("W/\"") && ifNoneMatch.endsWith("\"")
-                   && !ifNoneMatch.equals("W/\"")) {
-            ifNoneMatch = ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
+        if (ifNoneMatch.length() > 1 && ifNoneMatch.charAt(0) == '"' &&
+            ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
+            return ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
+        }
+
+        if (ifNoneMatch.length() > 3 && ifNoneMatch.startsWith("W/\"") &&
+            ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
+            return ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
         }
 
         return ifNoneMatch;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -91,7 +91,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             return ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
         }
 
-        if (ifNoneMatch.length() > 3 && ifNoneMatch.startsWith("W/\"") &&
+        if (ifNoneMatch.length() > 4 && ifNoneMatch.startsWith("W/\"") &&
             ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
             return ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -53,8 +53,6 @@ public final class WatchRequestConverter implements RequestConverterFunction {
     /**
      * Converts the specified {@code request} to a {@link WatchRequest} when the request has
      * {@link HttpHeaderNames#IF_NONE_MATCH}. {@code null} otherwise.
-     *
-     * {@link HttpHeaderNames#IF_NONE_MATCH} must be integer, ETag and Weak Comparison ETag.
      */
     @Override
     @Nullable
@@ -67,9 +65,14 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             return null;
         }
 
-        if (ifNoneMatch.startsWith("\"") && ifNoneMatch.endsWith("\"")) {
+        // Three below cases are valid:
+        // - <revision> (for backward compatibility)
+        // - "<revision>"
+        // - W/"<revision>"
+        if (ifNoneMatch.startsWith("\"") && ifNoneMatch.endsWith("\"") && !ifNoneMatch.equals("\"")) {
             ifNoneMatch = ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
-        } else if (ifNoneMatch.startsWith("W/\"") && ifNoneMatch.endsWith("\"")) {
+        } else if (ifNoneMatch.startsWith("W/\"") && ifNoneMatch.endsWith("\"")
+                   && !ifNoneMatch.equals("W/\"")) {
             ifNoneMatch = ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -82,7 +82,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
     }
 
     String extractRevision(String ifNoneMatch) {
-        // Three below cases are valid:
+        // Three below cases are valid. See https://github.com/line/centraldogma/issues/415
         // - <revision> (for backward compatibility)
         // - "<revision>"
         // - W/"<revision>"

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -84,18 +84,20 @@ public final class WatchRequestConverter implements RequestConverterFunction {
 
     @VisibleForTesting
     String extractRevision(String ifNoneMatch) {
+        final int length = ifNoneMatch.length();
+
         // Three below cases are valid. See https://github.com/line/centraldogma/issues/415
         // - <revision> (for backward compatibility)
         // - "<revision>"
         // - W/"<revision>"
-        if (ifNoneMatch.length() > 2 && ifNoneMatch.charAt(0) == '"' &&
-            ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
-            return ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
+        if (length > 2 && ifNoneMatch.charAt(0) == '"' &&
+            ifNoneMatch.charAt(length - 1) == '"') {
+            return ifNoneMatch.substring(1, length - 1);
         }
 
-        if (ifNoneMatch.length() > 4 && ifNoneMatch.startsWith("W/\"") &&
-            ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
-            return ifNoneMatch.substring(3, ifNoneMatch.length() - 1);
+        if (length > 4 && ifNoneMatch.startsWith("W/\"") &&
+            ifNoneMatch.charAt(length - 1) == '"') {
+            return ifNoneMatch.substring(3, length - 1);
         }
 
         return ifNoneMatch;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -81,6 +81,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
         return new WatchRequest(lastKnownRevision, timeoutMillis, notifyEntryNotFound);
     }
 
+    @VisibleForTesting
     String extractRevision(String ifNoneMatch) {
         // Three below cases are valid. See https://github.com/line/centraldogma/issues/415
         // - <revision> (for backward compatibility)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -60,7 +60,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
             ServiceRequestContext ctx, AggregatedHttpRequest request, Class<?> expectedResultType,
             @Nullable ParameterizedType expectedParameterizedResultType) throws Exception {
 
-        String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
+        final String ifNoneMatch = request.headers().get(HttpHeaderNames.IF_NONE_MATCH);
         if (isNullOrEmpty(ifNoneMatch)) {
             return null;
         }
@@ -80,7 +80,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
 
         return new WatchRequest(lastKnownRevision, timeoutMillis, notifyEntryNotFound);
     }
-    
+
     String extractRevision(String ifNoneMatch) {
         // Three below cases are valid:
         // - <revision> (for backward compatibility)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -27,7 +27,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Splitter;
 
@@ -81,8 +80,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
 
         return new WatchRequest(lastKnownRevision, timeoutMillis, notifyEntryNotFound);
     }
-
-    @VisibleForTesting
+    
     String extractRevision(String ifNoneMatch) {
         // Three below cases are valid:
         // - <revision> (for backward compatibility)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -53,6 +53,8 @@ public final class WatchRequestConverter implements RequestConverterFunction {
     /**
      * Converts the specified {@code request} to a {@link WatchRequest} when the request has
      * {@link HttpHeaderNames#IF_NONE_MATCH}. {@code null} otherwise.
+     *
+     * {@link HttpHeaderNames#IF_NONE_MATCH} must be integer, ETag and Weak Comparison ETag.
      */
     @Override
     @Nullable

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverter.java
@@ -86,7 +86,7 @@ public final class WatchRequestConverter implements RequestConverterFunction {
         // - <revision> (for backward compatibility)
         // - "<revision>"
         // - W/"<revision>"
-        if (ifNoneMatch.length() > 1 && ifNoneMatch.charAt(0) == '"' &&
+        if (ifNoneMatch.length() > 2 && ifNoneMatch.charAt(0) == '"' &&
             ifNoneMatch.charAt(ifNoneMatch.length() - 1) == '"') {
             return ifNoneMatch.substring(1, ifNoneMatch.length() - 1);
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -18,8 +18,6 @@ package com.linecorp.centraldogma.server.internal.api.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import javax.annotation.Nullable;
 
@@ -129,13 +127,11 @@ class WatchRequestConverterTest {
 
     @Test
     void emptyHeader() throws Exception {
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");
+        final HttpRequest request = HttpRequest.of(headers);
+        final ServiceRequestContext ctx = ServiceRequestContext.of(request);
 
-        when(request.headers()).thenReturn(headers);
-
-        final WatchRequest watchRequest = convert(ctx, request);
+        final WatchRequest watchRequest = convert(ctx, request.aggregate().join());
         assertThat(watchRequest).isNull();
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -81,7 +81,7 @@ class WatchRequestConverterTest {
         final String eighthRevision = converter.extractRevision(eighthIfNoneMatch);
         assertThat(eighthRevision).isEqualTo(eighthIfNoneMatch);
     }
-    
+
     @Test
     void emptyHeader() throws Exception {
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/");

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.api.converter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import com.linecorp.armeria.common.AggregatedHttpRequest;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Revision;
@@ -37,48 +39,92 @@ class WatchRequestConverterTest {
     private static final WatchRequestConverter converter = new WatchRequestConverter();
 
     @Test
-    void convertToWatchRequest() throws Exception {
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/",
-                                                         HttpHeaderNames.IF_NONE_MATCH, "-1",
-                                                         HttpHeaderNames.PREFER, "wait=10");
-        when(request.headers()).thenReturn(headers);
+    void convertRequestWithValidInNoneMatcherHeaderToWatchRequest() throws Exception {
+        final RequestHeaders firstHeaders = RequestHeaders.of(HttpMethod.GET, "/",
+                                                              HttpHeaderNames.IF_NONE_MATCH, "-1",
+                                                              HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest firstRequest = HttpRequest.of(firstHeaders);
+        final ServiceRequestContext firstCtx = ServiceRequestContext.of(firstRequest);
 
-        final WatchRequest watchRequest = convert(ctx, request);
-        assertThat(watchRequest).isNotNull();
-        assertThat(watchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
-        assertThat(watchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
+        final WatchRequest firstWatchRequest = convert(firstCtx, firstRequest.aggregate().join());
+        assertThat(firstWatchRequest).isNotNull();
+        assertThat(firstWatchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
+        assertThat(firstWatchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
+
+        final RequestHeaders secondHeaders = RequestHeaders.of(HttpMethod.GET, "/",
+                                                               HttpHeaderNames.IF_NONE_MATCH, "\"-1\"",
+                                                               HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest secondRequest = HttpRequest.of(secondHeaders);
+        final ServiceRequestContext secondCtx = ServiceRequestContext.of(secondRequest);
+
+        final WatchRequest secondWatchRequest = convert(secondCtx, secondRequest.aggregate().join());
+        assertThat(secondWatchRequest).isNotNull();
+        assertThat(secondWatchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
+        assertThat(secondWatchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
+
+        final RequestHeaders thirdHeaders = RequestHeaders.of(HttpMethod.GET, "/",
+                                                              HttpHeaderNames.IF_NONE_MATCH, "W/\"-1\"",
+                                                              HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest thirdRequest = HttpRequest.of(thirdHeaders);
+        final ServiceRequestContext thirdCtx = ServiceRequestContext.of(thirdRequest);
+
+        final WatchRequest thirdWatchRequest = convert(thirdCtx, thirdRequest.aggregate().join());
+        assertThat(thirdWatchRequest).isNotNull();
+        assertThat(thirdWatchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
+        assertThat(thirdWatchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
     }
 
     @Test
-    void convertRequestWithETaggedIfNoneMatchHeaderToWatchRequest() throws Exception {
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/",
-                                                         HttpHeaderNames.IF_NONE_MATCH, "\"-1\"",
-                                                         HttpHeaderNames.PREFER, "wait=10");
-        when(request.headers()).thenReturn(headers);
+    void convertRequestWithInvalidInNoneMatcherHeaderToWatchRequest() {
+        final RequestHeaders firstInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "w/\"-1\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest firstInvalidRequest = HttpRequest.of(firstInvalidHeaders);
+        final ServiceRequestContext firstCtx = ServiceRequestContext.of(firstInvalidRequest);
 
-        final WatchRequest watchRequest = convert(ctx, request);
-        assertThat(watchRequest).isNotNull();
-        assertThat(watchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
-        assertThat(watchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
-    }
+        assertThatThrownBy(() -> convert(firstCtx, firstInvalidRequest.aggregate().join()))
+                .isInstanceOf(IllegalArgumentException.class);
 
-    @Test
-    void convertRequestWithWeakComparisonETaggedIfNoneMatchHeaderToWatchRequest() throws Exception {
-        final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-        final AggregatedHttpRequest request = mock(AggregatedHttpRequest.class);
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET, "/",
-                                                         HttpHeaderNames.IF_NONE_MATCH, "W/\"-1\"",
-                                                         HttpHeaderNames.PREFER, "wait=10");
-        when(request.headers()).thenReturn(headers);
+        final RequestHeaders secondInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "W\"-1\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest secondInvalidRequest = HttpRequest.of(secondInvalidHeaders);
+        final ServiceRequestContext secondCtx = ServiceRequestContext.of(secondInvalidRequest);
 
-        final WatchRequest watchRequest = convert(ctx, request);
-        assertThat(watchRequest).isNotNull();
-        assertThat(watchRequest.lastKnownRevision()).isEqualTo(Revision.HEAD);
-        assertThat(watchRequest.timeoutMillis()).isEqualTo(10000); // 10 seconds
+        assertThatThrownBy(() -> convert(secondCtx, secondInvalidRequest.aggregate().join()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final RequestHeaders thirdInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "/\"-1\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest thirdInvalidRequest = HttpRequest.of(thirdInvalidHeaders);
+        final ServiceRequestContext thirdCtx = ServiceRequestContext.of(thirdInvalidRequest);
+
+        assertThatThrownBy(() -> convert(thirdCtx, thirdInvalidRequest.aggregate().join()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final RequestHeaders fourthInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "-1\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest fourthInvalidRequest = HttpRequest.of(fourthInvalidHeaders);
+        final ServiceRequestContext fourthCtx = ServiceRequestContext.of(fourthInvalidRequest);
+
+        assertThatThrownBy(() -> convert(fourthCtx, fourthInvalidRequest.aggregate().join()))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final RequestHeaders fifthInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "\"-1",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final HttpRequest fifthInvalidRequest = HttpRequest.of(fifthInvalidHeaders);
+        final ServiceRequestContext fifthCtx = ServiceRequestContext.of(fifthInvalidRequest);
+
+        assertThatThrownBy(() -> convert(fifthCtx, fifthInvalidRequest.aggregate().join()))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -96,6 +142,6 @@ class WatchRequestConverterTest {
     @Nullable
     private static WatchRequest convert(
             ServiceRequestContext ctx, AggregatedHttpRequest request) throws Exception {
-        return (WatchRequest) converter.convertRequest(ctx, request, null, null);
+        return converter.convertRequest(ctx, request, null, null);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -76,6 +76,10 @@ class WatchRequestConverterTest {
         final String seventhIfNoneMatch = "\"";
         final String seventhRevision = converter.extractRevision(seventhIfNoneMatch);
         assertThat(seventhRevision).isEqualTo(seventhIfNoneMatch);
+
+        final String eighthIfNoneMatch = "\"\"";
+        final String eighthRevision = converter.extractRevision(eighthIfNoneMatch);
+        assertThat(eighthRevision).isEqualTo(eighthIfNoneMatch);
     }
     
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/WatchRequestConverterTest.java
@@ -122,6 +122,27 @@ class WatchRequestConverterTest {
 
         assertThatThrownBy(() -> convert(fifthCtx, fifthInvalidRequest))
                 .isInstanceOf(IllegalArgumentException.class);
+
+        final RequestHeaders sixthInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "W/\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final AggregatedHttpRequest sixthInvalidRequest = AggregatedHttpRequest.of(sixthInvalidHeaders);
+        final ServiceRequestContext sixthCtx = ServiceRequestContext.of(sixthInvalidRequest.toHttpRequest());
+
+        assertThatThrownBy(() -> convert(sixthCtx, sixthInvalidRequest))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        final RequestHeaders seventhInvalidHeaders =
+                RequestHeaders.of(HttpMethod.GET, "/",
+                                  HttpHeaderNames.IF_NONE_MATCH, "\"",
+                                  HttpHeaderNames.PREFER, "wait=10");
+        final AggregatedHttpRequest seventhInvalidRequest = AggregatedHttpRequest.of(seventhInvalidHeaders);
+        final ServiceRequestContext seventhCtx =
+                ServiceRequestContext.of(seventhInvalidRequest.toHttpRequest());
+
+        assertThatThrownBy(() -> convert(seventhCtx, seventhInvalidRequest))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test


### PR DESCRIPTION
Motivation:

- `If-None-Match` is often used with `ETag`. Let centraldogma also allow valid `ETag`.

Modifications:

- Parse `ETag` to interpretable `Revision` parameter.

Result:

- Closes #415
