### PR TITLE
Add repo detail page 

### DIFF
--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import FileList, { FileListProps } from 'dogma/features/file/FileList';
-import { FileDto } from '../../../../src/dogma/features/file/FileDto';
+import { FileDto } from 'dogma/features/file/FileDto';
 
 describe('FileList', () => {
   let expectedProps: JSX.IntrinsicAttributes & FileListProps<object>;

--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import FileList, { FileListProps } from 'dogma/features/file/FileList';
+import { FileDto } from '../../../../src/dogma/features/file/FileDto';
+
+describe('FileList', () => {
+  let expectedProps: JSX.IntrinsicAttributes & FileListProps<object>;
+
+  beforeEach(() => {
+    const mockfileList = [
+      {
+        revision: 6,
+        path: '/123456',
+        type: 'TEXT',
+        url: '/api/v1/projects/Gamma/repos/repo1/contents/123456',
+      },
+      { revision: 6, path: '/abc', type: 'TEXT', url: '/api/v1/projects/Gamma/repos/repo1/contents/abc' },
+      {
+        revision: 6,
+        path: '/uuuuu',
+        type: 'TEXT',
+        url: '/api/v1/projects/Gamma/repos/repo1/contents/uuuuu',
+      },
+      {
+        revision: 6,
+        path: '/yyyyyyyy',
+        type: 'TEXT',
+        url: '/api/v1/projects/Gamma/repos/repo1/contents/yyyyyyyy',
+      },
+      {
+        revision: 6,
+        path: '/zzzzz',
+        type: 'TEXT',
+        url: '/api/v1/projects/Gamma/repos/repo1/contents/zzzzz',
+      },
+    ];
+    expectedProps = {
+      data: mockfileList,
+      projectName: 'ProjectAlpha',
+      repoName: 'repo1',
+    };
+  });
+
+  it('renders the file paths', () => {
+    const { getByText } = render(<FileList {...expectedProps} />);
+    let name;
+    expectedProps.data.forEach((file: FileDto) => {
+      name = getByText(file.path);
+      expect(name).toBeVisible();
+    });
+  });
+
+  it('renders a table with a row for each file', () => {
+    const { getByTestId } = render(<FileList {...expectedProps} />);
+    expect(getByTestId('table-body').children.length).toBe(5);
+  });
+
+  it('generates `${projectName}/repos/${repoName}/files/head{fileName}` url when the view icon is clicked', () => {
+    const { getByTestId } = render(<FileList {...expectedProps} />);
+    const fileName = '/zzzzz';
+    const repoViewLink = getByTestId(
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head-${fileName}`,
+    );
+    expect(repoViewLink).toHaveAttribute(
+      'href',
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head${fileName}`,
+    );
+  });
+});

--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -50,19 +50,27 @@ describe('FileList', () => {
   });
 
   it('renders a table with a row for each file', () => {
-    const { getByTestId } = render(<FileList {...expectedProps} />);
-    expect(getByTestId('table-body').children.length).toBe(5);
+    const { container } = render(<FileList {...expectedProps} />);
+    expect(container.querySelector('tbody').children.length).toBe(5);
   });
 
-  it('generates `${projectName}/repos/${repoName}/files/head{fileName}` url when the view icon is clicked', () => {
-    const { getByTestId } = render(<FileList {...expectedProps} />);
-    const fileName = '/zzzzz';
-    const repoViewLink = getByTestId(
-      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head-${fileName}`,
-    );
-    expect(repoViewLink).toHaveAttribute(
+  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the view icon', () => {
+    const { container } = render(<FileList {...expectedProps} />);
+    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
+    const firstFileName = '/123456';
+    expect(actionCell).toHaveAttribute(
       'href',
-      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head${fileName}`,
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head${firstFileName}`,
+    );
+  });
+
+  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the file path cell', () => {
+    const { container } = render(<FileList {...expectedProps} />);
+    const firstCell = container.querySelector('tbody').firstChild.firstChild.firstChild;
+    const firstFileName = '/123456';
+    expect(firstCell).toHaveAttribute(
+      'href',
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head${firstFileName}`,
     );
   });
 });

--- a/webapp/__tests__/dogma/feature/repository/RepoList.test.tsx
+++ b/webapp/__tests__/dogma/feature/repository/RepoList.test.tsx
@@ -41,7 +41,7 @@ describe('RepoList', () => {
     ];
     expectedProps = {
       data: mockRepos,
-      name: 'ProjectAlpha',
+      projectName: 'ProjectAlpha',
     };
   });
 
