### PR TITLE
Change to return CentralDogmaRepository from client.createRepository

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -45,6 +45,7 @@ import com.spotify.futures.CompletableFutures;
 import com.linecorp.armeria.common.thrift.ThriftFuture;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.RepositoryInfo;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
@@ -101,34 +102,26 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> createProject(String projectName) {
-        return run(callback -> {
-            validateProjectName(projectName);
-            client.createProject(projectName, callback);
-        });
+        validateProjectName(projectName);
+        return run(callback -> client.createProject(projectName, callback));
     }
 
     @Override
     public CompletableFuture<Void> removeProject(String projectName) {
-        return run(callback -> {
-            validateProjectName(projectName);
-            client.removeProject(projectName, callback);
-        });
+        validateProjectName(projectName);
+        return run(callback -> client.removeProject(projectName, callback));
     }
 
     @Override
     public CompletableFuture<Void> purgeProject(String projectName) {
-        return run(callback -> {
-            validateProjectName(projectName);
-            client.purgeProject(projectName, callback);
-        });
+        validateProjectName(projectName);
+        return run(callback -> client.purgeProject(projectName, callback));
     }
 
     @Override
     public CompletableFuture<Void> unremoveProject(String projectName) {
-        return run(callback -> {
-            validateProjectName(projectName);
-            client.unremoveProject(projectName, callback);
-        });
+        validateProjectName(projectName);
+        return run(callback -> client.unremoveProject(projectName, callback));
     }
 
     @Override
@@ -143,35 +136,31 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
-    public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
-        return run(callback -> {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            client.createRepository(projectName, repositoryName, callback);
-        });
+    public CompletableFuture<CentralDogmaRepository> createRepository(String projectName,
+                                                                      String repositoryName) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        return run(callback -> client.createRepository(projectName, repositoryName, callback))
+                .thenApply(unused -> forRepo(projectName, repositoryName));
     }
 
     @Override
     public CompletableFuture<Void> removeRepository(String projectName, String repositoryName) {
-        return run(callback -> {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            client.removeRepository(projectName, repositoryName, callback);
-        });
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        return run(callback -> client.removeRepository(projectName, repositoryName, callback));
     }
 
     @Override
     public CompletableFuture<Void> purgeRepository(String projectName, String repositoryName) {
-        return run(callback -> {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            client.purgeRepository(projectName, repositoryName, callback);
-        });
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        return run(callback -> client.purgeRepository(projectName, repositoryName, callback));
     }
 
     @Override
-    public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
+    public CompletableFuture<CentralDogmaRepository> unremoveRepository(String projectName,
+                                                                        String repositoryName) {
         validateProjectAndRepositoryName(projectName, repositoryName);
-        return run(callback -> {
-            client.unremoveRepository(projectName, repositoryName, callback);
-        });
+        return run(callback -> client.unremoveRepository(projectName, repositoryName, callback))
+                .thenApply(unused -> forRepo(projectName, repositoryName));
     }
 
     @Override

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -157,7 +157,8 @@ class LegacyCentralDogmaTest {
             callback.onComplete(null);
             return null;
         }).when(iface).createRepository(anyString(), anyString(), any());
-        assertThat(client.createRepository("project", "repo").get()).isNull();
+        assertThat(client.createRepository("project", "repo").get())
+                .isEqualTo(client.forRepo("project", "repo"));
         verify(iface).createRepository(eq("project"), eq("repo"), any());
     }
 
@@ -190,7 +191,8 @@ class LegacyCentralDogmaTest {
             callback.onComplete(null);
             return null;
         }).when(iface).unremoveRepository(anyString(), anyString(), any());
