### PR TITLE
Add metrics for mirroring

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
@@ -49,6 +49,7 @@ public final class DefaultMirroringServicePlugin implements Plugin {
             final CentralDogmaConfig cfg = context.config();
             mirroringService = new DefaultMirroringService(new File(cfg.dataDir(), "_mirrors"),
                                                            context.projectManager(),
+                                                           context.meterRegistry(),
                                                            cfg.numMirroringThreads(),
                                                            cfg.maxNumFilesPerMirror(),
                                                            cfg.maxNumBytesPerMirror());

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
@@ -52,7 +52,7 @@ final class MirroringTask {
     }
 
     private Counter counter(boolean success) {
-        return Counter.builder("mirror.result")
+        return Counter.builder("mirroring.result")
                       .tags(tags)
                       .tag("success", Boolean.toString(success))
                       .register(meterRegistry);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.io.File;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.mirror.Mirror;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+final class MirroringTask {
+
+    private static Iterable<Tag> generateTags(Mirror mirror) {
+        return ImmutableList.of(
+                Tag.of("direction", mirror.direction().name()),
+                Tag.of("remoteRepo", mirror.remoteRepoUri().toString()),
+                Tag.of("remoteBranch", firstNonNull(mirror.remoteBranch(), "")),
+                Tag.of("remotePath", mirror.remotePath()),
+                Tag.of("localRepo", mirror.localRepo().name()),
+                Tag.of("localPath", mirror.localPath()));
+    }
+
+    private final MeterRegistry meterRegistry;
+    private final Mirror mirror;
+    private final Iterable<Tag> tags;
+
+    MirroringTask(Mirror mirror, MeterRegistry meterRegistry) {
+        this.mirror = mirror;
+        this.meterRegistry = meterRegistry;
+        tags = generateTags(mirror);
+    }
+
+    private Counter counter(boolean success) {
+        return Counter.builder("mirror.result")
+                      .tags(tags)
+                      .tag("success", Boolean.toString(success))
+                      .register(meterRegistry);
+    }
+
+    void run(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes) {
+        try {
+            meterRegistry.timer("mirroring.task", tags)
+                         .record(() -> mirror.mirror(workDir, executor, maxNumFiles, maxNumBytes));
+            counter(true).increment();
+        } catch (Exception e) {
+            counter(false).increment();
+            throw e;
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServiceTest.java
@@ -43,6 +43,8 @@ import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 class DefaultMirroringServiceTest {
 
     @TempDir
@@ -81,7 +83,8 @@ class DefaultMirroringServiceTest {
 
         when(mr.mirrors()).thenReturn(ImmutableSet.of(mirror));
 
-        final DefaultMirroringService service = new DefaultMirroringService(temporaryFolder, pm, 1, 1, 1);
+        final DefaultMirroringService service = new DefaultMirroringService(
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1);
         service.start(mock(CommandExecutor.class));
 
         try {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
@@ -15,33 +15,24 @@
  */
 package com.linecorp.centraldogma.server.internal.mirror;
 
+import static com.linecorp.centraldogma.server.internal.mirror.MirroringTestUtils.EVERY_MINUTE;
+import static com.linecorp.centraldogma.server.internal.mirror.MirroringTestUtils.newMirror;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.net.URI;
 import java.time.ZonedDateTime;
 
 import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
-import com.cronutils.model.Cron;
-import com.cronutils.model.CronType;
-import com.cronutils.model.definition.CronDefinitionBuilder;
-import com.cronutils.parser.CronParser;
-
 import com.linecorp.centraldogma.server.mirror.Mirror;
-import com.linecorp.centraldogma.server.mirror.MirrorCredential;
-import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 class MirrorTest {
-
-    private static final Cron EVERY_MINUTE = new CronParser(
-            CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("0 * * * * ?");
 
     @Test
     void testGitMirror() {
@@ -168,26 +159,5 @@ class MirrorTest {
         assertThat(m.remotePath()).isEqualTo(expectedRemotePath);
         assertThat(m.remoteBranch()).isEqualTo(expectedRemoteBranch);
         return m;
-    }
-
-    private static <T extends Mirror> T newMirror(String remoteUri, Class<T> mirrorType) {
-        return newMirror(remoteUri, EVERY_MINUTE, mock(Repository.class), mirrorType);
-    }
-
-    private static <T extends Mirror> T newMirror(String remoteUri, Cron schedule,
-                                                  Repository repository, Class<T> mirrorType) {
-        final MirrorCredential credential = mock(MirrorCredential.class);
-        final Mirror mirror = Mirror.of(schedule, MirrorDirection.LOCAL_TO_REMOTE,
-                                        credential, repository, "/", URI.create(remoteUri), null);
-
-        assertThat(mirror).isInstanceOf(mirrorType);
-        assertThat(mirror.direction()).isEqualTo(MirrorDirection.LOCAL_TO_REMOTE);
-        assertThat(mirror.credential()).isSameAs(credential);
-        assertThat(mirror.localRepo()).isSameAs(repository);
-        assertThat(mirror.localPath()).isEqualTo("/");
-
-        @SuppressWarnings("unchecked")
-        final T castMirror = (T) mirror;
-        return castMirror;
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import static com.linecorp.centraldogma.server.internal.mirror.MirroringTestUtils.newMirror;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.metric.MoreMeters;
+import com.linecorp.centraldogma.server.mirror.Mirror;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class MirroringTaskTest {
+
+    @Test
+    void testSuccessMetrics() {
+        final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
+        mirror = spy(mirror);
+        doNothing().when(mirror).mirror(any(), any(), anyInt(), anyLong());
+        new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
+        assertThat(MoreMeters.measureAll(meterRegistry))
+                .contains(entry("mirror.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
+                                "localRepo=bar,remoteBranch=master,remotePath=/," +
+                                "remoteRepo=git://a.com/b.git,success=true}", 1.0));
+    }
+
+    @Test
+    void testFailureMetrics() {
+        final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
+        mirror = spy(mirror);
+        final RuntimeException e = new RuntimeException();
+        doThrow(e).when(mirror).mirror(any(), any(), anyInt(), anyLong());
+        final MirroringTask task = new MirroringTask(mirror, meterRegistry);
+        assertThatThrownBy(() -> task.run(null, null, 0, 0L))
+                .isSameAs(e);
+        assertThat(MoreMeters.measureAll(meterRegistry))
+                .contains(entry("mirror.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
+                                "localRepo=bar,remoteBranch=master,remotePath=/," +
+                                "remoteRepo=git://a.com/b.git,success=false}", 1.0));
+    }
+
+    @Test
+    void testTimerMetrics() {
+        final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
+        mirror = spy(mirror);
+        doAnswer(invocation -> {
+            Thread.sleep(1000);
+            return null;
+        }).when(mirror).mirror(any(), any(), anyInt(), anyLong());
+        new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
+        assertThat(MoreMeters.measureAll(meterRegistry))
+                .hasEntrySatisfying(
+                        "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +
+                        "localRepo=bar,remoteBranch=master,remotePath=/," +
+                        "remoteRepo=git://a.com/b.git}", v -> assertThat(v).isGreaterThanOrEqualTo(1));
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -46,7 +46,7 @@ class MirroringTaskTest {
         doNothing().when(mirror).mirror(any(), any(), anyInt(), anyLong());
         new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
-                .contains(entry("mirror.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
+                .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
                                 "localRepo=bar,remoteBranch=master,remotePath=/," +
                                 "remoteRepo=git://a.com/b.git,success=true}", 1.0));
     }
@@ -62,7 +62,7 @@ class MirroringTaskTest {
         assertThatThrownBy(() -> task.run(null, null, 0, 0L))
                 .isSameAs(e);
         assertThat(MoreMeters.measureAll(meterRegistry))
-                .contains(entry("mirror.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
+                .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
                                 "localRepo=bar,remoteBranch=master,remotePath=/," +
                                 "remoteRepo=git://a.com/b.git,success=false}", 1.0));
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -20,6 +20,7 @@ import static com.linecorp.centraldogma.server.internal.mirror.MirroringTestUtil
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.data.Percentage.withPercentage;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -81,6 +82,6 @@ class MirroringTaskTest {
                 .hasEntrySatisfying(
                         "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +
                         "localRepo=bar,remoteBranch=master,remotePath=/," +
-                        "remoteRepo=git://a.com/b.git}", v -> assertThat(v).isGreaterThanOrEqualTo(1));
+                        "remoteRepo=git://a.com/b.git}", v -> assertThat(v).isCloseTo(1, withPercentage(30)));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+
+import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorCredential;
+import com.linecorp.centraldogma.server.mirror.MirrorDirection;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+
+final class MirroringTestUtils {
+
+    static final Cron EVERY_MINUTE = new CronParser(
+            CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("0 * * * * ?");
+
+    private MirroringTestUtils() {}
+
+    static <T extends Mirror> T newMirror(String remoteUri, Class<T> mirrorType) {
+        return newMirror(remoteUri, EVERY_MINUTE, mock(Repository.class), mirrorType);
+    }
+
+    static <T extends Mirror> T newMirror(String remoteUri, Class<T> mirrorType,
+                                          String projectName, String repoName) {
+        final Repository repository = mock(Repository.class);
+        final Project project = mock(Project.class);
+        when(repository.parent()).thenReturn(project);
+        when(repository.name()).thenReturn(repoName);
+        when(project.name()).thenReturn(projectName);
+        return newMirror(remoteUri, EVERY_MINUTE, repository, mirrorType);
+    }
+
+    static <T extends Mirror> T newMirror(String remoteUri, Cron schedule,
+                                          Repository repository, Class<T> mirrorType) {
+        final MirrorCredential credential = mock(MirrorCredential.class);
+        final Mirror mirror = Mirror.of(schedule, MirrorDirection.LOCAL_TO_REMOTE,
+                                        credential, repository, "/", URI.create(remoteUri), null);
+
+        assertThat(mirror).isInstanceOf(mirrorType);
+        assertThat(mirror.direction()).isEqualTo(MirrorDirection.LOCAL_TO_REMOTE);
+        assertThat(mirror.credential()).isSameAs(credential);
+        assertThat(mirror.localRepo()).isSameAs(repository);
+        assertThat(mirror.localPath()).isEqualTo("/");
+
+        @SuppressWarnings("unchecked")
+        final T castMirror = (T) mirror;
+        return castMirror;
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
@@ -38,8 +38,6 @@ final class MirroringTestUtils {
     static final Cron EVERY_MINUTE = new CronParser(
             CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("0 * * * * ?");
 
-    private MirroringTestUtils() {}
-
     static <T extends Mirror> T newMirror(String remoteUri, Class<T> mirrorType) {
         return newMirror(remoteUri, EVERY_MINUTE, mock(Repository.class), mirrorType);
     }
@@ -70,4 +68,6 @@ final class MirroringTestUtils {
         final T castMirror = (T) mirror;
         return castMirror;
     }
+
+    private MirroringTestUtils() {}
 }


### PR DESCRIPTION
**Motivation**

It is difficult to determine the state of mirroring currently.
I propose that we add metrics for mirroring with the following properties:

1) Add metrics for the executor which schedules mirroring. By doing so, we can gain visibility on how long processing all configured mirrors takes. (this is equivalent to the time taken for a single task)
2) Add timer metrics for each mirroring task, and a counter for whether each mirroring task succeeded or not. I propose that tags be configured per mirroring configuration. While this may increase the number of metrics, I don't think the impact is significant since by design, there can't be a large number of centraldogma servers (due to zookeeper quorum).

**Modifications**
- Pass `MeterRegistry` to `DefaultMirroringService`
- Add metrics for the executor which schedules mirroring.
- Add metrics for each monitoring tasks
- Extract a utility test class which creates a `Mirror` for convenience.

**Result**
- Better visibility on mirroring