### PR TITLE
Upgrade dependencies for 0.60.0

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -16,13 +16,13 @@ spring-boot2 = "2.7.8"
 sshd = "2.9.2"
 
 [boms]
-armeria = { module = "com.linecorp.armeria:armeria-bom", version = "1.21.0" }
+armeria = { module = "com.linecorp.armeria:armeria-bom", version = "1.22.0" }
 jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.14.2" }
 junit5 = { module = "org.junit:junit-bom", version = "5.9.2" }
 
 [libraries.armeria]
 module = "com.linecorp.armeria:armeria"
-javadocs = "https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.19.0/"
+javadocs = "https://www.javadoc.io/doc/com.linecorp.armeria/armeria-javadoc/1.22.0/"
 [libraries.armeria-junit5]
 module = "com.linecorp.armeria:armeria-junit5"
 [libraries.armeria-logback]

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -8,17 +8,17 @@ guava = "31.1-jre"
 jgit = "5.13.0.202109080827-r"
 json-unit = "2.36.0"
 jmh = "1.36"
-micrometer = "1.10.2"
-mockito = "4.10.0"
+micrometer = "1.10.3"
+mockito = "4.11.0"
 slf4j = "1.7.36"
 spring-boot1 = "1.5.22.RELEASE"
-spring-boot2 = "2.7.4"
+spring-boot2 = "2.7.8"
 sshd = "2.9.2"
 
 [boms]
 armeria = { module = "com.linecorp.armeria:armeria-bom", version = "1.21.0" }
-jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.14.1" }
-junit5 = { module = "org.junit:junit-bom", version = "5.9.1" }
+jackson = { module = "com.fasterxml.jackson:jackson-bom", version = "2.14.2" }
+junit5 = { module = "org.junit:junit-bom", version = "5.9.2" }
 
 [libraries.armeria]
 module = "com.linecorp.armeria:armeria"
@@ -34,7 +34,7 @@ module = "com.linecorp.armeria:armeria-thrift0.9"
 
 [libraries.assertj]
 module = "org.assertj:assertj-core"
-version = "3.23.1"
+version = "3.24.2"
 
 [libraries.awaitility]
 module = "org.awaitility:awaitility"
@@ -111,7 +111,7 @@ version = "2.2"
 # Need to wait for spring boot 3 before upgrading to 7.x.x
 [libraries.hibernate-validator]
 module = "org.hibernate.validator:hibernate-validator"
-version = "6.2.3.Final"
+version = "6.2.5.Final"
 
 [libraries.jackson-annotations]
 module = "com.fasterxml.jackson.core:jackson-annotations"
@@ -307,10 +307,10 @@ exclusions = [
 
 [plugins]
 docker = { id = "com.bmuschko.docker-remote-api", version = "6.7.0" }
-download = { id = "de.undercouch.download", version = "5.3.0" }
+download = { id = "de.undercouch.download", version = "5.3.1" }
 jmh = { id = "me.champeau.jmh", version = "0.6.8" }
 jxr = { id = "net.davidecavestro.gradle.jxr", version = "0.2.1" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "1.1.0" }
-node-gradle = { id = "com.github.node-gradle.node", version = "3.5.0" }
-osdetector = { id = "com.google.osdetector", version = "1.7.1" }
+node-gradle = { id = "com.github.node-gradle.node", version = "3.5.1" }
+osdetector = { id = "com.google.osdetector", version = "1.7.2" }
 sphinx = { id = "kr.motd.sphinx", version = "2.10.1" }


### PR DESCRIPTION
- Micrometer 1.10.2 -> 1.10.3
- Spring Boot 2 2.7.4 -> 2.7.8
- Armeria 1.21.0 -> 1.22.0
- Jackson 2.14.1 -> 2.14.2
- Hibernate Validator 6.2.3.Final -> 6.2.5.Final

Build dependencies
- AssertJ 3.23.1 -> 3.24.1
- JUnit 5.9.1 -> 5.9.2
- Mockito 4.10.0 -> 4.11.0
- node-gradle 3.5.0 -> 3.5.1
- osdetector 1.7.1 -> 1.7.2
- undercouch.download 5.3.0 -> 5.3.1