### PR TITLE
Add `whenEndpointReady()` to Central Dogma client

### DIFF
--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogma.java
@@ -76,7 +76,6 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.internal.thrift.AuthorConverter;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService;
-import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.AsyncIface;
 import com.linecorp.centraldogma.internal.thrift.ChangeConverter;
 import com.linecorp.centraldogma.internal.thrift.Comment;
 import com.linecorp.centraldogma.internal.thrift.CommitConverter;
@@ -98,7 +97,7 @@ final class LegacyCentralDogma extends AbstractCentralDogma {
     private final CentralDogmaService.AsyncIface client;
     private final EndpointGroup endpointGroup;
 
-    LegacyCentralDogma(ScheduledExecutorService blockingTaskExecutor, AsyncIface client,
+    LegacyCentralDogma(ScheduledExecutorService blockingTaskExecutor, CentralDogmaService.AsyncIface client,
                        EndpointGroup endpointGroup) {
         super(blockingTaskExecutor);
         this.client = requireNonNull(client, "client");

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
-import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -30,7 +29,6 @@ import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuild
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.internal.client.ReplicationLagTolerantCentralDogma;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.AsyncIface;
-import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.Client;
 
 /**
  * Builds a legacy {@link CentralDogma} client based on Thrift.

--- a/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
+++ b/client/java-armeria-legacy/src/main/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaBuilder.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientRequestContext;
+import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.HttpHeaderNames;
@@ -29,6 +30,7 @@ import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuild
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.internal.client.ReplicationLagTolerantCentralDogma;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.AsyncIface;
+import com.linecorp.centraldogma.internal.thrift.CentralDogmaService.Client;
 
 /**
  * Builds a legacy {@link CentralDogma} client based on Thrift.
@@ -68,7 +70,7 @@ public class LegacyCentralDogmaBuilder extends AbstractArmeriaCentralDogmaBuilde
 
         final int maxRetriesOnReplicationLag = maxNumRetriesOnReplicationLag();
         final CentralDogma dogma = new LegacyCentralDogma(blockingTaskExecutor,
-                                                          builder.build(AsyncIface.class));
+                                                          builder.build(AsyncIface.class), endpointGroup);
         if (maxRetriesOnReplicationLag <= 0) {
             return dogma;
         } else {

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.RepositoryInfo;
@@ -81,7 +82,7 @@ class LegacyCentralDogmaTest {
 
     @BeforeEach
     void setUp() {
-        client = new LegacyCentralDogma(CommonPools.blockingTaskExecutor(), iface, endpointGroup);
+        client = new LegacyCentralDogma(CommonPools.blockingTaskExecutor(), iface, EndpointGroup.of());
     }
 
     @Test

--- a/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
+++ b/client/java-armeria-legacy/src/test/java/com/linecorp/centraldogma/client/armeria/legacy/LegacyCentralDogmaTest.java
@@ -81,7 +81,7 @@ class LegacyCentralDogmaTest {
 
     @BeforeEach
     void setUp() {
-        client = new LegacyCentralDogma(CommonPools.blockingTaskExecutor(), iface);
+        client = new LegacyCentralDogma(CommonPools.blockingTaskExecutor(), iface, endpointGroup);
     }
 
     @Test

--- a/client/java-armeria/build.gradle
+++ b/client/java-armeria/build.gradle
@@ -2,4 +2,6 @@ dependencies {
     api project(':client:java')
     // Armeria
     api 'com.linecorp.armeria:armeria'
+
+    testImplementation 'com.linecorp.armeria:armeria-junit5'
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import com.google.common.collect.Iterables;
@@ -35,7 +34,6 @@ import com.linecorp.armeria.client.ClientBuilder;
 import com.linecorp.armeria.client.ClientFactory;
 import com.linecorp.armeria.client.Clients;
 import com.linecorp.armeria.client.Endpoint;
-import com.linecorp.armeria.client.endpoint.DynamicEndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
 import com.linecorp.armeria.client.endpoint.EndpointSelectionStrategy;
 import com.linecorp.armeria.client.endpoint.dns.DnsAddressEndpointGroup;

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
@@ -166,18 +166,6 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
             group = new CompositeEndpointGroup(groups, EndpointSelectionStrategy.roundRobin());
         }
 
-        if (group instanceof DynamicEndpointGroup) {
-            // Wait until the initial endpointGroup list is ready.
-            try {
-                group.whenReady().get(10, TimeUnit.SECONDS);
-            } catch (Exception e) {
-                final UnknownHostException cause = new UnknownHostException(
-                        "failed to resolve any of: " + hosts);
-                cause.initCause(e);
-                throw cause;
-            }
-        }
-
         if (!healthCheckInterval.isZero()) {
             return HealthCheckedEndpointGroup.builder(group, HttpApiV1Constants.HEALTH_CHECK_PATH)
                                              .clientFactory(clientFactory)

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -142,6 +142,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
     }
 
     @Override
+    public CompletableFuture<Void> whenEndpointReady() {
+        return client.endpointGroup().whenReady().thenRun(() -> {});
+    }
+
+    @Override
     public CompletableFuture<Void> createProject(String projectName) {
         try {
             validateProjectName(projectName);
@@ -849,11 +854,6 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         } catch (Exception e) {
             return exceptionallyCompletedFuture(e);
         }
-    }
-
-    @Override
-    public CompletableFuture<Void> whenEndpointReady() {
-        return client.endpointGroup().whenReady().thenRun(() -> {});
     }
 
     @Nullable

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogma.java
@@ -851,6 +851,11 @@ final class ArmeriaCentralDogma extends AbstractCentralDogma {
         }
     }
 
+    @Override
+    public CompletableFuture<Void> whenEndpointReady() {
+        return client.endpointGroup().whenReady().thenRun(() -> {});
+    }
+
     @Nullable
     private static <T> Entry<T> watchFile(AggregatedHttpResponse res, QueryType queryType) {
         switch (res.status().code()) {

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilderTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilderTest.java
@@ -76,9 +76,11 @@ class ArmeriaCentralDogmaBuilderTest {
         final ArmeriaCentralDogmaBuilder b = new ArmeriaCentralDogmaBuilder();
         b.healthCheckIntervalMillis(0);
         b.host("1.2.3.4.sslip.io");
-        assertThat(b.endpointGroup()).isInstanceOf(DnsAddressEndpointGroup.class);
-        assertThat(b.endpointGroup().endpoints().size()).isEqualTo(1);
-        assertThat(b.endpointGroup().endpoints().get(0).host()).isEqualTo("1.2.3.4.sslip.io");
+        final EndpointGroup endpointGroup = b.endpointGroup();
+        endpointGroup.whenReady().join();
+        assertThat(endpointGroup).isInstanceOf(DnsAddressEndpointGroup.class);
+        assertThat(endpointGroup.endpoints().size()).isEqualTo(1);
+        assertThat(endpointGroup.endpoints().get(0).host()).isEqualTo("1.2.3.4.sslip.io");
     }
 
     @Test

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WhenEndpointReadyTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WhenEndpointReadyTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.armeria;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerBuilder;
+import com.linecorp.armeria.server.annotation.decorator.LoggingDecorator;
+import com.linecorp.armeria.server.logging.LoggingService;
+import com.linecorp.armeria.testing.junit5.server.ServerExtension;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants;
+
+class WhenEndpointReadyTest {
+
+    @RegisterExtension
+    static ServerExtension server = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) {
+            sb.service(HttpApiV1Constants.HEALTH_CHECK_PATH, (ctx, req) -> {
+                return HttpResponse.from(healthFuture.thenApply(unused -> HttpResponse.of(HttpStatus.OK)));
+            });
+            sb.decorator(LoggingService.newDecorator());
+        }
+    };
+
+    private static final CompletableFuture<Void> healthFuture = new CompletableFuture<>();
+
+    @Test
+    void shouldWaitHealthCheck() throws Exception {
+        final CentralDogma centralDogma = new ArmeriaCentralDogmaBuilder()
+                .host(server.httpSocketAddress().getHostName(), server.httpPort())
+                .healthCheckIntervalMillis(500)
+                .build();
+        Thread.sleep(3000);
+        assertThat(centralDogma.whenEndpointReady()).isNotDone();
+        healthFuture.complete(null);
+        await().untilAsserted(() -> {
+            assertThat(centralDogma.whenEndpointReady()).isDone();
+        });
+    }
+}

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WhenEndpointReadyTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WhenEndpointReadyTest.java
@@ -19,17 +19,14 @@ package com.linecorp.centraldogma.client.armeria;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.net.UnknownHostException;
 import java.util.concurrent.CompletableFuture;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServerBuilder;
-import com.linecorp.armeria.server.annotation.decorator.LoggingDecorator;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.testing.junit5.server.ServerExtension;
 import com.linecorp.centraldogma.client.CentralDogma;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -815,4 +815,11 @@ public interface CentralDogma {
     @Deprecated
     <T> Watcher<T> repositoryWatcher(String projectName, String repositoryName, String pathPattern,
                                      Function<Revision, ? extends T> function, Executor executor);
+
+    /**
+     * Returns a {@link CompletableFuture} which is completed when the initial endpoints of this
+     * client are ready. It is recommended to wait for the initial endpoints in order to send the first request
+     * without additional delay.
+     */
+    CompletableFuture<Void> whenEndpointReady();
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -490,6 +490,11 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
                 });
     }
 
+    @Override
+    public CompletableFuture<Void> whenEndpointReady() {
+        return delegate.whenEndpointReady();
+    }
+
     /**
      * Normalizes the given {@link Revision} and then executes the task by calling {@code taskRunner.apply()}
      * with the normalized {@link Revision}. The task can be executed repetitively when the task failed with


### PR DESCRIPTION
Motivation:

Central Dogma client waits for the initial endpoints of a
`DynamicEndpointGroup` by default when creating a new instance.
https://github.com/line/centraldogma/blob/b167d594af5abc06af30d7d6d7d8b68b320861d8/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java#L169-L179
Some users might expect this blocking operation and want
to use Central Dogma client later when needed.

Modifications:

- Add `whenEndpointReady()` to `CentralDogma` client so that users can wait
  for the initial endpoints according to their requirement.

Result:

- Breaking) Central Dogma client no longer waits for the initial
  endpoints by default. You should use `CentralDogma.whenEndpointReady()`
  to wait for the initial endpoints.