### PR TITLE
Add Feature Copy Buttons

### DIFF
--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -38,6 +38,8 @@ describe('FileList', () => {
       projectName: 'ProjectAlpha',
       repoName: 'repo1',
       handleCopyApiUrl: jest.fn(),
+      handleCopyWebUrl: jest.fn(),
+      handleCopyAsCliCommand: jest.fn(),
       handleCopyAsCurlCommand: jest.fn(),
     };
   });
@@ -78,14 +80,29 @@ describe('FileList', () => {
 
   it('calls handleCopyApiUrl when copy API URL button is clicked', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
-    const firstButton = getAllByText('Copy API URL', { selector: 'button' })[0];
+    const firstButton = getAllByText('API URL', { selector: 'button' })[0];
     fireEvent.click(firstButton);
     expect(expectedProps.handleCopyApiUrl).toHaveBeenCalledTimes(1);
   });
 
+
+  it('calls handleCopyWebUrl when copy Web URL button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('Web URL', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.handleCopyWebUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCopyAsCurlCommand when copy as a CLI command button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('CLI Command', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.handleCopyAsCliCommand).toHaveBeenCalledTimes(1);
+  });
+
   it('calls handleCopyAsCurlCommand when copy as a curl command button is clicked', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
-    const firstButton = getAllByText('Copy as a curl command', { selector: 'button' })[0];
+    const firstButton = getAllByText('cURL Command', { selector: 'button' })[0];
     fireEvent.click(firstButton);
     expect(expectedProps.handleCopyAsCurlCommand).toHaveBeenCalledTimes(1);
   });

--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import FileList, { FileListProps } from 'dogma/features/file/FileList';
 import { FileDto } from 'dogma/features/file/FileDto';
 
@@ -37,6 +37,8 @@ describe('FileList', () => {
       data: mockfileList,
       projectName: 'ProjectAlpha',
       repoName: 'repo1',
+      handleCopyApiUrl: jest.fn(),
+      handleCopyAsCurlCommand: jest.fn(),
     };
   });
 
@@ -72,5 +74,19 @@ describe('FileList', () => {
       'href',
       `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/files/head${firstFileName}`,
     );
+  });
+
+  it('calls handleCopyApiUrl when copy API URL button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('Copy API URL', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.handleCopyApiUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCopyAsCurlCommand when copy as a curl command button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('Copy as a curl command', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.handleCopyAsCurlCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import FileList, { FileListProps } from 'dogma/features/file/FileList';
 import { FileDto } from 'dogma/features/file/FileDto';
+import { CopySupport } from 'dogma/features/file/CopySupport';
 
 describe('FileList', () => {
   let expectedProps: JSX.IntrinsicAttributes & FileListProps<object>;
@@ -33,14 +34,19 @@ describe('FileList', () => {
         url: '/api/v1/projects/Gamma/repos/repo1/contents/zzzzz',
       },
     ];
+
+    const mockCopySupport: CopySupport = {
+      handleApiUrl: jest.fn(),
+      handleWebUrl: jest.fn(),
+      handleAsCliCommand: jest.fn(),
+      handleAsCurlCommand: jest.fn(),
+    };
+
     expectedProps = {
       data: mockfileList,
       projectName: 'ProjectAlpha',
       repoName: 'repo1',
-      handleCopyApiUrl: jest.fn(),
-      handleCopyWebUrl: jest.fn(),
-      handleCopyAsCliCommand: jest.fn(),
-      handleCopyAsCurlCommand: jest.fn(),
+      copySupport: mockCopySupport,
     };
   });
 
@@ -82,7 +88,7 @@ describe('FileList', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
     const firstButton = getAllByText('API URL', { selector: 'button' })[0];
     fireEvent.click(firstButton);
-    expect(expectedProps.handleCopyApiUrl).toHaveBeenCalledTimes(1);
+    expect(expectedProps.copySupport.handleApiUrl).toHaveBeenCalledTimes(1);
   });
 
 
@@ -90,20 +96,20 @@ describe('FileList', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
     const firstButton = getAllByText('Web URL', { selector: 'button' })[0];
     fireEvent.click(firstButton);
-    expect(expectedProps.handleCopyWebUrl).toHaveBeenCalledTimes(1);
+    expect(expectedProps.copySupport.handleWebUrl).toHaveBeenCalledTimes(1);
   });
 
   it('calls handleCopyAsCurlCommand when copy as a CLI command button is clicked', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
-    const firstButton = getAllByText('CLI Command', { selector: 'button' })[0];
+    const firstButton = getAllByText('CLI command', { selector: 'button' })[0];
     fireEvent.click(firstButton);
-    expect(expectedProps.handleCopyAsCliCommand).toHaveBeenCalledTimes(1);
+    expect(expectedProps.copySupport.handleAsCliCommand).toHaveBeenCalledTimes(1);
   });
 
   it('calls handleCopyAsCurlCommand when copy as a curl command button is clicked', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
-    const firstButton = getAllByText('cURL Command', { selector: 'button' })[0];
+    const firstButton = getAllByText('cURL command', { selector: 'button' })[0];
     fireEvent.click(firstButton);
-    expect(expectedProps.handleCopyAsCurlCommand).toHaveBeenCalledTimes(1);
+    expect(expectedProps.copySupport.handleAsCurlCommand).toHaveBeenCalledTimes(1);
   });
 });

