### PR TITLE
Allow configuring the initialization timeout of `CentralDogma` client for Spring integration.

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/AbstractArmeriaCentralDogmaBuilder.java
@@ -139,6 +139,7 @@ public class AbstractArmeriaCentralDogmaBuilder<B extends AbstractArmeriaCentral
         final HealthCheckedEndpointGroupBuilder healthCheckedEndpointGroupBuilder =
                 HealthCheckedEndpointGroup.builder(group, HttpApiV1Constants.HEALTH_CHECK_PATH)
                                           .clientFactory(clientFactory)
+                                          .allowEmptyEndpoints(false)
                                           .protocol(isUseTls() ? SessionProtocol.HTTPS
                                                                : SessionProtocol.HTTP);
         if (healthCheckInterval != null) {

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -139,7 +139,9 @@ public class CentralDogmaClientAutoConfiguration {
             try {
                 centralDogma.whenEndpointReady().get(initializationTimeoutMillis, TimeUnit.MILLISECONDS);
             } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                throw new IllegalStateException("Failed to initialize the endpoints of " + centralDogma, e);
+                throw new IllegalStateException(
+                        "Failed to initialize the endpoints of " + centralDogma + " in " +
+                        initializationTimeoutMillis + " milliseconds", e);
             }
         }
         return centralDogma;

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -246,7 +246,7 @@ public class CentralDogmaSettings {
 
     /**
      * Returns the number of milliseconds the Central Dogma client waits for initialization to complete.
-     * If {@code 0} is specified, Central Dogma client is immediately returned without waiting.
+     * If {@code 0} is specified, the Central Dogma client is immediately returned without waiting.
      * If unspecified, defaults to
      * {@value CentralDogmaClientAutoConfiguration#DEFAULT_INITIALIZATION_TIMEOUT_MILLIS}.
      */

--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -41,6 +41,7 @@ import com.google.common.base.MoreObjects;
  *   - replica3.examples.com:36462
  *   access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
  *   health-check-interval-millis: 15000
+ *   initialization-timeout-millis: 15000
  *   use-tls: false
  * }</pre>
  *
@@ -50,6 +51,7 @@ import com.google.common.base.MoreObjects;
  *   profile: beta
  *   access-token: appToken-cffed349-d573-457f-8f74-4727ad9341ce
  *   health-check-interval-millis: 15000
+ *   initialization-timeout-millis: 15000
  *   use-tls: false
  * }</pre>
  *
