### PR TITLE
Increase the Git timeout of GitMirror to 60 seconds

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirror.java
@@ -77,7 +77,7 @@ public final class GitMirror extends AbstractMirror {
     private static final Pattern DISALLOWED_CHARS = Pattern.compile("[^-_a-zA-Z]");
     private static final Pattern CONSECUTIVE_UNDERSCORES = Pattern.compile("_+");
 
-    private static final int GIT_TIMEOUT_SECS = 10;
+    private static final int GIT_TIMEOUT_SECS = 60;
 
     @Nullable
     private IgnoreNode ignoreNode;


### PR DESCRIPTION
Motivation:

The timeout of Git is 10 seconds. It would be a sufficient value when the server is under normal workloads.  However, a Git server is under heavy loads, the Git client fails to read content in 10 seconds.

As GitMirror job is performed as a background task, increasing the timeout won't have any other bad effect on the CD server.

Modifications:

- Change the timeout of Git mirror client to 60 seconds from 10 seconds.

Result:

Reduce Git mirroring failures on slow Git Servers.