### PR TITLE
Add file modification

### DIFF
--- a/webapp/__tests__/dogma/feature/file/FileList.test.tsx
+++ b/webapp/__tests__/dogma/feature/file/FileList.test.tsx
@@ -57,7 +57,7 @@ describe('FileList', () => {
     const { getByText } = render(<FileList {...expectedProps} />);
     let name;
     expectedProps.data.forEach((file: FileDto) => {
-      name = getByText(file.path);
+      name = getByText(file.path.slice(1));
       expect(name).toBeVisible();
     });
   });

--- a/webapp/src/dogma/common/components/CommitForm.tsx
+++ b/webapp/src/dogma/common/components/CommitForm.tsx
@@ -1,0 +1,107 @@
+import { Button, FormControl, Heading, Input, Stack, Textarea, VStack } from '@chakra-ui/react';
+import { SerializedError } from '@reduxjs/toolkit';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
+import { usePushFileChangesMutation } from 'dogma/features/api/apiSlice';
+import { createMessage } from 'dogma/features/message/messageSlice';
+import ErrorHandler from 'dogma/features/services/ErrorHandler';
+import { useAppDispatch } from 'dogma/store';
+import { useForm } from 'react-hook-form';
+
+type FormData = {
+  summary: string;
+  detail: string;
+};
+
+export type CommitFormProps = {
+  projectName: string;
+  repoName: string;
+  path: string;
+  name: string;
+  content: string;
+  readOnly: boolean;
+  setReadOnly: (readOnly: boolean) => void;
+  switchMode: () => void;
+};
+
+export const CommitForm = ({
+  projectName,
+  repoName,
+  path,
+  name,
+  content,
+  readOnly,
+  setReadOnly,
+  switchMode,
+}: CommitFormProps) => {
+  const [updateFile, { isLoading }] = usePushFileChangesMutation();
+  const { register, handleSubmit, reset } = useForm<FormData>();
+  const dispatch = useAppDispatch();
+  const onSubmit = async (formData: FormData) => {
+    const data = {
+      commitMessage: {
+        summary: formData.summary,
+        detail: formData.detail,
+      },
+      changes: [
+        {
+          path: path,
+          type: name.endsWith('.json') ? 'UPSERT_JSON' : 'UPSERT_TEXT',
+          content: content,
+        },
+      ],
+    };
+    try {
+      const response = await updateFile({ projectName, repoName, data }).unwrap();
+      if ((response as { error: FetchBaseQueryError | SerializedError }).error) {
+        throw (response as { error: FetchBaseQueryError | SerializedError }).error;
+      }
+      dispatch(
+        createMessage({
+          title: 'File updated',
+          text: `Successfully updated ${path}`,
+          type: 'success',
+        }),
+      );
+      setReadOnly(true);
+      reset();
+    } catch (error) {
+      dispatch(
+        createMessage({
+          title: `Failed to update ${path}`,
+          text: ErrorHandler.handle(error),
+          type: 'error',
+        }),
+      );
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <VStack p={4} gap="2" mb={6} align="stretch" display={readOnly ? 'none' : 'visible'}>
+        <Heading size="md">Commit changes</Heading>
+        <FormControl isRequired>
+          <Input
+            id="summary"
+            name="summary"
+            type="text"
+            placeholder="Add a summary"
+            {...register('summary', { required: true })}
+          />
+        </FormControl>
+        <Textarea
+          id="description"
+          name="description"
+          placeholder="Add an optional extended description..."
+          {...register('detail')}
+        />
+        <Stack direction="row" spacing={4} mt={2}>
+          <Button type="submit" colorScheme="teal" isLoading={isLoading} loadingText="Creating">
+            Commit
+          </Button>
+          <Button variant="outline" onClick={switchMode}>
+            Cancel
+          </Button>
+        </Stack>
+      </VStack>
+    </form>
+  );
+};

--- a/webapp/src/dogma/common/components/Navbar.tsx
+++ b/webapp/src/dogma/common/components/Navbar.tsx
@@ -109,8 +109,11 @@ export const Navbar = () => {
 
   const selectRef = useRef(null);
   useEffect(() => {
-    // TODO: Exclude hotkey from input elements
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = (e.target as HTMLElement).tagName.toLowerCase();
+      if (target == 'textarea' || target == 'input') {
+        return;
+      }
       if (e.key === '/') {
         e.preventDefault();
         selectRef.current.clearValue();

--- a/webapp/src/dogma/common/components/NewFile.tsx
+++ b/webapp/src/dogma/common/components/NewFile.tsx
@@ -41,10 +41,11 @@ type FormData = {
 export const NewFile = ({
   projectName,
   repoName,
+  initialPrefixes,
 }: {
   projectName: string;
   repoName: string;
-  revision: string;
+  initialPrefixes: string[];
 }) => {
   const { colorMode } = useColorMode();
   const [addNewFle, { isLoading }] = usePushFileChangesMutation();
@@ -55,7 +56,7 @@ export const NewFile = ({
     formState: { errors },
   } = useForm<FormData>();
   const dispatch = useAppDispatch();
-  const [prefixes] = useState([]);
+  const [prefixes] = useState(initialPrefixes);
   const onSubmit = async (formData: FormData) => {
     const path = `${prefixes.join('/')}/${formData.name}`;
     const data = {
@@ -77,7 +78,7 @@ export const NewFile = ({
       if ((response as { error: FetchBaseQueryError | SerializedError }).error) {
         throw (response as { error: FetchBaseQueryError | SerializedError }).error;
       }
-      Router.push(`/app/projects/${projectName}/repos/${repoName}/list/head/`);
+      Router.push(`/app/projects/${projectName}/repos/${repoName}/list/head${`/${prefixes.join('/')}`}`);
       reset();
       dispatch(
         createMessage({

--- a/webapp/src/dogma/common/components/NewFile.tsx
+++ b/webapp/src/dogma/common/components/NewFile.tsx
@@ -16,7 +16,7 @@ import {
   VStack,
   useColorMode,
 } from '@chakra-ui/react';
-import { useAddNewFileMutation } from 'dogma/features/api/apiSlice';
+import { usePushFileChangesMutation } from 'dogma/features/api/apiSlice';
 import { createMessage } from 'dogma/features/message/messageSlice';
 import { useAppDispatch } from 'dogma/store';
 import Router from 'next/router';
@@ -44,7 +44,7 @@ export const NewFile = ({
   revision: string;
 }) => {
   const { colorMode } = useColorMode();
-  const [addNewFle, { isLoading }] = useAddNewFileMutation();
+  const [addNewFle, { isLoading }] = usePushFileChangesMutation();
   const {
     register,
     handleSubmit,

--- a/webapp/src/dogma/common/components/NewFile.tsx
+++ b/webapp/src/dogma/common/components/NewFile.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-children-prop */
 import {
   Box,
   Button,
@@ -8,6 +9,8 @@ import {
   FormLabel,
   Heading,
   Input,
+  InputGroup,
+  InputLeftAddon,
   Radio,
   RadioGroup,
   Spacer,
@@ -105,11 +108,14 @@ export const NewFile = ({
         <VStack>
           <FormControl isInvalid={errors.name ? true : false} isRequired>
             <FormLabel>Path</FormLabel>
-            <Input
-              type="text"
-              placeholder="my-file-name"
-              {...register('name', { pattern: FILE_PATH_PATTERN })}
-            />
+            <InputGroup>
+              <InputLeftAddon children="/" />
+              <Input
+                type="text"
+                placeholder="my-file-name"
+                {...register('name', { pattern: FILE_PATH_PATTERN })}
+              />
+            </InputGroup>
             {errors.name && <FormErrorMessage>Invalid file name</FormErrorMessage>}
           </FormControl>
           <FormControl>

--- a/webapp/src/dogma/common/components/NewFile.tsx
+++ b/webapp/src/dogma/common/components/NewFile.tsx
@@ -105,7 +105,6 @@ export const NewFile = ({
         <VStack>
           <FormControl isInvalid={errors.name ? true : false} isRequired>
             <FormLabel>Path</FormLabel>
-            {/* TODO: Allow slash / in the file path/name, i.e.exclude this input from the document hotkey */}
             <Input
               type="text"
               placeholder="my-file-name"

--- a/webapp/src/dogma/common/components/editor/DeleteFileModal.tsx
+++ b/webapp/src/dogma/common/components/editor/DeleteFileModal.tsx
@@ -1,0 +1,126 @@
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Textarea,
+} from '@chakra-ui/react';
+import { SerializedError } from '@reduxjs/toolkit';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
+import { usePushFileChangesMutation } from 'dogma/features/api/apiSlice';
+import { createMessage } from 'dogma/features/message/messageSlice';
+import ErrorHandler from 'dogma/features/services/ErrorHandler';
+import { useAppDispatch } from 'dogma/store';
+import Router from 'next/router';
+import { useForm } from 'react-hook-form';
+
+type FormData = {
+  summary: string;
+  detail: string;
+};
+
+export const DeleteFileModal = ({
+  isOpen,
+  onClose,
+  path,
+  projectName,
+  repoName,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  path: string;
+  projectName: string;
+  repoName: string;
+}) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<FormData>();
+  const [deleteFile, { isLoading }] = usePushFileChangesMutation();
+  const dispatch = useAppDispatch();
+  const onSubmit = async (formData: FormData) => {
+    const data = {
+      commitMessage: {
+        summary: formData.summary,
+        detail: formData.detail,
+      },
+      changes: [
+        {
+          path: path,
+          type: 'REMOVE',
+          content: '',
+        },
+      ],
+    };
+    try {
+      const response = await deleteFile({ projectName, repoName, data }).unwrap();
+      if ((response as { error: FetchBaseQueryError | SerializedError }).error) {
+        throw (response as { error: FetchBaseQueryError | SerializedError }).error;
+      }
+      dispatch(
+        createMessage({
+          title: 'File deleted',
+          text: `Successfully deleted ${path}`,
+          type: 'success',
+        }),
+      );
+      reset();
+      Router.push(`/app/projects/${projectName}/repos/${repoName}/list/head/`);
+    } catch (error) {
+      dispatch(
+        createMessage({
+          title: `Failed to delete ${path}`,
+          text: ErrorHandler.handle(error),
+          type: 'error',
+        }),
+      );
+    }
+  };
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered motionPreset="slideInBottom">
+      <ModalOverlay />
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <ModalContent>
+          <ModalHeader>Delete {path}?</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <FormControl isRequired>
+              <Input
+                id="summary"
+                name="summary"
+                type="text"
+                placeholder="Add a summary"
+                {...register('summary', { required: true })}
+                mb={4}
+              />
+              {errors.summary && <FormErrorMessage>Please enter the commit message</FormErrorMessage>}
+            </FormControl>
+            <Textarea
+              id="description"
+              name="description"
+              placeholder="Add an optional extended description..."
+              {...register('detail')}
+            />
+          </ModalBody>
+          <ModalFooter>
+            <Button type="submit" colorScheme="red" mr={3} isLoading={isLoading} loadingText="Deleting">
+              Delete
+            </Button>
+            <Button variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </form>
+    </Modal>
+  );
+};

--- a/webapp/src/dogma/common/components/editor/DiscardChangesModal.tsx
+++ b/webapp/src/dogma/common/components/editor/DiscardChangesModal.tsx
@@ -1,0 +1,39 @@
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+} from '@chakra-ui/react';
+
+export const DiscardChangesModal = ({
+  isOpen,
+  onClose,
+  resetViewEditor,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  resetViewEditor: () => void;
+}) => {
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Are you sure?</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>Your changes will be discarded!</ModalBody>
+        <ModalFooter>
+          <Button colorScheme="red" mr={3} onClick={resetViewEditor}>
+            Discard changes
+          </Button>
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -42,6 +42,7 @@ export type GetFilesByProjectAndRepoName = {
   projectName: string;
   repoName: string;
   revision?: string;
+  filePath?: string;
 };
 
 export type GetFileContent = {
@@ -99,8 +100,8 @@ export const apiSlice = createApi({
       providesTags: ['File'],
     }),
     getFilesByProjectAndRepoAndRevisionName: builder.query<FileDto[], GetFilesByProjectAndRepoName>({
-      query: ({ projectName, repoName, revision }) =>
-        `/v1/projects/${projectName}/repos/${repoName}/list/?revision=${revision}`,
+      query: ({ projectName, repoName, revision, filePath }) =>
+        `/v1/projects/${projectName}/repos/${repoName}/list${filePath || ''}?revision=${revision || 'head'}`,
       providesTags: ['File'],
     }),
     getFileContent: builder.query<FileContentDto, GetFileContent>({

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -83,6 +83,7 @@ export const apiSlice = createApi({
     }),
     getReposByProjectName: builder.query<RepoDto[], string>({
       query: (projectName) => `/v1/projects/${projectName}/repos`,
+      providesTags: ['Repo'],
     }),
     addNewRepo: builder.mutation({
       query: ({ projectName, data }) => ({
@@ -95,11 +96,7 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['Repo'],
     }),
-    getFilesByProjectAndRepoName: builder.query<FileDto[], GetFilesByProjectAndRepoName>({
-      query: ({ projectName, repoName }) => `/v1/projects/${projectName}/repos/${repoName}/list`,
-      providesTags: ['File'],
-    }),
-    getFilesByProjectAndRepoAndRevisionName: builder.query<FileDto[], GetFilesByProjectAndRepoName>({
+    getFiles: builder.query<FileDto[], GetFilesByProjectAndRepoName>({
       query: ({ projectName, repoName, revision, filePath }) =>
         `/v1/projects/${projectName}/repos/${repoName}/list${filePath || ''}?revision=${revision || 'head'}`,
       providesTags: ['File'],
@@ -144,8 +141,7 @@ export const {
   useGetProjectsQuery,
   useGetMetadataByProjectNameQuery,
   useGetReposByProjectNameQuery,
-  useGetFilesByProjectAndRepoNameQuery,
-  useGetFilesByProjectAndRepoAndRevisionNameQuery,
+  useGetFilesQuery,
   useGetFileContentQuery,
   useGetHistoryQuery,
   useGetNormalisedRevisionQuery,

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -106,8 +106,9 @@ export const apiSlice = createApi({
     getFileContent: builder.query<FileContentDto, GetFileContent>({
       query: ({ projectName, repoName, filePath }) =>
         `/v1/projects/${projectName}/repos/${repoName}/contents/${filePath}`,
+      providesTags: ['File'],
     }),
-    addNewFile: builder.mutation({
+    pushFileChanges: builder.mutation({
       query: ({ projectName, repoName, data }) => ({
         url: `/v1/projects/${projectName}/repos/${repoName}/contents`,
         method: 'POST',
@@ -138,7 +139,7 @@ export const apiSlice = createApi({
 export const {
   useAddNewProjectMutation,
   useAddNewRepoMutation,
-  useAddNewFileMutation,
+  usePushFileChangesMutation,
   useGetProjectsQuery,
   useGetMetadataByProjectNameQuery,
   useGetReposByProjectNameQuery,

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -31,14 +31,14 @@ const FileList = <Data extends object>({
   const slug = `/app/projects/${projectName}/repos/${repoName}/files/${revision}${path}`;
   const columns = useMemo(
     () => [
-      columnHelper.accessor((row: FileDto) => row.path, {
+      columnHelper.accessor((row: FileDto) => row.path.split('/').pop(), {
         cell: (info) => (
           <ChakraLink
             fontWeight={'semibold'}
             href={
               info.row.original.type === 'DIRECTORY'
-                ? `${directoryPath}${info.getValue().slice(1)}`
-                : `${slug}${info.getValue()}`
+                ? `${directoryPath}${info.getValue()}`
+                : `${slug}/${info.getValue()}`
             }
           >
             <HStack>

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -58,7 +58,13 @@ const FileList = <Data extends object>({
           <Wrap>
             <WrapItem>
               <Menu>
-                <MenuButton as={Button} size="sm" leftIcon={<CopyIcon />} rightIcon={<ChevronDownIcon />}>
+                <MenuButton
+                  as={Button}
+                  size="sm"
+                  leftIcon={<CopyIcon />}
+                  rightIcon={<ChevronDownIcon />}
+                  variant="ghost"
+                >
                   Copy
                 </MenuButton>
                 <MenuList>

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -1,6 +1,6 @@
 import { PaginationState, createColumnHelper } from '@tanstack/react-table';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
-import { Badge, Box, HStack } from '@chakra-ui/react';
+import { Badge, Box, HStack, Text } from '@chakra-ui/react';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { useMemo, useState } from 'react';
@@ -34,6 +34,10 @@ const HistoryList = ({ projectName, repoName, handleTabChange, totalRevision }: 
           </ChakraLink>
         ),
         header: 'Revision',
+      }),
+      columnHelper.accessor((row: HistoryDto) => row.commitMessage.detail, {
+        cell: (info) => <Text>{info.getValue()}</Text>,
+        header: 'Detail',
       }),
       columnHelper.accessor((row: HistoryDto) => row.author.name, {
         cell: (info) => info.getValue(),

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -11,7 +11,10 @@ const FileContentPage = () => {
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
   const revision = router.query.revision ? (router.query.revision as string) : 'head';
   const filePath = router.query.path ? `${Array.from(router.query.path).join('/')}`.replace(/\/\//g, '/') : '';
-
+  const fileName = router.asPath
+    .split('/')
+    .filter((v) => v.length > 0)
+    .pop();
   const { data, isLoading, error } = useGetFileContentQuery(
     { projectName, repoName, filePath },
     {
@@ -29,17 +32,21 @@ const FileContentPage = () => {
     <Box p="2">
       <Breadcrumbs path={router.asPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">{`${router.asPath
-          .split('/')
-          .filter((v) => v.length > 0)
-          .pop()}`}</Heading>
+        <Heading size="lg">{fileName}</Heading>
         <Tooltip label="Go to History to view all revisions">
           <Tag borderRadius="full" colorScheme="blue">
             Revision {revision} <InfoIcon ml={2} />
           </Tag>
         </Tooltip>
       </Flex>
-      <FileEditor language={data.type.toLowerCase()} originalContent={data.content} />
+      <FileEditor
+        projectName={projectName}
+        repoName={repoName}
+        language={data.type.toLowerCase()}
+        originalContent={data.content}
+        path={data.path}
+        name={fileName}
+      />
     </Box>
   );
 };

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -139,7 +139,7 @@ cat ${project}/${repo}${path}`;
           <TabPanel>
             <Flex>
               <Spacer />
-              <Link href={`/app/projects/${projectName}/repos/${repoName}/new_file/head`}>
+              <Link href={`/app/projects/${projectName}/repos/${repoName}/new_file/head${filePath}`}>
                 <Button size="sm" rightIcon={<AiOutlinePlus />} colorScheme="teal">
                   New File
                 </Button>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -100,7 +100,7 @@ cat ${project}/${repo}${path}`;
     isLoading,
     error,
   } = useGetFilesByProjectAndRepoAndRevisionNameQuery(
-    { projectName, repoName, revision },
+    { projectName, repoName, revision, filePath },
     {
       refetchOnMountOrArgChange: true,
       skip: false,

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -13,10 +13,7 @@ import {
   Tag,
   Tooltip,
 } from '@chakra-ui/react';
-import {
-  useGetFilesByProjectAndRepoAndRevisionNameQuery,
-  useGetNormalisedRevisionQuery,
-} from 'dogma/features/api/apiSlice';
+import { useGetFilesQuery, useGetNormalisedRevisionQuery } from 'dogma/features/api/apiSlice';
 import FileList from 'dogma/features/file/FileList';
 import { useRouter } from 'next/router';
 import HistoryList from 'dogma/features/history/HistoryList';
@@ -99,7 +96,7 @@ cat ${project}/${repo}${path}`;
     data: fileData,
     isLoading,
     error,
-  } = useGetFilesByProjectAndRepoAndRevisionNameQuery(
+  } = useGetFilesQuery(
     { projectName, repoName, revision, filePath },
     {
       refetchOnMountOrArgChange: true,

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/new_file/head/[[...path]].tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/new_file/head/[[...path]].tsx
@@ -7,11 +7,14 @@ const NewFilePage = () => {
   const router = useRouter();
   const repoName = router.query.repoName ? (router.query.repoName as string) : '';
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
-  const revision = router.query.revision ? (router.query.revision as string) : 'head';
   return (
     <Box p="2">
       <Breadcrumbs path={router.asPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
-      <NewFile projectName={projectName} repoName={repoName} revision={revision} />
+      <NewFile
+        projectName={projectName}
+        repoName={repoName}
+        initialPrefixes={(router.query.path as string[]) || []}
+      />
     </Box>
   );
 };


### PR DESCRIPTION
## Motivation
Allow creating/updating/deleting a file.

## Modification
- Add update file.
- Add delete file.
- Extract modals to their own components.
- Rename `addNewFile` endpoint to `pushFileChanges`.
- Exclude slash `/` hotkey from input fields.
- Support nested directories/files.

## Result
- `npm run develop`
- Create a new file.
- Note: slash `/` is now usable.
<img width="377" alt="Screen Shot 2023-02-06 at 18 26 49" src="https://user-images.githubusercontent.com/5079588/216961221-6293173a-c868-4bab-9b85-bc18e9631210.png">

- Navigate to the file content page to update/delete the file.
<img width="1249" alt="Screen Shot 2023-02-06 at 15 19 00" src="https://user-images.githubusercontent.com/5079588/216922211-45f73cbe-bcac-4d69-8cf6-1bc938f7d205.png">

<img width="1238" alt="Screen Shot 2023-02-06 at 18 35 42" src="https://user-images.githubusercontent.com/5079588/216961539-eb5b93ff-69e0-48fd-b813-33c08fb5a753.png">

