### PR TITLE
Fix to set the author of a repository correctly

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -133,7 +133,8 @@ public class MetadataService {
                 }
 
                 logger.warn("Adding missing repository metadata: {}/{}", projectName, repo);
-                final CompletableFuture<Revision> addRepoFuture = addRepo(Author.SYSTEM, projectName, repo);
+                final Author author = projectManager.get(projectName).repos().get(repo).author();
+                final CompletableFuture<Revision> addRepoFuture = addRepo(author, projectName, repo);
                 addRepoFuture.handle((revision, cause) -> {
                     if (cause != null) {
                         future.completeExceptionally(cause);

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -160,6 +160,7 @@ class MetadataServiceTest {
         }
         // Do not throw RedundantChangeException when the same metadata are added multiple times.
         CompletableFutures.allAsList(builder.build()).join();
+        assertThat(mds.getProject(project1).join().repo(repo2).creation().user()).isEqualTo(author.email());
     }
 
     @Test


### PR DESCRIPTION
Motivation:
The author of a repository is not set correctly to metadata when
`MetadataService.fetchMetadata()` is called before the metadata information of a repository is added.

Modification:
- Use the author of the repository to when adding the metadata of the repository.

Result:
- The repository author is now correctly set.