### PR TITLE
Execute mapper only once when the child watcher gets notified

### DIFF
--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/TransformingWatcherTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/TransformingWatcherTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.client.armeria;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.Watcher;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class TransformingWatcherTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("foo").join();
+            client.createRepository("foo", "bar").join();
+            client.push("foo", "bar", Revision.HEAD,
+                        "Add baz.txt", Change.ofTextUpsert("/baz.txt", "")).join();
+        }
+    };
+
+    @Test
+    void mapperIsCalledOnlyOnceWhenFileIsChanged() throws Exception {
+        final Watcher<String> watcher = dogma.client().fileWatcher("foo", "bar", Query.ofText("/baz.txt"));
+        assertThat(watcher.initialValueFuture().join().value()).isEmpty();
+        final AtomicInteger mapperCounter = new AtomicInteger();
+        final Watcher<Integer> childWatcher = watcher.newChild(str -> mapperCounter.getAndIncrement());
+        for (int i = 0; i < 10; i++) {
+            childWatcher.watch(value -> {
+                /* no-op */
+            });
+        }
+
+        Thread.sleep(1000);
+        // mapperCount is called for the first latest.
+        assertThat(mapperCounter.get()).isOne();
+
+        dogma.client().push("foo", "bar", Revision.HEAD, "Modify baz.txt", Change.ofTextUpsert("/baz.txt", "1"))
+             .join();
+
+        // mapperCount is called only once when the value is updated.
+        await().until(() -> mapperCounter.get() == 2);
+        Thread.sleep(1000);
+        // It's still the same.
+        assertThat(mapperCounter.get()).isEqualTo(2);
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -268,6 +268,6 @@ public interface Watcher<T> extends AutoCloseable {
     default <U> Watcher<U> newChild(Function<? super T, ? extends U> mapper, Executor mapperExecutor) {
         requireNonNull(mapper, "mapper");
         requireNonNull(mapperExecutor, "mapperExecutor");
-        return new TransformingWatcher<>(this, mapper, watchScheduler());
+        return new TransformingWatcher<>(this, mapper, mapperExecutor);
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
@@ -70,6 +71,11 @@ public interface Watcher<T> extends AutoCloseable {
             }
         });
     }
+
+    /**
+     * Returns the {@link ScheduledExecutorService} that is used to schedule watch.
+     */
+    ScheduledExecutorService watchScheduler();
 
     /**
      * Returns the {@link CompletableFuture} which is completed when the initial value retrieval is done
@@ -161,7 +167,7 @@ public interface Watcher<T> extends AutoCloseable {
     }
 
     /**
-     * Returns the latest {@link Revision} and value of {@code watchFile()} result.
+     * Returns the latest {@link Revision} and value of {@code watchFile()} or {@code watchRepository()} result.
      *
      * @throws IllegalStateException if the value is not available yet.
      *                               Use {@link #awaitInitialValue(long, TimeUnit)} first or
@@ -170,7 +176,7 @@ public interface Watcher<T> extends AutoCloseable {
     Latest<T> latest();
 
     /**
-     * Returns the latest value of {@code watchFile()} result.
+     * Returns the latest value of {@code watchFile()} or {@code watchRepository()} result.
      *
      * @throws IllegalStateException if the value is not available yet.
      *                               Use {@link #awaitInitialValue(long, TimeUnit)} first or
@@ -182,7 +188,7 @@ public interface Watcher<T> extends AutoCloseable {
     }
 
     /**
-     * Returns the latest value of {@code watchFile()} result.
+     * Returns the latest value of {@code watchFile()} or {@code watchRepository()} result.
      *
      * @param defaultValue the default value which is returned when the value is not available yet
      */
@@ -246,14 +252,22 @@ public interface Watcher<T> extends AutoCloseable {
     }
 
     /**
-     * Forks into a new {@link Watcher}, that reuses the current watcher and applies a transformation.
-     *
-     * @return A {@link Watcher} that is effectively filtering in a sense that,
-     *         its listeners are <b>not</b> notified when a change has no effect on the transformed value.
-     *         Furthermore, it does not need to be closed after use.
+     * Returns a {@link Watcher} that applies the {@link Function} for the {@link Latest#value()}.
+     * This {@link Watcher} must be closed regardless of closing the returned {@link Watcher}
+     * when it's not used anymore.
      */
-    default <U> Watcher<U> newChild(Function<T, U> transformer) {
-        requireNonNull(transformer, "transformer");
-        return new TransformingWatcher<>(this, transformer);
+    default <U> Watcher<U> newChild(Function<? super T, ? extends U> mapper) {
+        return newChild(mapper, watchScheduler());
+    }
+
+    /**
+     * Returns a {@link Watcher} that applies the {@link Function} for the {@link Latest#value()}.
+     * This {@link Watcher} must be closed regardless of closing the returned {@link Watcher}
+     * when it's not used anymore.
+     */
+    default <U> Watcher<U> newChild(Function<? super T, ? extends U> mapper, Executor mapperExecutor) {
+        requireNonNull(mapper, "mapper");
+        requireNonNull(mapperExecutor, "mapperExecutor");
+        return new TransformingWatcher<>(this, mapper, watchScheduler());
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/AbstractWatcher.java
@@ -39,6 +39,8 @@ import java.util.function.BiConsumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
 import com.linecorp.centraldogma.client.Watcher;
@@ -115,7 +117,7 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
 
     private final List<Map.Entry<BiConsumer<? super Revision, ? super T>, Executor>> updateListeners;
     private final AtomicReference<State> state;
-    private final CompletableFuture<Latest<T>> initialValueFuture;
+    private final CompletableFuture<Latest<T>> initialValueFuture = new CompletableFuture<>();
 
     private volatile Latest<T> latest;
     private volatile ScheduledFuture<?> currentScheduleFuture;
@@ -134,7 +136,11 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
 
         updateListeners = new CopyOnWriteArrayList<>();
         state = new AtomicReference<>(State.INIT);
-        initialValueFuture = new CompletableFuture<>();
+    }
+
+    @Override
+    public ScheduledExecutorService watchScheduler() {
+        return watchScheduler;
     }
 
     @Override
@@ -330,5 +336,19 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
         }
 
         close();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this).omitNullValues()
+                          .add("client", client)
+                          .add("watchScheduler", watchScheduler)
+                          .add("projectName", projectName)
+                          .add("repositoryName", repositoryName)
+                          .add("pathPattern", pathPattern)
+                          .add("timeoutMillis", timeoutMillis)
+                          .add("errorOnEntryNotFound", errorOnEntryNotFound)
+                          .add("latest", latest)
+                          .toString();
     }
 }

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -641,8 +641,9 @@ class WatchTest {
                 .getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
-        assertThatThrownBy(() -> watcher.watch((rev, node) -> {
-        })).isInstanceOf(IllegalStateException.class);
+        await().untilAsserted(() -> assertThatThrownBy(
+                () -> watcher.watch((rev, node) -> {}))
+                .isInstanceOf(IllegalStateException.class));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Motivation:
I found out while I implementing #651.
The child watcher created via `Watcher#newChild(mapper)` executes the specified mapper
every time when a listener is notified. If there are 1000 listeners, mapper is called 1000 times.
This could be a problem if the mapper has heavy logic.

Modifications:
- Execute mapper only once when the entry is changed.
- Add `Watcher.newWatcher(Function, Executor)` that executes the mapper using the executor.

Result:
- The mapper `Function` of a Child watcher is executed only once when the child watcher gets notified.