### PR TITLE
Add Author as a field in Repository

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
@@ -26,10 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
-
-import com.google.common.base.Throwables;
 
 import com.linecorp.armeria.common.CommonPools;
 import com.linecorp.armeria.common.RequestContext;
@@ -48,7 +45,6 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionRange;
 import com.linecorp.centraldogma.server.command.CommitResult;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
-import com.linecorp.centraldogma.server.storage.StorageException;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
@@ -60,30 +56,20 @@ final class CachingRepository implements Repository {
 
     private final Repository repo;
     private final RepositoryCache cache;
-    private final Commit firstCommit;
 
     CachingRepository(Repository repo, RepositoryCache cache) {
         this.repo = requireNonNull(repo, "repo");
         this.cache = requireNonNull(cache, "cache");
-
-        try {
-            final List<Commit> history = repo.history(Revision.INIT, Revision.INIT, ALL_PATH, 1).join();
-            firstCommit = history.get(0);
-        } catch (CompletionException e) {
-            final Throwable cause = Exceptions.peel(e);
-            Throwables.throwIfUnchecked(cause);
-            throw new StorageException("failed to retrieve the initial commit", cause);
-        }
     }
 
     @Override
     public long creationTimeMillis() {
-        return firstCommit.when();
+        return repo.creationTimeMillis();
     }
 
     @Override
     public Author author() {
-        return firstCommit.author();
+        return repo.author();
     }
 
     @Override
@@ -325,7 +311,6 @@ final class CachingRepository implements Repository {
     public String toString() {
         return toStringHelper(this)
                 .add("repo", repo)
-                .add("firstCommit", firstCommit)
                 .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -30,10 +30,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.spotify.futures.CompletableFutures;
@@ -83,30 +81,12 @@ public interface Repository {
     /**
      * Returns the creation time of this {@link Repository}.
      */
-    default long creationTimeMillis() {
-        try {
-            final List<Commit> history = history(Revision.INIT, Revision.INIT, ALL_PATH, 1).join();
-            return history.get(0).when();
-        } catch (CompletionException e) {
-            final Throwable cause = Throwables.getRootCause(e);
-            Throwables.throwIfUnchecked(cause);
-            throw new StorageException("failed to retrieve the initial commit", cause);
-        }
-    }
+    long creationTimeMillis();
 
     /**
      * Returns the author who created this {@link Repository}.
      */
-    default Author author() {
-        try {
-            final List<Commit> history = history(Revision.INIT, Revision.INIT, ALL_PATH, 1).join();
-            return history.get(0).author();
-        } catch (CompletionException e) {
-            final Throwable cause = Throwables.getRootCause(e);
-            Throwables.throwIfUnchecked(cause);
-            throw new StorageException("failed to retrieve the initial commit", cause);
-        }
-    }
+    Author author();
 
     /**
      * Returns the {@link CompletableFuture} whose value is the absolute {@link Revision} of the

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepositoryTest.java
@@ -29,7 +29,6 @@ import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
@@ -410,14 +409,8 @@ class CachingRepositoryTest {
     }
 
     private Repository newCachingRepo(MeterRegistry meterRegistry) {
-        when(delegateRepo.history(INIT, INIT, Repository.ALL_PATH, 1)).thenReturn(completedFuture(
-                ImmutableList.of(new Commit(INIT, SYSTEM, "", "", Markup.PLAINTEXT))));
-
         final Repository cachingRepo = new CachingRepository(
                 delegateRepo, new RepositoryCache("maximumSize=1000", meterRegistry));
-
-        // Verify that CachingRepository calls delegateRepo.history() once to retrieve the initial commit.
-        verify(delegateRepo, times(1)).history(INIT, INIT, Repository.ALL_PATH, 1);
 
         verifyNoMoreInteractions(delegateRepo);
         clearInvocations(delegateRepo);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitIdDatabaseTest.java
@@ -139,11 +139,11 @@ class CommitIdDatabaseTest {
         final File commitIdDatabaseFile = new File(repoDir, "commit_ids.dat");
 
         // Create a repository which contains some commits.
-        GitRepository repo = new GitRepository(mock(Project.class), repoDir, commonPool(), 0, Author.SYSTEM);
+        GitRepository repo = new GitRepository(mock(Project.class), repoDir, commonPool(), 1000, Author.SYSTEM);
         Revision headRevision = null;
         try {
             for (int i = 1; i <= numCommits; i++) {
-                headRevision = repo.commit(new Revision(i), 0, Author.SYSTEM, "",
+                headRevision = repo.commit(new Revision(i), 0, Author.DEFAULT, "",
                                            Change.ofTextUpsert("/" + i + ".txt", "")).join().revision();
             }
         } finally {
@@ -167,6 +167,8 @@ class CommitIdDatabaseTest {
             repo.internalClose();
         }
 
+        assertThat(repo.creationTimeMillis()).isEqualTo(1000);
+        assertThat(repo.author()).isEqualTo(Author.SYSTEM);
         assertThat(Files.size(commitIdDatabaseFile.toPath())).isEqualTo((numCommits + 1) * 24L);
     }
 


### PR DESCRIPTION
Motivation:
`Repository.author()` and `Repository.creationTimeMillis()` have a blocking call in it.
We can add `author` and `creationTimeMillis` as member variables and assign them in the constructor to avoid the blocking call.

Modifications:
- Add `author` and `creationTimeMillis` as member variables
- Change `Repository.author()` and `Repository.creationTimeMillis()` methods not to have implementation

Result:
- `Repository.author()` and `Repository.creationTimeMillis()` do not block anymore.