### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -8,16 +8,16 @@ guava = "31.1-jre"
 jgit = "5.13.0.202109080827-r"
 json-unit = "2.35.0"
 jmh = "1.35"
-micrometer = "1.9.3"
+micrometer = "1.9.4"
 mockito = "4.8.0"
 slf4j = "1.7.36"
 spring-boot1 = "1.5.22.RELEASE"
-spring-boot2 = "2.7.3"
+spring-boot2 = "2.7.4"
 
 [boms]
-armeria = { module = "com.linecorp.armeria:armeria-bom", version = "1.19.0" }
+armeria = { module = "com.linecorp.armeria:armeria-bom", version = "1.20.0" }
 jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.13.4" }
-junit5 = { module = "org.junit:junit-bom", version = "5.9.0" }
+junit5 = { module = "org.junit:junit-bom", version = "5.9.1" }
 
 [libraries.armeria]
 module = "com.linecorp.armeria:armeria"
@@ -129,7 +129,7 @@ module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
 
 [libraries.javassist]
 module = "org.javassist:javassist"
-version = "3.29.1-GA"
+version = "3.29.2-GA"
 
 [libraries.javax-annotation]
 module = "javax.annotation:javax.annotation-api"
@@ -306,10 +306,10 @@ exclusions = [
 
 [plugins]
 docker = { id = "com.bmuschko.docker-remote-api", version = "6.7.0" }
-download = { id = "de.undercouch.download", version = "5.1.0" }
-jmh = { id = "me.champeau.jmh", version = "0.6.7" }
+download = { id = "de.undercouch.download", version = "5.2.1" }
+jmh = { id = "me.champeau.jmh", version = "0.6.8" }
 jxr = { id = "net.davidecavestro.gradle.jxr", version = "0.2.1" }
 log = { id = "com.boazj.log", version = "0.1.0" }
 node-gradle = { id = "com.github.node-gradle.node", version = "3.4.0" }
-osdetector = { id = "com.google.osdetector", version = "1.6.2" }
-sphinx = { id = "kr.motd.sphinx", version = "2.10.0" }
+osdetector = { id = "com.google.osdetector", version = "1.7.1" }
+sphinx = { id = "kr.motd.sphinx", version = "2.10.1" }


### PR DESCRIPTION
- Armeria 1.19.0 -> 1.20.0
- Javassist 3.29.1-GA -> 3.29.2-GA
- Micrometer 1.9.3 -> 1.9.4
- Spring Boot 2.7.3 -> 2.7.4
- Build
  - de.undercouch.download 5.1.0 -> 5.2.0
  - JUnit 5.9.0 -> 5.9.1
  - kr.motd.sphinx 2.10.0 -> 2.10.1
  - OS detector 1.6.2 -> 1.7.1