### PR TITLE
Improve the error message of an `TimeoutException` raised by `CentralDogmaBeanFactory`

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -320,7 +320,7 @@ public class CentralDogmaBeanFactory {
                     final String message =
                             "Failed to resolve the initial endpoints of the given Central Dogma client in" +
                             initialTimeoutMillis + " ms. You may want to increase 'initialValueTimeout' or " +
-                            "waiting for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
+                            "wait for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
                             "before initiating this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';
                     throw new IllegalStateException(message, ex);
                 } else {

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -321,7 +321,7 @@ public class CentralDogmaBeanFactory {
                     final String message =
                             "Failed to resolve the initial endpoints of the given Central Dogma client in " +
                             initialTimeoutMillis + " ms. You may want to increase 'initialValueTimeout' or " +
-                            "wait for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
+                            "wait for the initial endpoints using 'CentralDogma.whenEndpointReady().get()' " +
                             "before initializing this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';
                     throw new CentralDogmaException(message, ex);
                 } else {

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -322,7 +322,7 @@ public class CentralDogmaBeanFactory {
                             "Failed to resolve the initial endpoints of the given Central Dogma client in" +
                             initialTimeoutMillis + " ms. You may want to increase 'initialValueTimeout' or " +
                             "wait for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
-                            "before initiating this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';
+                            "before initializing this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';
                     throw new CentralDogmaException(message, ex);
                 } else {
                     throw ex;

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -37,6 +37,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.Latest;
 import com.linecorp.centraldogma.client.Watcher;
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Query;
 
 import javassist.util.proxy.ProxyFactory;
@@ -322,7 +323,7 @@ public class CentralDogmaBeanFactory {
                             initialTimeoutMillis + " ms. You may want to increase 'initialValueTimeout' or " +
                             "wait for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
                             "before initiating this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';
-                    throw new IllegalStateException(message, ex);
+                    throw new CentralDogmaException(message, ex);
                 } else {
                     throw ex;
                 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -319,7 +319,7 @@ public class CentralDogmaBeanFactory {
                         TimeUnit.MILLISECONDS.convert(initialValueTimeout, initialValueTimeoutUnit);
                 if (!dogma.whenEndpointReady().isDone()) {
                     final String message =
-                            "Failed to resolve the initial endpoints of the given Central Dogma client in" +
+                            "Failed to resolve the initial endpoints of the given Central Dogma client in " +
                             initialTimeoutMillis + " ms. You may want to increase 'initialValueTimeout' or " +
                             "wait for the initial endpoints using 'CentralDogma.whenEndpointReady()' " +
                             "before initializing this " + CentralDogmaBeanFactory.class.getSimpleName() + '.';


### PR DESCRIPTION
Motivation:

If an `TimeoutException` is raised by `CentralDogmaBeanFactory`,
users may be hard to figure out why the error is raised.
If the cause of the exception is raised by the unresolved endpoints,
you can provide precise messages and guides for mitigation.

Modifications:

- Provide a detailed error message when `Watcher.awaitInitialValue()`
  raises `TimeoutException` and the endpoint of `CentralDogma` is not
  resolved.

Result:

- You can see the detailed error message when `CentralDogmaBeanFactory`
  raises a `TimeoutException` because there are no endpoints in the
  client.