### PR TITLE
Add a workaround for EmptyEndpointException with `HealthCheckedEndpoint`

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -140,6 +140,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         authorization = "Bearer " + requireNonNull(accessToken, "accessToken");
     }
 
+    @VisibleForTesting
+    WebClient webClient() {
+        return client;
+    }
+
     @Override
     public CompletableFuture<Void> createProject(String projectName) {
         try {


### PR DESCRIPTION
Motivation:

Even if an `EndopintGroup` resolves the initial endpoints,
EndpointSelector could continue to return a null endpoint.
See https://github.com/line/armeria/pull/3978 the details.
The bug has been fixed in Armeria but some users whou use Armeria 1.13.4
could see `EmptyEndpointException` and difficult to apply a workaround.
Because a `HealthCheckedEndpoint` is created a `CentralDogma` client
internally.

Modifications:

- Wait for the initial endpoints before returns a new client.

Result:

- You no longer see `EmptyEndpointException` with `CentralDogma` client.