### PR TITLE
Update dependencies

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -32,7 +32,7 @@ import com.google.common.base.MoreObjects;
 /**
  * Settings for a Central Dogma client.
  *
- * <h3>Example with {@code "hosts"} option</h3>
+ * <h2>Example with {@code "hosts"} option</h2>
  * <pre>{@code
  * centraldogma:
  *   hosts:
@@ -44,7 +44,7 @@ import com.google.common.base.MoreObjects;
  *   use-tls: false
  * }</pre>
  *
- * <h3>Example with {@code "profile"} option</h3>
+ * <h2>Example with {@code "profile"} option</h2>
  * <pre>{@code
  * centraldogma:
  *   profile: beta

--- a/dependencies.yml
+++ b/dependencies.yml
@@ -3,9 +3,9 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 boms:
-- com.fasterxml.jackson:jackson-bom:2.13.2.1
-- com.linecorp.armeria:armeria-bom:1.16.0
-- io.micrometer:micrometer-bom:1.8.5
+- com.fasterxml.jackson:jackson-bom:2.13.3
+- com.linecorp.armeria:armeria-bom:1.17.0
+- io.micrometer:micrometer-bom:1.9.1
 - org.junit:junit-bom:5.8.2
 
 ch.qos.logback:
@@ -59,7 +59,7 @@ com.github.jengelman.gradle.plugins:
   shadow: { version: '6.1.0' }
 
 com.github.node-gradle:
-  gradle-node-plugin: { version: '3.2.1' }
+  gradle-node-plugin: { version: '3.4.0' }
 
 com.google.code.findbugs:
   jsr305: { version: '3.0.2' }
@@ -115,7 +115,7 @@ com.linecorp.armeria:
     - https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.14.1/
 
 com.puppycrawl.tools:
-  checkstyle: { version: '10.1' }
+  checkstyle: { version: '10.3.1' }
 
 com.spotify:
   completable-futures:
@@ -133,10 +133,10 @@ gradle.plugin.net.davidecavestro:
 io.micrometer:
   micrometer-core:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.8.5/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-core/1.9.1/
   micrometer-registry-prometheus:
     javadocs:
-    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.8.5/
+    - https://www.javadoc.io/doc/io.micrometer/micrometer-registry-prometheus/1.9.1/
 
 javax.annotation:
   javax.annotation-api: { version: '1.3.2' }
@@ -165,12 +165,13 @@ kr.motd.gradle:
 me.champeau.jmh:
   jmh-gradle-plugin: { version: '0.6.6' }
 
+# Used only in testing-module.
 net.javacrumbs.json-unit:
-  json-unit: { version: &JSON_UNIT_VERSION '2.34.0' }
+  json-unit: { version: &JSON_UNIT_VERSION '2.35.0' }
   json-unit-fluent: { version: *JSON_UNIT_VERSION }
 
 com.guardsquare:
-  proguard-gradle: { version: '7.2.0' }
+  proguard-gradle: { version: '7.2.2' }
 
 # Ensure that we use the same ZooKeeper version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
@@ -204,7 +205,7 @@ org.apache.zookeeper:
     - org.slf4j:slf4j-log4j12
 
 org.assertj:
-  assertj-core: { version: '3.22.0' }
+  assertj-core: { version: '3.23.1' }
 
 org.awaitility:
   awaitility: { version: '4.2.0' }
@@ -224,10 +225,10 @@ org.hibernate.validator:
   hibernate-validator: { version: '6.2.3.Final' }
 
 org.javassist:
-  javassist: { version: '3.28.0-GA' }
+  javassist: { version: '3.29.0-GA' }
 
 org.mockito:
-  mockito-core: { version: &MOCKITO_VERSION '4.5.0' }
+  mockito-core: { version: &MOCKITO_VERSION '4.6.1' }
   mockito-junit-jupiter: { version: *MOCKITO_VERSION }
 
 org.mortbay.jetty.alpn:
@@ -248,7 +249,7 @@ org.slf4j:
 
 org.springframework.boot:
   spring-boot-starter:
-    version: &SPRING_BOOT_VERSION '2.6.6'
+    version: &SPRING_BOOT_VERSION '2.7.1'
     javadocs:
     - https://docs.spring.io/spring/docs/current/javadoc-api/
   spring-boot-starter-test: { version: *SPRING_BOOT_VERSION }


### PR DESCRIPTION
- Armeria 1.16.0 -> 1.17.0
- Jackson 2.13.2.1 -> 2.13.3
- Javassist 3.28.0-GA -> 3.29.0-GA
- Micrometer 1.8.5 -> 1.9.1
- Spring Boot 2.6.6 -> 2.7.1
- Build
  - AssertJ 3.22.0 -> 3.23.1
  - Checkstyle 10.1 -> 10.3.1
  - gradle-node-plugin 3.2.1 -> 3.4.0
  - JSON Unit 2.34.0 -> 2.35.0
  - Mockito 4.5.0 -> 4.6.1
  - Proguard 7.2.0 -> 7.2.2