### PR TITLE
Add file editor

### DIFF
--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -29,9 +29,9 @@ describe('FileList', () => {
       },
       {
         revision: 6,
-        path: '/zzzzz',
-        type: 'TEXT',
-        url: '/api/v1/projects/Gamma/repos/repo1/contents/zzzzz',
+        path: '/mydir',
+        type: 'DIRECTORY',
+        url: '/api/v1/projects/Gamma/repos/repo1/contents/mydir',
       },
     ];
 
@@ -46,7 +46,13 @@ describe('FileList', () => {
       data: mockfileList,
       projectName: 'ProjectAlpha',
       repoName: 'repo1',
+      path: '',
+      directoryPath: '/app/projects/ProjectAlpha/repos/repo1/list/head/',
+      revision: 'head',
       copySupport: mockCopySupport,
+      path: '',
+      directoryPath: '/app/projects/ProjectAlpha/repos/repo1/list/head/',
+      revision: 'head',
     };
   });
 
@@ -64,7 +70,7 @@ describe('FileList', () => {
     expect(container.querySelector('tbody').children.length).toBe(5);
   });
 
-  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the view icon', () => {
+  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the view icon when the type is a file', () => {
     const { container } = render(<FileList {...expectedProps} />);
     const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
     const firstFileName = '/123456';
@@ -74,7 +80,14 @@ describe('FileList', () => {
     );
   });
 
