### PR TITLE
Display repository members

### DIFF
--- a/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
+++ b/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
@@ -1,8 +1,9 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import RepoMemberList, { RepoMemberListProps } from 'dogma/features/repo/RepoMemberList';
 import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
+import { formatDistance } from 'date-fns';
 
-describe('RepoPermissionList', () => {
+describe('RepoMemberList', () => {
   let expectedProps: JSX.IntrinsicAttributes & RepoMemberListProps<object>;
 
   beforeEach(() => {
@@ -54,7 +55,9 @@ describe('RepoPermissionList', () => {
     const { container } = render(<RepoMemberList {...expectedProps} />);
     const tbody = container.querySelector('tbody');
     const timestamp = tbody.children[0].children[3].firstChild;
-    expect(timestamp).toHaveTextContent('19 days ago');
+    expect(timestamp).toHaveTextContent(
+      formatDistance(new Date('2022-11-30T02:43:04.655753Z'), new Date(), { addSuffix: true }),
+    );
   });
 
   it('renders the delete button', () => {

--- a/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
+++ b/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
@@ -1,0 +1,84 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import RepoMemberList, { RepoMemberListProps } from 'dogma/features/repo/RepoMemberList';
+import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
+
+describe('RepoPermissionList', () => {
+  let expectedProps: JSX.IntrinsicAttributes & RepoMemberListProps<object>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    const mockRepoMembers = [
+      {
+        login: 'lz123456@localhost.localdomain',
+        role: 'OWNER',
+        creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-11-30T02:43:04.655753Z' },
+      },
+      {
+        login: 'lb56789@localhost.localdomain',
+        role: 'MEMBER',
+        creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
+      },
+    ];
+    expectedProps = {
+      data: mockRepoMembers,
+    };
+  });
+
+  it('renders the login ID', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    expect(tbody.children.length).toBe(2);
+    const firstCell = tbody.firstChild.firstChild.firstChild;
+    expect(firstCell).toHaveTextContent('lz123456@localhost.localdomain');
+    const secondCell = tbody.lastChild.firstChild.firstChild;
+    expect(secondCell).toHaveTextContent('lb56789@localhost.localdomain');
+  });
+
+  it('renders the role', () => {
+    const { getByText } = render(<RepoMemberList {...expectedProps} />);
+    let role;
+    expectedProps.data.forEach((repo: RepoMemberDetailDto) => {
+      role = getByText(repo.role);
+      expect(role).toBeVisible();
+    });
+  });
+
+  it('renders the creator (added by)', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const firstCreator = tbody.children[0].children[2].firstChild;
+    expect(firstCreator).toHaveTextContent('lz123456@localhost.localdomain');
+  });
+
+  it('renders the timestamp (added at)', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const timestamp = tbody.children[0].children[3].firstChild;
+    expect(timestamp).toHaveTextContent('19 days ago');
+  });
+
+  it('renders the delete button', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const firstCreator = tbody.children[0].children[4].firstChild;
+    expect(firstCreator).toHaveTextContent('Delete');
+  });
+
+  it('renders a table with a row for each member', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    expect(container.querySelector('tbody').children.length).toBe(2);
+  });
+
+  it('displays a matching login ID when searched', () => {
+    const { queryByPlaceholderText, container } = render(<RepoMemberList {...expectedProps} />);
+    const inputElement = queryByPlaceholderText(/search.../i);
+    fireEvent.change(inputElement!, { target: { value: 'lz123' } });
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    const tbody = container.querySelector('tbody');
+    expect(tbody.children.length).toBe(1);
+    const firstCell = tbody.firstChild.firstChild.firstChild;
+    expect(firstCell).toHaveTextContent('lz123456@localhost.localdomain');
+  });
+});

--- a/webapp/src/dogma/common/components/DateWithTooltip.tsx
+++ b/webapp/src/dogma/common/components/DateWithTooltip.tsx
@@ -1,0 +1,10 @@
+import { Badge, Tooltip } from '@chakra-ui/react';
+import { format, formatDistance } from 'date-fns';
+
+export const DateWithTooltip = ({ date }: { date: string }) => {
+  return (
+    <Tooltip label={format(new Date(date), 'dd MMM yyyy HH:mm z')}>
+      <Badge>{formatDistance(new Date(date), new Date(), { addSuffix: true })}</Badge>
+    </Tooltip>
+  );
+};

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -1,11 +1,11 @@
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
-import { format, formatDistance } from 'date-fns';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
-import { Badge, Box, Button, HStack, Tag, Tooltip } from '@chakra-ui/react';
+import { Box, Button, HStack, Tag } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { FaHistory } from 'react-icons/fa';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 
 export type HistoryListProps<Data extends object> = {
   data: Data[];
@@ -44,13 +44,7 @@ const HistoryList = <Data extends object>({
       header: 'Author',
     }),
     columnHelper.accessor((row: HistoryDto) => row.timestamp, {
-      cell: (info) => (
-        <Box>
-          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
-            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
-          </Tooltip>
-        </Box>
-      ),
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
       header: 'Timestamp',
     }),
     columnHelper.accessor((row: HistoryDto) => row.revision.revisionNumber, {

--- a/webapp/src/dogma/features/project/ProjectMetadataDto.ts
+++ b/webapp/src/dogma/features/project/ProjectMetadataDto.ts
@@ -1,3 +1,4 @@
+import { RepoMemberDto } from 'dogma/features/repo/RepoMemberDto';
 import { RepoPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
 
 export interface ProjectCreatorDto {
@@ -10,13 +11,6 @@ export interface ProjectMetadataDto {
   repos: RepoPermissionDto;
   members: RepoMemberDto;
   tokens: RepoTokenDto;
-  creation: ProjectCreatorDto;
-}
-
-type RepoMemberDto = Map<string, RepoMemberDetailDto>;
-export interface RepoMemberDetailDto {
-  login: string;
-  role: string;
   creation: ProjectCreatorDto;
 }
 

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -1,8 +1,8 @@
 import { ViewIcon, DeleteIcon } from '@chakra-ui/icons';
-import { Wrap, WrapItem, Button, Box, HStack, Badge, Tooltip } from '@chakra-ui/react';
+import { Wrap, WrapItem, Button, Box, HStack } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { format, formatDistance } from 'date-fns';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
 import NextLink from 'next/link';
@@ -37,13 +37,7 @@ const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data
       header: 'Creator',
     }),
     columnHelper.accessor((row: RepoDto) => row.createdAt, {
-      cell: (info) => (
-        <Box>
-          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
-            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
-          </Tooltip>
-        </Box>
-      ),
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
       header: 'Created',
     }),
     columnHelper.accessor((row: RepoDto) => row.headRevision, {

--- a/webapp/src/dogma/features/repo/RepoMemberDto.ts
+++ b/webapp/src/dogma/features/repo/RepoMemberDto.ts
@@ -1,0 +1,9 @@
+import { RepoCreatorDto } from 'dogma/features/repo/RepoPermissionDto';
+
+export type RepoMemberDto = Map<string, RepoMemberDetailDto>;
+
+export interface RepoMemberDetailDto {
+  login: string;
+  role: string;
+  creation: RepoCreatorDto;
+}

--- a/webapp/src/dogma/features/repo/RepoMemberList.tsx
+++ b/webapp/src/dogma/features/repo/RepoMemberList.tsx
@@ -17,7 +17,11 @@ const RepoMemberList = <Data extends object>({ data }: RepoMemberListProps<Data>
       header: 'Login ID',
     }),
     columnHelper.accessor((row: RepoMemberDetailDto) => row.role, {
-      cell: (info) => info.getValue(),
+      cell: (info) => (
+        <Badge colorScheme={info.getValue().toLowerCase() === 'owner' ? 'blue' : 'gray'}>
+          {info.getValue()}
+        </Badge>
+      ),
       header: 'Role',
     }),
     columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.user, {

--- a/webapp/src/dogma/features/repo/RepoMemberList.tsx
+++ b/webapp/src/dogma/features/repo/RepoMemberList.tsx
@@ -1,0 +1,50 @@
+import { DeleteIcon } from '@chakra-ui/icons';
+import { Box, Button, Badge, Tooltip } from '@chakra-ui/react';
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { format, formatDistance } from 'date-fns';
+import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
+import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
+
+export type RepoMemberListProps<Data extends object> = {
+  data: Data[];
+};
+
+const RepoMemberList = <Data extends object>({ data }: RepoMemberListProps<Data>) => {
+  const columnHelper = createColumnHelper<RepoMemberDetailDto>();
+  const columns = [
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.login, {
+      cell: (info) => info.getValue(),
+      header: 'Login ID',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.role, {
+      cell: (info) => info.getValue(),
+      header: 'Role',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.user, {
+      cell: (info) => info.getValue(),
+      header: 'Added By',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.timestamp, {
+      cell: (info) => (
+        <Box>
+          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
+            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
+          </Tooltip>
+        </Box>
+      ),
+      header: 'Added At',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.login, {
+      cell: () => (
+        <Button leftIcon={<DeleteIcon />} size="sm" colorScheme="red">
+          Delete
+        </Button>
+      ),
+      header: 'Actions',
+      enableSorting: false,
+    }),
+  ];
+  return <DynamicDataTable columns={columns as ColumnDef<Data, any>[]} data={data} />;
+};
+
+export default RepoMemberList;

--- a/webapp/src/dogma/features/repo/RepoMemberList.tsx
+++ b/webapp/src/dogma/features/repo/RepoMemberList.tsx
@@ -1,7 +1,7 @@
 import { DeleteIcon } from '@chakra-ui/icons';
-import { Box, Button, Badge, Tooltip } from '@chakra-ui/react';
+import { Button, Badge } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { format, formatDistance } from 'date-fns';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
 import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
 
@@ -29,13 +29,7 @@ const RepoMemberList = <Data extends object>({ data }: RepoMemberListProps<Data>
       header: 'Added By',
     }),
     columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.timestamp, {
-      cell: (info) => (
-        <Box>
-          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
-            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
-          </Tooltip>
-        </Box>
-      ),
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
       header: 'Added At',
     }),
     columnHelper.accessor((row: RepoMemberDetailDto) => row.login, {

--- a/webapp/src/dogma/features/repo/RepoMemberList.tsx
+++ b/webapp/src/dogma/features/repo/RepoMemberList.tsx
@@ -18,7 +18,7 @@ const RepoMemberList = <Data extends object>({ data }: RepoMemberListProps<Data>
     }),
     columnHelper.accessor((row: RepoMemberDetailDto) => row.role, {
       cell: (info) => (
-        <Badge colorScheme={info.getValue().toLowerCase() === 'owner' ? 'blue' : 'gray'}>
+        <Badge colorScheme={info.getValue().toLowerCase() === 'owner' ? 'blue' : 'green'}>
           {info.getValue()}
         </Badge>
       ),

--- a/webapp/src/pages/api/v1/projects/[projectName]/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/index.ts
@@ -38,7 +38,12 @@ const projectMetadata = {
     },
     'lb56789@localhost.localdomain': {
       login: 'lb56789@localhost.localdomain',
-      role: 'OWNER',
+      role: 'MEMBER',
+      creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
+    },
+    'la88888@localhost.localdomain': {
+      login: 'la88888@localhost.localdomain',
+      role: 'MEMBER',
       creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
     },
   },

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -18,7 +18,7 @@ const ProjectDetailPage = () => {
     skip: false,
   });
   const { data: metadata, isLoading } = useGetMetadataByProjectNameQuery(projectName, {
-    refetchOnMountOrArgChange: true,
+    refetchOnFocus: true,
     skip: false,
   });
   const [tabIndex, setTabIndex] = useState(0);

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -6,7 +6,9 @@ import RepoMemberList from 'dogma/features/repo/RepoMemberList';
 import RepoPermissionList from 'dogma/features/repo/RepoPermissionList';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
+
+const tabs = ['repositories', 'permissions', 'members', 'tokens', 'mirror'];
 
 const ProjectDetailPage = () => {
   const router = useRouter();
@@ -20,7 +22,6 @@ const ProjectDetailPage = () => {
     skip: false,
   });
   const [tabIndex, setTabIndex] = useState(0);
-  const tabs = useMemo(() => ['repositories', 'permissions', 'members', 'tokens', 'mirror'], []);
   const switchTab = (index: number) => {
     setTabIndex(index);
     window.location.hash = tabs[index];
@@ -30,7 +31,7 @@ const ProjectDetailPage = () => {
     if (index !== -1) {
       setTabIndex(index);
     }
-  }, [tabs]);
+  }, []);
   if (isLoading) {
     return <>Loading...</>;
   }

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs } f
 import { NewItemCard } from 'dogma/common/components/NewItemCard';
 import { useGetMetadataByProjectNameQuery, useGetReposByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import RepoList from 'dogma/features/repo/RepoList';
+import RepoMemberList from 'dogma/features/repo/RepoMemberList';
 import RepoPermissionList from 'dogma/features/repo/RepoPermissionList';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -72,7 +73,9 @@ const ProjectDetailPage = () => {
           <TabPanel>
             <RepoPermissionList data={Array.from(Object.values(metadata.repos))} projectName={projectName} />
           </TabPanel>
-          <TabPanel>TODO: Members</TabPanel>
+          <TabPanel>
+            <RepoMemberList data={Array.from(Object.values(metadata.members))} />
+          </TabPanel>
           <TabPanel>TODO: Tokens</TabPanel>
           <TabPanel>TODO: Mirror</TabPanel>
         </TabPanels>

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -6,7 +6,7 @@ import RepoMemberList from 'dogma/features/repo/RepoMemberList';
 import RepoPermissionList from 'dogma/features/repo/RepoPermissionList';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 const ProjectDetailPage = () => {
   const router = useRouter();
@@ -20,24 +20,17 @@ const ProjectDetailPage = () => {
     skip: false,
   });
   const [tabIndex, setTabIndex] = useState(0);
+  const tabs = useMemo(() => ['repositories', 'permissions', 'members', 'tokens', 'mirror'], []);
+  const switchTab = (index: number) => {
+    setTabIndex(index);
+    window.location.hash = tabs[index];
+  };
   useEffect(() => {
-    switch (window.location.hash) {
-      case '#permissions':
-        setTabIndex(1);
-        break;
-      case '#members':
-        setTabIndex(2);
-        break;
-      case '#tokens':
-        setTabIndex(3);
-        break;
-      case '#mirror':
-        setTabIndex(4);
-        break;
-      default:
-        break;
+    const index = tabs.findIndex((tab) => tab === window.location.hash?.slice(1));
+    if (index !== -1) {
+      setTabIndex(index);
     }
-  }, []);
+  }, [tabs]);
   if (isLoading) {
     return <>Loading...</>;
   }
@@ -48,23 +41,16 @@ const ProjectDetailPage = () => {
         <Spacer />
         <NewItemCard title="New Repository" label="Name" placeholder="New name here..." />
       </Flex>
-      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={(index) => setTabIndex(index)}>
+      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={switchTab}>
         <TabList>
-          <Tab as={Link} href="#repositories" shallow={true}>
-            <Heading size="sm">Repositories</Heading>
-          </Tab>
-          <Tab as={Link} href="#permissions" shallow={true}>
-            <Heading size="sm">Permissions</Heading>
-          </Tab>
-          <Tab as={Link} href="#members" shallow={true}>
-            <Heading size="sm">Members</Heading>
-          </Tab>
-          <Tab as={Link} href="#tokens" shallow={true}>
-            <Heading size="sm">Tokens</Heading>
-          </Tab>
-          <Tab as={Link} href="#mirror" shallow={true}>
-            <Heading size="sm">Mirror</Heading>
-          </Tab>
+          {tabs.map((tab) => (
+            <Tab as={Link} key={tab} href={`#${tab}`} shallow={true}>
+              <Heading size="sm">
+                {tab.charAt(0).toUpperCase()}
+                {tab.slice(1)}
+              </Heading>
+            </Tab>
+          ))}
         </TabList>
         <TabPanels>
           <TabPanel>

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -50,19 +50,19 @@ const ProjectDetailPage = () => {
       </Flex>
       <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={(index) => setTabIndex(index)}>
         <TabList>
-          <Tab as={Link} href="#repositories">
+          <Tab as={Link} href="#repositories" shallow={true}>
             <Heading size="sm">Repositories</Heading>
           </Tab>
-          <Tab as={Link} href="#permissions">
+          <Tab as={Link} href="#permissions" shallow={true}>
             <Heading size="sm">Permissions</Heading>
           </Tab>
-          <Tab as={Link} href="#members">
+          <Tab as={Link} href="#members" shallow={true}>
             <Heading size="sm">Members</Heading>
           </Tab>
-          <Tab as={Link} href="#tokens">
+          <Tab as={Link} href="#tokens" shallow={true}>
             <Heading size="sm">Tokens</Heading>
           </Tab>
-          <Tab as={Link} href="#mirror">
+          <Tab as={Link} href="#mirror" shallow={true}>
             <Heading size="sm">Mirror</Heading>
           </Tab>
         </TabList>

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -3,7 +3,9 @@ import { NewItemCard } from 'dogma/common/components/NewItemCard';
 import { useGetMetadataByProjectNameQuery, useGetReposByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import RepoList from 'dogma/features/repo/RepoList';
 import RepoPermissionList from 'dogma/features/repo/RepoPermissionList';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
 const ProjectDetailPage = () => {
   const router = useRouter();
@@ -16,6 +18,25 @@ const ProjectDetailPage = () => {
     refetchOnMountOrArgChange: true,
     skip: false,
   });
+  const [tabIndex, setTabIndex] = useState(0);
+  useEffect(() => {
+    switch (window.location.hash) {
+      case '#permissions':
+        setTabIndex(1);
+        break;
+      case '#members':
+        setTabIndex(2);
+        break;
+      case '#tokens':
+        setTabIndex(3);
+        break;
+      case '#mirror':
+        setTabIndex(4);
+        break;
+      default:
+        break;
+    }
+  }, []);
   if (isLoading) {
     return <>Loading...</>;
   }
@@ -26,21 +47,21 @@ const ProjectDetailPage = () => {
         <Spacer />
         <NewItemCard title="New Repository" label="Name" placeholder="New name here..." />
       </Flex>
-      <Tabs variant="enclosed-colored" size="lg">
+      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={(index) => setTabIndex(index)}>
         <TabList>
-          <Tab>
+          <Tab as={Link} href="#repositories">
             <Heading size="sm">Repositories</Heading>
           </Tab>
-          <Tab>
+          <Tab as={Link} href="#permissions">
             <Heading size="sm">Permissions</Heading>
           </Tab>
-          <Tab>
+          <Tab as={Link} href="#members">
             <Heading size="sm">Members</Heading>
           </Tab>
-          <Tab>
+          <Tab as={Link} href="#tokens">
             <Heading size="sm">Tokens</Heading>
           </Tab>
-          <Tab>
+          <Tab as={Link} href="#mirror">
             <Heading size="sm">Mirror</Heading>
           </Tab>
         </TabList>


### PR DESCRIPTION
## Motivation
Display repository members

## Modification
- Add RepoMemberDto.
- Display repo member list in the member tab.
- Add an anchor to each tab to retain the active tab on page refresh

## Result
<img width="1253" alt="Screen Shot 2022-12-20 at 13 57 17" src="https://user-images.githubusercontent.com/5079588/208602883-af8dfb37-2934-4581-b002-c1a50c2c1745.png">


