### PR TITLE
Display client error

### DIFF
--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -13,23 +13,23 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode, useEffect } from 'react';
-import { useToast } from '@chakra-ui/react';
-import { useAppSelector } from 'dogma/store';
+import { ReactNode } from 'react';
 
-export const Deferred = (props: { children: ReactNode }) => {
-  const { errorText, errorType } = useAppSelector((state) => state.message);
-  const toast = useToast();
-  useEffect(() => {
-    if (errorText) {
-      toast({
-        title: errorType,
-        description: errorText,
-        status: errorType,
-        duration: 10000,
-        isClosable: true,
-      });
-    }
-  });
-  return <>{props.children}</>;
+interface LoadingProps {
+  isLoading: boolean;
+  error: any;
+  children: () => ReactNode;
+}
+export const Deferred = (props: LoadingProps) => {
+  if (props.isLoading) {
+    // TODO(ikhoon): Add a loading indicator/spinner.
+    return <div>Loading...</div>;
+  }
+
+  if (props.error) {
+    // TODO(ikhoon): Link to an error page.
+    return <div>Link to an error page</div>;
+  }
+
+  return <div>{props.children()}</div>;
 };

--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -13,23 +13,23 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useAppSelector } from 'dogma/store';
 
-interface LoadingProps {
-  isLoading: boolean;
-  error: any;
-  children: () => ReactNode;
-}
-export const Deferred = (props: LoadingProps) => {
-  if (props.isLoading) {
-    // TODO(ikhoon): Add a loading indicator/spinner.
-    return <div>Loading...</div>;
-  }
-
-  if (props.error) {
-    // TODO(ikhoon): Link to an error page.
-    return <div>Link to an error page</div>;
-  }
-
-  return <div>{props.children()}</div>;
+export const Deferred = (props: { children: ReactNode }) => {
+  const { errorText, errorType } = useAppSelector((state) => state.message);
+  const toast = useToast();
+  useEffect(() => {
+    if (errorText) {
+      toast({
+        title: errorType,
+        description: errorText,
+        status: errorType,
+        duration: 10000,
+        isClosable: true,
+      });
+    }
+  });
+  return <>{props.children}</>;
 };

--- a/webapp/src/dogma/common/components/ErrorWrapper.tsx
+++ b/webapp/src/dogma/common/components/ErrorWrapper.tsx
@@ -1,0 +1,20 @@
+import { ReactNode, useEffect } from 'react';
+import { useToast } from '@chakra-ui/react';
+import { useAppSelector } from 'dogma/store';
+
+export const ErrorWrapper = (props: { children: ReactNode }) => {
+  const { errorText, errorType } = useAppSelector((state) => state.message);
+  const toast = useToast();
+  useEffect(() => {
+    if (errorText) {
+      toast({
+        title: errorType,
+        description: errorText,
+        status: errorType,
+        duration: 10000,
+        isClosable: true,
+      });
+    }
+  });
+  return <>{props.children}</>;
+};

--- a/webapp/src/dogma/common/components/ErrorWrapper.tsx
+++ b/webapp/src/dogma/common/components/ErrorWrapper.tsx
@@ -3,18 +3,18 @@ import { useToast } from '@chakra-ui/react';
 import { useAppSelector } from 'dogma/store';
 
 export const ErrorWrapper = (props: { children: ReactNode }) => {
-  const { errorText, errorType } = useAppSelector((state) => state.message);
+  const { title, text, type } = useAppSelector((state) => state.message);
   const toast = useToast();
   useEffect(() => {
-    if (errorText) {
+    if (text) {
       toast({
-        title: errorType,
-        description: errorText,
-        status: errorType,
+        title: title,
+        description: text,
+        status: type,
         duration: 10000,
         isClosable: true,
       });
     }
-  });
+  }, [title, text, type, toast]);
   return <>{props.children}</>;
 };

--- a/webapp/src/dogma/features/auth/Authorized.tsx
+++ b/webapp/src/dogma/features/auth/Authorized.tsx
@@ -18,8 +18,9 @@ import { ReactNode, useEffect } from 'react';
 import { useAppDispatch, useAppSelector } from 'dogma/store';
 import { getUser, checkSecurityEnabled } from 'dogma/features/auth/authSlice';
 import { useRouter } from 'next/router';
