### PR TITLE
Make a server unhealthy when it is about to shut down.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -362,10 +362,10 @@ public class CentralDogma implements AutoCloseable {
             server = startServer(pm, executor, meterRegistry, sessionManager);
             logger.info("Started the RPC server at: {}", server.activePorts());
             logger.info("Started the Central Dogma successfully.");
-            serverHealth.setHealthy(true);
             success = true;
         } finally {
             if (success) {
+                serverHealth.setHealthy(true);
                 this.repositoryWorker = repositoryWorker;
                 this.purgeWorker = purgeWorker;
                 this.pm = pm;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtil.java
@@ -165,6 +165,7 @@ public final class HttpApiUtil {
 
         final ObjectNode node = JsonNodeFactory.instance.objectNode();
         if (cause != null) {
+            cause = Exceptions.peel(cause);
             node.put("exception", cause.getClass().getName());
             if (message == null) {
                 message = cause.getMessage();

--- a/server/src/test/java/com/linecorp/centraldogma/server/HealthCheckServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/HealthCheckServiceTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServerPort;
+import com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants;
+
+class HealthCheckServiceTest {
+
+    @TempDir
+    private static Path rootDir;
+
+    @Test
+    void healthCheck() {
+        try (CentralDogma dogma = new CentralDogmaBuilder(rootDir.toFile()).build()) {
+            dogma.start().join();
+            final ServerPort serverPort = dogma.config().ports().get(0);
+
+            final BlockingWebClient client =
+                    BlockingWebClient.of("http://127.0.0.1:" + serverPort.localAddress().getPort());
+            AggregatedHttpResponse response = client.get(HttpApiV1Constants.HEALTH_CHECK_PATH);
+            assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+            final CompletableFuture<Void> closeFuture = dogma.stop();
+            response = client.get(HttpApiV1Constants.HEALTH_CHECK_PATH);
+            assertThat(response.status()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+            closeFuture.join();
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import java.util.concurrent.CompletionException;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.server.ServiceRequestContext;
+
+class HttpApiUtilTest {
+
+    @Test
+    void shouldPeelUnnecessaryExceptions() {
+        final ServiceRequestContext ctx = ServiceRequestContext.of(HttpRequest.of(HttpMethod.GET, "/"));
+        final HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        final CompletionException redundant =
+                new CompletionException(new IllegalArgumentException("Invalid input"));
+        final HttpResponse httpResponse = HttpApiUtil.newResponse(ctx, status, redundant);
+        final AggregatedHttpResponse response = httpResponse.aggregate().join();
+        assertThatJson(response.contentUtf8())
+                .isEqualTo("{\"exception\":\"java.lang.IllegalArgumentException\"," +
+                           "\"message\":\"Invalid input\"}");
+    }
+}


### PR DESCRIPTION
Motivation:

If a server stops, it closes the internal resources first and finally stops Armeria server. Since there is no custom `HealthChecker` specified, the status of the server becomes unhealthy when Armeria server starts to shut down. Meanwhile, clients try to send new requests to the closing server which get `ShuttingDownException`s.

I also found that a `CompletionException` is not properly peeled when an `HttpResponse` is created by `HttpApiUtil`.
```
com.linecorp.centraldogma.common.CentralDogmaException: unexpected response: [:status=500, content-type=application/json; charset=utf-8, ...]
   {"exception":"java.util.concurrent.CompletionException","message":"com.linecorp.centraldogma.common.ShuttingDownException"}
	at com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogma.handleErrorResponse(ArmeriaCentralDogma.java:1135)
	at com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogma.normalizeRevision(ArmeriaCentralDogma.java:396)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:642)
```

Modifications:

- Add a `SettableHealthChecker` which becomes healthy when an Armeria server is completely started and becomes unhealthy when a Central Dogma server is about to close.
- Peel an exception before it is converted to an `HttpResponse` in `HttpApiUtil`.

Result:
- Close #704
- You will no longer see `ShuttingDownException` warning messages.