### PR TITLE
Update dependencies

### DIFF
--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatcherTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatcherTest.java
@@ -84,7 +84,7 @@ class WatcherTest {
                                               .watcher(Query.ofText("/baz.txt"))
                                               .map(txt -> 1)
                                               .map(intValue -> Integer.toString(intValue))
-                                              .map(str -> "1".equals(str) ? true : false)
+                                              .map("1"::equals)
                                               .start();
 
         assertThat(watcher.initialValueFuture().join().value()).isTrue();
@@ -100,7 +100,7 @@ class WatcherTest {
         final Watcher<Boolean> watcher = originalWatcher
                 .newChild(txt -> 1)
                 .newChild(intValue -> Integer.toString(intValue))
-                .newChild(str -> "1".equals(str) ? true : false);
+                .newChild("1"::equals);
 
         assertThat(watcher.initialValueFuture().join().value()).isTrue();
         originalWatcher.close();

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,21 +3,21 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.13.0
-- com.linecorp.armeria:armeria-bom:1.13.4
-- io.micrometer:micrometer-bom:1.7.6
+- com.fasterxml.jackson:jackson-bom:2.13.1
+- com.linecorp.armeria:armeria-bom:1.14.0
+- io.micrometer:micrometer-bom:1.8.2
 - org.junit:junit-bom:5.8.2
 
 ch.qos.logback:
   logback-classic:
-    version: '1.2.7'
+    version: '1.2.10'
     javadocs:
-    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.7/
+    - https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.10/
 
 com.beust:
   # Please check `jcommander` version of Maven Central Repository before updating
   # https://search.maven.org/artifact/com.beust/jcommander
-  jcommander: { version: '1.81' }
+  jcommander: { version: '1.82' }
 
 com.boazj.gradle:
   gradle-log-plugin: { version: '0.1.0' }
@@ -114,7 +114,7 @@ com.linecorp.armeria:
     - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.9.0/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '9.2' }
+  checkstyle: { version: '9.2.1' }
 
 com.spotify:
   completable-futures:
@@ -169,7 +169,7 @@ net.javacrumbs.json-unit:
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.1.1' }
+  proguard-gradle: { version: '7.2.0' }
 
 # Ensure that we use the same ZooKeeper version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
@@ -203,7 +203,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.21.0' }
+  assertj-core: { version: '3.22.0' }
 
 org.awaitility:
   awaitility: { version: '4.1.1' }
@@ -225,18 +225,18 @@ org.javassist:
   javassist: { version: '3.28.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '4.1.0' }
+  mockito-core: { version: &MOCKITO_VERSION '4.3.1' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
   jetty-alpn-agent: { version: '2.0.10' }
 
 org.openjdk.jmh:
-  jmh-core: { version: &JMH_VERSION '1.33' }
+  jmh-core: { version: &JMH_VERSION '1.34' }
   jmh-generator-annprocess: { version: *JMH_VERSION }
 
 org.slf4j:
-  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.32' }
+  jcl-over-slf4j: { version: &SLF4J_VERSION '1.7.35' }
   jul-to-slf4j: { version: *SLF4J_VERSION }
   log4j-over-slf4j: { version: *SLF4J_VERSION }
   slf4j-api:
@@ -246,7 +246,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.5.5'
+    version: &SPRING_BOOT_VERSION '2.6.3'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
- Armeria 1.13.4 -> 1.14.0
- Jackson 2.13.0 -> 2.13.1
- JCommander 1.81 -> 1.82
- Logback 1.2.7 -> 1.2.10
- Micrometer 1.7.6 -> 1.8.2
- SLFJ4 1.7.32 -> 1.7.35
- Spring Boot 2.5.5 -> 2.6.3
- Build
  - AssertJ 3.21.0 -> 3.22.0
  - Checkstyle 9.2 -> 9.2.1
  - JMH 1.33 -> 1.34
  - Mocktio 4.1.0 -> 4.3.1
  - Proguard 7.1.1 -> 7.2.0