-  it('has `${projectName}/repos/${repoName}/files/head{fileName}` on the file path cell', () => {
+  it('has `${directoryPath}${folderName.slice(1)}` on the view icon when the type is a directory', () => {
+    const { container } = render(<FileList {...expectedProps} />);
+    const actionCell = container.querySelector('tbody').lastChild.firstChild.lastChild;
+    const folderName = '/mydir';
+    expect(actionCell).toHaveAttribute('href', `${expectedProps.directoryPath}${folderName.slice(1)}`);
+  });
+
+  it('links to `${projectName}/repos/${repoName}/files/head{fileName}` when the type is non-directory', () => {
     const { container } = render(<FileList {...expectedProps} />);
     const firstCell = container.querySelector('tbody').firstChild.firstChild.firstChild;
     const firstFileName = '/123456';
@@ -90,7 +103,6 @@ describe('FileList', () => {
     fireEvent.click(firstButton);
     expect(expectedProps.copySupport.handleApiUrl).toHaveBeenCalledTimes(1);
   });
-
 
   it('calls handleCopyWebUrl when copy Web URL button is clicked', () => {
     const { getAllByText } = render(<FileList {...expectedProps} />);
@@ -111,5 +123,47 @@ describe('FileList', () => {
     const firstButton = getAllByText('cURL command', { selector: 'button' })[0];
     fireEvent.click(firstButton);
     expect(expectedProps.copySupport.handleAsCurlCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('links to `${directoryPath}${folderName.slice(1)}` when the type is a directory', () => {
+    const { container } = render(<FileList {...expectedProps} />);
+    const firstCell = container.querySelector('tbody').lastChild.firstChild.firstChild;
+    const folderName = '/mydir';
+    expect(firstCell).toHaveAttribute('href', `${expectedProps.directoryPath}${folderName.slice(1)}`);
+  });
+
+  it('calls handleCopyApiUrl when copy API URL button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('API URL', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.copySupport.handleApiUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCopyWebUrl when copy Web URL button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('Web URL', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.copySupport.handleWebUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCopyAsCurlCommand when copy as a CLI command button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('CLI command', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.copySupport.handleAsCliCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls handleCopyAsCurlCommand when copy as a curl command button is clicked', () => {
+    const { getAllByText } = render(<FileList {...expectedProps} />);
+    const firstButton = getAllByText('cURL command', { selector: 'button' })[0];
+    fireEvent.click(firstButton);
+    expect(expectedProps.copySupport.handleAsCurlCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('links to `${directoryPath}${folderName.slice(1)}` when the type is a directory', () => {
+    const { container } = render(<FileList {...expectedProps} />);
+    const firstCell = container.querySelector('tbody').lastChild.firstChild.firstChild;
+    const folderName = '/mydir';
+    expect(firstCell).toHaveAttribute('href', `${expectedProps.directoryPath}${folderName.slice(1)}`);
   });
 });

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -11,6 +11,7 @@
         "@chakra-ui/react": "^2.4.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@monaco-editor/react": "^4.4.6",
         "@reduxjs/toolkit": "^1.8.5",
         "@tanstack/react-table": "^8.7.0",
         "axios": "^1.1.3",
@@ -2788,6 +2789,31 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.3.2.tgz",
+      "integrity": "sha512-BTDbpHl3e47r3AAtpfVFTlAi7WXv4UQ/xZmz8atKl4q7epQV5e7+JbigFDViWF71VBi4IIBdcWP57Hj+OWuc9g==",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.21.0 < 1"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.4.6.tgz",
+      "integrity": "sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.3.2",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@motionone/animation": {
@@ -9829,6 +9855,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/monaco-editor": {
+      "version": "0.34.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.34.1.tgz",
+      "integrity": "sha512-FKc80TyiMaruhJKKPz5SpJPIjL+dflGvz4CpuThaPMc94AyN7SeC9HQ8hrvaxX7EyHdJcUY5i4D0gNyJj1vSZQ==",
+      "peer": true
+    },
     "node_modules/mrmime": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-1.0.1.tgz",
@@ -11178,6 +11210,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
     },
     "node_modules/string-length": {
       "version": "4.0.2",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -19,6 +19,7 @@
     "@chakra-ui/react": "^2.4.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
+    "@monaco-editor/react": "^4.4.6",
     "@reduxjs/toolkit": "^1.8.5",
     "@tanstack/react-table": "^8.7.0",
     "axios": "^1.1.3",

--- a/webapp/src/dogma/common/components/ChakraLink.tsx
+++ b/webapp/src/dogma/common/components/ChakraLink.tsx
@@ -1,14 +1,6 @@
-import { Link, LinkProps, OmitCommonProps } from '@chakra-ui/react';
+import { Link, LinkProps } from '@chakra-ui/react';
 import NextLink from 'next/link';
-import { DetailedHTMLProps, AnchorHTMLAttributes } from 'react';
 
-export const ChakraLink = (
-  props: JSX.IntrinsicAttributes &
-    OmitCommonProps<
-      DetailedHTMLProps<AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>,
-      keyof LinkProps
-    > &
-    LinkProps & { as?: 'a' },
-) => {
+export const ChakraLink = (props: LinkProps) => {
   return <Link as={NextLink} {...props}></Link>;
 };

--- a/webapp/src/dogma/common/components/Navbar.tsx
+++ b/webapp/src/dogma/common/components/Navbar.tsx
@@ -108,6 +108,7 @@ export const Navbar = () => {
 
   const selectRef = useRef(null);
   useEffect(() => {
+    // TODO: Exclude hotkey from input elements
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === '/') {
         e.preventDefault();
@@ -147,7 +148,7 @@ export const Navbar = () => {
             name="project-search"
             options={projectOptions}
             value={selectedOption?.value}
-            onChange={(option) => handleChange(option as ProjectOptionType)}
+            onChange={(option: ProjectOptionType) => handleChange(option)}
             placeholder="Jump to project ..."
             closeMenuOnSelect={true}
             openMenuOnFocus={true}

--- a/webapp/src/dogma/common/components/editor/EditModeToggle.tsx
+++ b/webapp/src/dogma/common/components/editor/EditModeToggle.tsx
@@ -1,0 +1,21 @@
+import { Text, FormLabel, Switch } from '@chakra-ui/react';
+import { ChangeEventHandler } from 'react';
+
+export const EditModeToggle = ({
+  switchMode,
+  value,
+  label,
+}: {
+  switchMode: ChangeEventHandler;
+  value: boolean;
+  label: string;
+}) => {
+  return (
+    <>
+      <FormLabel htmlFor="edit" mb="2">
+        <Text>{label}</Text>
+      </FormLabel>
+      <Switch id="edit" colorScheme="teal" onChange={switchMode} isChecked={!value} />
+    </>
+  );
+};

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -1,0 +1,178 @@
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Spacer,
+  Stack,
+  Tab,
+  TabList,
+  TabPanel,
+  TabPanels,
+  Tabs,
+  Textarea,
+  VStack,
+  useColorMode,
+  useDisclosure,
+} from '@chakra-ui/react';
+import Editor, { DiffEditor, OnMount } from '@monaco-editor/react';
+import { EditModeToggle } from 'dogma/common/components/editor/EditModeToggle';
+import React, { useState, useRef } from 'react';
+import { FcEditImage, FcCancel } from 'react-icons/fc';
+
+export type FileEditorProps = {
+  language: string;
+  originalContent: string;
+};
+
+const FileEditor = ({ language, originalContent }: FileEditorProps) => {
+  const [tabIndex, setTabIndex] = useState(0);
+  const handleTabChange = (index: number) => {
+    setTabIndex(index);
+  };
+  const [fileContent, setFileContent] = useState('');
+  const editorRef = useRef(null);
+  const handleEditorMount: OnMount = (editor) => {
+    editorRef.current = editor;
+    setFileContent(
+      language.toLowerCase() === 'json'
+        ? JSON.stringify(JSON.parse(originalContent), null, 2)
+        : originalContent,
+    );
+  };
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [readOnly, setReadOnly] = useState(true);
+  const returnToViewMode = () => (readOnly ? setReadOnly(false) : onOpen());
+  const resetViewEditor = () => {
+    editorRef.current.setValue(fileContent);
+    setReadOnly(true);
+    setTabIndex(0);
+    onClose();
+  };
+  const { colorMode } = useColorMode();
+  const [diffSideBySide, setDiffSideBySide] = useState(false);
+  const [editorExpanded, setEditorExpanded] = useState(false);
+  return (
+    <Box>
+      <Flex>
+        <Spacer />
+        <Button
+          onClick={returnToViewMode}
+          leftIcon={readOnly ? <FcEditImage /> : <FcCancel />}
+          colorScheme={readOnly ? 'teal' : 'blue'}
+          variant="ghost"
+        >
+          {readOnly ? 'Edit' : 'Cancel changes'}
+        </Button>
+      </Flex>
+      <Tabs
+        variant="enclosed-colored"
+        size="lg"
+        index={tabIndex}
+        onChange={handleTabChange}
+        colorScheme={readOnly ? 'blue' : 'yellow'}
+      >
+        <TabList>
+          <Tab>
+            <Heading size="sm">{readOnly ? 'View file' : 'Edit file'}</Heading>
+          </Tab>
+          <Tab display={readOnly ? 'none' : 'visible'}>
+            <Heading size="sm">Preview Changes</Heading>
+          </Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <Box>
+              <Flex mb="2">
+                <Spacer />
+                <EditModeToggle
+                  switchMode={() => setEditorExpanded(!editorExpanded)}
+                  value={!editorExpanded}
+                  label="Expand"
+                />
+              </Flex>
+              <Editor
+                height={editorExpanded ? editorRef.current.getModel().getLineCount() * 20 : '50vh'}
+                language={language}
+                theme={colorMode === 'light' ? 'light' : 'vs-dark'}
+                value={fileContent}
+                options={{
+                  autoIndent: 'full',
+                  formatOnPaste: true,
+                  formatOnType: true,
+                  readOnly: readOnly,
+                  automaticLayout: true,
+                  scrollBeyondLastLine: false,
+                }}
+                onMount={handleEditorMount}
+              />
+            </Box>
+          </TabPanel>
+          <TabPanel display={readOnly ? 'none' : 'visible'}>
+            <Flex mb="2">
+              <Spacer />
+              <EditModeToggle
+                switchMode={() => setDiffSideBySide(!diffSideBySide)}
+                value={!diffSideBySide}
+                label="Render side by side?"
+              />
+            </Flex>
+            <DiffEditor
+              height="50vh"
+              language={language}
+              theme={colorMode === 'light' ? 'light' : 'vs-dark'}
+              original={fileContent}
+              modified={editorRef?.current?.getValue()}
+              options={{
+                autoIndent: 'full',
+                formatOnPaste: true,
+                formatOnType: true,
+                diffWordWrap: 'on',
+                useTabStops: true,
+                renderSideBySide: diffSideBySide,
+                scrollBeyondLastLine: false,
+              }}
+            />
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+      <VStack p={4} gap="2" mb={6} align="stretch" display={readOnly ? 'none' : 'visible'}>
+        <Heading size="md">Commit changes</Heading>
+        <Input name="summary" placeholder="Add a summary" />
+        <Textarea placeholder="Add an optional extended description..." />
+        <Stack direction="row" spacing={4} mt={2}>
+          <Button colorScheme="teal">Commit</Button>
+          <Button variant="outline" onClick={returnToViewMode}>
+            Cancel
+          </Button>
+        </Stack>
+      </VStack>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Are you sure?</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>Your changes will be discarded!</ModalBody>
+          <ModalFooter>
+            <Button colorScheme="red" mr={3} onClick={resetViewEditor}>
+              Discard changes
+            </Button>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </Box>
+  );
+};
+
+export default FileEditor;

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -43,9 +43,7 @@ const FileEditor = ({ language, originalContent }: FileEditorProps) => {
   const handleEditorMount: OnMount = (editor) => {
     editorRef.current = editor;
     setFileContent(
-      language === 'json'
-        ? JSON.stringify(JSON.parse(originalContent), null, 2)
-        : originalContent,
+      language === 'json' ? JSON.stringify(JSON.parse(originalContent), null, 2) : originalContent,
     );
   };
   const { isOpen, onOpen, onClose } = useDisclosure();

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -43,7 +43,7 @@ const FileEditor = ({ language, originalContent }: FileEditorProps) => {
   const handleEditorMount: OnMount = (editor) => {
     editorRef.current = editor;
     setFileContent(
-      language.toLowerCase() === 'json'
+      language === 'json'
         ? JSON.stringify(JSON.parse(originalContent), null, 2)
         : originalContent,
     );

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -21,11 +21,19 @@ import { AuthState } from 'dogma/features/auth/authSlice';
 import { FileDto } from 'dogma/features/file/FileDto';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
 import { ProjectMetadataDto } from 'dogma/features/project/ProjectMetadataDto';
+import { FileContentDto } from 'dogma/features/file/FileContentDto';
 
 export type GetFilesByProjectAndRepoName = {
   projectName: string;
   repoName: string;
   revision?: string;
+};
+
+export type GetFileContent = {
+  projectName: string;
+  repoName: string;
+  revision: string;
+  filePath: string;
 };
 
 export const apiSlice = createApi({
@@ -55,6 +63,10 @@ export const apiSlice = createApi({
       query: ({ projectName, repoName, revision }) =>
         `/v1/projects/${projectName}/repos/${repoName}/list/?revision=${revision}`,
     }),
+    getFileContent: builder.query<FileContentDto, GetFileContent>({
+      query: ({ projectName, repoName, revision, filePath }) =>
+        `/v1/projects/${projectName}/repos/${repoName}/files/revisions/${revision}/${filePath}?queryType=IDENTITY`,
+    }),
     getHistoryByProjectAndRepoName: builder.query<HistoryDto[], GetFilesByProjectAndRepoName>({
       query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/history`,
     }),
@@ -67,5 +79,6 @@ export const {
   useGetReposByProjectNameQuery,
   useGetFilesByProjectAndRepoNameQuery,
   useGetFilesByProjectAndRepoAndRevisionNameQuery,
+  useGetFileContentQuery,
   useGetHistoryByProjectAndRepoNameQuery,
 } = apiSlice;

--- a/webapp/src/dogma/features/file/FileContentDto.ts
+++ b/webapp/src/dogma/features/file/FileContentDto.ts
@@ -1,0 +1,7 @@
+export interface FileContentDto {
+  content: string;
+  name: string;
+  path: string;
+  revision: string;
+  type: 'TEXT' | 'DIRECTORY' | 'JSON' | 'YML';
+}

--- a/webapp/src/dogma/features/file/FileContentDto.ts
+++ b/webapp/src/dogma/features/file/FileContentDto.ts
@@ -3,5 +3,5 @@ export interface FileContentDto {
   name: string;
   path: string;
   revision: string;
-  type: 'TEXT' | 'DIRECTORY' | 'JSON' | 'YML';
+  type: 'TEXT' | 'DIRECTORY' | 'JSON' | 'YAML';
 }

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -6,7 +6,7 @@ import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable
 import { FileDto } from 'dogma/features/file/FileDto';
 import NextLink from 'next/link';
 import { FcFile, FcOpenedFolder } from 'react-icons/fc';
-import { CopySupport } from './CopySupport';
+import { CopySupport } from 'dogma/features/file/CopySupport';
 
 export type FileListProps<Data extends object> = {
   data: Data[];

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -12,17 +12,33 @@ export type FileListProps<Data extends object> = {
   data: Data[];
   projectName: string;
   repoName: string;
+  path: string;
+  directoryPath: string;
+  revision: string;
   copySupport: CopySupport;
 };
 
-const FileList = <Data extends object>({ data, projectName, repoName, copySupport }: FileListProps<Data>) => {
+const FileList = <Data extends object>({
+  data,
+  projectName,
+  repoName,
+  path,
+  directoryPath,
+  revision,
+  copySupport,
+}: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
+  const slug = `/app/projects/${projectName}/repos/${repoName}/files/${revision}${path}`;
   const columns = [
     columnHelper.accessor((row: FileDto) => row.path, {
       cell: (info) => (
         <ChakraLink
           fontWeight={'semibold'}
-          href={`/app/projects/${projectName}/repos/${repoName}/files/head${info.getValue()}`}
+          href={
+            info.row.original.type === 'DIRECTORY'
+              ? `${directoryPath}${info.getValue().slice(1)}`
+              : `${slug}${info.getValue()}`
+          }
         >
           <HStack>
             <Box>{info.row.original.type === 'DIRECTORY' ? <FcOpenedFolder /> : <FcFile />}</Box>
@@ -40,7 +56,13 @@ const FileList = <Data extends object>({ data, projectName, repoName, copySuppor
       cell: (info) => (
         <Wrap>
           <WrapItem>
-            <NextLink href={`/app/projects/${projectName}/repos/${repoName}/files/head${info.getValue()}`}>
+            <NextLink
+              href={
+                info.row.original.type === 'DIRECTORY'
+                  ? `${directoryPath}${info.getValue().slice(1)}`
+                  : `${slug}${info.getValue()}`
+              }
+            >
               <Button leftIcon={<ViewIcon />} colorScheme="blue" size="sm">
                 View
               </Button>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -69,11 +69,6 @@ const FileList = <Data extends object>({
             </NextLink>
           </WrapItem>
           <WrapItem>
-            <Button leftIcon={<EditIcon />} colorScheme="gray" size="sm">
-              Edit
-            </Button>
-          </WrapItem>
-          <WrapItem>
             <Menu>
               <MenuButton as={Button} size="sm" leftIcon={<CopyIcon />} rightIcon={<ChevronDownIcon />}>
                 Copy

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -1,4 +1,4 @@
-import { EditIcon, ViewIcon, CopyIcon, ChevronDownIcon } from '@chakra-ui/icons';
+import { ViewIcon, CopyIcon, ChevronDownIcon } from '@chakra-ui/icons';
 import { Button, Wrap, WrapItem, Box, HStack, Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';

--- a/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/files/revisions/[revision]/[...fileName].ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/files/revisions/[revision]/[...fileName].ts
@@ -1,0 +1,22 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const mockFile = {
+  revision: '5',
+  path: '/file1',
+  type: 'JSON',
+  content:
+    '[{"name":"orange","repos":[],"members":[{"login":"User2","additionUser":"User","additionTime":"2017-11-13T17:23:12.068+09:00[Asia/Seoul]"}],"tokens":[{"appId":"cook","secret":"y","additionUser":"User","additionTime":"2017-11-13T17:23:12.206+09:00[Asia/Seoul]"},{"appId":"ive","secret":"z","additionUser":"User","additionTime":"2017-11-13T17:23:12.227+09:00[Asia/Seoul]"},{"appId":"jobs","secret":"x","additionUser":"User","additionTime":"2017-11-13T17:23:12.186+09:00[Asia/Seoul]"}],"additionUser":"User","additionTime":"2017-11-13T17:23:11.883+09:00[Asia/Seoul]","removed":true},{"name":"apple","repos":[{"name":"coffee","additionUser":"User","additionTime":"2017-11-13T17:23:12.163+09:00[Asia/Seoul]"},{"name":"hamburger","additionUser":"User","additionTime":"2017-11-13T17:23:12.139+09:00[Asia/Seoul]"}],"members":[],"tokens":[],"additionUser":"User","additionTime":"2017-11-13T17:23:11.706+09:00[Asia/Seoul]","removed":false}]',
+  name: 'file1',
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  switch (req.method) {
+    case 'GET':
+      res.status(200).json(mockFile);
+      break;
+    default:
+      res.setHeader('Allow', ['GET']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+      break;
+  }
+}

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -1,0 +1,38 @@
+import { InfoIcon } from '@chakra-ui/icons';
+import { Box, Flex, Heading, Tag, Tooltip } from '@chakra-ui/react';
+import { useGetFileContentQuery } from 'dogma/features/api/apiSlice';
+import { useRouter } from 'next/router';
+import FileEditor from 'dogma/common/components/editor/FileEditor';
+
+const FileContentPage = () => {
+  const router = useRouter();
+  const repoName = router.query.repoName ? (router.query.repoName as string) : '';
+  const projectName = router.query.projectName ? (router.query.projectName as string) : '';
+  const revision = router.query.revision ? (router.query.revision as string) : 'head';
+  const filePath = router.query.path ? `/${Array.from(router.query.path).join('/')}` : '';
+  const { data, isLoading } = useGetFileContentQuery(
+    { projectName, repoName, revision, filePath },
+    {
+      refetchOnMountOrArgChange: true,
+      skip: false,
+    },
+  );
+  if (isLoading) {
+    return <>Loading...</>;
+  }
+  return (
+    <Box p="2">
+      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+        <Heading size="lg">{`${filePath}`}</Heading>
+        <Tooltip label="Go to History to view all revisions">
+          <Tag borderRadius="full" colorScheme="blue">
+            Revision {revision} <InfoIcon ml={2} />
+          </Tag>
+        </Tooltip>
+      </Flex>
+      <FileEditor language={data.type.toLowerCase()} originalContent={data.content} />
+    </Box>
+  );
+};
+
+export default FileContentPage;

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/head/[fileName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/head/[fileName]/index.tsx
@@ -1,5 +1,0 @@
-const FileContentPage = () => {
-  return <>TODO: File content page</>;
-};
-
-export default FileContentPage;

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -12,6 +12,7 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
+  Tag,
   Tooltip,
   useDisclosure,
 } from '@chakra-ui/react';
@@ -24,7 +25,6 @@ import { useRouter } from 'next/router';
 import { NewFileForm } from 'dogma/common/components/NewFileForm';
 import HistoryList from 'dogma/features/history/HistoryList';
 import { useState } from 'react';
-import { Tag } from '@chakra-ui/react';
 import { createMessage, resetState } from 'dogma/features/message/messageSlice';
 import { useAppDispatch } from 'dogma/store';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
@@ -35,6 +35,8 @@ const RepositoryDetailPage = () => {
   const repoName = router.query.repoName ? (router.query.repoName as string) : '';
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
   const revision = router.query.revision ? (router.query.revision as string) : 'head';
+  const filePath = router.query.path ? `/${Array.from(router.query.path).join('/')}` : '';
+  const directoryPath = router.asPath;
   const { data: fileData = [] } = useGetFilesByProjectAndRepoAndRevisionNameQuery(
     { projectName, repoName, revision },
     {
@@ -140,16 +142,19 @@ cat ${project}/${repo}${path}`;
           <TabPanel>
             <FileList
               data={fileData}
-              projectName={projectName as string}
-              repoName={repoName as string}
+              projectName={projectName}
+              repoName={repoName}
+              path={filePath}
+              directoryPath={directoryPath}
+              revision={revision}
               copySupport={clipboardCopySupport as CopySupport}
             />
           </TabPanel>
           <TabPanel>
             <HistoryList
               data={historyData}
-              projectName={projectName as string}
-              repoName={repoName as string}
+              projectName={projectName}
+              repoName={repoName}
               handleTabChange={handleTabChange}
             />
           </TabPanel>


### PR DESCRIPTION
## Motivation
Allow viewing/editing files.

## Modification
- Add monaco editor. https://www.npmjs.com/package/@monaco-editor/react
- Update FileList to allow recursive structure for folder.
- Add file content.
- Add some placeholder components.
- Add edit and preview modes

### Notes regarding the choice of file editor  
The old app is using Ace. It's quite stable but there are some warnings and it needs some workaround to make it work with Nextjs. https://github.com/securingsincity/react-ace

Thus, we look into other options https://en.wikipedia.org/wiki/Comparison_of_JavaScript-based_source_code_editors.
Both Codemirror and Monaco seem to be a great choice in terms of setup and UI. There's a caveat when using Monaco for JSON. Need a workaround to format the code properly.

Since Armeria is moving away from Codemirror https://github.com/line/armeria/pull/4516, we go with Monaco. 

## Result
<img width="1253" alt="Screen Shot 2022-12-26 at 18 04 18" src="https://user-images.githubusercontent.com/5079588/209541874-48470cc4-fe25-4c63-9136-d7a977ef9123.png">

<img width="829" alt="Screen Shot 2022-12-27 at 11 52 15" src="https://user-images.githubusercontent.com/5079588/209612997-af4d8506-edb9-4767-95a0-99c863d5c20e.png">
