### PR TITLE
Add a workaround for `EmptyEndpointException` with `HealthCheckedEndpoint`

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.JsonNodeType;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -139,6 +140,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         super(blockingTaskExecutor);
         this.client = requireNonNull(client, "client");
         authorization = "Bearer " + requireNonNull(accessToken, "accessToken");
+    }
+
+    @VisibleForTesting
+    WebClient webClient() {
+        return client;
     }
 
     @Override


### PR DESCRIPTION
Motivation:

Even if an `EndopintGroup` resolves the initial endpoints,
EndpointSelector could continue to return a null endpoint.
See https://github.com/line/armeria/pull/3978 for the details.
The bug has been fixed in Armeria but some users who use Armeria 1.13.4
could see `EmptyEndpointException` and difficult to apply a workaround.
Because a `CentralDogma` client creates a `HealthCheckedEndpoint`
internally that users can't access.

Modifications:

- Wait for the initial endpoints before returning a new client.

Result:

- You no longer see an `EmptyEndpointException` with your `CentralDogma` client.