-import { WEB_AUTH_LOGIN } from 'dogma/features/auth/util';
 import { isFulfilled } from '@reduxjs/toolkit';
+
+const WEB_AUTH_LOGIN = '/web/auth/login';
 
 export const Authorized = (props: { children: ReactNode }) => {
   const dispatch = useAppDispatch();

--- a/webapp/src/dogma/features/auth/authSlice.ts
+++ b/webapp/src/dogma/features/auth/authSlice.ts
@@ -84,7 +84,7 @@ export const checkSecurityEnabled = createAsyncThunk(
         localStorage.removeItem('sessionId');
       }
       const error: string = ErrorHandler.handle(err);
-      dispatch(createMessageError(error));
+      dispatch(createMessageInfo('Currently in anonymous mode'));
       return rejectWithValue(error);
     }
   },

--- a/webapp/src/dogma/features/auth/authSlice.ts
+++ b/webapp/src/dogma/features/auth/authSlice.ts
@@ -18,7 +18,7 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import { UserDto } from 'dogma/features/auth/UserDto';
 import axios from 'axios';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
-import { createMessageError, createMessageInfo } from 'dogma/features/message/messageSlice';
+import { createMessage } from 'dogma/features/message/messageSlice';
 
 axios.defaults.baseURL = process.env.NEXT_PUBLIC_HOST || '';
 
@@ -26,7 +26,6 @@ export const getUser = createAsyncThunk('/auth/user', async (_, { getState, disp
   try {
     const { auth } = getState() as { auth: AuthState };
     if (!auth.sessionId) {
-      dispatch(createMessageInfo('Login required'));
       return rejectWithValue('Login required');
     }
     const { data } = await axios.get(`/api/v0/users/me`, {
@@ -40,7 +39,7 @@ export const getUser = createAsyncThunk('/auth/user', async (_, { getState, disp
       localStorage.removeItem('sessionId');
     }
     const error: string = ErrorHandler.handle(err);
-    dispatch(createMessageError(error));
+    dispatch(createMessage({ title: '', text: error, type: 'error' }));
     return rejectWithValue(error);
   }
 });
@@ -68,7 +67,7 @@ export const login = createAsyncThunk(
         localStorage.removeItem('sessionId');
       }
       const error: string = ErrorHandler.handle(err);
-      dispatch(createMessageError(error));
+      dispatch(createMessage({ title: '', text: error, type: 'error' }));
       return rejectWithValue(error);
     }
   },
@@ -84,7 +83,7 @@ export const checkSecurityEnabled = createAsyncThunk(
         localStorage.removeItem('sessionId');
       }
       const error: string = ErrorHandler.handle(err);
-      dispatch(createMessageInfo('Currently in anonymous mode'));
+      dispatch(createMessage({ title: '', text: error, type: 'error' }));
       return rejectWithValue(error);
     }
   },
@@ -103,7 +102,7 @@ export const logout = createAsyncThunk('/auth/logout', async (_, { getState, dis
     }
   } catch (err) {
     const error: string = ErrorHandler.handle(err);
-    dispatch(createMessageError(error));
+    dispatch(createMessage({ title: '', text: error, type: 'error' }));
     return rejectWithValue(error);
   }
 });

