### PR TITLE
Add breadcrumbs

### DIFF
--- a/webapp/__tests__/dogma/common/components/Breadcrumbs.test.tsx
+++ b/webapp/__tests__/dogma/common/components/Breadcrumbs.test.tsx
@@ -1,0 +1,47 @@
+import { render } from '@testing-library/react';
+import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
+
+describe('Breadcrumbs', () => {
+  it('renders the breadcrumb', () => {
+    const { container } = render(<Breadcrumbs path={'/app/projects'} omitIndexList={[]} suffixes={{}} />);
+    const crumb = container.querySelector('nav').firstChild.firstChild.firstChild;
+    expect(crumb).toHaveTextContent('app');
+  });
+
+  it('does not render the omitted crumbs', () => {
+    const { container } = render(<Breadcrumbs path={'/app/projects'} omitIndexList={[0]} suffixes={{}} />);
+    const crumb = container.querySelector('nav').firstChild.firstChild.firstChild;
+    expect(crumb).toHaveTextContent('projects');
+  });
+
+  it('adds suffix to the crumb link', () => {
+    const { container } = render(
+      <Breadcrumbs
+        path={'/app/projects/my-project-name/repos/repo1'}
+        omitIndexList={[]}
+        suffixes={{ 2: '/list/head' }}
+      />,
+    );
+    const crumb = container.querySelector('nav').firstChild.childNodes[2].firstChild;
+    expect(crumb).toHaveTextContent('my-project-name');
+    expect(crumb).toHaveAttribute('href', '/app/projects/my-project-name/list/head');
+  });
+
+  it('renders the directory link', () => {
+    const { container } = render(
+      <Breadcrumbs
+        path={
+          '/app/projects/my-project-name/repos/my-repo-name/files/head/folder/subfolder/subfolder2/my-file-name'
+        }
+        omitIndexList={[]}
+        suffixes={{}}
+      />,
+    );
+    const crumb = container.querySelector('nav').firstChild.childNodes[8].firstChild;
+    expect(crumb).toHaveTextContent('subfolder');
+    expect(crumb).toHaveAttribute(
+      'href',
+      '/app/projects/my-project-name/repos/my-repo-name/list/head/folder/subfolder',
+    );
+  });
+});

--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -50,9 +50,6 @@ describe('FileList', () => {
       directoryPath: '/app/projects/ProjectAlpha/repos/repo1/list/head/',
       revision: 'head',
       copySupport: mockCopySupport,
-      path: '',
-      directoryPath: '/app/projects/ProjectAlpha/repos/repo1/list/head/',
-      revision: 'head',
     };
   });
 

--- a/webapp/src/dogma/common/components/Breadcrumbs.tsx
+++ b/webapp/src/dogma/common/components/Breadcrumbs.tsx
@@ -1,0 +1,44 @@
+import { Breadcrumb, BreadcrumbItem, BreadcrumbLink, Text } from '@chakra-ui/react';
+import { FcNext } from 'react-icons/fc';
+import NextLink from 'next/link';
+
+export const Breadcrumbs = ({
+  path,
+  omitIndexList,
+  // /project/projectName/repos/repoName -> /project/projectName/repos/repoName/list/head
+  suffixes,
+}: {
+  path: string;
+  omitIndexList: number[];
+  suffixes: { [key: number]: string };
+}) => {
+  const asPathNestedRoutes = path
+    // If the path belongs to a file, the top level should be a directory
+    .replace('/files/head', '/list/head')
+    .split('/')
+    .filter((v) => v.length > 0);
+  if (asPathNestedRoutes && asPathNestedRoutes[asPathNestedRoutes.length - 1].startsWith('#')) {
+    asPathNestedRoutes.pop();
+  }
+  const prefixes: string[] = [];
+  return (
+    <Breadcrumb spacing="8px" separator={<FcNext />} mb={5} fontWeight="medium" fontSize="sm">
+      {asPathNestedRoutes.map((page, i) => {
+        prefixes.push(page);
+        if (!omitIndexList.includes(i)) {
+          return (
+            <BreadcrumbItem key={i}>
+              {i < asPathNestedRoutes.length - 1 ? (
+                <BreadcrumbLink as={NextLink} href={`/${prefixes.join('/')}${suffixes[i] || ''}`}>
+                  {decodeURI(page)}
+                </BreadcrumbLink>
+              ) : (
+                <Text> {decodeURI(page)}</Text>
+              )}
+            </BreadcrumbItem>
+          );
+        }
+      })}
+    </Breadcrumb>
+  );
+};

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -1,5 +1,6 @@
 import { Box, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
 import { NewRepository } from 'dogma/common/components/NewRepository';
+import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 import { useGetMetadataByProjectNameQuery, useGetReposByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import RepoList from 'dogma/features/repo/RepoList';
 import RepoMemberList from 'dogma/features/repo/RepoMemberList';
@@ -38,6 +39,7 @@ const ProjectDetailPage = () => {
   }
   return (
     <Box p="2">
+      <Breadcrumbs path={router.asPath.split('?')[0]} omitIndexList={[0]} suffixes={{ 4: '/list/head' }} />
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
         <Heading size="lg">Project {projectName}</Heading>
       </Flex>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -3,6 +3,7 @@ import { Box, Flex, Heading, Tag, Tooltip } from '@chakra-ui/react';
 import { useGetFileContentQuery } from 'dogma/features/api/apiSlice';
 import { useRouter } from 'next/router';
 import FileEditor from 'dogma/common/components/editor/FileEditor';
+import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 
 const FileContentPage = () => {
   const router = useRouter();
@@ -22,8 +23,12 @@ const FileContentPage = () => {
   }
   return (
     <Box p="2">
+      <Breadcrumbs path={router.asPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">{`${filePath}`}</Heading>
+        <Heading size="lg">{`${router.asPath
+          .split('/')
+          .filter((v) => v.length > 0)
+          .pop()}`}</Heading>
         <Tooltip label="Go to History to view all revisions">
           <Tag borderRadius="full" colorScheme="blue">
             Revision {revision} <InfoIcon ml={2} />

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -29,6 +29,7 @@ import { createMessage, resetState } from 'dogma/features/message/messageSlice';
 import { useAppDispatch } from 'dogma/store';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
 import { CopySupport } from 'dogma/features/file/CopySupport';
+import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -128,8 +129,9 @@ cat ${project}/${repo}${path}`;
 
   return (
     <Box p="2">
+      <Breadcrumbs path={directoryPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">Repository {repoName} </Heading>
+        <Heading size="lg">{filePath || repoName} </Heading>
         <Tooltip label="Go to History to view all revisions">
           <Tag borderRadius="full" colorScheme="blue">
             Revision {revision} <InfoIcon ml={2} />


### PR DESCRIPTION
## Motivation
Allow the user to go back to the top level. This is especially helpful when there are nested directories.

## Modification
- Add breadcrumbs component.
- Add breadcrumbs to the top of each page.

## Result
- `npm run mock`
- Navigate to the file/directory.

<img width="1102" alt="Screen Shot 2023-01-20 at 10 19 37" src="https://user-images.githubusercontent.com/5079588/213610655-96132862-c407-41bc-998a-64439c2fa0e5.png">