--- a/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
+++ b/webapp/__tests__/dogma/feature/repo/RepoMemberList.test.tsx
@@ -1,0 +1,87 @@
+import { act, fireEvent, render } from '@testing-library/react';
+import RepoMemberList, { RepoMemberListProps } from 'dogma/features/repo/RepoMemberList';
+import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
+import { formatDistance } from 'date-fns';
+
+describe('RepoMemberList', () => {
+  let expectedProps: JSX.IntrinsicAttributes & RepoMemberListProps<object>;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    const mockRepoMembers = [
+      {
+        login: 'lz123456@localhost.localdomain',
+        role: 'OWNER',
+        creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-11-30T02:43:04.655753Z' },
+      },
+      {
+        login: 'lb56789@localhost.localdomain',
+        role: 'MEMBER',
+        creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
+      },
+    ];
+    expectedProps = {
+      data: mockRepoMembers,
+    };
+  });
+
+  it('renders the login ID', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    expect(tbody.children.length).toBe(2);
+    const firstCell = tbody.firstChild.firstChild.firstChild;
+    expect(firstCell).toHaveTextContent('lz123456@localhost.localdomain');
+    const secondCell = tbody.lastChild.firstChild.firstChild;
+    expect(secondCell).toHaveTextContent('lb56789@localhost.localdomain');
+  });
+
+  it('renders the role', () => {
+    const { getByText } = render(<RepoMemberList {...expectedProps} />);
+    let role;
+    expectedProps.data.forEach((repo: RepoMemberDetailDto) => {
+      role = getByText(repo.role);
+      expect(role).toBeVisible();
+    });
+  });
+
+  it('renders the creator (added by)', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const firstCreator = tbody.children[0].children[2].firstChild;
+    expect(firstCreator).toHaveTextContent('lz123456@localhost.localdomain');
+  });
+
+  it('renders the timestamp (added at)', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const timestamp = tbody.children[0].children[3].firstChild;
+    expect(timestamp).toHaveTextContent(
+      formatDistance(new Date('2022-11-30T02:43:04.655753Z'), new Date(), { addSuffix: true }),
+    );
+  });
+
+  it('renders the delete button', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    const tbody = container.querySelector('tbody');
+    const firstCreator = tbody.children[0].children[4].firstChild;
+    expect(firstCreator).toHaveTextContent('Delete');
+  });
+
+  it('renders a table with a row for each member', () => {
+    const { container } = render(<RepoMemberList {...expectedProps} />);
+    expect(container.querySelector('tbody').children.length).toBe(2);
+  });
+
+  it('displays a matching login ID when searched', () => {
+    const { queryByPlaceholderText, container } = render(<RepoMemberList {...expectedProps} />);
+    const inputElement = queryByPlaceholderText(/search.../i);
+    fireEvent.change(inputElement!, { target: { value: 'lz123' } });
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+    const tbody = container.querySelector('tbody');
+    expect(tbody.children.length).toBe(1);
+    const firstCell = tbody.firstChild.firstChild.firstChild;
+    expect(firstCell).toHaveTextContent('lz123456@localhost.localdomain');
+  });
+});

--- a/webapp/src/dogma/common/components/DateWithTooltip.tsx
+++ b/webapp/src/dogma/common/components/DateWithTooltip.tsx
@@ -1,0 +1,10 @@
+import { Badge, Tooltip } from '@chakra-ui/react';
+import { format, formatDistance } from 'date-fns';
+
+export const DateWithTooltip = ({ date }: { date: string }) => {
+  return (
+    <Tooltip label={format(new Date(date), 'dd MMM yyyy HH:mm z')}>
+      <Badge>{formatDistance(new Date(date), new Date(), { addSuffix: true })}</Badge>
+    </Tooltip>
+  );
+};

