### PR TITLE
Correctly copy CLI binaries to dist path

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -95,7 +95,7 @@ task copyClientBinaries(group: 'Build',
         description: "Copies client binaries into ${project.ext.relativeDistDir}/bin/native", type: Copy) {
     dependsOn tasks.downloadClientBinaries
 
-    from project.ext.cliDownloadDir
+    from "${project.ext.cliDownloadDir}/$cliVersion"
     into "${project.ext.distDir}/bin/native"
     fileMode 0755
 }


### PR DESCRIPTION
Motivation:

`dogma` script expects the binaries to be in `dist/bin/native/` but `cli-version` was appended.
Hence, `dogma.{os}-{arch}` binaries were copied into
`dist/bin/native/{cli-version}/` and `dogma` script failed to run.

Modifications:

- Specify `cli-version` when copying CLI binaries.

Result:

Correctly run CLI binaries with the `dogma` script.