@@ -69,7 +69,10 @@ describe('RepoList', () => {
   it('generates `${projectName}/repos/${repoName}` url when the view icon is clicked', () => {
     const { getByTestId } = render(<RepoList {...expectedProps} />);
     const repoName = 'repo1';
-    const repoViewLink = getByTestId('ProjectAlpha/repos-repo1');
-    expect(repoViewLink).toHaveAttribute('href', `ProjectAlpha/repos/${repoName}`);
+    const repoViewLink = getByTestId(`/app/projects/${expectedProps.projectName}/repos/-${repoName}`);
+    expect(repoViewLink).toHaveAttribute(
+      'href',
+      `/app/projects/${expectedProps.projectName}/repos/${repoName}`,
+    );
   });
 });

--- a/webapp/__tests__/dogma/feature/repository/RepoList.test.tsx
+++ b/webapp/__tests__/dogma/feature/repository/RepoList.test.tsx
@@ -55,24 +55,27 @@ describe('RepoList', () => {
   });
 
   it('renders a table with a row for each repo', () => {
-    const { getByTestId } = render(<RepoList {...expectedProps} />);
-    expect(getByTestId('table-body').children.length).toBe(3);
+    const { container } = render(<RepoList {...expectedProps} />);
+    expect(container.querySelector('tbody').children.length).toBe(3);
   });
 
-  it('does not generates `${projectName}/repos/${repoName}` url when the table row is clicked', () => {
-    const { getByTestId } = render(<RepoList {...expectedProps} />);
-    const row = getByTestId('table-body').children[0];
-    fireEvent.click(row);
-    expect(pathName).toEqual('');
-  });
-
-  it('generates `${projectName}/repos/${repoName}` url when the view icon is clicked', () => {
-    const { getByTestId } = render(<RepoList {...expectedProps} />);
-    const repoName = 'repo1';
-    const repoViewLink = getByTestId(`/app/projects/${expectedProps.projectName}/repos/-${repoName}`);
-    expect(repoViewLink).toHaveAttribute(
+  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the view icon', () => {
+    const { container } = render(<RepoList {...expectedProps} />);
+    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
+    const firstRepoName = 'meta';
+    expect(actionCell).toHaveAttribute(
       'href',
-      `/app/projects/${expectedProps.projectName}/repos/${repoName}`,
+      `/app/projects/${expectedProps.projectName}/repos/${firstRepoName}`,
+    );
+  });
+
+  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the file path cell', () => {
+    const { container } = render(<RepoList {...expectedProps} />);
+    const firstCell = container.querySelector('tbody').firstChild.firstChild.firstChild;
+    const firstRepoName = 'meta';
+    expect(firstCell).toHaveAttribute(
+      'href',
+      `/app/projects/${expectedProps.projectName}/repos/${firstRepoName}`,
     );
   });
 });

--- a/webapp/src/dogma/common/components/NewFileForm.tsx
+++ b/webapp/src/dogma/common/components/NewFileForm.tsx
@@ -1,0 +1,51 @@
+import {
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  DrawerBody,
+  Button,
+  DrawerFooter,
+  Input,
+  Textarea,
+  Text,
+  Divider,
+  Box,
+} from '@chakra-ui/react';
+
+export const NewFileForm = () => {
+  return (
+    <DrawerContent>
+      <DrawerCloseButton />
+      <DrawerHeader>New File</DrawerHeader>
+      <DrawerBody>
+        <form
+          id="my-form"
+          onSubmit={(e) => {
+            e.preventDefault();
+            console.log('submitted');
+          }}
+        >
+          <Box p={4}>
+            <Text>Path</Text>
+            <Input
+              name="path"
+              placeholder="Type 1) a file name 2) a directory name and '/' key or 3) 'backspace' key to go one directory up."
+            />
+            <Text>Content</Text>
+            <Textarea placeholder="Here is a sample placeholder" overflow="hidden" rows={20} height="auto" />
+            <Divider />
+            <Text>Summary</Text>
+            <Input name="summary" placeholder="Add a new file" />
+            <Text>Detail</Text>
+            <Textarea />
+          </Box>
+        </form>
+      </DrawerBody>
+      <DrawerFooter>
+        <Button type="submit" form="my-form" colorScheme="teal">
+          Commit
+        </Button>
+      </DrawerFooter>
+    </DrawerContent>
+  );
+};