--- a/webapp/src/dogma/features/file/CopySupport.ts
+++ b/webapp/src/dogma/features/file/CopySupport.ts
@@ -1,0 +1,6 @@
+export interface CopySupport {
+  handleApiUrl: (project: string, repo: string, path: string) => Promise<void>;
+  handleWebUrl: (project: string, repo: string, path: string) => Promise<void>;
+  handleAsCliCommand: (project: string, repo: string, path: string) => Promise<void>;
+  handleAsCurlCommand: (project: string, repo: string, path: string) => Promise<void>;
+}

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -61,7 +61,11 @@ const FileList = <Data extends object>({
               colorScheme="gray"
               size="sm"
               onClick={() =>
-                handleCopyApiUrl(`/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`)
+                handleCopyApiUrl(
+                  `${
+                    window.location.origin
+                  }/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`,
+                )
               }
             >
               Copy API URL

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -12,6 +12,7 @@ export type FileListProps<Data extends object> = {
   projectName: string;
   repoName: string;
   handleCopyApiUrl: Function;
+  handleCopyAsCurlCommand: Function;
 };
 
 const FileList = <Data extends object>({
@@ -19,6 +20,7 @@ const FileList = <Data extends object>({
   projectName,
   repoName,
   handleCopyApiUrl,
+  handleCopyAsCurlCommand,
 }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
@@ -69,6 +71,22 @@ const FileList = <Data extends object>({
               }
             >
               Copy API URL
+            </Button>
+          </WrapItem>
+          <WrapItem>
+            <Button
+              leftIcon={<CopyIcon />}
+              colorScheme="gray"
+              size="sm"
+              onClick={() =>
+                handleCopyAsCurlCommand(
+                  `${
+                    window.location.origin
+                  }/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`,
+                )
+              }
+            >
+              Copy as a curl command
             </Button>
           </WrapItem>
         </Wrap>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -1,4 +1,4 @@
-import { EditIcon, ViewIcon } from '@chakra-ui/icons';
+import { EditIcon, ViewIcon, CopyIcon } from '@chakra-ui/icons';
 import { Button, Wrap, WrapItem, Box, HStack } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
@@ -11,9 +11,15 @@ export type FileListProps<Data extends object> = {
   data: Data[];
   projectName: string;
   repoName: string;
+  handleCopyApiUrl: Function;
 };
 
-const FileList = <Data extends object>({ data, projectName, repoName }: FileListProps<Data>) => {
+const FileList = <Data extends object>({
+  data,
+  projectName,
+  repoName,
+  handleCopyApiUrl,
+}: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
     columnHelper.accessor((row: FileDto) => row.path, {
@@ -47,6 +53,18 @@ const FileList = <Data extends object>({ data, projectName, repoName }: FileList
           <WrapItem>
             <Button leftIcon={<EditIcon />} colorScheme="gray" size="sm">
               Edit
+            </Button>
+          </WrapItem>
+          <WrapItem>
+            <Button
+              leftIcon={<CopyIcon />}
+              colorScheme="gray"
+              size="sm"
+              onClick={() =>
+                handleCopyApiUrl(`/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`)
+              }
+            >
+              Copy API URL
             </Button>
           </WrapItem>
         </Wrap>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -74,10 +74,10 @@ const FileList = <Data extends object>({
                   Web URL
                 </MenuItem>
                 <MenuItem onClick={() => handleCopyAsCliCommand(projectName, repoName, info.getValue())}>
-                  CLI Command
+                  CLI command
                 </MenuItem>
                 <MenuItem onClick={() => handleCopyAsCurlCommand(projectName, repoName, info.getValue())}>
-                  cURL Command
+                  cURL command
                 </MenuItem>
               </MenuList>
             </Menu>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -6,26 +6,16 @@ import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable
 import { FileDto } from 'dogma/features/file/FileDto';
 import NextLink from 'next/link';
 import { FcFile, FcOpenedFolder } from 'react-icons/fc';
+import { CopySupport } from './CopySupport';
 
 export type FileListProps<Data extends object> = {
   data: Data[];
   projectName: string;
   repoName: string;
-  handleCopyApiUrl: Function;
-  handleCopyWebUrl: Function;
-  handleCopyAsCliCommand: Function;
-  handleCopyAsCurlCommand: Function;
+  copySupport: CopySupport;
 };
 
-const FileList = <Data extends object>({
-  data,
-  projectName,
-  repoName,
-  handleCopyApiUrl,
-  handleCopyWebUrl,
-  handleCopyAsCliCommand,
-  handleCopyAsCurlCommand,
-}: FileListProps<Data>) => {
+const FileList = <Data extends object>({ data, projectName, repoName, copySupport }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const columns = [
     columnHelper.accessor((row: FileDto) => row.path, {
@@ -67,16 +57,20 @@ const FileList = <Data extends object>({
                 Copy
               </MenuButton>
               <MenuList>
-                <MenuItem onClick={() => handleCopyApiUrl(projectName, repoName, info.getValue())}>
+                <MenuItem onClick={() => copySupport.handleApiUrl(projectName, repoName, info.getValue())}>
                   API URL
                 </MenuItem>
-                <MenuItem onClick={() => handleCopyWebUrl(projectName, repoName, info.getValue())}>
+                <MenuItem onClick={() => copySupport.handleWebUrl(projectName, repoName, info.getValue())}>
                   Web URL
                 </MenuItem>
-                <MenuItem onClick={() => handleCopyAsCliCommand(projectName, repoName, info.getValue())}>
+                <MenuItem
+                  onClick={() => copySupport.handleAsCliCommand(projectName, repoName, info.getValue())}
+                >
                   CLI command
                 </MenuItem>
-                <MenuItem onClick={() => handleCopyAsCurlCommand(projectName, repoName, info.getValue())}>
+                <MenuItem
+                  onClick={() => copySupport.handleAsCurlCommand(projectName, repoName, info.getValue())}
+                >
                   cURL command
                 </MenuItem>
               </MenuList>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -62,13 +62,7 @@ const FileList = <Data extends object>({
               leftIcon={<CopyIcon />}
               colorScheme="gray"
               size="sm"
-              onClick={() =>
-                handleCopyApiUrl(
-                  `${
-                    window.location.origin
-                  }/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`,
-                )
-              }
+              onClick={() => handleCopyApiUrl(projectName, repoName, info.getValue())}
             >
               Copy API URL
             </Button>
@@ -78,13 +72,7 @@ const FileList = <Data extends object>({
               leftIcon={<CopyIcon />}
               colorScheme="gray"
               size="sm"
-              onClick={() =>
-                handleCopyAsCurlCommand(
-                  `${
-                    window.location.origin
-                  }/api/v1/projects/${projectName}/repos/${repoName}/contents${info.getValue()}`,
-                )
-              }
+              onClick={() => handleCopyAsCurlCommand(projectName, repoName, info.getValue())}
             >
               Copy as a curl command
             </Button>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -1,5 +1,5 @@
-import { EditIcon, ViewIcon, CopyIcon } from '@chakra-ui/icons';
-import { Button, Wrap, WrapItem, Box, HStack } from '@chakra-ui/react';
+import { EditIcon, ViewIcon, CopyIcon, ChevronDownIcon } from '@chakra-ui/icons';
+import { Button, Wrap, WrapItem, Box, HStack, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
@@ -12,6 +12,8 @@ export type FileListProps<Data extends object> = {
   projectName: string;
   repoName: string;
   handleCopyApiUrl: Function;
+  handleCopyWebUrl: Function;
+  handleCopyAsCliCommand: Function;
   handleCopyAsCurlCommand: Function;
 };
 
@@ -20,6 +22,8 @@ const FileList = <Data extends object>({
   projectName,
   repoName,
   handleCopyApiUrl,
+  handleCopyWebUrl,
+  handleCopyAsCliCommand,
   handleCopyAsCurlCommand,
 }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
@@ -58,24 +62,25 @@ const FileList = <Data extends object>({
             </Button>
           </WrapItem>
           <WrapItem>
-            <Button
-              leftIcon={<CopyIcon />}
-              colorScheme="gray"
-              size="sm"
-              onClick={() => handleCopyApiUrl(projectName, repoName, info.getValue())}
-            >
-              Copy API URL
-            </Button>
-          </WrapItem>
-          <WrapItem>
-            <Button
-              leftIcon={<CopyIcon />}
-              colorScheme="gray"
-              size="sm"
-              onClick={() => handleCopyAsCurlCommand(projectName, repoName, info.getValue())}
-            >
-              Copy as a curl command
-            </Button>
+            <Menu>
+              <MenuButton as={Button} size="sm" leftIcon={<CopyIcon />} rightIcon={<ChevronDownIcon />}>
+                Copy
+              </MenuButton>
+              <MenuList>
+                <MenuItem onClick={() => handleCopyApiUrl(projectName, repoName, info.getValue())}>
+                  API URL
+                </MenuItem>
+                <MenuItem onClick={() => handleCopyWebUrl(projectName, repoName, info.getValue())}>
+                  Web URL
+                </MenuItem>
+                <MenuItem onClick={() => handleCopyAsCliCommand(projectName, repoName, info.getValue())}>
+                  CLI Command
+                </MenuItem>
+                <MenuItem onClick={() => handleCopyAsCurlCommand(projectName, repoName, info.getValue())}>
+                  cURL Command
+                </MenuItem>
+              </MenuList>
+            </Menu>
           </WrapItem>
         </Wrap>
       ),

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -1,11 +1,11 @@
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
-import { format, formatDistance } from 'date-fns';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
-import { Badge, Box, Button, HStack, Tag, Tooltip } from '@chakra-ui/react';
+import { Box, Button, HStack, Tag } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { FaHistory } from 'react-icons/fa';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 
 export type HistoryListProps<Data extends object> = {
   data: Data[];
@@ -44,13 +44,7 @@ const HistoryList = <Data extends object>({
       header: 'Author',
     }),
     columnHelper.accessor((row: HistoryDto) => row.timestamp, {
-      cell: (info) => (
-        <Box>
-          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
-            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
-          </Tooltip>
-        </Box>
-      ),
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
       header: 'Timestamp',
     }),
     columnHelper.accessor((row: HistoryDto) => row.revision.revisionNumber, {

--- a/webapp/src/dogma/features/message/messageSlice.ts
+++ b/webapp/src/dogma/features/message/messageSlice.ts
@@ -21,8 +21,11 @@ export const messageSlice = createSlice({
       state.text = action.payload.text;
       state.type = action.payload.type;
     },
+    resetState(state: MessageState) {
+      Object.assign(state, initialState);
+    },
   },
 });
 
-export const { createMessage } = messageSlice.actions;
+export const { createMessage, resetState } = messageSlice.actions;
 export const messageReducer = messageSlice.reducer;

--- a/webapp/src/dogma/features/project/ProjectMetadataDto.ts
+++ b/webapp/src/dogma/features/project/ProjectMetadataDto.ts
@@ -1,3 +1,4 @@
+import { RepoMemberDto } from 'dogma/features/repo/RepoMemberDto';
 import { RepoPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
 
 export interface ProjectCreatorDto {
@@ -10,13 +11,6 @@ export interface ProjectMetadataDto {
   repos: RepoPermissionDto;
   members: RepoMemberDto;
   tokens: RepoTokenDto;
-  creation: ProjectCreatorDto;
-}
-
-type RepoMemberDto = Map<string, RepoMemberDetailDto>;
-export interface RepoMemberDetailDto {
-  login: string;
-  role: string;
   creation: ProjectCreatorDto;
 }
 

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -1,8 +1,8 @@
 import { ViewIcon, DeleteIcon } from '@chakra-ui/icons';
-import { Wrap, WrapItem, Button, Box, HStack, Badge, Tooltip } from '@chakra-ui/react';
+import { Wrap, WrapItem, Button, Box, HStack } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
-import { format, formatDistance } from 'date-fns';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
 import NextLink from 'next/link';
@@ -37,13 +37,7 @@ const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data
       header: 'Creator',
     }),
     columnHelper.accessor((row: RepoDto) => row.createdAt, {
-      cell: (info) => (
-        <Box>
-          <Tooltip label={format(new Date(info.getValue()), 'dd MMM yyyy HH:mm z')}>
-            <Badge>{formatDistance(new Date(info.getValue()), new Date(), { addSuffix: true })}</Badge>
-          </Tooltip>
-        </Box>
-      ),
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
       header: 'Created',
     }),
     columnHelper.accessor((row: RepoDto) => row.headRevision, {

--- a/webapp/src/dogma/features/repo/RepoMemberDto.ts
+++ b/webapp/src/dogma/features/repo/RepoMemberDto.ts
@@ -1,0 +1,9 @@
+import { RepoCreatorDto } from 'dogma/features/repo/RepoPermissionDto';
+
+export type RepoMemberDto = Map<string, RepoMemberDetailDto>;
+
+export interface RepoMemberDetailDto {
+  login: string;
+  role: string;
+  creation: RepoCreatorDto;
+}

--- a/webapp/src/dogma/features/repo/RepoMemberList.tsx
+++ b/webapp/src/dogma/features/repo/RepoMemberList.tsx
@@ -1,0 +1,48 @@
+import { DeleteIcon } from '@chakra-ui/icons';
+import { Button, Badge } from '@chakra-ui/react';
+import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
+import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
+import { RepoMemberDetailDto } from 'dogma/features/repo/RepoMemberDto';
+
+export type RepoMemberListProps<Data extends object> = {
+  data: Data[];
+};
+
+const RepoMemberList = <Data extends object>({ data }: RepoMemberListProps<Data>) => {
+  const columnHelper = createColumnHelper<RepoMemberDetailDto>();
+  const columns = [
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.login, {
+      cell: (info) => info.getValue(),
+      header: 'Login ID',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.role, {
+      cell: (info) => (
+        <Badge colorScheme={info.getValue().toLowerCase() === 'owner' ? 'blue' : 'green'}>
+          {info.getValue()}
+        </Badge>
+      ),
+      header: 'Role',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.user, {
+      cell: (info) => info.getValue(),
+      header: 'Added By',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.creation.timestamp, {
+      cell: (info) => <DateWithTooltip date={info.getValue()} />,
+      header: 'Added At',
+    }),
+    columnHelper.accessor((row: RepoMemberDetailDto) => row.login, {
+      cell: () => (
+        <Button leftIcon={<DeleteIcon />} size="sm" colorScheme="red">
+          Delete
+        </Button>
+      ),
+      header: 'Actions',
+      enableSorting: false,
+    }),
+  ];
+  return <DynamicDataTable columns={columns as ColumnDef<Data, any>[]} data={data} />;
+};
+
+export default RepoMemberList;

--- a/webapp/src/pages/api/v1/projects/[projectName]/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/index.ts
@@ -38,7 +38,12 @@ const projectMetadata = {
     },
     'lb56789@localhost.localdomain': {
       login: 'lb56789@localhost.localdomain',
-      role: 'OWNER',
+      role: 'MEMBER',
+      creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
+    },
+    'la88888@localhost.localdomain': {
+      login: 'la88888@localhost.localdomain',
+      role: 'MEMBER',
       creation: { user: 'lz123456@localhost.localdomain', timestamp: '2022-12-16T02:54:12.431395Z' },
     },
   },

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -2,8 +2,13 @@ import { Box, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs } f
 import { NewItemCard } from 'dogma/common/components/NewItemCard';
 import { useGetMetadataByProjectNameQuery, useGetReposByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import RepoList from 'dogma/features/repo/RepoList';
+import RepoMemberList from 'dogma/features/repo/RepoMemberList';
 import RepoPermissionList from 'dogma/features/repo/RepoPermissionList';
+import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+
+const tabs = ['repositories', 'permissions', 'members', 'tokens', 'mirror'];
 
 const ProjectDetailPage = () => {
   const router = useRouter();
@@ -13,9 +18,20 @@ const ProjectDetailPage = () => {
     skip: false,
   });
   const { data: metadata, isLoading } = useGetMetadataByProjectNameQuery(projectName, {
-    refetchOnMountOrArgChange: true,
+    refetchOnFocus: true,
     skip: false,
   });
+  const [tabIndex, setTabIndex] = useState(0);
+  const switchTab = (index: number) => {
+    setTabIndex(index);
+    window.location.hash = tabs[index];
+  };
+  useEffect(() => {
+    const index = tabs.findIndex((tab) => tab === window.location.hash?.slice(1));
+    if (index !== -1) {
+      setTabIndex(index);
+    }
+  }, []);
   if (isLoading) {
     return <>Loading...</>;
   }
@@ -26,23 +42,16 @@ const ProjectDetailPage = () => {
         <Spacer />
         <NewItemCard title="New Repository" label="Name" placeholder="New name here..." />
       </Flex>
-      <Tabs variant="enclosed-colored" size="lg">
+      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={switchTab}>
         <TabList>
-          <Tab>
-            <Heading size="sm">Repositories</Heading>
-          </Tab>
-          <Tab>
-            <Heading size="sm">Permissions</Heading>
-          </Tab>
-          <Tab>
-            <Heading size="sm">Members</Heading>
-          </Tab>
-          <Tab>
-            <Heading size="sm">Tokens</Heading>
-          </Tab>
-          <Tab>
-            <Heading size="sm">Mirror</Heading>
-          </Tab>
+          {tabs.map((tab) => (
+            <Tab as={Link} key={tab} href={`#${tab}`} shallow={true}>
+              <Heading size="sm">
+                {tab.charAt(0).toUpperCase()}
+                {tab.slice(1)}
+              </Heading>
+            </Tab>
+          ))}
         </TabList>
         <TabPanels>
           <TabPanel>
@@ -51,7 +60,9 @@ const ProjectDetailPage = () => {
           <TabPanel>
             <RepoPermissionList data={Array.from(Object.values(metadata.repos))} projectName={projectName} />
           </TabPanel>
-          <TabPanel>TODO: Members</TabPanel>
+          <TabPanel>
+            <RepoMemberList data={Array.from(Object.values(metadata.members))} />
+          </TabPanel>
           <TabPanel>TODO: Tokens</TabPanel>
           <TabPanel>TODO: Mirror</TabPanel>
         </TabPanels>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -24,7 +24,10 @@ import { useRouter } from 'next/router';
 import { NewFileForm } from 'dogma/common/components/NewFileForm';
 import HistoryList from 'dogma/features/history/HistoryList';
 import { useState } from 'react';
-import { Tag, useToast } from '@chakra-ui/react';
+import { Tag } from '@chakra-ui/react';
+import { createMessage } from 'dogma/features/message/messageSlice';
+import { store } from 'dogma/store';
+import ErrorHandler from 'dogma/features/services/ErrorHandler';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -47,7 +50,6 @@ const RepositoryDetailPage = () => {
   );
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [tabIndex, setTabIndex] = useState(0);
-  const toast = useToast();
 
   const handleTabChange = (index: number) => {
     setTabIndex(index);
@@ -55,20 +57,10 @@ const RepositoryDetailPage = () => {
   const handleCopyApiUrl = async (apiUrl: string) => {
     try {
       await navigator.clipboard.writeText(apiUrl);
-      toast({
-        title: 'copied to clipboard',
-        status: 'success',
-        duration: 1000,
-        isClosable: true,
-      });
+      store.dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
     } catch (err) {
-      toast({
-        title: 'failed to copy to clipboard',
-        description: err.message,
-        status: 'error',
-        duration: 10000,
-        isClosable: true,
-      });
+      const error: string = ErrorHandler.handle(err);
+      store.dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
     }
   };
   return (

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -68,11 +68,15 @@ const RepositoryDetailPage = () => {
     }
   };
 
-  const handleCopyApiUrl = async (apiUrl: string) => {
+  const constructApiUrl = (project: string, repo: string, path: string): string => {
+    return `${window.location.origin}/api/v1/projects/${project}/repos/${repo}/contents${path}`;
+  };
+  const handleCopyApiUrl = async (project: string, repo: string, path: string) => {
+    const apiUrl: string = constructApiUrl(project, repo, path);
     copyToClipboard(apiUrl);
   };
-
-  const handleCopyAsCurlCommand = async (apiUrl: string) => {
+  const handleCopyAsCurlCommand = async (project: string, repo: string, path: string) => {
+    const apiUrl: string = constructApiUrl(project, repo, path);
     const curlCommand = `curl -XGET "${apiUrl}"`;
     copyToClipboard(curlCommand);
   };

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -26,7 +26,7 @@ import HistoryList from 'dogma/features/history/HistoryList';
 import { useState } from 'react';
 import { Tag } from '@chakra-ui/react';
 import { createMessage } from 'dogma/features/message/messageSlice';
-import { store } from 'dogma/store';
+import { useAppDispatch } from 'dogma/store';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
 
 const RepositoryDetailPage = () => {
@@ -50,6 +50,7 @@ const RepositoryDetailPage = () => {
   );
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [tabIndex, setTabIndex] = useState(0);
+  const dispatch = useAppDispatch();
 
   const handleTabChange = (index: number) => {
     setTabIndex(index);
@@ -57,10 +58,10 @@ const RepositoryDetailPage = () => {
   const handleCopyApiUrl = async (apiUrl: string) => {
     try {
       await navigator.clipboard.writeText(apiUrl);
-      store.dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
+      dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
     } catch (err) {
       const error: string = ErrorHandler.handle(err);
-      store.dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
+      dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
     }
   };
   return (

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -24,7 +24,7 @@ import { useRouter } from 'next/router';
 import { NewFileForm } from 'dogma/common/components/NewFileForm';
 import HistoryList from 'dogma/features/history/HistoryList';
 import { useState } from 'react';
-import { Tag } from '@chakra-ui/react';
+import { Tag, useToast } from '@chakra-ui/react';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -47,8 +47,29 @@ const RepositoryDetailPage = () => {
   );
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [tabIndex, setTabIndex] = useState(0);
+  const toast = useToast();
+
   const handleTabChange = (index: number) => {
     setTabIndex(index);
+  };
+  const handleCopyApiUrl = async (apiUrl: string) => {
+    try {
+      await navigator.clipboard.writeText(apiUrl);
+      toast({
+        title: 'copied to clipboard',
+        status: 'success',
+        duration: 1000,
+        isClosable: true,
+      });
+    } catch (err) {
+      toast({
+        title: 'failed to copy to clipboard',
+        description: err.message,
+        status: 'error',
+        duration: 10000,
+        isClosable: true,
+      });
+    }
   };
   return (
     <Box p="2">
@@ -79,7 +100,12 @@ const RepositoryDetailPage = () => {
         </TabList>
         <TabPanels>
           <TabPanel>
-            <FileList data={fileData} projectName={projectName as string} repoName={repoName as string} />
+            <FileList
+              data={fileData}
+              projectName={projectName as string}
+              repoName={repoName as string}
+              handleCopyApiUrl={handleCopyApiUrl}
+            />
           </TabPanel>
           <TabPanel>
             <HistoryList

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -73,6 +73,8 @@ const RepositoryDetailPage = () => {
     if (revision !== 'head') {
       apiUrl += `?revision=${revision}`;
     }
+
+    return apiUrl;
   };
 
   const handleCopyApiUrl = async (project: string, repo: string, path: string) => {
@@ -86,9 +88,13 @@ const RepositoryDetailPage = () => {
   };
 
   const handleCopyAsCliCommand = async (project: string, repo: string, path: string) => {
-    const cliCommand = `dogma --connect "${window.location.origin}" \\
+    let cliCommand = `dogma --connect "${window.location.origin}" \\
 --token "<access-token>" \\
 cat ${project}/${repo}${path}`;
+
+  if (revision !== 'head') {
+    cliCommand += ` --revision=${revision}`;
+  }
     copyToClipboard(cliCommand);
   };
 

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -25,7 +25,7 @@ import { NewFileForm } from 'dogma/common/components/NewFileForm';
 import HistoryList from 'dogma/features/history/HistoryList';
 import { useState } from 'react';
 import { Tag } from '@chakra-ui/react';
-import { createMessage } from 'dogma/features/message/messageSlice';
+import { createMessage, resetState } from 'dogma/features/message/messageSlice';
 import { useAppDispatch } from 'dogma/store';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
 
@@ -59,10 +59,12 @@ const RepositoryDetailPage = () => {
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
+      await dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
     } catch (err) {
       const error: string = ErrorHandler.handle(err);
-      dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
+      await dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
+    } finally {
+      dispatch(resetState());
     }
   };
 
@@ -71,9 +73,10 @@ const RepositoryDetailPage = () => {
   };
 
   const handleCopyAsCurlCommand = async (apiUrl: string) => {
-    // TODO(clavinjune): copy a whole curl command
-    copyToClipboard(apiUrl);
+    const curlCommand = `curl -XGET "${apiUrl}"`;
+    copyToClipboard(curlCommand);
   };
+
   return (
     <Box p="2">
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -69,7 +69,10 @@ const RepositoryDetailPage = () => {
   };
 
   const constructApiUrl = (project: string, repo: string, path: string): string => {
-    return `${window.location.origin}/api/v1/projects/${project}/repos/${repo}/contents${path}`;
+    let apiUrl = `${window.location.origin}/api/v1/projects/${project}/repos/${repo}/contents${path}`;
+    if (revision !== 'head') {
+      apiUrl += `?revision=${revision}`;
+    }
   };
 
   const handleCopyApiUrl = async (project: string, repo: string, path: string) => {

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -81,7 +81,7 @@ const RepositoryDetailPage = () => {
   };
 
   const handleCopyWebUrl = async (project: string, repo: string, path: string) => {
-    const webUrl = `${window.location.origin}/app/projects/${project}/repos/${repo}/files/head${path}`;
+    const webUrl = `${window.location.origin}/app/projects/${project}/repos/${repo}/files/${revision}${path}`;
     copyToClipboard(webUrl);
   };
 

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -28,6 +28,7 @@ import { Tag } from '@chakra-ui/react';
 import { createMessage, resetState } from 'dogma/features/message/messageSlice';
 import { useAppDispatch } from 'dogma/store';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
+import { CopySupport } from 'dogma/features/file/CopySupport';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -77,32 +78,35 @@ const RepositoryDetailPage = () => {
     return apiUrl;
   };
 
-  const handleCopyApiUrl = async (project: string, repo: string, path: string) => {
-    const apiUrl: string = constructApiUrl(project, repo, path);
-    copyToClipboard(apiUrl);
-  };
+  const clipboardCopySupport: CopySupport = {
+    async handleApiUrl(project: string, repo: string, path: string) {
+      const apiUrl: string = constructApiUrl(project, repo, path);
+      copyToClipboard(apiUrl);
+    },
 
-  const handleCopyWebUrl = async (project: string, repo: string, path: string) => {
-    const webUrl = `${window.location.origin}/app/projects/${project}/repos/${repo}/files/${revision}${path}`;
-    copyToClipboard(webUrl);
-  };
+    async handleWebUrl(project: string, repo: string, path: string) {
+      const webUrl = `${window.location.origin}/app/projects/${project}/repos/${repo}/files/${revision}${path}`;
+      copyToClipboard(webUrl);
+    },
 
-  const handleCopyAsCliCommand = async (project: string, repo: string, path: string) => {
-    let cliCommand = `dogma --connect "${window.location.origin}" \\
+    async handleAsCliCommand(project: string, repo: string, path: string) {
+      let cliCommand = `dogma --connect "${window.location.origin}" \\
 --token "<access-token>" \\
 cat ${project}/${repo}${path}`;
 
-  if (revision !== 'head') {
-    cliCommand += ` --revision=${revision}`;
-  }
-    copyToClipboard(cliCommand);
-  };
+      if (revision !== 'head') {
+        cliCommand += ` --revision=${revision}`;
+      }
 
-  const handleCopyAsCurlCommand = async (project: string, repo: string, path: string) => {
-    const apiUrl: string = constructApiUrl(project, repo, path);
-    const curlCommand = `curl -XGET "${apiUrl}" \\
+      copyToClipboard(cliCommand);
+    },
+
+    async handleAsCurlCommand(project: string, repo: string, path: string) {
+      const apiUrl: string = constructApiUrl(project, repo, path);
+      const curlCommand = `curl -XGET "${apiUrl}" \\
 -H "Authorization: Bearer <access-token>"`;
-    copyToClipboard(curlCommand);
+      copyToClipboard(curlCommand);
+    },
   };
 
   return (
@@ -138,10 +142,7 @@ cat ${project}/${repo}${path}`;
               data={fileData}
               projectName={projectName as string}
               repoName={repoName as string}
-              handleCopyApiUrl={handleCopyApiUrl}
-              handleCopyWebUrl={handleCopyWebUrl}
-              handleCopyAsCliCommand={handleCopyAsCliCommand}
-              handleCopyAsCurlCommand={handleCopyAsCurlCommand}
+              copySupport={clipboardCopySupport as CopySupport}
             />
           </TabPanel>
           <TabPanel>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -95,7 +95,7 @@ const RepositoryDetailPage = () => {
 cat ${project}/${repo}${path}`;
 
       if (revision !== 'head') {
-        cliCommand += ` --revision=${revision}`;
+        cliCommand += ` --revision ${revision}`;
       }
 
       copyToClipboard(cliCommand);

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -71,13 +71,26 @@ const RepositoryDetailPage = () => {
   const constructApiUrl = (project: string, repo: string, path: string): string => {
     return `${window.location.origin}/api/v1/projects/${project}/repos/${repo}/contents${path}`;
   };
+
   const handleCopyApiUrl = async (project: string, repo: string, path: string) => {
     const apiUrl: string = constructApiUrl(project, repo, path);
     copyToClipboard(apiUrl);
   };
+
+  const handleCopyWebUrl = async (project: string, repo: string, path: string) => {
+    const webUrl = `${window.location.origin}/app/projects/${project}/repos/${repo}/files/head${path}`;
+    copyToClipboard(webUrl);
+  };
+
+  const handleCopyAsCliCommand = async (project: string, repo: string, path: string) => {
+    const cliCommand = `dogma --connect ${window.location.origin} cat ${project}/${repo}${path}`;
+    copyToClipboard(cliCommand);
+  };
+
   const handleCopyAsCurlCommand = async (project: string, repo: string, path: string) => {
     const apiUrl: string = constructApiUrl(project, repo, path);
-    const curlCommand = `curl -XGET "${apiUrl}"`;
+    const curlCommand = `curl -XGET "${apiUrl}" \\
+-H "Authorization: Bearer <access-token>"`;
     copyToClipboard(curlCommand);
   };
 
@@ -115,6 +128,8 @@ const RepositoryDetailPage = () => {
               projectName={projectName as string}
               repoName={repoName as string}
               handleCopyApiUrl={handleCopyApiUrl}
+              handleCopyWebUrl={handleCopyWebUrl}
+              handleCopyAsCliCommand={handleCopyAsCliCommand}
               handleCopyAsCurlCommand={handleCopyAsCurlCommand}
             />
           </TabPanel>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -83,7 +83,9 @@ const RepositoryDetailPage = () => {
   };
 
   const handleCopyAsCliCommand = async (project: string, repo: string, path: string) => {
-    const cliCommand = `dogma --connect ${window.location.origin} cat ${project}/${repo}${path}`;
+    const cliCommand = `dogma --connect "${window.location.origin}" \\
+--token "<access-token>" \\
+cat ${project}/${repo}${path}`;
     copyToClipboard(cliCommand);
   };
 

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision].tsx
@@ -55,14 +55,24 @@ const RepositoryDetailPage = () => {
   const handleTabChange = (index: number) => {
     setTabIndex(index);
   };
-  const handleCopyApiUrl = async (apiUrl: string) => {
+
+  const copyToClipboard = async (text: string) => {
     try {
-      await navigator.clipboard.writeText(apiUrl);
+      await navigator.clipboard.writeText(text);
       dispatch(createMessage({ title: '', text: 'copied to clipboard', type: 'success' }));
     } catch (err) {
       const error: string = ErrorHandler.handle(err);
       dispatch(createMessage({ title: 'failed to copy to clipboard', text: error, type: 'error' }));
     }
+  };
+
+  const handleCopyApiUrl = async (apiUrl: string) => {
+    copyToClipboard(apiUrl);
+  };
+
+  const handleCopyAsCurlCommand = async (apiUrl: string) => {
+    // TODO(clavinjune): copy a whole curl command
+    copyToClipboard(apiUrl);
   };
   return (
     <Box p="2">
@@ -98,6 +108,7 @@ const RepositoryDetailPage = () => {
               projectName={projectName as string}
               repoName={repoName as string}
               handleCopyApiUrl={handleCopyApiUrl}
+              handleCopyAsCurlCommand={handleCopyAsCurlCommand}
             />
           </TabPanel>
           <TabPanel>


### PR DESCRIPTION
## Motivation

Show copy buttons on new-webapp as requested on #665 

## Modification

- Add `handleCopyApiUrl`, `handleCopyWebUrl`, `handleCopyAsCliCommand`, `handleCopyAsCurlCommand` function in FileList
- Show toast on success / error
- Add `resetState` action on messageSlice
- Add tests

## Result

<img width="1154" alt="image" src="https://user-images.githubusercontent.com/24659468/209702037-4798a444-477f-47a5-a94a-5b0ccb880274.png">

**On Success**

<img width="943" alt="image" src="https://user-images.githubusercontent.com/24659468/209702108-85bc042e-a5a0-4d47-bfb6-e854c41d0b28.png">

**On Error**

<img width="1008" alt="image" src="https://user-images.githubusercontent.com/24659468/209702213-64d3f6cc-b626-4a8c-b7f0-a399d645f5c7.png">