### PR TITLE
Improve the error message of a `TimeoutException` from `watcher.await…

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -137,9 +137,9 @@ public interface Watcher<T> extends AutoCloseable {
             final long initialTimeoutMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
             throw new TimeoutException("Failed to get the initial value in " + initialTimeoutMillis + " ms. " +
                                        "It's probably because the timeout value is too small or " +
-                                       "the target entry doesn't exist. Please consider using " +
-                                       "'errorOnEntryNotFound option' to get " +
-                                       EntryNotFoundException.class.getSimpleName() + " for that case.");
+                                       "the target entry doesn't exist. Please consider using the " +
+                                       "'errorOnEntryNotFound' option to get an " +
+                                       EntryNotFoundException.class.getSimpleName() + " for a missing entry.");
         } catch (ExecutionException e) {
             throw new Error(e);
         }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -133,6 +133,13 @@ public interface Watcher<T> extends AutoCloseable {
         requireNonNull(unit, "unit");
         try {
             return initialValueFuture().get(timeout, unit);
+        } catch (TimeoutException e) {
+            final long initialTimeoutMillis = TimeUnit.MILLISECONDS.convert(timeout, unit);
+            throw new TimeoutException("Failed to get the initial value in " + initialTimeoutMillis + " ms. " +
+                                       "It's probably because the timeout value is too small or " +
+                                       "the target entry doesn't exist. Please consider using " +
+                                       "'errorOnEntryNotFound option' to get " +
+                                       EntryNotFoundException.class.getSimpleName() + " for that case.");
         } catch (ExecutionException e) {
             throw new Error(e);
         }

--- a/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -562,11 +562,11 @@ class WatchTest {
 
         // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue)
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
         assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS))
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
         assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS, new TextNode("test")))
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
         await().untilAsserted(() -> assertThatThrownBy(() -> watcher.watch((rev, node) -> { /* no-op */ }))
@@ -596,7 +596,7 @@ class WatchTest {
         });
 
         // check entry does not exist when to get initial value
-        assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(
+        assertThatThrownBy(watcher::awaitInitialValue).rootCause().isInstanceOf(
                 EntryNotFoundException.class);
 
         // add file
@@ -680,6 +680,24 @@ class WatchTest {
     }
 
     @Test
+    void repositoryWatcher_noEntry() {
+        final ClientType clientType = ClientType.DEFAULT;
+        revertTestFiles(clientType);
+        final CentralDogma client = clientType.client(dogma);
+        final String pathPattern = "/test_not_found/**";
+
+        // create watcher
+        final Watcher<Revision> watcher = client.forRepo(dogma.project(), dogma.repo1())
+                                                .watcher(PathPattern.of(pathPattern))
+                                                .timeoutMillis(100)
+                                                .start();
+
+        assertThatThrownBy(() -> watcher.awaitInitialValue(500, TimeUnit.MILLISECONDS))
+                .isInstanceOf(TimeoutException.class)
+                .hasMessageContaining("Failed to get the initial value in 500 ms.");
+    }
+
+    @Test
     void repositoryWatcher_errorOnEntryNotFound() {
         final ClientType clientType = ClientType.DEFAULT;
         revertTestFiles(clientType);
@@ -695,11 +713,11 @@ class WatchTest {
 
         // check entry does not exist when to get initial value
         assertThatThrownBy(watcher::awaitInitialValue)
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
         assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS))
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
         assertThatThrownBy(() -> watcher.awaitInitialValue(100, TimeUnit.MILLISECONDS, Revision.INIT))
-                .getRootCause().isInstanceOf(EntryNotFoundException.class);
+                .rootCause().isInstanceOf(EntryNotFoundException.class);
 
         // when initialValueFuture throw 'EntryNotFoundException', you can't use 'watch' method.
         await().untilAsserted(() -> assertThatThrownBy(() -> watcher.watch((rev, node) -> { /* no-op */ }))
@@ -728,7 +746,7 @@ class WatchTest {
         });
 
         // check entry does not exist when to get initial value
-        assertThatThrownBy(watcher::awaitInitialValue).getRootCause().isInstanceOf(
+        assertThatThrownBy(watcher::awaitInitialValue).rootCause().isInstanceOf(
                 EntryNotFoundException.class);
 
         // add file


### PR DESCRIPTION
…InitialValue()`

Motivation:
A `TimeoutException` is raised when using `watcher.awaitInitialValue(...)` if the target entry doesn't exist. We can give a hint that uses `errorOnEntryNotFound` in the exception message so that users who don't know the flag can give it a try if it's the problem.

Modifications:
- Provide a detailed error message when `Watcher.awaitInitialValue(...)` raises `TimeoutException`.

Result:

You can see the detailed error message when `Watcher.awaitInitialValue(...)` raises a `TimeoutException` because the target doesn't exist.