### PR TITLE
Copy generated static files into the `server` module

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -65,6 +65,14 @@ if (rootProject.ext.testJavaVersion >= 16) {
     }
 }
 
+if (!rootProject.hasProperty('noWeb')) {
+    sourceSets {
+        main {
+            output.dir project(':webapp').file('build/javaweb'), builtBy: ':webapp:copyWeb'
+        }
+    }
+}
+
 def clientRelocations = [
         'ace-builds/src-min-noconflict/',
         'angular/angular.min.js',

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -751,8 +751,15 @@ public class CentralDogma implements AutoCloseable {
                                    .build(),
                         "/index.html"));
             }
-            sb.serviceUnder("/",
+
+            sb.serviceUnder("/legacy-web",
                             FileService.builder(CentralDogma.class.getClassLoader(), "webapp")
+                                       .cacheControl(ServerCacheControl.REVALIDATED)
+                                       .build());
+
+            sb.serviceUnder("/",
+                            FileService.builder(CentralDogma.class.getClassLoader(),
+                                                "com/linecorp/centraldogma/webapp")
                                        .cacheControl(ServerCacheControl.REVALIDATED)
                                        .build());
         }

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 node {
-    version = '16.17.0'
-    npmVersion = '8.15.0'
+    version = '18.11.0'
+    npmVersion = '9.1.1'
     download = true
     npmInstallCommand = "ci"
 
@@ -21,6 +21,25 @@ dependencies {
     testImplementation(project(":server"))
     testImplementation(project(":server-auth:shiro"))
     testImplementation libs.shiro.core
+}
+
+task buildWeb(type: NpmTask) {
+    dependsOn tasks.npmInstall
+    args = ['run', 'build']
+    inputs.dir('src')
+    inputs.dir('pages')
+    inputs.file('package.json')
+    inputs.file('package-lock.json')
+    inputs.file('next.config.js')
+
+    outputs.dir('build/web')
+}
+
+task copyWeb(type: Copy) {
+    dependsOn buildWeb
+
+    from 'build/web'
+    into 'build/javaweb/com/linecorp/centraldogma/webapp'
 }
 
 task simpleTestServer(type: JavaExec) {

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -1,4 +1,7 @@
 const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
-module.exports = withBundleAnalyzer({});
+const nextConfig = {
+  trailingSlash: true,
+};
+module.exports = withBundleAnalyzer(nextConfig);

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -6,7 +6,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "develop": "NEXT_PUBLIC_HOST=\"http://127.0.0.1:36462\" next dev",
     "mock": "NEXT_PUBLIC_HOST='' next dev",
-    "build": "next build",
+    "build": "NEXT_PUBLIC_HOST='' next build && next export -o build/web/",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix --ext .json,.js,.jsx,.ts,.tsx .",

--- a/webapp/pages/index.tsx
+++ b/webapp/pages/index.tsx
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+const Index = () => {
+  // TODO(ikhoon):
+  //  - Move pages folder under 'src/' directory. https://nextjs.org/docs/advanced-features/src-directory
+  //  - Implement index page.
+  return <div>Welcome to Central Dogma!</div>;
+};
+
+export default Index;

--- a/webapp/pages/web/auth/login.tsx
+++ b/webapp/pages/web/auth/login.tsx
@@ -9,7 +9,7 @@ const LoginPage = () => {
   const user = useAppSelector((state) => state.auth.user);
   useEffect(() => {
     if (user) {
-      router.push('/app/projects');
+      router.push('/');
     }
   }, [router, user]);
   return (


### PR DESCRIPTION
Motivation:

The `webapp` module should be served by a Central Domga server.

Modification:

- Add an `pages/index.tsx` to serve the initial html file.
- Add build tasks for the front and copy the resources to server.

Result:

You can now serve the new front webapp using a Central Dogma server.