--- a/webapp/src/dogma/features/auth/authSlice.ts
+++ b/webapp/src/dogma/features/auth/authSlice.ts
@@ -116,7 +116,7 @@ export interface AuthState {
 }
 
 const initialState: AuthState = {
-  isInAnonymousMode: true,
+  isInAnonymousMode: false,
   sessionId,
   user: null,
   ready: false,
@@ -128,6 +128,11 @@ export const authSlice = createSlice({
   reducers: {},
   extraReducers: (builder) => {
     builder
+      .addCase(checkSecurityEnabled.rejected, (state) => {
+        state.isInAnonymousMode = true;
+        state.sessionId = '';
+        state.ready = true;
+      })
       .addCase(login.fulfilled, (state, { payload }) => {
         state.sessionId = payload.access_token;
       })
@@ -135,17 +140,8 @@ export const authSlice = createSlice({
         state.sessionId = '';
       })
       .addCase(logout.fulfilled, (state) => {
-        state.isInAnonymousMode = true;
         state.sessionId = '';
         state.user = null;
-      })
-      .addCase(checkSecurityEnabled.fulfilled, (state) => {
-        state.isInAnonymousMode = false;
-      })
-      .addCase(checkSecurityEnabled.rejected, (state) => {
-        state.isInAnonymousMode = true;
-        state.sessionId = '';
-        state.ready = true;
       })
       .addCase(getUser.fulfilled, (state, { payload }) => {
         state.user = payload;
@@ -153,8 +149,8 @@ export const authSlice = createSlice({
       })
       .addCase(getUser.rejected, (state) => {
         state.user = null;
-        state.ready = true;
         state.sessionId = '';
+        state.ready = true;
       });
   },
 });

--- a/webapp/src/dogma/features/auth/util.ts
+++ b/webapp/src/dogma/features/auth/util.ts
@@ -1,1 +1,0 @@
-export const WEB_AUTH_LOGIN = '/web/auth/login';

--- a/webapp/src/dogma/features/message/messageSlice.ts
+++ b/webapp/src/dogma/features/message/messageSlice.ts
@@ -1,0 +1,29 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface MessageState {
+  errorText: string;
+  errorType: 'error' | 'info' | 'warning' | 'success' | 'loading';
+}
+
+const initialState: MessageState = {
+  errorText: '',
+  errorType: 'info',
+};
+
+export const messageSlice = createSlice({
+  name: 'message',
+  initialState,
+  reducers: {
+    createMessageError(state: MessageState, action: PayloadAction<string>) {
+      state.errorText = action.payload;
+      state.errorType = 'error';
+    },
+    createMessageWarning(state: MessageState, action: PayloadAction<string>) {
+      state.errorText = action.payload;
+      state.errorType = 'warning';
+    },
+  },
+});
+
+export const { createMessageError, createMessageWarning } = messageSlice.actions;
+export const messageReducer = messageSlice.reducer;

--- a/webapp/src/dogma/features/message/messageSlice.ts
+++ b/webapp/src/dogma/features/message/messageSlice.ts
@@ -22,8 +22,12 @@ export const messageSlice = createSlice({
       state.errorText = action.payload;
       state.errorType = 'warning';
     },
+    createMessageInfo(state: MessageState, action: PayloadAction<string>) {
+      state.errorText = action.payload;
+      state.errorType = 'info';
+    },
   },
 });
 
-export const { createMessageError, createMessageWarning } = messageSlice.actions;
+export const { createMessageError, createMessageWarning, createMessageInfo } = messageSlice.actions;
 export const messageReducer = messageSlice.reducer;

--- a/webapp/src/dogma/features/message/messageSlice.ts
+++ b/webapp/src/dogma/features/message/messageSlice.ts
@@ -1,33 +1,28 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 export interface MessageState {
-  errorText: string;
-  errorType: 'error' | 'info' | 'warning' | 'success' | 'loading';
+  title: string;
+  text: string;
+  type: 'error' | 'info' | 'warning' | 'success' | 'loading';
 }
 
 const initialState: MessageState = {
-  errorText: '',
-  errorType: 'info',
+  title: '',
+  text: '',
+  type: 'info',
 };
 
 export const messageSlice = createSlice({
   name: 'message',
   initialState,
   reducers: {
-    createMessageError(state: MessageState, action: PayloadAction<string>) {
-      state.errorText = action.payload;
-      state.errorType = 'error';
-    },
-    createMessageWarning(state: MessageState, action: PayloadAction<string>) {
-      state.errorText = action.payload;
-      state.errorType = 'warning';
-    },
-    createMessageInfo(state: MessageState, action: PayloadAction<string>) {
-      state.errorText = action.payload;
-      state.errorType = 'info';
+    createMessage(state: MessageState, action: PayloadAction<MessageState>) {
+      state.title = action.payload.title;
+      state.text = action.payload.text;
+      state.type = action.payload.type;
     },
   },
 });
 
-export const { createMessageError, createMessageWarning, createMessageInfo } = messageSlice.actions;
+export const { createMessage } = messageSlice.actions;
 export const messageReducer = messageSlice.reducer;

--- a/webapp/src/dogma/features/services/ErrorHandler.ts
+++ b/webapp/src/dogma/features/services/ErrorHandler.ts
@@ -1,0 +1,16 @@
+class ErrorHandler {
+  static handle(error: any): string {
+    if (error.response && error.response.data.message) {
+      return error.response.data.message;
+    }
+    if (error.message) {
+      return error.message;
+    }
+    if (typeof error === 'string') {
+      return error;
+    }
+    return 'Uncaught Error';
+  }
+}
+
+export default ErrorHandler;

--- a/webapp/src/dogma/store.ts
+++ b/webapp/src/dogma/store.ts
@@ -19,9 +19,11 @@ import { authReducer } from 'dogma/features/auth/authSlice';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import { apiSlice } from 'dogma/features/api/apiSlice';
 import { setupListeners } from '@reduxjs/toolkit/query';
+import { messageReducer } from 'dogma/features/message/messageSlice';
 
 const reducer = {
   auth: authReducer,
+  message: messageReducer,
   [apiSlice.reducerPath]: apiSlice.reducer,
 };
 export const store = configureStore({

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -7,8 +7,9 @@ import { NextPage } from 'next';
 import { ReactElement, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
-import { WEB_AUTH_LOGIN } from 'dogma/features/auth/util';
 import { ErrorWrapper } from 'dogma/common/components/ErrorWrapper';
+
+const WEB_AUTH_LOGIN = '/web/auth/login';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -24,6 +25,7 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
     router.pathname === WEB_AUTH_LOGIN
       ? (page: ReactElement) => page
       : (page: ReactElement) => <Layout>{page}</Layout>;
+
   return (
     <Provider store={store}>
       <ChakraProvider theme={theme}>

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import { ReactElement, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
 import { WEB_AUTH_LOGIN } from 'dogma/features/auth/util';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -26,7 +27,9 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   return (
     <Provider store={store}>
       <ChakraProvider theme={theme}>
-        <Authorized>{getLayout(<Component {...pageProps} />)}</Authorized>
+        <Deferred>
+          <Authorized>{getLayout(<Component {...pageProps} />)}</Authorized>
+        </Deferred>
       </ChakraProvider>
     </Provider>
   );

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -8,7 +8,7 @@ import { ReactElement, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
 import { WEB_AUTH_LOGIN } from 'dogma/features/auth/util';
-import { Deferred } from 'dogma/common/components/Deferred';
+import { ErrorWrapper } from 'dogma/common/components/ErrorWrapper';
 
 export type NextPageWithLayout<P = {}, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -27,9 +27,9 @@ const MyApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   return (
     <Provider store={store}>
       <ChakraProvider theme={theme}>
-        <Deferred>
+        <ErrorWrapper>
           <Authorized>{getLayout(<Component {...pageProps} />)}</Authorized>
-        </Deferred>
+        </ErrorWrapper>
       </ChakraProvider>
     </Provider>
   );


### PR DESCRIPTION
## Motivation
Show client side error to the user.

## Modification
- Convert any caught error to string.
- Add a message reducer to handle any client side error.
- Dispatch caught auth error to the message reducer.
- Show an error toast in the UI.
- Default anonymous state to false.

## Result
- Error can be displayed using a component instead of the browser alert.
- Any caught / client side error can be dispatched to the message reducer. 
- The following error types are supported `'error' | 'info' | 'warning' | 'success' | 'loading'`.
- The app starts with false anonymous mode. 


<img width="558" alt="Screen Shot 2022-11-24 at 13 56 20" src="https://user-images.githubusercontent.com/5079588/203714699-0f402206-fa47-400c-913f-a1dabdb37f9b.png">