-        assertThat(client.unremoveRepository("project", "repo").get()).isNull();
+        assertThat(client.unremoveRepository("project", "repo").get())
+                .isEqualTo(client.forRepo("project", "repo"));
         verify(iface).unremoveRepository(eq("project"), eq("repo"), any());
     }
 

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -73,6 +73,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.RepositoryInfo;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.AuthorizationException;
@@ -234,7 +235,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
-    public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
+    public CompletableFuture<CentralDogmaRepository> createRepository(String projectName,
+                                                                      String repositoryName) {
         try {
             validateProjectAndRepositoryName(projectName, repositoryName);
 
@@ -244,19 +246,17 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
             return client.execute(headers(HttpMethod.POST, path), toBytes(root))
                          .aggregate()
-                         .thenApply(ArmeriaCentralDogma::createRepository);
+                         .thenApply(res -> {
+                             switch (res.status().code()) {
+                                 case 200:
+                                 case 201:
+                                     return forRepo(projectName, repositoryName);
+                             }
+                             return handleErrorResponse(res);
+                         });
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
-    }
-
-    private static Void createRepository(AggregatedHttpResponse res) {
-        switch (res.status().code()) {
-            case 200:
-            case 201:
-                return null;
-        }
-        return handleErrorResponse(res);
     }
 
     @Override
@@ -304,24 +304,23 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
-    public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
+    public CompletableFuture<CentralDogmaRepository> unremoveRepository(String projectName,
+                                                                        String repositoryName) {
         try {
             validateProjectAndRepositoryName(projectName, repositoryName);
             return client.execute(headers(HttpMethod.PATCH,
                                           pathBuilder(projectName, repositoryName).toString()),
                                   UNREMOVE_PATCH)
                          .aggregate()
-                         .thenApply(ArmeriaCentralDogma::unremoveRepository);
+                         .thenApply(res -> {
+                             if (res.status().code() == 200) {
+                                 return forRepo(projectName, repositoryName);
+                             }
+                             return handleErrorResponse(res);
+                         });
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
-    }
-
-    private static Void unremoveRepository(AggregatedHttpResponse res) {
-        if (res.status().code() == 200) {
-            return null;
-        }
-        return handleErrorResponse(res);
     }
 
     @Override

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/CentralDogmaRepositoryTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/CentralDogmaRepositoryTest.java
@@ -48,8 +48,8 @@ class CentralDogmaRepositoryTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("foo").join();
-            client.createRepository("foo", "bar").join();
-            client.forRepo("foo", "bar")
+            client.createRepository("foo", "bar")
+                  .join()
                   .commit("commit2", ImmutableList.of(Change.ofJsonUpsert("/foo.json", "{ \"a\": \"b\" }")))
                   .push()
                   .join();

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatcherTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatcherTest.java
@@ -37,8 +37,8 @@ class WatcherTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("foo").join();
-            client.createRepository("foo", "bar").join();
-            client.forRepo("foo", "bar")
+            client.createRepository("foo", "bar")
+                  .join()
                   .commit("Add baz.txt", Change.ofTextUpsert("/baz.txt", ""))
                   .push().join();
         }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -93,7 +93,7 @@ public interface CentralDogma {
     /**
      * Creates a repository.
      */
-    CompletableFuture<Void> createRepository(String projectName, String repositoryName);
+    CompletableFuture<CentralDogmaRepository> createRepository(String projectName, String repositoryName);
 
     /**
      * Removes a repository. A removed repository can be unremoved using
@@ -109,7 +109,7 @@ public interface CentralDogma {
     /**
      * Unremoves a repository.
      */
-    CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName);
+    CompletableFuture<CentralDogmaRepository> unremoveRepository(String projectName, String repositoryName);
 
     /**
      * Retrieves the list of the repositories.

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
@@ -17,9 +17,11 @@ package com.linecorp.centraldogma.client;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.common.Change;
@@ -280,5 +282,34 @@ public final class CentralDogmaRepository {
     public WatcherRequest<Revision> watcher(PathPattern pathPattern) {
         requireNonNull(pathPattern, "pathPattern");
         return new WatcherRequest<>(this, pathPattern, blockingTaskExecutor);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CentralDogmaRepository)) {
+            return false;
+        }
+        final CentralDogmaRepository that = (CentralDogmaRepository) o;
+        return centralDogma == that.centralDogma &&
+               projectName.equals(that.projectName) && repositoryName.equals(that.repositoryName) &&
+               blockingTaskExecutor == that.blockingTaskExecutor;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(centralDogma, projectName, repositoryName, blockingTaskExecutor);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("centralDogma", centralDogma)
+                          .add("projectName", projectName)
+                          .add("repositoryName", repositoryName)
+                          .add("blockingTaskExecutor", blockingTaskExecutor)
+                          .toString();
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -46,6 +46,7 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.RepositoryInfo;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
@@ -132,7 +133,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     }
 
     @Override
-    public CompletableFuture<Void> createRepository(String projectName, String repositoryName) {
+    public CompletableFuture<CentralDogmaRepository> createRepository(String projectName,
+                                                                      String repositoryName) {
         return delegate.createRepository(projectName, repositoryName);
     }
 
@@ -147,7 +149,8 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     }
 
     @Override
-    public CompletableFuture<Void> unremoveRepository(String projectName, String repositoryName) {
+    public CompletableFuture<CentralDogmaRepository> unremoveRepository(String projectName,
+                                                                        String repositoryName) {
         return delegate.unremoveRepository(projectName, repositoryName);
     }
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CentralDogmaEndpointGroupTest.java
@@ -67,8 +67,8 @@ class CentralDogmaEndpointGroupTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("directory").join();
-            client.createRepository("directory", "my-service").join();
-            client.forRepo("directory", "my-service")
+            client.createRepository("directory", "my-service")
+                  .join()
                   .commit("commit", Change.ofJsonUpsert("/endpoint.json", HOST_AND_PORT_LIST_JSON))
                   .push()
                   .join();

--- a/it/src/test/java/com/linecorp/centraldogma/it/ClientType.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/ClientType.java
@@ -22,6 +22,7 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 enum ClientType {
+    @SuppressWarnings("unused")
     DEFAULT(CentralDogmaExtension::client),
     LEGACY(CentralDogmaExtension::legacyClient);
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/MergeFileTest.java
@@ -46,8 +46,8 @@ class MergeFileTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("myPro").join();
-            client.createRepository("myPro", "myRepo").join();
-            client.forRepo("myPro", "myRepo")
+            client.createRepository("myPro", "myRepo")
+                  .join()
                   .commit("Initial files",
                           Change.ofJsonUpsert("/foo.json", "{ \"a\": \"bar\" }"),
                           Change.ofJsonUpsert("/foo1.json", "{ \"b\": \"baz\" }"),

--- a/it/src/test/java/com/linecorp/centraldogma/it/PrematureClientFactoryCloseTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/PrematureClientFactoryCloseTest.java
@@ -43,8 +43,8 @@ class PrematureClientFactoryCloseTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("foo").join();
-            client.createRepository("foo", "bar").join();
-            client.forRepo("foo", "bar")
+            client.createRepository("foo", "bar")
+                  .join()
                   .commit("Add baz.txt", Change.ofTextUpsert("/baz.txt", ""))
                   .push().join();
         }

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -34,10 +34,10 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -546,10 +546,9 @@ class WatchTest {
         watcher2.close();
     }
 
-    @ParameterizedTest
-    @EnumSource(value = ClientType.class, mode = Mode.EXCLUDE, names = "LEGACY")
-    void fileWatcher_errorOnEntryNotFound(ClientType clientType) {
-        // prepare test
+    @Test
+    void fileWatcher_errorOnEntryNotFound() {
+        final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
         final CentralDogma client = clientType.client(dogma);
         final String filePath = "/test_not_found/test.json";
@@ -570,15 +569,14 @@ class WatchTest {
                 .getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
-        assertThatThrownBy(() -> watcher.watch((rev, node) -> {
-        })).isInstanceOf(IllegalStateException.class);
+        await().untilAsserted(() -> assertThatThrownBy(() -> watcher.watch((rev, node) -> { /* no-op */ }))
+                .isInstanceOf(IllegalStateException.class));
         watcher.close();
     }
 