--- a/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
@@ -61,9 +61,7 @@ export const DynamicDataTable = <Data extends object>({ data, columns }: Dynamic
                         ) : (
                           <TriangleUpIcon aria-label="sorted ascending" />
                         )
-                      ) : (
-                        <TriangleUpIcon aria-label="sorted ascending" />
-                      )}
+                      ) : null}
                     </chakra.span>
                   </Th>
                 );

--- a/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
@@ -118,7 +118,7 @@ export const DynamicDataTable = <Data extends object>({
                     <WrapItem>
                       <Link
                         data-testid={`${urlPrefix}-${row.getVisibleCells()[0].getValue()}`}
-                        href={`${urlPrefix}/${row.getVisibleCells()[0].getValue()}`}
+                        href={`${urlPrefix}${row.getVisibleCells()[0].getValue()}`}
                       >
                         <IconButton colorScheme="blue" aria-label="View" size="sm" icon={<ViewIcon />} />
                       </Link>

--- a/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
@@ -1,27 +1,5 @@
-import { DeleteIcon, TriangleDownIcon, TriangleUpIcon, ViewIcon } from '@chakra-ui/icons';
-import {
-  Button,
-  ButtonGroup,
-  chakra,
-  IconButton,
-  Popover,
-  PopoverArrow,
-  PopoverBody,
-  PopoverCloseButton,
-  PopoverContent,
-  PopoverFooter,
-  PopoverHeader,
-  PopoverTrigger,
-  Table,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-  Wrap,
-  WrapItem,
-} from '@chakra-ui/react';
+import { TriangleDownIcon, TriangleUpIcon } from '@chakra-ui/icons';
+import { chakra, Table, Tbody, Td, Text, Th, Thead, Tr } from '@chakra-ui/react';
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -33,20 +11,14 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { Filter } from 'dogma/common/components/table/Filter';
-import Link from 'next/link';
 import { useState } from 'react';
 
 export type DynamicDataTableProps<Data extends object> = {
   data: Data[];
-  urlPrefix: string;
   columns: ColumnDef<Data, any>[];
 };
 
-export const DynamicDataTable = <Data extends object>({
-  data,
-  urlPrefix,
-  columns,
-}: DynamicDataTableProps<Data>) => {
+export const DynamicDataTable = <Data extends object>({ data, columns }: DynamicDataTableProps<Data>) => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const table = useReactTable({
@@ -96,11 +68,10 @@ export const DynamicDataTable = <Data extends object>({
                   </Th>
                 );
               })}
-              <Th>Actions</Th>
             </Tr>
           ))}
         </Thead>
-        <Tbody data-testid="table-body">
+        <Tbody>
           {table.getRowModel().rows.map((row) => {
             return (
               <Tr key={row.id} data-testid="table-row">
@@ -113,37 +84,6 @@ export const DynamicDataTable = <Data extends object>({
                     </Td>
                   );
                 })}
-                <Td>
-                  <Wrap>
-                    <WrapItem>
-                      <Link
-                        data-testid={`${urlPrefix}-${row.getVisibleCells()[0].getValue()}`}
-                        href={`${urlPrefix}${row.getVisibleCells()[0].getValue()}`}
-                      >
-                        <IconButton colorScheme="blue" aria-label="View" size="sm" icon={<ViewIcon />} />
-                      </Link>
-                    </WrapItem>
-                    <WrapItem>
-                      <Popover>
-                        <PopoverTrigger>
-                          <IconButton colorScheme="red" aria-label="Delete" size="sm" icon={<DeleteIcon />} />
-                        </PopoverTrigger>
-                        <PopoverContent>
-                          <PopoverHeader fontWeight="semibold">Danger</PopoverHeader>
-                          <PopoverArrow />
-                          <PopoverCloseButton />
-                          <PopoverBody>Are you sure you want to continue with your action?</PopoverBody>
-                          <PopoverFooter display="flex" justifyContent="flex-end">
-                            <ButtonGroup size="sm">
-                              <Button variant="outline">Cancel</Button>
-                              <Button colorScheme="red">Delete</Button>
-                            </ButtonGroup>
-                          </PopoverFooter>
-                        </PopoverContent>
-                      </Popover>
-                    </WrapItem>
-                  </Wrap>
-                </Td>
               </Tr>
             );
           })}

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -18,6 +18,12 @@ import { RepoDto } from 'dogma/features/repo/RepoDto';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { ProjectDto } from 'dogma/features/project/ProjectDto';
 import { AuthState } from 'dogma/features/auth/authSlice';
