### PR TITLE
Add maxCommits to CentralDogma.getHistory()

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -328,7 +328,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                                                       Revision to,
                                                       PathPattern pathPattern,
                                                       int maxCommits) {
-        // maxCommits is not supported for the legacy client.
+        checkArgument(maxCommits == 0, "maxCommits is not supported in LegacyCentralDogma.");
         validateProjectAndRepositoryName(projectName, repositoryName);
         requireNonNull(from, "from");
         requireNonNull(to, "to");
@@ -456,7 +456,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                                                        PathPattern pathPattern,
                                                        long timeoutMillis,
                                                        boolean errorOnEntryNotFound) {
-        // Legacy client does not support 'errorOnEntryNotFound'
+        checkArgument(!errorOnEntryNotFound, "errorOnEntryNotFound is not supported in LegacyCentralDogma.");
         validateProjectAndRepositoryName(projectName, repositoryName);
         requireNonNull(lastKnownRevision, "lastKnownRevision");
         requireNonNull(pathPattern, "pathPattern");
@@ -479,7 +479,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                      Revision lastKnownRevision, Query<T> query,
                                                      long timeoutMillis, boolean errorOnEntryNotFound) {
-        // Legacy client does not support 'errorOnEntryNotFound'
+        checkArgument(!errorOnEntryNotFound, "errorOnEntryNotFound is not supported in LegacyCentralDogma.");
         validateProjectAndRepositoryName(projectName, repositoryName);
         requireNonNull(lastKnownRevision, "lastKnownRevision");
         requireNonNull(query, "query");

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -326,7 +326,9 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
                                                       String repositoryName,
                                                       Revision from,
                                                       Revision to,
-                                                      PathPattern pathPattern) {
+                                                      PathPattern pathPattern,
+                                                      int maxCommits) {
+        // maxCommits is not supported for the legacy client.
         validateProjectAndRepositoryName(projectName, repositoryName);
         requireNonNull(from, "from");
         requireNonNull(to, "to");

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -102,6 +102,7 @@ import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.ShuttingDownException;
+import com.linecorp.centraldogma.internal.HistoryConstants;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.internal.api.v1.WatchTimeout;
@@ -143,9 +144,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> createProject(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
-
             final ObjectNode root = JsonNodeFactory.instance.objectNode();
             root.put("name", projectName);
 
@@ -168,8 +168,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> removeProject(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
             return client.execute(headers(HttpMethod.DELETE, pathBuilder(projectName).toString()))
                          .aggregate()
                          .thenApply(ArmeriaCentralDogma::removeProject);
@@ -189,10 +189,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> purgeProject(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
-            return client.execute(
-                    headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED).toString()))
+            return client.execute(headers(HttpMethod.DELETE, pathBuilder(projectName).append(REMOVED)
+                                                                                     .toString()))
                          .aggregate()
                          .thenApply(ArmeriaCentralDogma::handlePurgeResult);
         } catch (Exception e) {
@@ -202,8 +202,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> unremoveProject(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
             return client.execute(headers(HttpMethod.PATCH, pathBuilder(projectName).toString()),
                                   UNREMOVE_PATCH)
                          .aggregate()
@@ -237,9 +237,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<CentralDogmaRepository> createRepository(String projectName,
                                                                       String repositoryName) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-
             final String path = pathBuilder(projectName).append(REPOS).toString();
             final ObjectNode root = JsonNodeFactory.instance.objectNode();
             root.put("name", repositoryName);
@@ -261,8 +260,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> removeRepository(String projectName, String repositoryName) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
             return client.execute(headers(HttpMethod.DELETE,
                                           pathBuilder(projectName, repositoryName).toString()))
                          .aggregate()
@@ -283,8 +282,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Void> purgeRepository(String projectName, String repositoryName) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
             return client.execute(headers(HttpMethod.DELETE,
                                           pathBuilder(projectName, repositoryName).append(REMOVED).toString()))
                          .aggregate()
@@ -306,8 +305,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<CentralDogmaRepository> unremoveRepository(String projectName,
                                                                         String repositoryName) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
             return client.execute(headers(HttpMethod.PATCH,
                                           pathBuilder(projectName, repositoryName).toString()),
                                   UNREMOVE_PATCH)
@@ -325,8 +324,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Map<String, RepositoryInfo>> listRepositories(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
             return client.execute(headers(HttpMethod.GET, pathBuilder(projectName).append(REPOS).toString()))
                          .aggregate()
                          .thenApply(ArmeriaCentralDogma::listRepositories);
@@ -354,8 +353,8 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
 
     @Override
     public CompletableFuture<Set<String>> listRemovedRepositories(String projectName) {
+        validateProjectName(projectName);
         try {
-            validateProjectName(projectName);
             return client.execute(headers(HttpMethod.GET,
                                           pathBuilder(projectName).append(REPOS)
                                                                   .append(REMOVED_PARAM).toString()))
@@ -369,10 +368,9 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<Revision> normalizeRevision(String projectName, String repositoryName,
                                                          Revision revision) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(revision, "revision");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(revision, "revision");
-
             final String path = pathBuilder(projectName, repositoryName)
                     .append("/revision/")
                     .append(revision.text())
@@ -396,11 +394,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<Map<String, EntryType>> listFiles(String projectName, String repositoryName,
                                                                Revision revision, PathPattern pathPattern) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(revision, "revision");
+        requireNonNull(pathPattern, "pathPattern");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(revision, "revision");
-            requireNonNull(pathPattern, "pathPattern");
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/list").append(pathPattern.encoded()).append("?revision=").append(revision.major());
 
@@ -431,11 +428,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public <T> CompletableFuture<Entry<T>> getFile(String projectName, String repositoryName, Revision revision,
                                                    Query<T> query) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(revision, "revision");
+        requireNonNull(query, "query");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(revision, "revision");
-            requireNonNull(query, "query");
-
             // TODO(trustin) No need to normalize a revision once server response contains it.
             return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
@@ -464,11 +460,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<Map<String, Entry<?>>> getFiles(String projectName, String repositoryName,
                                                              Revision revision, PathPattern pathPattern) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(revision, "revision");
+        requireNonNull(pathPattern, "pathPattern");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(revision, "revision");
-            requireNonNull(pathPattern, "pathPattern");
-
             // TODO(trustin) No need to normalize a revision once server response contains it.
             return maybeNormalizeRevision(projectName, repositoryName, revision).thenCompose(normRev -> {
                 final StringBuilder path = pathBuilder(projectName, repositoryName);
@@ -513,11 +508,10 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public <T> CompletableFuture<MergedEntry<T>> mergeFiles(String projectName, String repositoryName,
                                                             Revision revision, MergeQuery<T> mergeQuery) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(revision, "revision");
+        requireNonNull(mergeQuery, "mergeQuery");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(revision, "revision");
-            requireNonNull(mergeQuery, "mergeQuery");
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/merge?revision=").append(revision.major());
             mergeQuery.mergeSources().forEach(
@@ -582,17 +576,23 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<List<Commit>> getHistory(String projectName, String repositoryName,
                                                       Revision from, Revision to,
-                                                      PathPattern pathPattern) {
+                                                      PathPattern pathPattern,
+                                                      int maxCommits) {
+        requireNonNull(from, "from");
+        requireNonNull(to, "to");
+        requireNonNull(pathPattern, "pathPattern");
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        checkArgument(maxCommits >= 0 && maxCommits <= HistoryConstants.MAX_MAX_COMMITS,
+                      "maxCommits: %s (expected: 0 <= maxCommits <= %s)",
+                      maxCommits, HistoryConstants.MAX_MAX_COMMITS);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(from, "from");
-            requireNonNull(to, "to");
-            requireNonNull(pathPattern, "pathPattern");
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/commits/").append(from.text());
             path.append("?to=").append(to.text());
             path.append("&path=").append(pathPattern.encoded());
+            if (maxCommits > 0) {
+                path.append("&maxCommits=").append(maxCommits);
+            }
 
             return client.execute(headers(HttpMethod.GET, path.toString()))
                          .aggregate()
@@ -625,12 +625,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public <T> CompletableFuture<Change<T>> getDiff(String projectName, String repositoryName, Revision from,
                                                     Revision to, Query<T> query) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(from, "from");
+        requireNonNull(to, "to");
+        requireNonNull(query, "query");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(from, "from");
-            requireNonNull(to, "to");
-            requireNonNull(query, "query");
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/compare");
             path.append("?path=").append(encodeParam(query.path()));
@@ -660,12 +659,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     @Override
     public CompletableFuture<List<Change<?>>> getDiff(String projectName, String repositoryName, Revision from,
                                                       Revision to, PathPattern pathPattern) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(from, "from");
+        requireNonNull(to, "to");
+        requireNonNull(pathPattern, "pathPattern");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(from, "from");
-            requireNonNull(to, "to");
-            requireNonNull(pathPattern, "pathPattern");
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/compare");
             path.append("?pathPattern=").append(pathPattern.encoded());
@@ -699,24 +697,19 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<List<Change<?>>> getPreviewDiffs(String projectName, String repositoryName,
                                                               Revision baseRevision,
                                                               Iterable<? extends Change<?>> changes) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(baseRevision, "baseRevision");
+        requireNonNull(changes, "changes");
         try {
-            try {
-                validateProjectAndRepositoryName(projectName, repositoryName);
-                requireNonNull(baseRevision, "baseRevision");
-                requireNonNull(changes, "changes");
+            final String path = pathBuilder(projectName, repositoryName)
+                    .append("/preview?revision=")
+                    .append(baseRevision.text())
+                    .toString();
 
-                final String path = pathBuilder(projectName, repositoryName)
-                        .append("/preview?revision=")
-                        .append(baseRevision.text())
-                        .toString();
-
-                final ArrayNode changesNode = toJson(changes);
-                return client.execute(headers(HttpMethod.POST, path), toBytes(changesNode))
-                             .aggregate()
-                             .thenApply(ArmeriaCentralDogma::getPreviewDiffs);
-            } catch (Exception e) {
-                return exceptionallyCompletedFuture(e);
-            }
+            final ArrayNode changesNode = toJson(changes);
+            return client.execute(headers(HttpMethod.POST, path), toBytes(changesNode))
+                         .aggregate()
+                         .thenApply(ArmeriaCentralDogma::getPreviewDiffs);
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
@@ -740,15 +733,14 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<PushResult> push(String projectName, String repositoryName, Revision baseRevision,
                                               String summary, String detail, Markup markup,
                                               Iterable<? extends Change<?>> changes) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(baseRevision, "baseRevision");
+        requireNonNull(summary, "summary");
+        checkArgument(!summary.isEmpty(), "summary is empty.");
+        requireNonNull(markup, "markup");
+        requireNonNull(changes, "changes");
+        checkArgument(!Iterables.isEmpty(changes), "changes is empty.");
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(baseRevision, "baseRevision");
-            requireNonNull(summary, "summary");
-            checkArgument(!summary.isEmpty(), "summary is empty.");
-            requireNonNull(markup, "markup");
-            requireNonNull(changes, "changes");
-            checkArgument(!Iterables.isEmpty(changes), "changes is empty.");
-
             final String path = pathBuilder(projectName, repositoryName)
                     .append("/contents?revision=")
                     .append(baseRevision.text())
@@ -794,12 +786,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     public CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                        Revision lastKnownRevision, PathPattern pathPattern,
                                                        long timeoutMillis, boolean errorOnEntryNotFound) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(lastKnownRevision, "lastKnownRevision");
+        requireNonNull(pathPattern, "pathPattern");
+        checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(lastKnownRevision, "lastKnownRevision");
-            requireNonNull(pathPattern, "pathPattern");
-            checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
-
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/contents").append(pathPattern.encoded());
 
@@ -827,11 +818,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     public <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                                      Revision lastKnownRevision, Query<T> query,
                                                      long timeoutMillis, boolean errorOnEntryNotFound) {
+        validateProjectAndRepositoryName(projectName, repositoryName);
+        requireNonNull(lastKnownRevision, "lastKnownRevision");
+        requireNonNull(query, "query");
+        checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
         try {
-            validateProjectAndRepositoryName(projectName, repositoryName);
-            requireNonNull(lastKnownRevision, "lastKnownRevision");
-            requireNonNull(query, "query");
-            checkArgument(timeoutMillis > 0, "timeoutMillis: %s (expected: > 0)", timeoutMillis);
 
             final StringBuilder path = pathBuilder(projectName, repositoryName);
             path.append("/contents").append(query.path());

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -44,6 +44,7 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryType;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
+import com.linecorp.centraldogma.internal.HistoryConstants;
 
 /**
  * Central Dogma client.
@@ -322,7 +323,27 @@ public interface CentralDogma {
     @Deprecated
     default CompletableFuture<List<Commit>> getHistory(
             String projectName, String repositoryName, Revision from, Revision to, String pathPattern) {
-        return getHistory(projectName, repositoryName, from, to, toPathPattern(pathPattern));
+        return getHistory(projectName, repositoryName, from, to, toPathPattern(pathPattern), 0);
+    }
+
+    /**
+     * Retrieves the history of the files matched by the given {@link PathPattern} between
+     * two {@link Revision}s.
+     *
+     * <p>Note that this method does not retrieve the diffs but only metadata about the changes.
+     * Use {@link DiffRequest} to retrieve the diffs.
+     *
+     * @return a {@link List} that contains the {@link Commit}s of the files matched by the given
+     *         {@link PathPattern} in the specified repository
+     *
+     * @deprecated Use {@link HistoryRequest#get(Revision, Revision)} via
+     *             {@link CentralDogmaRepository#history(PathPattern)}.
+     */
+    @Deprecated
+    default CompletableFuture<List<Commit>> getHistory(
+            String projectName, String repositoryName, Revision from, Revision to,
+            PathPattern pathPattern) {
+        return getHistory(projectName, repositoryName, from, to, pathPattern, 0);
     }
 
     /**
@@ -333,6 +354,7 @@ public interface CentralDogma {
      * CentralDogma dogma = ...
      * dogma.forRepo(projectName, repositoryName)
      *      .history(pathPattern)
+     *      .maxCommits(maxCommits)
      *      .get(from, to);
      * }</pre>
      *
@@ -343,7 +365,8 @@ public interface CentralDogma {
      *         {@link PathPattern} in the specified repository
      */
     CompletableFuture<List<Commit>> getHistory(
-            String projectName, String repositoryName, Revision from, Revision to, PathPattern pathPattern);
+            String projectName, String repositoryName, Revision from, Revision to,
+            PathPattern pathPattern, int maxCommits);
 
     /**
      * Returns the diff of a file between two {@link Revision}s. This method is a shortcut of

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -44,7 +44,6 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.QueryType;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
-import com.linecorp.centraldogma.internal.HistoryConstants;
 
 /**
  * Central Dogma client.

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
@@ -140,7 +140,7 @@ public final class CentralDogmaRepository {
      * Returns a new {@link HistoryRequest} that is used to retrieve the history of all files in the
      * Central Dogma repository.
      * Call {@link HistoryRequest#get(Revision, Revision)} to perform the same operation as
-     * {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern)}.
+     * {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern, int)}.
      */
     public HistoryRequest history() {
         return history(PathPattern.all());
@@ -150,7 +150,7 @@ public final class CentralDogmaRepository {
      * Returns a new {@link HistoryRequest} that is used to retrieve the history of files in the
      * Central Dogma repository.
      * Call {@link HistoryRequest#get(Revision, Revision)} to perform the same operation as
-     * {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern)}.
+     * {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern, int)}.
      */
     public HistoryRequest history(PathPattern pathPattern) {
         requireNonNull(pathPattern, "pathPattern");

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/HistoryRequest.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/HistoryRequest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.centraldogma.client;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
@@ -23,19 +24,34 @@ import java.util.concurrent.CompletableFuture;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.HistoryConstants;
 
 /**
- * Prepares to send a {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern)} request
- * to the Central Dogma repository.
+ * Prepares to send a {@link CentralDogma#getHistory(String, String, Revision, Revision, PathPattern, int)}
+ * request to the Central Dogma repository.
  */
 public final class HistoryRequest {
 
     private final CentralDogmaRepository centralDogmaRepo;
     private final PathPattern pathPattern;
+    private int maxCommits;
 
     HistoryRequest(CentralDogmaRepository centralDogmaRepo, PathPattern pathPattern) {
         this.centralDogmaRepo = centralDogmaRepo;
         this.pathPattern = pathPattern;
+    }
+
+    /**
+     * Sets the maximum number of commits to retrieve. {@code 0} is used by default which means retrieving
+     * all commits. The number of retrieved commits can't be greater than
+     * {@value HistoryConstants#MAX_MAX_COMMITS}.
+     */
+    public HistoryRequest maxCommits(int maxCommits) {
+        checkArgument(maxCommits >= 0 && maxCommits <= HistoryConstants.MAX_MAX_COMMITS,
+                      "maxCommits: %s (expected: 0 <= maxCommits <= %s)",
+                      maxCommits, HistoryConstants.MAX_MAX_COMMITS);
+        this.maxCommits = maxCommits;
+        return this;
     }
 
     /**
@@ -51,6 +67,6 @@ public final class HistoryRequest {
         requireNonNull(to, "to");
         return centralDogmaRepo.centralDogma().getHistory(centralDogmaRepo.projectName(),
                                                           centralDogmaRepo.repositoryName(),
-                                                          from, to, pathPattern);
+                                                          from, to, pathPattern, maxCommits);
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/HistoryRequest.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/HistoryRequest.java
@@ -42,7 +42,7 @@ public final class HistoryRequest {
     }
 
     /**
-     * Sets the maximum number of commits to retrieve. {@code 0} is used by default which means retrieving
+     * Sets the maximum number of commits to retrieve. {@code 0} is used by default which means to retreive
      * all commits. The number of retrieved commits can't be greater than
      * {@value HistoryConstants#MAX_MAX_COMMITS}.
      */

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -296,20 +296,20 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     @Override
     public CompletableFuture<List<Commit>> getHistory(
             String projectName, String repositoryName, Revision from,
-            Revision to, PathPattern pathPattern) {
+            Revision to, PathPattern pathPattern, int maxCommits) {
         return normalizeRevisionsAndExecuteWithRetries(
                 projectName, repositoryName, from, to,
                 new BiFunction<Revision, Revision, CompletableFuture<List<Commit>>>() {
                     @Override
                     public CompletableFuture<List<Commit>> apply(Revision normFromRev, Revision normToRev) {
                         return delegate.getHistory(projectName, repositoryName,
-                                                   normFromRev, normToRev, pathPattern);
+                                                   normFromRev, normToRev, pathPattern, maxCommits);
                     }
 
                     @Override
                     public String toString() {
                         return "getHistory(" + projectName + ", " + repositoryName + ", " +
-                               from + ", " + to + ", " + pathPattern + ')';
+                               from + ", " + to + ", " + pathPattern + ", " + maxCommits + ')';
                     }
                 });
     }

--- a/common/src/main/java/com/linecorp/centraldogma/internal/HistoryConstants.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/HistoryConstants.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.internal;
+
+public final class HistoryConstants {
+
+    public static final int MAX_MAX_COMMITS = 1000;
+
+    private HistoryConstants() {}
+}

--- a/it/src/test/java/com/linecorp/centraldogma/it/CacheTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CacheTest.java
@@ -117,14 +117,14 @@ class CacheTest {
 
         // Get the history in various combination of from/to revisions.
         final List<Commit> history1 =
-                client.getHistory(project, REPO_FOO, HEAD, new Revision(-2), PathPattern.all()).join();
+                client.getHistory(project, REPO_FOO, HEAD, new Revision(-2), PathPattern.all(), 0).join();
         final List<Commit> history2 =
-                client.getHistory(project, REPO_FOO, HEAD, INIT, PathPattern.all()).join();
+                client.getHistory(project, REPO_FOO, HEAD, INIT, PathPattern.all(), 0).join();
         final List<Commit> history3 =
-                client.getHistory(project, REPO_FOO, res1.revision(), new Revision(-2), PathPattern.all())
+                client.getHistory(project, REPO_FOO, res1.revision(), new Revision(-2), PathPattern.all(), 0)
                       .join();
         final List<Commit> history4 =
-                client.getHistory(project, REPO_FOO, res1.revision(), INIT, PathPattern.all()).join();
+                client.getHistory(project, REPO_FOO, res1.revision(), INIT, PathPattern.all(), 0).join();
 
         // and they should all same.
         assertThat(history1).isEqualTo(history2);

--- a/it/src/test/java/com/linecorp/centraldogma/it/FileHistoryAndDiffTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/FileHistoryAndDiffTest.java
@@ -16,11 +16,20 @@
 
 package com.linecorp.centraldogma.it;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
 
@@ -31,13 +40,44 @@ class FileHistoryAndDiffTest {
 
     // getDiff
 
-    @ParameterizedTest
-    @EnumSource(ClientType.class)
-    void getHistory(ClientType clientType) {
-        // TODO(trustin): Implement me.
-        final CentralDogma client = clientType.client(dogma);
-        System.err.println(
-                client.getHistory(dogma.project(), dogma.repo1(),
-                                  new Revision(1), Revision.HEAD, PathPattern.all()).join());
+    @Test
+    void history() {
+        final CentralDogma client = ClientType.DEFAULT.client(dogma);
+        for (int i = 0; i < 10; i++) {
+            final String path = i % 2 == 0 ? "/even_json_file.json" : "/odd_json_file.json";
+            final Change<JsonNode> change = Change.ofJsonUpsert(path, String.format("{ \"key\" : \"%d\"}", i));
+            client.forRepo(dogma.project(), dogma.repo1())
+                  .commit(String.valueOf(i), change)
+                  .push().join();
+        }
+
+        List<Commit> commits = client.forRepo(dogma.project(), dogma.repo1())
+                                     .history(PathPattern.of("/even_json_file.json"))
+                                     .get(Revision.HEAD, Revision.INIT)
+                                     .join();
+        List<Integer> summaries = extractSummaryAsInt(commits);
+        assertThat(summaries).containsExactly(8, 6, 4, 2, 0);
+
+        commits = client.forRepo(dogma.project(), dogma.repo1())
+                        .history(PathPattern.of("/even_json_file.json"))
+                        .maxCommits(3)
+                        .get(Revision.HEAD, Revision.INIT)
+                        .join();
+        summaries = extractSummaryAsInt(commits);
+        assertThat(summaries).containsExactly(8, 6, 4);
+
+        commits = client.forRepo(dogma.project(), dogma.repo1())
+                        .history(PathPattern.of("/odd_json_file.json"))
+                        .get(Revision.HEAD, Revision.INIT)
+                        .join();
+        summaries = extractSummaryAsInt(commits);
+        assertThat(summaries).containsExactly(9, 7, 5, 3, 1);
+    }
+
+    private static ImmutableList<Integer> extractSummaryAsInt(List<Commit> commits) {
+        return commits.stream()
+                      .map(Commit::summary)
+                      .map(Integer::valueOf)
+                      .collect(toImmutableList());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -54,6 +54,7 @@ import com.linecorp.centraldogma.common.QueryExecutionException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.common.RevisionRange;
+import com.linecorp.centraldogma.internal.HistoryConstants;
 import com.linecorp.centraldogma.server.command.CommitResult;
 import com.linecorp.centraldogma.server.internal.replication.ReplicationLog;
 import com.linecorp.centraldogma.server.storage.StorageException;
@@ -65,7 +66,7 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 public interface Repository {
 
     int DEFAULT_MAX_COMMITS = 100;
-    int MAX_MAX_COMMITS = 1000;
+    int MAX_MAX_COMMITS = HistoryConstants.MAX_MAX_COMMITS;
 
     String ALL_PATH = "/**";
 


### PR DESCRIPTION
Motivation:
It would be nice if we can specify the number of maximum commits for history call
as we have in Go client.

Modification:
- Add `maxCommit` parameter to `CentralDogma.getHistory()` and `maxCommit` setter to `HistoryRequest`.

Result:
- You can now limit the number of commits when retrieving the commit history.
  ```java
  centralDogma.forRepo("foo", "bar")
              .history()
              .maxCommits(5)
              .get(Revision.HEAD, Revision.INIT);
  ```