### PR TITLE
Fix the test failure in `CentralDogmaInitializationTimeoutTest`

### DIFF
--- a/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
+++ b/client/java-spring-boot-autoconfigure/src/test/java/com/linecorp/centraldogma/client/spring/CentralDogmaInitializationTimeoutTest.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.client.spring;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -33,6 +34,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.google.common.util.concurrent.Uninterruptibles;
+
+import com.linecorp.armeria.client.retry.Backoff;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.server.Server;
 import com.linecorp.centraldogma.client.CentralDogma;
@@ -59,13 +63,26 @@ class CentralDogmaInitializationTimeoutTest {
     @BeforeAll
     static void beforeAll() {
         lock.lock();
-        server = Server.builder()
-                       .http(TEST_SERVER_PORT)
-                       .service(HttpApiV1Constants.HEALTH_CHECK_PATH,
-                                (ctx, req) -> HttpResponse.delayed(HttpResponse.of("OK"),
-                                                                   Duration.ofSeconds(5)))
-                       .build();
-        server.start().join();
+        final int maxAttempts = 8;
+        for (int i = 1; i <= maxAttempts; i++) {
+            try {
+                final Server server =
+                        Server.builder()
+                              .http(TEST_SERVER_PORT)
+                              .service(HttpApiV1Constants.HEALTH_CHECK_PATH,
+                                       (ctx, req) -> HttpResponse.delayed(HttpResponse.of("OK"),
+                                                                          Duration.ofSeconds(5)))
+                              .build();
+                server.start().join();
+                CentralDogmaInitializationTimeoutTest.server = server;
+            } catch (Exception ex) {
+                if (i < maxAttempts) {
+                    // Ignore the exception silently apart from the last attempts.
+                    final long sleep = Backoff.ofDefault().nextDelayMillis(maxAttempts);
+                    Uninterruptibles.sleepUninterruptibly(sleep, TimeUnit.MILLISECONDS);
+                }
+            }
+        }
     }
 
     @AfterAll


### PR DESCRIPTION
Motivation:

Since `CentralDogmaInitializationTimeoutTest` uses a pre-defined port, the test is easily broken.
```
CentralDogmaInitializationTimeoutTest > initializationError FAILED
    java.util.concurrent.CompletionException: java.net.BindException: Address already in use
        at java.base/java.util.concurrent.CompletableFuture.reportJoin(CompletableFuture.java:413)
        at java.base/java.util.concurrent.CompletableFuture.join(CompletableFuture.java:2118)
        at com.linecorp.armeria.common.util.EventLoopCheckingFuture.join(EventLoopCheckingFuture.java:87)
        at com.linecorp.centraldogma.client.spring.CentralDogmaInitializationTimeoutTest.beforeAll(CentralDogmaInitializationTimeoutTest.java:68)
```

Modifications:

- Retry to start the server up to 8 times with the default `Backoff`.

Result:

Hope the test doesn't fail. 🙏🙏🙏