### PR TITLE
Fix flaky test in `ZooKeeperQuotaTest`

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -126,5 +126,5 @@ jobs:
 
       - name: Run flaky tests
         run: |
-          ./gradlew --no-daemon --stacktrace -PnoLint -PflakyTests=true
+          ./gradlew --no-daemon --stacktrace check -PnoLint -PflakyTests=true
         shell: bash

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -901,7 +901,7 @@ public final class ZooKeeperCommandExecutor
         final QuotaConfig writeQuota = writeLock.writeQuota;
         if (lease == null) {
             safeRelease(mtx);
-            throw new TooManyRequestsException("commits", executionPath, writeQuota.requestQuota());
+            throw new TooManyRequestsException("commits", executionPath, writeQuota.permitsPerSecond());
         } else {
             quotaExecutor.schedule(() -> writeLock.semaphore.returnLease(lease),
                                    writeQuota.timeWindowSeconds(), TimeUnit.SECONDS);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperQuotaTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperQuotaTest.java
@@ -44,7 +44,7 @@ class ZooKeeperQuotaTest {
     @Test
     void testLimitation() throws Exception {
         try (Cluster cluster = Cluster.builder()
-                                      .writeQuota(new QuotaConfig(MAX_QUOTA, 1))
+                                      .writeQuota(new QuotaConfig(MAX_QUOTA, 3))
                                       .build(ZooKeeperCommandExecutorTest::newMockDelegate)) {
             final int iteration = MAX_QUOTA * 5;
             final ImmutableList.Builder<CompletableFuture<?>> resultsBuilder =

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperQuotaTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperQuotaTest.java
@@ -59,7 +59,8 @@ class ZooKeeperQuotaTest {
             final ImmutableList<CompletableFuture<?>> results = resultsBuilder.build();
             int limited = 0;
             int succeeded = 0;
-            final String expectedMessage = String.format("'/project/repo1' (quota limit: %d.0/sec)", MAX_QUOTA);
+            final String expectedMessage = String.format("'/project/repo1' (quota limit: %d.0/sec)",
+                                                         MAX_QUOTA / 3);
             for (int i = 0; i < iteration; i++) {
                 try {
                     results.get(i).join();


### PR DESCRIPTION
Motivation:
`ZooKeeperQuotaTest.testLimitation()` test the write quota with 3 request quotas and 1 second window. https://github.com/line/centraldogma/blob/master/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperQuotaTest.java#L47 So basically if more than 3 requests are commited in a second, it raises `TooManyRequestException`. However, if it takes more than 333 milliseconds to acquire the `InterProcessMutex`, https://github.com/line/centraldogma/blob/master/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java#L784 the test always fails because acquiring the write lock happens after that. https://github.com/line/centraldogma/blob/master/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java#L790

Acquire the `InterProcessMutex` takes more than 333 milliseconds mostly because it's released after storing the log. https://github.com/line/centraldogma/blob/master/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java#L1069-L1100

Modification:
- Increase time window to 3 seconds acquiring the `InterProcessMutex` doesn't affect the write quota