-    @ParameterizedTest
-    @EnumSource(value = ClientType.class, mode = Mode.EXCLUDE, names = "LEGACY")
-    void fileWatcher_errorOnEntryNotFound_watchIsNotWorking(ClientType clientType) throws Exception {
-        // prepare test
+    @Test
+    void fileWatcher_errorOnEntryNotFound_watchIsNotWorking() throws Exception {
+        final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
         final CentralDogma client = clientType.client(dogma);
         final String filePath = "/test_not_found/test.json";
@@ -617,10 +615,9 @@ class WatchTest {
         watcher.close();
     }
 
-    @ParameterizedTest
-    @EnumSource(value = ClientType.class, mode = Mode.EXCLUDE, names = "LEGACY")
-    void fileWatcher_errorOnEntryNotFound_EntryIsRemovedOnWatching(ClientType clientType) throws Exception {
-        // prepare test
+    @Test
+    void fileWatcher_errorOnEntryNotFound_EntryIsRemovedOnWatching() throws Exception {
+        final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
         final CentralDogma client = clientType.client(dogma);
         final String filePath = "/test/test2.json";
@@ -682,10 +679,9 @@ class WatchTest {
         watcher.close();
     }
 
-    @ParameterizedTest
-    @EnumSource(value = ClientType.class, mode = Mode.EXCLUDE, names = "LEGACY")
-    void repositoryWatcher_errorOnEntryNotFound(ClientType clientType) {
-        // prepare test
+    @Test
+    void repositoryWatcher_errorOnEntryNotFound() {
+        final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
         final CentralDogma client = clientType.client(dogma);
         final String pathPattern = "/test_not_found/**";
@@ -706,18 +702,14 @@ class WatchTest {
                 .getRootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
-        await().untilAsserted(() -> assertThatThrownBy(
-                () -> watcher.watch((rev, node) -> {
-                }))
+        await().untilAsserted(() -> assertThatThrownBy(() -> watcher.watch((rev, node) -> { /* no-op */ }))
                 .isInstanceOf(IllegalStateException.class));
     }
 
-    @ParameterizedTest
-    @EnumSource(value = ClientType.class, mode = Mode.EXCLUDE, names = "LEGACY")
-    void repositoryWatcher_errorOnEntryNotFound_watchIsNotWorking(ClientType clientType) throws Exception {
-        // prepare test
+    @Test
+    void repositoryWatcher_errorOnEntryNotFound_watchIsNotWorking() throws Exception {
+        final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
-
         final CentralDogma client = clientType.client(dogma);
         final String pathPattern = "/test_not_found/**";
         final String filePath = "/test_not_found/test.json";

--- a/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ContentCompressionTest.java
@@ -66,8 +66,8 @@ class ContentCompressionTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject(PROJ).join();
-            client.createRepository(PROJ, REPO).join();
-            client.forRepo(PROJ, REPO)
+            client.createRepository(PROJ, REPO)
+                  .join()
                   .commit("Create a large file.", Change.ofTextUpsert(PATH, CONTENT))
                   .push().join();
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -38,8 +38,8 @@ class MetricsTest {
         @Override
         protected void scaffold(CentralDogma client) {
             client.createProject("foo").join();
-            client.createRepository("foo", "bar").join();
-            client.forRepo("foo", "bar")
+            client.createRepository("foo", "bar")
+                  .join()
                   .commit("Initial file", Change.ofJsonUpsert("/foo.json", "{ \"a\": \"bar\" }"))
                   .push()
                   .join();


### PR DESCRIPTION
Motivation:
We introduced `CentralDogmaRepository` class in #651 and it would be nice if we return it from
`centralDogma.createRepository(...)` so users can chain the next call.
```java
dogma.createRepository("foo", "bar)
     .join()
     .commit(...)
     .push();
```

Modifications:
- Change to return `CentralDogmaRepository` from `centralDogma.createRepository(...)` and `centralDogma.unremoveRepository(...).
- Fix flaky test in `WatchTest`.`

Result:
- (Breaking) `createRepository` and `unremoveRepository` from `CentralDogma` now returns `CentralDogmaRepository`.