+import { FileDto } from 'dogma/features/file/FileDto';
+
+export type GetFilesByProjectAndRepoName = {
+  projectName: string;
+  repoName: string;
+};
 
 export const apiSlice = createApi({
   reducerPath: 'api',
@@ -34,9 +40,13 @@ export const apiSlice = createApi({
       query: () => '/v1/projects',
     }),
     getReposByProjectName: builder.query<RepoDto[], string>({
-      query: (name) => `/v1/projects/${name}`,
+      query: (name) => `/v1/projects/${name}/repos`,
+    }),
+    getFilesByProjectAndRepoName: builder.query<FileDto[], GetFilesByProjectAndRepoName>({
+      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/list`,
     }),
   }),
 });
 
-export const { useGetProjectsQuery, useGetReposByProjectNameQuery } = apiSlice;
+export const { useGetProjectsQuery, useGetReposByProjectNameQuery, useGetFilesByProjectAndRepoNameQuery } =
+  apiSlice;

--- a/webapp/src/dogma/features/file/FileDto.ts
+++ b/webapp/src/dogma/features/file/FileDto.ts
@@ -1,0 +1,6 @@
+export interface FileDto {
+  path: string;
+  revision: number;
+  type: string;
+  url: string;
+}

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -1,6 +1,9 @@
+import { DeleteIcon, ViewIcon } from '@chakra-ui/icons';
+import { Button, Wrap, WrapItem } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
 import { FileDto } from 'dogma/features/file/FileDto';
+import Link from 'next/link';
 
 export type FileListProps<Data extends object> = {
   data: Data[];
@@ -11,10 +14,15 @@ export type FileListProps<Data extends object> = {
 const FileList = <Data extends object>({ data, projectName, repoName }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
-    columnHelper.accessor((row: FileDto) => row.path, {
-      cell: (info) => info.getValue(),
-      header: 'Path',
-    }),
+    columnHelper.accessor(
+      (row: FileDto) => (
+        <Link href={`/app/projects/${projectName}/repos/${repoName}/files/head${row.path}`}>{row.path}</Link>
+      ),
+      {
+        cell: (info) => info.getValue(),
+        header: 'Path',
+      },
+    ),
     columnHelper.accessor((row: FileDto) => row.revision, {
       cell: (info) => info.getValue(),
       header: 'Revision',
@@ -23,14 +31,30 @@ const FileList = <Data extends object>({ data, projectName, repoName }: FileList
       cell: (info) => info.getValue(),
       header: 'Type',
     }),
+    columnHelper.accessor(
+      (row: FileDto) => (
+        <Wrap>
+          <WrapItem>
+            <Link href={`/app/projects/${projectName}/repos/${repoName}/files/head${row.path}`}>
+              <Button leftIcon={<ViewIcon />} colorScheme="blue" size="sm">
+                View
+              </Button>
+            </Link>
+          </WrapItem>
+          <WrapItem>
+            <Button leftIcon={<DeleteIcon />} colorScheme="red" size="sm">
+              Delete
+            </Button>
+          </WrapItem>
+        </Wrap>
+      ),
+      {
+        cell: (info) => info.getValue(),
+        header: 'Actions',
+      },
+    ),
   ];
-  return (
-    <DynamicDataTable
-      columns={columns as ColumnDef<Data, any>[]}
-      data={data}
-      urlPrefix={`/app/projects/${projectName}/repos/${repoName}/files/head`}
-    />
-  );
+  return <DynamicDataTable columns={columns as ColumnDef<Data, any>[]} data={data} />;
 };
 
 export default FileList;

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -11,15 +11,15 @@ export type FileListProps<Data extends object> = {
 const FileList = <Data extends object>({ data, projectName, repoName }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
-    columnHelper.accessor('path', {
+    columnHelper.accessor((row: FileDto) => row.path, {
       cell: (info) => info.getValue(),
       header: 'Path',
     }),
-    columnHelper.accessor('revision', {
+    columnHelper.accessor((row: FileDto) => row.revision, {
       cell: (info) => info.getValue(),
       header: 'Revision',
     }),
-    columnHelper.accessor('type', {
+    columnHelper.accessor((row: FileDto) => row.type, {
       cell: (info) => info.getValue(),
       header: 'Type',
     }),

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -14,15 +14,14 @@ export type FileListProps<Data extends object> = {
 const FileList = <Data extends object>({ data, projectName, repoName }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
-    columnHelper.accessor(
-      (row: FileDto) => (
-        <Link href={`/app/projects/${projectName}/repos/${repoName}/files/head${row.path}`}>{row.path}</Link>
+    columnHelper.accessor((row: FileDto) => row.path, {
+      cell: (info) => (
+        <Link href={`/app/projects/${projectName}/repos/${repoName}/files/head${info.getValue()}`}>
+          {info.getValue()}
+        </Link>
       ),
-      {
-        cell: (info) => info.getValue(),
-        header: 'Path',
-      },
-    ),
+      header: 'Path',
+    }),
     columnHelper.accessor((row: FileDto) => row.revision, {
       cell: (info) => info.getValue(),
       header: 'Revision',
@@ -51,6 +50,7 @@ const FileList = <Data extends object>({ data, projectName, repoName }: FileList
       {
         cell: (info) => info.getValue(),
         header: 'Actions',
+        enableSorting: false,
       },
     ),
   ];

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -1,0 +1,36 @@
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
+import { FileDto } from 'dogma/features/file/FileDto';
+
+export type FileListProps<Data extends object> = {
+  data: Data[];
+  projectName: string;
+  repoName: string;
+};
+
+const FileList = <Data extends object>({ data, projectName, repoName }: FileListProps<Data>) => {
+  const columnHelper = createColumnHelper<FileDto>();
+  const columns = [
+    columnHelper.accessor('path', {
+      cell: (info) => info.getValue(),
+      header: 'Path',
+    }),
+    columnHelper.accessor('revision', {
+      cell: (info) => info.getValue(),
+      header: 'Revision',
+    }),
+    columnHelper.accessor('type', {
+      cell: (info) => info.getValue(),
+      header: 'Type',
+    }),
+  ];
+  return (
+    <DynamicDataTable
+      columns={columns as ColumnDef<Data, any>[]}
+      data={data}
+      urlPrefix={`/app/projects/${projectName}/repos/${repoName}/files/head`}
+    />
+  );
+};
+
+export default FileList;

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -14,13 +14,12 @@ export type RepoListProps<Data extends object> = {
 const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data>) => {
   const columnHelper = createColumnHelper<RepoDto>();
   const columns = [
-    columnHelper.accessor(
-      (row: RepoDto) => <Link href={`/app/projects/${projectName}/repos/${row.name}`}>{row.name}</Link>,
-      {
-        cell: (info) => info.getValue(),
-        header: 'Name',
-      },
-    ),
+    columnHelper.accessor((row: RepoDto) => row.name, {
+      cell: (info) => (
+        <Link href={`/app/projects/${projectName}/repos/${info.getValue()}`}>{info.getValue()}</Link>
+      ),
+      header: 'Name',
+    }),
     columnHelper.accessor((row: RepoDto) => row.creator.name, {
       cell: (info) => info.getValue(),
       header: 'Creator',
@@ -57,6 +56,7 @@ const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data
       {
         cell: (info) => info.getValue(),
         header: 'Actions',
+        enableSorting: false,
       },
     ),
   ];

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -5,10 +5,10 @@ import { RepoDto } from 'dogma/features/repo/RepoDto';
 
 export type RepoListProps<Data extends object> = {
   data: Data[];
-  name: string;
+  projectName: string;
 };
 
-const RepoList = <Data extends object>({ data, name }: RepoListProps<Data>) => {
+const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data>) => {
   const columnHelper = createColumnHelper<RepoDto>();
   const columns = [
     columnHelper.accessor((row: RepoDto) => row.name, {
@@ -33,7 +33,11 @@ const RepoList = <Data extends object>({ data, name }: RepoListProps<Data>) => {
     }),
   ];
   return (
-    <DynamicDataTable columns={columns as ColumnDef<Data, any>[]} data={data} urlPrefix={name + '/repos'} />
+    <DynamicDataTable
+      columns={columns as ColumnDef<Data, any>[]}
+      data={data}
+      urlPrefix={`/app/projects/${projectName}/repos/`}
+    />
   );
 };
 

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -1,3 +1,5 @@
+import { ViewIcon, DeleteIcon } from '@chakra-ui/icons';
+import { Wrap, WrapItem, Link, Button } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { formatDistance } from 'date-fns';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
@@ -11,10 +13,13 @@ export type RepoListProps<Data extends object> = {
 const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data>) => {
   const columnHelper = createColumnHelper<RepoDto>();
   const columns = [
-    columnHelper.accessor((row: RepoDto) => row.name, {
-      cell: (info) => info.getValue(),
-      header: 'Name',
-    }),
+    columnHelper.accessor(
+      (row: RepoDto) => <Link href={`/app/projects/${projectName}/repos/${row.name}`}>{row.name}</Link>,
+      {
+        cell: (info) => info.getValue(),
+        header: 'Name',
+      },
+    ),
     columnHelper.accessor((row: RepoDto) => row.creator.name, {
       cell: (info) => info.getValue(),
       header: 'Creator',
@@ -31,14 +36,30 @@ const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data
         isNumeric: true,
       },
     }),
+    columnHelper.accessor(
+      (row: RepoDto) => (
+        <Wrap>
+          <WrapItem>
+            <Link href={`/app/projects/${projectName}/repos/${row.name}`}>
+              <Button leftIcon={<ViewIcon />} colorScheme="blue" size="sm">
+                View
+              </Button>
+            </Link>
+          </WrapItem>
+          <WrapItem>
+            <Button leftIcon={<DeleteIcon />} colorScheme="red" size="sm">
+              Delete
+            </Button>
+          </WrapItem>
+        </Wrap>
+      ),
+      {
+        cell: (info) => info.getValue(),
+        header: 'Actions',
+      },
+    ),
   ];
-  return (
-    <DynamicDataTable
-      columns={columns as ColumnDef<Data, any>[]}
-      data={data}
-      urlPrefix={`/app/projects/${projectName}/repos/`}
-    />
-  );
+  return <DynamicDataTable columns={columns as ColumnDef<Data, any>[]} data={data} />;
 };
 
 export default RepoList;

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -1,9 +1,10 @@
 import { ViewIcon, DeleteIcon } from '@chakra-ui/icons';
-import { Wrap, WrapItem, Link, Button } from '@chakra-ui/react';
+import { Wrap, WrapItem, Button } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { formatDistance } from 'date-fns';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
+import Link from 'next/link';
 
 export type RepoListProps<Data extends object> = {
   data: Data[];

--- a/webapp/src/pages/api/v1/projects/abcd/repos/index.ts
+++ b/webapp/src/pages/api/v1/projects/abcd/repos/index.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 
-export const mockRepos = [
+const mockRepos = [
   {
     name: 'meta',
     creator: { name: 'System', email: 'system@localhost.localdomain' },

--- a/webapp/src/pages/api/v1/projects/abcd/repos/repo1/list.ts
+++ b/webapp/src/pages/api/v1/projects/abcd/repos/repo1/list.ts
@@ -1,0 +1,46 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+const fileList = [
+  {
+    revision: 6,
+    path: '/123456',
+    type: 'TEXT',
+    url: '/api/v1/projects/Gamma/repos/repo1/contents/123456',
+  },
+  { revision: 6, path: '/abc', type: 'TEXT', url: '/api/v1/projects/Gamma/repos/repo1/contents/abc' },
+  {
+    revision: 6,
+    path: '/uuuuu',
+    type: 'TEXT',
+    url: '/api/v1/projects/Gamma/repos/repo1/contents/uuuuu',
+  },
+  {
+    revision: 6,
+    path: '/yyyyyyyy',
+    type: 'TEXT',
+    url: '/api/v1/projects/Gamma/repos/repo1/contents/yyyyyyyy',
+  },
+  {
+    revision: 6,
+    path: '/zzzzz',
+    type: 'TEXT',
+    url: '/api/v1/projects/Gamma/repos/repo1/contents/zzzzz',
+  },
+];
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { fileItem } = req.body;
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(fileList);
+      break;
+    case 'POST':
+      fileList.push(fileItem);
+      res.status(200).json(fileList);
+      break;
+    default:
+      res.setHeader('Allow', ['GET', 'POST']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+      break;
+  }
+}

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -38,7 +38,7 @@ const ProjectDetailPage = () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <RepoList data={data} name={projectName as string} />
+            <RepoList data={data} projectName={projectName as string} />
           </TabPanel>
           <TabPanel>TODO: Permissions</TabPanel>
           <TabPanel>TODO: Members</TabPanel>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/head/[fileName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/head/[fileName]/index.tsx
@@ -1,0 +1,5 @@
+const FileContentPage = () => {
+  return <>TODO: File content page</>;
+};
+
+export default FileContentPage;

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/index.tsx
@@ -1,7 +1,9 @@
 import { AddIcon } from '@chakra-ui/icons';
 import {
   Box,
-  ButtonGroup,
+  Button,
+  Drawer,
+  DrawerOverlay,
   Flex,
   Heading,
   Spacer,
@@ -10,12 +12,12 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
-  Tag,
-  TagLabel,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { useGetFilesByProjectAndRepoNameQuery } from 'dogma/features/api/apiSlice';
 import FileList from 'dogma/features/file/FileList';
 import { useRouter } from 'next/router';
+import { NewFileForm } from 'dogma/common/components/NewFileForm';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -28,17 +30,19 @@ const RepositoryDetailPage = () => {
       skip: false,
     },
   );
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
     <Box p="2">
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
         <Heading size="lg">Repository {repoName}</Heading>
         <Spacer />
-        <ButtonGroup gap="2">
-          <Tag size="lg" variant="subtle" colorScheme="blue">
-            <AddIcon mr={2} />
-            <TagLabel>New File</TagLabel>
-          </Tag>
-        </ButtonGroup>
+        <Button leftIcon={<AddIcon />} colorScheme="teal" onClick={onOpen} variant="ghost">
+          New File
+        </Button>
+        <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="xl">
+          <DrawerOverlay />
+          <NewFileForm />
+        </Drawer>
       </Flex>
       <Tabs variant="enclosed-colored" size="lg">
         <TabList>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/index.tsx
@@ -1,10 +1,33 @@
 import { AddIcon } from '@chakra-ui/icons';
-import { Box, ButtonGroup, Flex, Heading, Spacer, Tag, TagLabel } from '@chakra-ui/react';
+import {
+  Box,
+  ButtonGroup,
+  Flex,
+  Heading,
+  Spacer,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Tag,
+  TagLabel,
+} from '@chakra-ui/react';
+import { useGetFilesByProjectAndRepoNameQuery } from 'dogma/features/api/apiSlice';
+import FileList from 'dogma/features/file/FileList';
 import { useRouter } from 'next/router';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
-  const { repoName } = router.query;
+  const repoName = router.query.repoName ? (router.query.repoName as string) : '';
+  const projectName = router.query.projectName ? (router.query.projectName as string) : '';
+  const { data = [] } = useGetFilesByProjectAndRepoNameQuery(
+    { projectName, repoName },
+    {
+      refetchOnMountOrArgChange: true,
+      skip: false,
+    },
+  );
   return (
     <Box p="2">
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
@@ -17,6 +40,22 @@ const RepositoryDetailPage = () => {
           </Tag>
         </ButtonGroup>
       </Flex>
+      <Tabs variant="enclosed-colored" size="lg">
+        <TabList>
+          <Tab>
+            <Heading size="sm">Files</Heading>
+          </Tab>
+          <Tab>
+            <Heading size="sm">History</Heading>
+          </Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <FileList data={data} projectName={projectName as string} repoName={repoName as string} />
+          </TabPanel>
+          <TabPanel>TODO: History</TabPanel>
+        </TabPanels>
+      </Tabs>
     </Box>
   );
 };


### PR DESCRIPTION
## Motivation
Display a file list on the repo detail page.

## Modification
- Add `useGetFilesByProjectAndRepoNameQuery` to `apiSlice`'s endpoint.
- Create a repo detail page with two tabs: files and history.
- Add FileList component containing the files data. 
- Update DynamicDataTable to use absolute link for the view icon.
- Add new file component (layout only, no functionality yet).

## Result
Follow these instructions to view the result locally. 

- npm run mock
- Click on project `abcd`
- Click on repo `repo1`
