### PR TITLE
Update history 

### DIFF
--- a/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
+++ b/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
@@ -9,20 +9,16 @@ describe('HistoryList', () => {
   beforeEach(() => {
     const mockHistoryList: HistoryDto[] = [
       {
-        revision: { major: 8, minor: 0, revisionNumber: '8' },
-        author: { name: 'ldap123456', email: 'ldap123456@localhost.localdomain' },
-        timestamp: '2022-11-30T11:48:57Z',
-        summary: 'Edit /zzzzz',
-        detail: { content: '', markup: 'PLAINTEXT' },
-        diffs: [],
+        revision: 2,
+        author: { name: 'System', email: 'system@localhost.localdomain' },
+        commitMessage: { summary: 'Update repository', detail: '', markup: 'PLAINTEXT' },
+        pushedAt: '2023-01-11T08:17:22Z',
       },
       {
-        revision: { major: 7, minor: 0, revisionNumber: '7' },
-        author: { name: 'ldap123456', email: 'ldap123456@localhost.localdomain' },
-        timestamp: '2022-11-30T10:57:41Z',
-        summary: 'Add /test',
-        detail: { content: 'zzz', markup: 'PLAINTEXT' },
-        diffs: [],
+        revision: 1,
+        author: { name: 'System', email: 'system@localhost.localdomain' },
+        commitMessage: { summary: 'Create a new repository', detail: '', markup: 'PLAINTEXT' },
+        pushedAt: '2023-01-10T08:17:22Z',
       },
     ];
     expectedProps = {
@@ -38,28 +34,12 @@ describe('HistoryList', () => {
     expect(container.querySelector('tbody').children.length).toBe(2);
   });
 
-  it('links the view icon to `${projectName}/repos/${repoName}/list/${revisionNumber}`', () => {
-    const { container } = render(<HistoryList {...expectedProps} />);
-    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
-    expect(actionCell).toHaveAttribute(
-      'href',
-      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/list/${8}`,
-    );
-  });
-
-  it('calls handleTabChange when the view icon is clicked', () => {
-    const { container } = render(<HistoryList {...expectedProps} />);
-    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
-    fireEvent.click(actionCell);
-    expect(expectedProps.handleTabChange).toHaveBeenCalledTimes(1);
-  });
-
   it('links the revision cell to `${projectName}/repos/${repoName}/list/${revisionNumber}`', () => {
     const { container } = render(<HistoryList {...expectedProps} />);
     const firstCell = container.querySelector('tbody').firstChild.firstChild.firstChild;
     expect(firstCell).toHaveAttribute(
       'href',
-      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/list/${8}`,
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/list/${2}`,
     );
   });
 

--- a/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
+++ b/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
@@ -34,6 +34,22 @@ describe('HistoryList', () => {
     expect(container.querySelector('tbody').children.length).toBe(2);
   });
 
+  it('links the view icon to `${projectName}/repos/${repoName}/list/${revisionNumber}`', () => {
+    const { container } = render(<HistoryList {...expectedProps} />);
+    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
+    expect(actionCell).toHaveAttribute(
+      'href',
+      `/app/projects/${expectedProps.projectName}/repos/${expectedProps.repoName}/list/${2}`,
+    );
+  });
+
+  it('calls handleTabChange when the view icon is clicked', () => {
+    const { container } = render(<HistoryList {...expectedProps} />);
+    const actionCell = container.querySelector('tbody').firstChild.firstChild.lastChild;
+    fireEvent.click(actionCell);
+    expect(expectedProps.handleTabChange).toHaveBeenCalledTimes(1);
+  });
+
   it('links the revision cell to `${projectName}/repos/${repoName}/list/${revisionNumber}`', () => {
     const { container } = render(<HistoryList {...expectedProps} />);
     const firstCell = container.querySelector('tbody').firstChild.firstChild.firstChild;

--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -13,12 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import Error from 'next/error';
 import { ReactNode } from 'react';
 
 interface LoadingProps {
   isLoading: boolean;
-  error: Error;
+  error: any;
   children: () => ReactNode;
 }
 export const Deferred = (props: LoadingProps) => {

--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -13,11 +13,12 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import Error from 'next/error';
 import { ReactNode } from 'react';
 
 interface LoadingProps {
   isLoading: boolean;
-  error: any;
+  error: Error;
   children: () => ReactNode;
 }
 export const Deferred = (props: LoadingProps) => {

--- a/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
@@ -6,19 +6,26 @@ import {
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
+  getPaginationRowModel,
   getSortedRowModel,
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { Filter } from 'dogma/common/components/table/Filter';
+import { PaginationBar } from 'dogma/common/components/table/PaginationBar';
 import { useState } from 'react';
 
 export type DynamicDataTableProps<Data extends object> = {
   data: Data[];
   columns: ColumnDef<Data>[];
+  pagination?: boolean;
 };
 
-export const DynamicDataTable = <Data extends object>({ data, columns }: DynamicDataTableProps<Data>) => {
+export const DynamicDataTable = <Data extends object>({
+  data,
+  columns,
+  pagination = false,
+}: DynamicDataTableProps<Data>) => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const table = useReactTable({
@@ -29,6 +36,7 @@ export const DynamicDataTable = <Data extends object>({ data, columns }: Dynamic
     getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
     state: {
       sorting,
       columnFilters,
@@ -87,6 +95,7 @@ export const DynamicDataTable = <Data extends object>({ data, columns }: Dynamic
           })}
         </Tbody>
       </Table>
+      {pagination && <PaginationBar table={table} />}
     </>
   );
 };

--- a/webapp/src/dogma/common/components/table/PaginationBar.tsx
+++ b/webapp/src/dogma/common/components/table/PaginationBar.tsx
@@ -1,0 +1,62 @@
+import { Flex, Input, Text, Select, Spacer, IconButton } from '@chakra-ui/react';
+import { Table as ReactTable } from '@tanstack/react-table';
+import { MdNavigateBefore, MdNavigateNext, MdSkipNext, MdSkipPrevious } from 'react-icons/md';
+
+export const PaginationBar = <Data extends object>({ table }: { table: ReactTable<Data> }) => {
+  return (
+    <Flex gap={2} mt={2} alignItems="center">
+      <IconButton
+        aria-label="First page"
+        icon={<MdSkipPrevious />}
+        onClick={() => table.setPageIndex(0)}
+        disabled={!table.getCanPreviousPage()}
+      />
+      <IconButton
+        aria-label="Prev page"
+        icon={<MdNavigateBefore />}
+        onClick={() => table.previousPage()}
+        disabled={!table.getCanPreviousPage()}
+      />
+      <IconButton
+        aria-label="Next page"
+        icon={<MdNavigateNext />}
+        onClick={() => table.nextPage()}
+        disabled={!table.getCanNextPage()}
+      />
+      <IconButton
+        aria-label="Last page"
+        icon={<MdSkipNext />}
+        onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+        disabled={!table.getCanNextPage()}
+      />
+      <Text>Page</Text>
+      <Text fontWeight="bold">
+        {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
+      </Text>
+      <Spacer />
+      <Text>Go to page:</Text>
+      <Input
+        type="number"
+        defaultValue={table.getState().pagination.pageIndex + 1}
+        onChange={(e) => {
+          const page = e.target.value ? Number(e.target.value) - 1 : 0;
+          table.setPageIndex(page);
+        }}
+        width={20}
+      />
+      <Select
+        value={table.getState().pagination.pageSize}
+        onChange={(e) => {
+          table.setPageSize(Number(e.target.value));
+        }}
+        width="auto"
+      >
+        {[10, 20, 30, 40, 50].map((pageSize) => (
+          <option key={pageSize} value={pageSize}>
+            Show {pageSize}
+          </option>
+        ))}
+      </Select>
+    </Flex>
+  );
+};

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -81,7 +81,7 @@ export const apiSlice = createApi({
         `/v1/projects/${projectName}/repos/${repoName}/files/revisions/${revision}/${filePath}?queryType=IDENTITY`,
     }),
     getHistoryByProjectAndRepoName: builder.query<HistoryDto[], GetFilesByProjectAndRepoName>({
-      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/commits/`,
+      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/commits`,
     }),
   }),
 });

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -64,7 +64,7 @@ export const apiSlice = createApi({
       invalidatesTags: ['Project'],
     }),
     getMetadataByProjectName: builder.query<ProjectMetadataDto, string>({
-      query: (projectName) => `/v1/projects/${projectName}/`,
+      query: (projectName) => `/v1/projects/${projectName}`,
     }),
     getReposByProjectName: builder.query<RepoDto[], string>({
       query: (projectName) => `/v1/projects/${projectName}/repos`,
@@ -81,7 +81,7 @@ export const apiSlice = createApi({
         `/v1/projects/${projectName}/repos/${repoName}/files/revisions/${revision}/${filePath}?queryType=IDENTITY`,
     }),
     getHistoryByProjectAndRepoName: builder.query<HistoryDto[], GetFilesByProjectAndRepoName>({
-      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/history`,
+      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/commits/`,
     }),
   }),
 });

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -7,6 +7,7 @@ import { FileDto } from 'dogma/features/file/FileDto';
 import NextLink from 'next/link';
 import { FcFile, FcOpenedFolder } from 'react-icons/fc';
 import { CopySupport } from 'dogma/features/file/CopySupport';
+import { useMemo } from 'react';
 
 export type FileListProps<Data extends object> = {
   data: Data[];
@@ -29,76 +30,79 @@ const FileList = <Data extends object>({
 }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const slug = `/app/projects/${projectName}/repos/${repoName}/files/${revision}${path}`;
-  const columns = [
-    columnHelper.accessor((row: FileDto) => row.path, {
-      cell: (info) => (
-        <ChakraLink
-          fontWeight={'semibold'}
-          href={
-            info.row.original.type === 'DIRECTORY'
-              ? `${directoryPath}${info.getValue().slice(1)}`
-              : `${slug}${info.getValue()}`
-          }
-        >
-          <HStack>
-            <Box>{info.row.original.type === 'DIRECTORY' ? <FcOpenedFolder /> : <FcFile />}</Box>
-            <Box>{info.getValue()}</Box>
-          </HStack>
-        </ChakraLink>
-      ),
-      header: 'Path',
-    }),
-    columnHelper.accessor((row: FileDto) => row.revision, {
-      cell: (info) => info.getValue(),
-      header: 'Revision',
-    }),
-    columnHelper.accessor((row: FileDto) => row.path, {
-      cell: (info) => (
-        <Wrap>
-          <WrapItem>
-            <NextLink
-              href={
-                info.row.original.type === 'DIRECTORY'
-                  ? `${directoryPath}${info.getValue().slice(1)}`
-                  : `${slug}${info.getValue()}`
-              }
-            >
-              <Button leftIcon={<ViewIcon />} colorScheme="blue" size="sm">
-                View
-              </Button>
-            </NextLink>
-          </WrapItem>
-          <WrapItem>
-            <Menu>
-              <MenuButton as={Button} size="sm" leftIcon={<CopyIcon />} rightIcon={<ChevronDownIcon />}>
-                Copy
-              </MenuButton>
-              <MenuList>
-                <MenuItem onClick={() => copySupport.handleApiUrl(projectName, repoName, info.getValue())}>
-                  API URL
-                </MenuItem>
-                <MenuItem onClick={() => copySupport.handleWebUrl(projectName, repoName, info.getValue())}>
-                  Web URL
-                </MenuItem>
-                <MenuItem
-                  onClick={() => copySupport.handleAsCliCommand(projectName, repoName, info.getValue())}
-                >
-                  CLI command
-                </MenuItem>
-                <MenuItem
-                  onClick={() => copySupport.handleAsCurlCommand(projectName, repoName, info.getValue())}
-                >
-                  cURL command
-                </MenuItem>
-              </MenuList>
-            </Menu>
-          </WrapItem>
-        </Wrap>
-      ),
-      header: 'Actions',
-      enableSorting: false,
-    }),
-  ];
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((row: FileDto) => row.path, {
+        cell: (info) => (
+          <ChakraLink
+            fontWeight={'semibold'}
+            href={
+              info.row.original.type === 'DIRECTORY'
+                ? `${directoryPath}${info.getValue().slice(1)}`
+                : `${slug}${info.getValue()}`
+            }
+          >
+            <HStack>
+              <Box>{info.row.original.type === 'DIRECTORY' ? <FcOpenedFolder /> : <FcFile />}</Box>
+              <Box>{info.getValue()}</Box>
+            </HStack>
+          </ChakraLink>
+        ),
+        header: 'Path',
+      }),
+      columnHelper.accessor((row: FileDto) => row.revision, {
+        cell: (info) => info.getValue(),
+        header: 'Revision',
+      }),
+      columnHelper.accessor((row: FileDto) => row.path, {
+        cell: (info) => (
+          <Wrap>
+            <WrapItem>
+              <NextLink
+                href={
+                  info.row.original.type === 'DIRECTORY'
+                    ? `${directoryPath}${info.getValue().slice(1)}`
+                    : `${slug}${info.getValue()}`
+                }
+              >
+                <Button leftIcon={<ViewIcon />} colorScheme="blue" size="sm">
+                  View
+                </Button>
+              </NextLink>
+            </WrapItem>
+            <WrapItem>
+              <Menu>
+                <MenuButton as={Button} size="sm" leftIcon={<CopyIcon />} rightIcon={<ChevronDownIcon />}>
+                  Copy
+                </MenuButton>
+                <MenuList>
+                  <MenuItem onClick={() => copySupport.handleApiUrl(projectName, repoName, info.getValue())}>
+                    API URL
+                  </MenuItem>
+                  <MenuItem onClick={() => copySupport.handleWebUrl(projectName, repoName, info.getValue())}>
+                    Web URL
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => copySupport.handleAsCliCommand(projectName, repoName, info.getValue())}
+                  >
+                    CLI command
+                  </MenuItem>
+                  <MenuItem
+                    onClick={() => copySupport.handleAsCurlCommand(projectName, repoName, info.getValue())}
+                  >
+                    cURL command
+                  </MenuItem>
+                </MenuList>
+              </Menu>
+            </WrapItem>
+          </Wrap>
+        ),
+        header: 'Actions',
+        enableSorting: false,
+      }),
+    ],
+    [columnHelper, copySupport, directoryPath, projectName, repoName, slug],
+  );
   return <DynamicDataTable columns={columns as ColumnDef<Data>[]} data={data} />;
 };
 

--- a/webapp/src/dogma/features/history/HistoryDto.ts
+++ b/webapp/src/dogma/features/history/HistoryDto.ts
@@ -1,5 +1,5 @@
 export interface HistoryDto {
-  revision: string;
+  revision: number;
   author: HistoryAuthorDto;
   commitMessage: HistoryDetailDto;
   pushedAt: string;
@@ -12,6 +12,6 @@ export interface HistoryAuthorDto {
 
 export interface HistoryDetailDto {
   summary: string;
-  content: string;
+  detail: string;
   markup: string;
 }

--- a/webapp/src/dogma/features/history/HistoryDto.ts
+++ b/webapp/src/dogma/features/history/HistoryDto.ts
@@ -1,16 +1,8 @@
 export interface HistoryDto {
-  revision: HistoryRevisionDto;
+  revision: string;
   author: HistoryAuthorDto;
-  timestamp: string;
-  summary: string;
-  detail: HistoryDetailDto;
-  diffs: string[];
-}
-
-export interface HistoryRevisionDto {
-  major: number;
-  minor: number;
-  revisionNumber: string;
+  commitMessage: HistoryDetailDto;
+  pushedAt: string;
 }
 
 export interface HistoryAuthorDto {
@@ -19,6 +11,7 @@ export interface HistoryAuthorDto {
 }
 
 export interface HistoryDetailDto {
+  summary: string;
   content: string;
   markup: string;
 }

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -63,7 +63,7 @@ const HistoryList = <Data extends object>({
     ],
     [columnHelper, handleTabChange, projectName, repoName],
   );
-  return <DynamicDataTable columns={columns as ColumnDef<Data>[]} data={data} />;
+  return <DynamicDataTable columns={columns as ColumnDef<Data>[]} data={data} pagination={true} />;
 };
 
 export default HistoryList;

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -52,8 +52,8 @@ const HistoryList = <Data extends object>({
       columnHelper.accessor((row: HistoryDto) => row.revision, {
         cell: (info) => (
           <NextLink href={`/app/projects/${projectName}/repos/${repoName}/list/${info.row.original.revision}/`}>
-            <Button leftIcon={<FaHistory />} size="sm" onClick={() => handleTabChange(0)}>
-              View
+            <Button colorScheme="blue" leftIcon={<FaHistory />} size="sm" onClick={() => handleTabChange(0)}>
+              View Revision {info.row.original.revision}
             </Button>
           </NextLink>
         ),

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -1,11 +1,12 @@
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
-import { Box, Button, HStack, Tag } from '@chakra-ui/react';
+import { Badge, Box, Button, HStack } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { FaHistory } from 'react-icons/fa';
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
+import { useMemo } from 'react';
 
 export type HistoryListProps<Data extends object> = {
   data: Data[];
@@ -21,46 +22,47 @@ const HistoryList = <Data extends object>({
   handleTabChange,
 }: HistoryListProps<Data>) => {
   const columnHelper = createColumnHelper<HistoryDto>();
-  const columns = [
-    columnHelper.accessor((row: HistoryDto) => `${row.revision.revisionNumber} ${row.summary}`, {
-      cell: (info) => (
-        <ChakraLink
-          fontWeight="semibold"
-          href={`/app/projects/${projectName}/repos/${repoName}/list/${info.row.original.revision.revisionNumber}/`}
-          onClick={() => handleTabChange(0)}
-        >
-          <HStack>
-            <Box>
-              <Tag colorScheme="blue">{info.row.original.revision.revisionNumber}</Tag>
-            </Box>
-            <Box>{info.row.original.summary}</Box>
-          </HStack>
-        </ChakraLink>
-      ),
-      header: 'Revision',
-    }),
-    columnHelper.accessor((row: HistoryDto) => row.author.name, {
-      cell: (info) => info.getValue(),
-      header: 'Author',
-    }),
-    columnHelper.accessor((row: HistoryDto) => row.timestamp, {
-      cell: (info) => <DateWithTooltip date={info.getValue()} />,
-      header: 'Timestamp',
-    }),
-    columnHelper.accessor((row: HistoryDto) => row.revision.revisionNumber, {
-      cell: (info) => (
-        <NextLink
-          href={`/app/projects/${projectName}/repos/${repoName}/list/${info.row.original.revision.revisionNumber}/`}
-        >
-          <Button leftIcon={<FaHistory />} size="sm" onClick={() => handleTabChange(0)}>
-            View
-          </Button>
-        </NextLink>
-      ),
-      header: 'Actions',
-      enableSorting: false,
-    }),
-  ];
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((row: HistoryDto) => `${row.revision} ${row.commitMessage.summary}`, {
+        cell: (info) => (
+          <ChakraLink
+            fontWeight="semibold"
+            href={`/app/projects/${projectName}/repos/${repoName}/list/${info.row.original.revision}/`}
+            onClick={() => handleTabChange(0)}
+          >
+            <HStack>
+              <Box>
+                <Badge colorScheme="blue">{info.row.original.revision}</Badge>
+              </Box>
+              <Box>{info.row.original.commitMessage.summary}</Box>
+            </HStack>
+          </ChakraLink>
+        ),
+        header: 'Revision',
+      }),
+      columnHelper.accessor((row: HistoryDto) => row.author.name, {
+        cell: (info) => info.getValue(),
+        header: 'Author',
+      }),
+      columnHelper.accessor((row: HistoryDto) => row.pushedAt, {
+        cell: (info) => <DateWithTooltip date={info.getValue()} />,
+        header: 'Timestamp',
+      }),
+      columnHelper.accessor((row: HistoryDto) => row.revision, {
+        cell: (info) => (
+          <NextLink href={`/app/projects/${projectName}/repos/${repoName}/list/${info.row.original.revision}/`}>
+            <Button leftIcon={<FaHistory />} size="sm" onClick={() => handleTabChange(0)}>
+              View
+            </Button>
+          </NextLink>
+        ),
+        header: 'Actions',
+        enableSorting: false,
+      }),
+    ],
+    [columnHelper, handleTabChange, projectName, repoName],
+  );
   return <DynamicDataTable columns={columns as ColumnDef<Data>[]} data={data} />;
 };
 

--- a/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
@@ -18,7 +18,7 @@ const makeData = (len: number) => {
     historyList.push(newHistory(i));
   }
 };
-makeData(10);
+makeData(30);
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
   const { historyItem } = req.body;

--- a/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
@@ -5,22 +5,10 @@ import { faker } from '@faker-js/faker';
 
 const newHistory = (i: number): HistoryDto => {
   return {
-    revision: {
-      major: faker.datatype.number({ min: 0, max: 10 }),
-      minor: faker.datatype.number({ min: 0, max: 10 }),
-      revisionNumber: i.toString(),
-    },
-    author: {
-      name: faker.internet.userName(),
-      email: faker.internet.email(),
-    },
-    timestamp: faker.datatype.datetime().toISOString(),
-    summary: faker.lorem.sentence(),
-    detail: {
-      content: faker.lorem.paragraph(),
-      markup: 'PLAINTEXT',
-    },
-    diffs: [],
+    revision: i.toString(),
+    author: { name: faker.internet.userName(), email: faker.internet.email() },
+    commitMessage: { summary: faker.lorem.sentence(), content: faker.lorem.paragraph(), markup: 'PLAINTEXT' },
+    pushedAt: faker.datatype.datetime().toISOString(),
   };
 };
 

--- a/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/repos/[repoName]/commits/index.ts
@@ -5,9 +5,9 @@ import { faker } from '@faker-js/faker';
 
 const newHistory = (i: number): HistoryDto => {
   return {
-    revision: i.toString(),
+    revision: i,
     author: { name: faker.internet.userName(), email: faker.internet.email() },
-    commitMessage: { summary: faker.lorem.sentence(), content: faker.lorem.paragraph(), markup: 'PLAINTEXT' },
+    commitMessage: { summary: faker.lorem.sentence(), detail: faker.lorem.paragraph(), markup: 'PLAINTEXT' },
     pushedAt: faker.datatype.datetime().toISOString(),
   };
 };

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -98,7 +98,7 @@ cat ${project}/${repo}${path}`;
   };
 
   const {
-    data: fileData = [],
+    data: fileData,
     isLoading: isFileDataLoading,
     error: fileError,
   } = useGetFilesByProjectAndRepoAndRevisionNameQuery(
@@ -156,7 +156,7 @@ cat ${project}/${repo}${path}`;
         <TabPanels>
           <TabPanel>
             <FileList
-              data={fileData}
+              data={fileData || []}
               projectName={projectName}
               repoName={repoName}
               path={filePath}


### PR DESCRIPTION
## Motivation
Update history to use v1 API. 

Version 0: [https://github.com/line/centraldogma/blob/1ceed8a869d364e2b6fd12ae1bbbc0fb0c83f292[…]ntraldogma/server/internal/admin/service/RepositoryService.java](https://github.com/line/centraldogma/blob/1ceed8a869d364e2b6fd12ae1bbbc0fb0c83f292/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java#L170-L184)
Version 1: [https://github.com/line/centraldogma/blob/e46e977e8c2836047e44f7389b00da41412a44a5[…]linecorp/centraldogma/server/internal/api/ContentServiceV1.java](https://github.com/line/centraldogma/blob/e46e977e8c2836047e44f7389b00da41412a44a5/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java#L319-L332)

## Modification
- Update API endpoints (and remove trailing `/`)
- Update history.
- Memoize file and history tables. https://react-table-v7.tanstack.com/docs/quick-start#define-columns

## Result
The history for a newly created project is now available.

<img width="959" alt="Screen Shot 2023-01-11 at 15 24 16" src="https://user-images.githubusercontent.com/5079588/211754996-131ef06f-6c30-4953-a708-645f8007b840.png">