### PR TITLE
Add a trailing slash to the auth URLs

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -744,22 +744,16 @@ public class CentralDogma implements AutoCloseable {
                 sb.service(LOGIN_PATH, authProvider.webLoginService());
                 // Will redirect to /web/auth/logout by default.
                 sb.service(LOGOUT_PATH, authProvider.webLogoutService());
-
-                sb.serviceUnder(BUILTIN_WEB_BASE_PATH, new OrElseDefaultHttpFileService(
-                        FileService.builder(CentralDogma.class.getClassLoader(), "auth-webapp")
-                                   .cacheControl(ServerCacheControl.REVALIDATED)
-                                   .build(),
-                        "/index.html"));
             }
-
-            sb.serviceUnder("/legacy-web",
-                            FileService.builder(CentralDogma.class.getClassLoader(), "webapp")
-                                       .cacheControl(ServerCacheControl.REVALIDATED)
-                                       .build());
 
             sb.serviceUnder("/",
                             FileService.builder(CentralDogma.class.getClassLoader(),
                                                 "com/linecorp/centraldogma/webapp")
+                                       .cacheControl(ServerCacheControl.REVALIDATED)
+                                       .build());
+
+            sb.serviceUnder("/legacy-web",
+                            FileService.builder(CentralDogma.class.getClassLoader(), "webapp")
                                        .cacheControl(ServerCacheControl.REVALIDATED)
                                        .build());
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
@@ -42,13 +42,14 @@ public interface AuthProvider {
      * A login page path for the web console. If a user, who has not logged into the web console yet,
      * opens the web console, the web browser would bring the user to the login page.
      */
-    String LOGIN_PATH = "/link/auth/login";
+    // TODO(ikhoon): Remove the trailing slash once https://github.com/line/armeria/issues/4542 is resolved.
+    String LOGIN_PATH = "/link/auth/login/";
 
     /**
      * A logout page path for the web console. If a user clicks the logout button on the navigation bar,
      * the web browser would bring the user to the logout page.
      */
-    String LOGOUT_PATH = "/link/auth/logout";
+    String LOGOUT_PATH = "/link/auth/logout/";
 
     /**
      * A base path of the built-in web app.
@@ -58,12 +59,12 @@ public interface AuthProvider {
     /**
      * A path which provides a built-in HTML login form to a user.
      */
-    String BUILTIN_WEB_LOGIN_PATH = BUILTIN_WEB_BASE_PATH + "/login";
+    String BUILTIN_WEB_LOGIN_PATH = BUILTIN_WEB_BASE_PATH + "/login/";
 
     /**
      * A path which provides a built-in HTML logout page to a user.
      */
-    String BUILTIN_WEB_LOGOUT_PATH = BUILTIN_WEB_BASE_PATH + "/logout";
+    String BUILTIN_WEB_LOGOUT_PATH = BUILTIN_WEB_BASE_PATH + "/logout/";
 
     /**
      * A set of {@link Route}s which handles a login request. It is necessary only if
@@ -86,7 +87,7 @@ public interface AuthProvider {
      * the browser would bring a user to the built-in web login page served on {@value BUILTIN_WEB_LOGIN_PATH}.
      */
     default HttpService webLoginService() {
-        // Redirect to the default page: /link/auth/login -> /web/auth/login
+        // Redirect to the default page: /link/auth/login -> /web/auth/login/
         return (ctx, req) -> HttpResponse.of(
                 ResponseHeaders.of(HttpStatus.MOVED_PERMANENTLY, HttpHeaderNames.LOCATION,
                                    BUILTIN_WEB_LOGIN_PATH));

--- a/webapp/src/dogma/features/auth/Authorized.tsx
+++ b/webapp/src/dogma/features/auth/Authorized.tsx
@@ -45,7 +45,7 @@ export const Authorized = (props: { children: ReactNode }) => {
     return <>{props.children}</>;
   }
   if (typeof window !== 'undefined' && !auth.isAuthenticated) {
-    router.push(WEB_AUTH_LOGIN);
+    router.push(`${process.env.NEXT_PUBLIC_HOST}/link/auth/login/`);
   }
   return <></>;
 };


### PR DESCRIPTION
Motivation:

Next.js generates index.html files under the target paths when `trailingSlash` option is enabled. Additionally, `/` is automatically added to a routing path.
https://nextjs.org/docs/api-reference/next.config.js/trailing-slash

Note:

This PR is a temporary workaround to respond to trailing slashs properly. The URLs will be reverted and `trailingSlash` option is disabled when https://github.com/line/armeria/issues/4542 is resolved.

Modifications:

- Appended `/` to URLs related to authentication.
- Remove the legacy auth file service to avoid path conllisions.

Result:

- Users can login with Shiro authentication.