### PR TITLE
Fix equals() implementation in AbstractCommand (#751)

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommand.java
@@ -54,12 +54,11 @@ abstract class AbstractCommand<T> implements Command<T> {
     }
 
     @Override
-    @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
     public boolean equals(Object obj) {
         if (this == obj) {
             return true;
         }
-        if (!(this instanceof AbstractCommand)) {
+        if (!(obj instanceof AbstractCommand)) {
             return false;
         }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/CreateSessionCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/CreateSessionCommandTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.command;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectOutputStream;
@@ -77,5 +78,19 @@ class CreateSessionCommandTest {
             oos.writeObject(object);
             return Base64.getEncoder().encodeToString(baos.toByteArray());
         }
+    }
+
+    @Test
+    void testEquals() {
+        final Session session =
+                new Session("session-id-12345",
+                        "foo",
+                        Instant.EPOCH,
+                        Instant.EPOCH.plus(1, ChronoUnit.MINUTES),
+                        "abc");
+        final CreateSessionCommand command = new CreateSessionCommand(1234L,
+                new Author("foo", "bar@baz.com"),
+                session);
+        assertThat(command).isNotEqualTo("string");
     }
 }


### PR DESCRIPTION
Motivation:
The `equals` method in `AbstractCommand` is not correctly implemented.

Modification:
- Implement `AbstractCommand.equals()` correctly.

Result:
- `ClassCastException` is not raised anymore when checking the equality of sub `AbstractCommand`s that don't override `equals()` method.
- Fixes #751 