### PR TITLE
Fix a wrong tarball name in publish-release.yml

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,6 +46,6 @@ jobs:
         uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: dist/build/${{ github.ref }}.tgz
-          asset_name: ${{ github.ref }}.tgz
+          file: dist/build/${{ github.ref_name }}.tgz
+          asset_name: ${{ github.ref_name }}.tgz
           tag: ${{ github.ref }}


### PR DESCRIPTION
Motivation:

The filename of a a tarball which is uploaded to a release note should be `centraldogma-x.y.z.tgz`. But `refs/tags/` is prefixed to the name. https://github.com/line/centraldogma/actions/runs/3418769975/jobs/5691473376

Modifications:

- Use `github.ref_name` instead of `github.ref` to get a short ref name. https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Result:

Correctly upload a built tarball using GitHub Actions.