### PR TITLE
Remove gradle-log-plugin

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -80,10 +80,6 @@ module = "com.spotify:completable-futures"
 version = "0.3.5"
 relocations = { from = "com.spotify.futures", to = "com.linecorp.centraldogma.internal.shaded.futures" }
 
-[libraries.gradle-log-plugin]
-module = "com.boazj.gradle:gradle-log-plugin"
-version = "0.1.0"
-
 [libraries.guava]
 module = "com.google.guava:guava"
 version.ref = "guava"
@@ -309,7 +305,6 @@ docker = { id = "com.bmuschko.docker-remote-api", version = "6.7.0" }
 download = { id = "de.undercouch.download", version = "5.2.1" }
 jmh = { id = "me.champeau.jmh", version = "0.6.8" }
 jxr = { id = "net.davidecavestro.gradle.jxr", version = "0.2.1" }
-log = { id = "com.boazj.log", version = "0.1.0" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
 node-gradle = { id = "com.github.node-gradle.node", version = "3.4.0" }
 osdetector = { id = "com.google.osdetector", version = "1.7.1" }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -7,7 +7,6 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath libs.gradle.log.plugin
         classpath libs.guava
     }
 }
@@ -17,8 +16,6 @@ plugins {
     alias libs.plugins.download
 }
 
-apply plugin: 'com.boazj.log'
-
 evaluationDependsOn(':server')
 evaluationDependsOn(':server-auth:saml')
 evaluationDependsOn(':server-auth:shiro')
@@ -27,15 +24,6 @@ ext {
     distDir = "${project.buildDir}/dist"
     relativeDistDir = distDir.substring("${rootProject.projectDir}/".length())
     cliDownloadDir = "${gradle.gradleUserHomeDir}/caches/centraldogma-go/cli"
-}
-
-dependencies {
-    // Logging
-    runtimeOnly libs.logback
-    runtimeOnly libs.armeria.logback
-    runtimeOnly libs.slf4j.jcl.over.slf4j
-    runtimeOnly libs.slf4j.jul.to.slf4j
-    runtimeOnly libs.slf4j.log4j.over.slf4j
 }
 
 // Do not generate a JAR for this project.
@@ -181,65 +169,3 @@ tasks.startup.mustRunAfter(tasks.shutdown)
 task restart(group: 'Execution',
              description: "Restarts Central Dogma at ${project.ext.relativeDistDir}",
              dependsOn: [tasks.shutdown, tasks.startup])
-
-tail {
-    log = files("${project.ext.distDir}/log/centraldogma.log")
-}
-
-tasks.tail.configure {
-    group = 'Execution'
-    description = "Tails the log file at ${project.ext.relativeDistDir}/log/centraldogma.log"
-
-    doFirst {
-        // Print the last 8KiB of the log file before tailing, because gradle-tail-plugin does not.
-        logger.info("Tailing ${project.ext.relativeDistDir}/log/centraldogma.log ..")
-        def path = "${project.ext.distDir}/log/centraldogma.log"
-        if (new File(path).exists()) {
-            def file = new RandomAccessFile(path, 'r')
-            def startPos = Math.max(0, file.length() - 8192)
-            if (startPos != 0) {
-                file.seek(startPos)
-                // Skip the first line which may be partial.
-                file.readLine()
-            }
-
-            for (;;) {
-                def line = file.readLine()
-                if (line == null) {
-                    break
-                }
-                logger.quiet(line)
-            }
-        }
-
-        if (!new File("${project.ext.distDir}/centraldogma.pid").exists()) {
-            logger.warn("> PID file does not exist at ${project.ext.relativeDistDir}/centraldogma.pid; " +
-                        "is Central Dogma running?")
-        }
-
-        logger.quiet("> Enter 'q', 'quit' or 'exit' to stop tailing.")
-    }
-}
-
-tasks.tail.doLast {
-    killTailerThreads()
-}
-
-afterEvaluate {
-    killTailerThreads()
-}
-
-// Terminates the Tailer threads created by gradle-log-plugin, which may linger
-// when Gradle daemons are reused.
-private static def killTailerThreads() {
-    Thread.allStackTraces.forEach({ thread, trace ->
-        for (StackTraceElement e : trace) {
-            if (e.className == 'org.apache.commons.io.input.Tailer') {
-                // Thread.stop() is not a great way to terminate a thread in general,
-                // but Tailer does not respect Thread.interrupt().
-                thread.stop()
-                break
-            }
-        }
-    })
-}

--- a/site/src/sphinx/setup-installation.rst
+++ b/site/src/sphinx/setup-installation.rst
@@ -50,12 +50,6 @@ To stop the server, use the ``bin/shutdown`` script:
         $ ./gradlew startup
         $ ./gradlew shutdown
 
-    You can also tail the log file:
-
-    .. code-block:: shell
-
-        $ ./gradlew tail
-
 Running on Docker
 -----------------
 You can also pull Central Dogma image from `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_


### PR DESCRIPTION
Motivation:
[Gradle Log Plugin](https://github.com/boazj/gradle-log-plugin) isn't maintained and it isn't used by anyone.

Modifications:
- Remove the Gradle Log Plugin

Result:
- Build pass