### PR TITLE
Make a Next.js test app login with a Central Dogma server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ typings/
 
 # dotenv environment variables file
 .env
+.env*.local
 
 # next.js build output
 .next

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthProvider.java
@@ -88,9 +88,15 @@ public interface AuthProvider {
      */
     default HttpService webLoginService() {
         // Redirect to the default page: /link/auth/login -> /web/auth/login/
-        return (ctx, req) -> HttpResponse.of(
-                ResponseHeaders.of(HttpStatus.MOVED_PERMANENTLY, HttpHeaderNames.LOCATION,
-                                   BUILTIN_WEB_LOGIN_PATH));
+        return (ctx, req) -> {
+            String returnTo = ctx.queryParam("return_to");
+            if (returnTo != null) {
+                returnTo += BUILTIN_WEB_LOGIN_PATH;
+            } else {
+                returnTo = BUILTIN_WEB_LOGIN_PATH;
+            }
+            return HttpResponse.ofRedirect(HttpStatus.MOVED_PERMANENTLY, returnTo);
+        };
     }
 
     /**
@@ -99,10 +105,16 @@ public interface AuthProvider {
      * {@value BUILTIN_WEB_LOGOUT_PATH}.
      */
     default HttpService webLogoutService() {
-        // Redirect to the default page: /link/auth/logout -> /web/auth/logout
-        return (ctx, req) -> HttpResponse.of(
-                ResponseHeaders.of(HttpStatus.MOVED_PERMANENTLY, HttpHeaderNames.LOCATION,
-                                   BUILTIN_WEB_LOGOUT_PATH));
+        // Redirect to the default page: /link/auth/logout -> /web/auth/logout/
+        return (ctx, req) -> {
+            String returnTo = ctx.queryParam("return_to");
+            if (returnTo != null) {
+                returnTo += BUILTIN_WEB_LOGOUT_PATH;
+            } else {
+                returnTo = BUILTIN_WEB_LOGOUT_PATH;
+            }
+            return HttpResponse.ofRedirect(HttpStatus.MOVED_PERMANENTLY, returnTo);
+        };
     }
 
     /**

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     testImplementation libs.shiro.core
 }
 
+// Set `NEXTJS_ENV=development` to `.env.local` file to produce source maps for the minified JavaScript files.
 task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall
     args = ['run', 'build']

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     testImplementation libs.shiro.core
 }
 
-// Set `NEXTJS_ENV=development` to `.env.local` file to produce source maps for the minified JavaScript files.
+// Set `NEXT_ENV=development` to `.env.local` file to produce source maps for the minified JavaScript files.
 task buildWeb(type: NpmTask) {
     dependsOn tasks.npmInstall
     args = ['run', 'build']

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -2,6 +2,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 const nextConfig = {
+  productionBrowserSourceMaps: process.env.NEXTJS_ENV === 'development',
   trailingSlash: true,
 };
 module.exports = withBundleAnalyzer(nextConfig);

--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -2,7 +2,7 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 const nextConfig = {
-  productionBrowserSourceMaps: process.env.NEXTJS_ENV === 'development',
+  productionBrowserSourceMaps: process.env.NEXT_ENV === 'development',
   trailingSlash: true,
 };
 module.exports = withBundleAnalyzer(nextConfig);

--- a/webapp/src/dogma/features/auth/Authorized.tsx
+++ b/webapp/src/dogma/features/auth/Authorized.tsx
@@ -48,7 +48,11 @@ export const Authorized = (props: { children: ReactNode }) => {
     return <>{props.children}</>;
   }
   if (typeof window !== 'undefined' && !auth.isAuthenticated) {
-    router.push(`${process.env.NEXT_PUBLIC_HOST}/link/auth/login/`);
+    if (process.env.NEXT_PUBLIC_HOST) {
+      router.push(`${process.env.NEXT_PUBLIC_HOST}/link/auth/login/?return_to=http://127.0.0.1:3000`);
+    } else {
+      router.push(`/link/auth/login/`);
+    }
   }
   return <></>;
 };

--- a/webapp/src/dogma/features/auth/Authorized.tsx
+++ b/webapp/src/dogma/features/auth/Authorized.tsx
@@ -49,7 +49,7 @@ export const Authorized = (props: { children: ReactNode }) => {
   }
   if (typeof window !== 'undefined' && !auth.isAuthenticated) {
     if (process.env.NEXT_PUBLIC_HOST) {
-      router.push(`${process.env.NEXT_PUBLIC_HOST}/link/auth/login/?return_to=http://127.0.0.1:3000`);
+      router.push(`${process.env.NEXT_PUBLIC_HOST}/link/auth/login/?return_to=${window.location.origin}`);
     } else {
       router.push(`/link/auth/login/`);
     }


### PR DESCRIPTION
Motivation:

A dev server running on `3000` port redirects to the `http://DOGMA_HOST/link/auth/login` to get configured login page URL. The client expects the server to redirect to the dev server's login page if Shiro auth provider is configured. However, a Central Dogma server assumes the web client is hosted in the same origin and returns a relative path. As a result, the dev client loses a chance to render the login page and a Central Dogma hosted login page is rendered instead.
```
http://127.0.0.1:3000/ -> http://127.0.0.1:36462/link/auth/login ->
http://127.0.0.1:36462/web/auth/login
```
To request a login request from the dev server, the Central Dogma server should redirect to `http://127.0.0.1:3000/web/auth/login`.

Modifications:

- Prefix a host to the login path if `return_to` exists and redirect to the absolute URL.

Result:

A Next.js dev server can login with a Central Dogma server.