@@ -101,6 +103,15 @@ public class CentralDogmaSettings {
      */
     @Nullable
     private Long retryIntervalOnReplicationLagMillis;
+
+    /**
+     * The number of milliseconds the Central Dogma client waits for initialization to complete.
+     * {@code 0} means the Central Dogma client is immediately returned without waiting for the initialization.
+     * If unspecified, defaults to
+     * {@value CentralDogmaClientAutoConfiguration#DEFAULT_INITIALIZATION_TIMEOUT_MILLIS}.
+     */
+    @Nullable
+    private Long initializationTimeoutMillis;
 
     /**
      * Returns the Central Dogma client profile name.
@@ -222,6 +233,27 @@ public class CentralDogmaSettings {
         this.retryIntervalOnReplicationLagMillis = retryIntervalOnReplicationLagMillis;
     }
 
+    /**
+     * Returns the number of milliseconds the Central Dogma client waits for initialization to complete.
+     * If {@code 0} is specified, Central Dogma client is immediately returned without waiting.
+     *
+     * @return {@code null} if not specified.
+     */
+    @Nullable
+    public Long initializationTimeoutMillis() {
+        return initializationTimeoutMillis;
+    }
+
+    /**
+     * Returns the number of milliseconds the Central Dogma client waits for initialization to complete.
+     * If {@code 0} is specified, Central Dogma client is immediately returned without waiting.
+     * If unspecified, defaults to
+     * {@value CentralDogmaClientAutoConfiguration#DEFAULT_INITIALIZATION_TIMEOUT_MILLIS}.
+     */
+    public void setInitializationTimeoutMillis(@Nullable Long initializationTimeoutMillis) {
+        this.initializationTimeoutMillis = initializationTimeoutMillis;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
@@ -229,6 +261,7 @@ public class CentralDogmaSettings {
                           .add("hosts", hosts)
                           .add("accessToken", accessToken != null ? "********" : null)
                           .add("healthCheckIntervalMillis", healthCheckIntervalMillis)
+                          .add("initializationTimeoutMillis", initializationTimeoutMillis)
                           .add("useTls", useTls)
                           .add("maxNumRetriesOnReplicationLag", maxNumRetriesOnReplicationLag)
                           .add("retryIntervalOnReplicationLagMillis", retryIntervalOnReplicationLagMillis)

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.spring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import javax.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.server.Server;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest.TestConfiguration;
+import com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = TestConfiguration.class)
+@ActiveProfiles({ "local", "initTimeout" })
+class CentralDogmaInitializationTimeoutTest {
+
+    // TODO(ikhoon): Randomize the port number to avoid flakiness.
+    private static final Lock lock = new ReentrantLock();
+    private static final int TEST_SERVER_PORT = 56463;
+
+    private Server server;
+
+    @SpringBootApplication
+    static class TestConfiguration {}
+
+    @Inject
+    private CentralDogma client;
+
+    @BeforeEach
+    void setUp() {
+        lock.lock();
+        server = Server.builder()
+                       .http(TEST_SERVER_PORT)
+                       .service(HttpApiV1Constants.HEALTH_CHECK_PATH,
+                                (ctx, req) -> HttpResponse.delayed(HttpResponse.of("OK"),
+                                                                   Duration.ofSeconds(5)))
+                       .build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Wait for the stop to complete to release the port quickly.
+        try {
+            server.stop().join();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Test
+    void initializedEndpoints() {
+        assertThat(client.whenEndpointReady()).isCompleted();
+    }
+}

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
@@ -24,8 +24,8 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import javax.inject.Inject;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -48,7 +48,7 @@ class CentralDogmaInitializationTimeoutTest {
     private static final Lock lock = new ReentrantLock();
     private static final int TEST_SERVER_PORT = 56463;
 
-    private Server server;
+    private static Server server;
 
     @SpringBootApplication
     static class TestConfiguration {}
@@ -56,8 +56,8 @@ class CentralDogmaInitializationTimeoutTest {
     @Inject
     private CentralDogma client;
 
-    @BeforeEach
-    void setUp() {
+    @BeforeAll
+    static void beforeAll() {
         lock.lock();
         server = Server.builder()
                        .http(TEST_SERVER_PORT)
@@ -65,13 +65,13 @@ class CentralDogmaInitializationTimeoutTest {
                                 (ctx, req) -> HttpResponse.delayed(HttpResponse.of("OK"),
                                                                    Duration.ofSeconds(5)))
                        .build();
-//        server.start().join();
+        server.start().join();
     }
 
-    @AfterEach
-    void tearDown() {
-        // Immediately close the server to release the port quickly.
+    @AfterAll
+    static void afterAll() {
         try {
+            // Immediately close the server to release the port quickly.
             server.close();
         } finally {
             lock.unlock();

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
@@ -36,7 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.spring.CentralDogmaClientAutoConfigurationWithDnsEndpointGroupConfiguratorTest.TestConfiguration;
+import com.linecorp.centraldogma.client.spring.CentralDogmaInitializationTimeoutTest.TestConfiguration;
 import com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants;
 
 @ExtendWith(SpringExtension.class)

--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
@@ -65,13 +65,14 @@ class CentralDogmaInitializationTimeoutTest {
                                 (ctx, req) -> HttpResponse.delayed(HttpResponse.of("OK"),
                                                                    Duration.ofSeconds(5)))
                        .build();
+//        server.start().join();
     }
 
     @AfterEach
     void tearDown() {
-        // Wait for the stop to complete to release the port quickly.
+        // Immediately close the server to release the port quickly.
         try {
-            server.stop().join();
+            server.close();
         } finally {
             lock.unlock();
         }

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-confTest.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-confTest.yml
@@ -1,4 +1,3 @@
 centraldogma:
-  profile: myprofile
   # Disable the endpoints initialization
   initialization-timeout-millis: 0

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-initTimeout.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-initTimeout.yml
@@ -1,0 +1,5 @@
+centraldogma:
+  hosts:
+    - 127.0.0.1:56463
+  initialization-timeout-millis: 15000
+  health-check-interval-millis: 5000

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-otherProps.yml
@@ -4,3 +4,5 @@ centraldogma:
   accessToken: my-dogma-access-token
   max-num-retries-on-replication-lag: 42
   retry-interval-on-replication-lag-millis: 10000
+  # Disable the endpoints initialization
+  initialization-timeout-millis: 0

--- a/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useHosts.yml
+++ b/client/java-spring-boot-autoconfigure/src/test/resources/config/application-useHosts.yml
@@ -3,3 +3,5 @@ centraldogma:
   - alice.com
   - bob.com:8080
   - charlie.com:36462
+  # Disable the endpoints initialization
+  initialization-timeout-millis: 0


### PR DESCRIPTION
Motivation:

3.2 seconds is used for the default timeout if an endpoint is not
determined while executing a request.
While a server is starting up, a resolution of endpoints may take
longer than 3.2 seconds because the server could be busy initializing
the application context.
To solve the problem, `CentralDogma.whenEndpointReady()` was introduced
to wait for the initial endpoints before starting a request.

However, users found it easy to forget to call the API and use directly a
`CentralDogma` client without waiting for it. It is difficult to call
`whenEndpointReady().get()` because it is to block the current thread.
But a `CentralDogma` bean is a managed instance created in the main
thread when a Spring application context is initialized. So we can
safely call `CentralDogma.whenEndpointReady().get()` before returning a
client.

Modifications:

- Add `initializationTimeoutMillis` to `CentralDogmaSettings` so as to
  to let users configure the timeout
  - If unspecified, 15 seconds is used by default.
  - 0 disables the waiting for initialization.

Result:

- You can now configure the initialization timeout for a `CentralDogma`
  client when using Spring integration modules.
  ```yml
  centraldogma:
    hosts:
       - ...
    initialization-timeout-millis: 15000
  ```
- Fixes #691