### PR TITLE
Clean up new webapp

### DIFF
--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -13,6 +13,9 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
+import { Spinner, Text, VStack, useColorMode } from '@chakra-ui/react';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
+import Error from 'next/error';
 import { ReactNode } from 'react';
 
 interface LoadingProps {
@@ -21,15 +24,22 @@ interface LoadingProps {
   children: () => ReactNode;
 }
 export const Deferred = (props: LoadingProps) => {
+  const { colorMode } = useColorMode();
   if (props.isLoading) {
-    // TODO(ikhoon): Add a loading indicator/spinner.
-    return <div>Loading...</div>;
+    return (
+      <VStack mt="25%">
+        <Spinner thickness="4px" speed="0.65s" emptyColor="gray.200" color="teal" size="xl" />
+        <Text>Loading...</Text>
+      </VStack>
+    );
   }
-
   if (props.error) {
-    // TODO(ikhoon): Link to an error page.
-    return <div>Link to an error page</div>;
+    return (
+      <Error
+        statusCode={(props.error as FetchBaseQueryError).status as number}
+        withDarkMode={colorMode === 'dark'}
+      />
+    );
   }
-
-  return <div>{props.children()}</div>;
+  return <>{props.children()}</>;
 };

--- a/webapp/src/dogma/common/components/MetadataButton.tsx
+++ b/webapp/src/dogma/common/components/MetadataButton.tsx
@@ -4,10 +4,8 @@ import { FcSettings } from 'react-icons/fc';
 
 export const MetadataButton = ({ href, text, props }: { href: string; text?: string; props?: ButtonProps }) => {
   return (
-    <Link href={href}>
-      <Button colorScheme="teal" variant="outline" rightIcon={<FcSettings />} {...props}>
-        {text ?? 'Metadata'}
-      </Button>
-    </Link>
+    <Button as={Link} href={href} colorScheme="teal" variant="outline" rightIcon={<FcSettings />} {...props}>
+      {text ?? 'Metadata'}
+    </Button>
   );
 };

--- a/webapp/src/dogma/common/components/Navbar.tsx
+++ b/webapp/src/dogma/common/components/Navbar.tsx
@@ -92,7 +92,7 @@ export const Navbar = () => {
   const { colorMode, toggleColorMode } = useColorMode();
   const { user } = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
-  const result = useGetProjectsQuery({ admin: user?.roles?.includes('LEVEL_ADMIN') || false });
+  const result = useGetProjectsQuery({ admin: false });
   const projects = result.data || [];
   const projectOptions: ProjectOptionType[] = projects.map((project: ProjectDto) => ({
     value: project.name,

--- a/webapp/src/dogma/common/components/Navbar.tsx
+++ b/webapp/src/dogma/common/components/Navbar.tsx
@@ -184,8 +184,8 @@ export const Navbar = () => {
                 <Avatar name={user.login} size="sm" />
               </MenuButton>
               <MenuList>
-                <MenuItem>
-                  <RouteLink href="/app/settings/tokens">Application tokens</RouteLink>
+                <MenuItem as={RouteLink} href="/app/settings/tokens">
+                  Application tokens
                 </MenuItem>
                 <MenuDivider />
                 <MenuItem

--- a/webapp/src/dogma/features/auth/Authorized.tsx
+++ b/webapp/src/dogma/features/auth/Authorized.tsx
@@ -24,7 +24,7 @@ const WEB_AUTH_LOGIN = '/web/auth/login';
 
 export const Authorized = (props: { children: ReactNode }) => {
   const dispatch = useAppDispatch();
-  const { ready, isInAnonymousMode, user } = useAppSelector((state) => state.auth);
+  const { isLoading, isInAnonymousMode, user } = useAppSelector((state) => state.auth);
 
   useEffect(() => {
     const validateSession = async () => {
@@ -37,7 +37,7 @@ export const Authorized = (props: { children: ReactNode }) => {
   }, [dispatch]);
 
   const router = useRouter();
-  if (!ready) {
+  if (isLoading) {
     return <p>Loading...</p>;
   }
   if (isInAnonymousMode || router.pathname === WEB_AUTH_LOGIN || user) {

--- a/webapp/src/dogma/features/auth/authSlice.ts
+++ b/webapp/src/dogma/features/auth/authSlice.ts
@@ -112,14 +112,14 @@ export interface AuthState {
   isInAnonymousMode: boolean;
   sessionId: string;
   user: UserDto;
-  ready: boolean;
+  isLoading: boolean;
 }
 
 const initialState: AuthState = {
   isInAnonymousMode: false,
   sessionId,
   user: null,
-  ready: false,
+  isLoading: true,
 };
 
 export const authSlice = createSlice({
@@ -131,7 +131,7 @@ export const authSlice = createSlice({
       .addCase(checkSecurityEnabled.rejected, (state) => {
         state.isInAnonymousMode = true;
         state.sessionId = '';
-        state.ready = true;
+        state.isLoading = false;
       })
       .addCase(login.fulfilled, (state, { payload }) => {
         state.sessionId = payload.access_token;
@@ -145,12 +145,12 @@ export const authSlice = createSlice({
       })
       .addCase(getUser.fulfilled, (state, { payload }) => {
         state.user = payload;
-        state.ready = true;
+        state.isLoading = false;
       })
       .addCase(getUser.rejected, (state) => {
         state.user = null;
         state.sessionId = '';
-        state.ready = true;
+        state.isLoading = false;
       });
   },
 });

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -6,6 +6,7 @@ import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { useMemo, useState } from 'react';
 import { useGetHistoryQuery } from 'dogma/features/api/apiSlice';
 import { DynamicDataTable } from 'dogma/common/components/table/DynamicDataTable';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 export type HistoryListProps = {
   projectName: string;
@@ -70,20 +71,18 @@ const HistoryList = ({ projectName, repoName, handleTabChange, totalRevision }: 
     revision: -pageIndex * pageSize - 1,
     to: Math.max(-totalRevision, -(pageIndex + 1) * pageSize),
   });
-  if (isLoading) {
-    return <>Loading...</>;
-  }
-  if (error) {
-    return <>{JSON.stringify(error)}</>;
-  }
   return (
-    <DynamicDataTable
-      data={data || []}
-      columns={columns}
-      setPagination={setPagination}
-      pagination={pagination}
-      pageCount={Math.ceil(totalRevision / pageSize)}
-    />
+    <Deferred isLoading={isLoading} error={error}>
+      {() => (
+        <DynamicDataTable
+          data={data || []}
+          columns={columns}
+          setPagination={setPagination}
+          pagination={pagination}
+          pageCount={Math.ceil(totalRevision / pageSize)}
+        />
+      )}
+    </Deferred>
   );
 };
 

--- a/webapp/src/dogma/features/project/Projects.tsx
+++ b/webapp/src/dogma/features/project/Projects.tsx
@@ -14,24 +14,19 @@
  * under the License.
  */
 import { useGetProjectsQuery } from 'dogma/features/api/apiSlice';
-import { useColorMode, IconButton } from '@chakra-ui/react';
+import { IconButton } from '@chakra-ui/react';
 import { FcServices } from 'react-icons/fc';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { ProjectDto } from 'dogma/features/project/ProjectDto';
-import Error from 'next/error';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
-import { createMessage } from 'dogma/features/message/messageSlice';
-import ErrorHandler from 'dogma/features/services/ErrorHandler';
-import { useAppDispatch, useAppSelector } from 'dogma/store';
+import { useAppSelector } from 'dogma/store';
 import { DataTableClientPagination } from 'dogma/common/components/table/DataTableClientPagination';
 import { createColumnHelper } from '@tanstack/react-table';
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { useMemo } from 'react';
 import { RestoreProject } from 'dogma/features/project/RestoreProject';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 export const Projects = () => {
-  const { colorMode } = useColorMode();
-  const dispatch = useAppDispatch();
   const { user } = useAppSelector((state) => state.auth);
   const {
     data: projects,
@@ -68,20 +63,9 @@ export const Projects = () => {
     ],
     [columnHelper],
   );
-  if (isLoading) {
-    return <>Loading...</>;
-  }
-  if (error) {
-    dispatch(
-      createMessage({
-        title: 'Failed to create a retrieve projects',
-        text: ErrorHandler.handle(error),
-        type: 'error',
-      }),
-    );
-    return (
-      <Error statusCode={(error as FetchBaseQueryError).status as number} withDarkMode={colorMode === 'dark'} />
-    );
-  }
-  return <DataTableClientPagination columns={columns} data={projects} />;
+  return (
+    <Deferred isLoading={isLoading} error={error}>
+      {() => <DataTableClientPagination columns={columns} data={projects} />}
+    </Deferred>
+  );
 };

--- a/webapp/src/pages/404.tsx
+++ b/webapp/src/pages/404.tsx
@@ -1,0 +1,9 @@
+import { useColorMode } from '@chakra-ui/react';
+import Error from 'next/error';
+
+const FourOhFour = () => {
+  const { colorMode } = useColorMode();
+  return <Error statusCode={404} withDarkMode={colorMode === 'dark'} />;
+};
+
+export default FourOhFour;

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Heading, Spacer, Tab, TabList, TabPanel, TabPanels, Tabs } from '@chakra-ui/react';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 import { MetadataButton } from 'dogma/common/components/MetadataButton';
+import { Deferred } from 'dogma/common/components/Deferred';
 import { useGetReposQuery } from 'dogma/features/api/apiSlice';
 import { NewRepo } from 'dogma/features/repo/NewRepo';
 import RepoList from 'dogma/features/repo/RepoList';
@@ -9,37 +10,42 @@ import { useRouter } from 'next/router';
 const ProjectDetailPage = () => {
   const router = useRouter();
   const projectName = router.query.projectName as string;
-  const { data: repoData, isLoading } = useGetReposQuery(projectName, {
+  const {
+    data: repoData,
+    isLoading,
+    error,
+  } = useGetReposQuery(projectName, {
     refetchOnMountOrArgChange: true,
     skip: false,
   });
-  if (isLoading) {
-    return <>Loading...</>;
-  }
   return (
-    <Box p="2">
-      <Breadcrumbs path={router.asPath.split('?')[0]} omitIndexList={[0]} suffixes={{ 4: '/list/head' }} />
-      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">Project {projectName}</Heading>
-      </Flex>
-      <Tabs variant="enclosed-colored" size="lg">
-        <TabList>
-          <Tab>
-            <Heading size="sm">Repositories</Heading>
-          </Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <Flex gap={2}>
-              <Spacer />
-              <MetadataButton href={`/app/projects/metadata/${projectName}`} props={{ size: 'sm' }} />
-              <NewRepo projectName={projectName} />
-            </Flex>
-            <RepoList data={repoData || []} projectName={projectName} />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Box>
+    <Deferred isLoading={isLoading} error={error}>
+      {() => (
+        <Box p="2">
+          <Breadcrumbs path={router.asPath.split('?')[0]} omitIndexList={[0]} suffixes={{ 4: '/list/head' }} />
+          <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+            <Heading size="lg">Project {projectName}</Heading>
+          </Flex>
+          <Tabs variant="enclosed-colored" size="lg">
+            <TabList>
+              <Tab>
+                <Heading size="sm">Repositories</Heading>
+              </Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <Flex gap={2}>
+                  <Spacer />
+                  <MetadataButton href={`/app/projects/metadata/${projectName}`} props={{ size: 'sm' }} />
+                  <NewRepo projectName={projectName} />
+                </Flex>
+                <RepoList data={repoData || []} projectName={projectName} />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Box>
+      )}
+    </Deferred>
   );
 };
 

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -4,6 +4,7 @@ import { useGetFileContentQuery } from 'dogma/features/api/apiSlice';
 import { useRouter } from 'next/router';
 import FileEditor from 'dogma/common/components/editor/FileEditor';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 const FileContentPage = () => {
   const router = useRouter();
@@ -22,32 +23,30 @@ const FileContentPage = () => {
       skip: false,
     },
   );
-  if (isLoading) {
-    return <>Loading...</>;
-  }
-  if (error) {
-    return <>{JSON.stringify(error)}</>;
-  }
   return (
-    <Box p="2">
-      <Breadcrumbs path={router.asPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
-      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">{fileName}</Heading>
-        <Tooltip label="Go to History to view all revisions">
-          <Tag borderRadius="full" colorScheme="blue">
-            Revision {revision} <InfoIcon ml={2} />
-          </Tag>
-        </Tooltip>
-      </Flex>
-      <FileEditor
-        projectName={projectName}
-        repoName={repoName}
-        language={data.type.toLowerCase()}
-        originalContent={data.content}
-        path={data.path}
-        name={fileName}
-      />
-    </Box>
+    <Deferred isLoading={isLoading} error={error}>
+      {() => (
+        <Box p="2">
+          <Breadcrumbs path={router.asPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
+          <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+            <Heading size="lg">{fileName}</Heading>
+            <Tooltip label="Go to History to view all revisions">
+              <Tag borderRadius="full" colorScheme="blue">
+                Revision {revision} <InfoIcon ml={2} />
+              </Tag>
+            </Tooltip>
+          </Flex>
+          <FileEditor
+            projectName={projectName}
+            repoName={repoName}
+            language={data.type.toLowerCase()}
+            originalContent={data.content}
+            path={data.path}
+            name={fileName}
+          />
+        </Box>
+      )}
+    </Deferred>
   );
 };
 

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -153,11 +153,15 @@ cat ${project}/${repo}${path}`;
                 href={`/app/projects/metadata/${projectName}/${repoName}`}
                 props={{ size: 'sm' }}
               />
-              <Link href={`/app/projects/${projectName}/repos/${repoName}/new_file/head${filePath}`}>
-                <Button size="sm" rightIcon={<AiOutlinePlus />} colorScheme="teal">
-                  New File
-                </Button>
-              </Link>
+              <Button
+                as={Link}
+                href={`/app/projects/${projectName}/repos/${repoName}/new_file/head${filePath}`}
+                size="sm"
+                rightIcon={<AiOutlinePlus />}
+                colorScheme="teal"
+              >
+                New File
+              </Button>
             </Flex>
             <FileList
               data={fileData || []}

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/list/[revision]/[[...path]]/index.tsx
@@ -12,7 +12,6 @@ import {
   Tabs,
   Tag,
   Tooltip,
-  useColorMode,
 } from '@chakra-ui/react';
 import { useGetFilesQuery, useGetNormalisedRevisionQuery } from 'dogma/features/api/apiSlice';
 import FileList from 'dogma/features/file/FileList';
@@ -26,12 +25,10 @@ import { CopySupport } from 'dogma/features/file/CopySupport';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 import { AiOutlinePlus } from 'react-icons/ai';
 import Link from 'next/link';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/dist/query';
-import Error from 'next/error';
 import { MetadataButton } from 'dogma/common/components/MetadataButton';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 const RepositoryDetailPage = () => {
-  const { colorMode } = useColorMode();
   const router = useRouter();
   const repoName = router.query.repoName ? (router.query.repoName as string) : '';
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
@@ -99,8 +96,8 @@ cat ${project}/${repo}${path}`;
 
   const {
     data: fileData,
-    isLoading,
-    error,
+    isLoading: isGetFilesLoading,
+    error: isGetFilesError,
   } = useGetFilesQuery(
     { projectName, repoName, revision, filePath },
     {
@@ -111,79 +108,75 @@ cat ${project}/${repo}${path}`;
   const {
     data: revisionData,
     isLoading: isNormalRevisionLoading,
-    error: isError,
+    error: isNormalRevisionError,
   } = useGetNormalisedRevisionQuery({ projectName, repoName, revision: -1 });
-  if (isLoading || isNormalRevisionLoading) {
-    return <>Loading...</>;
-  }
-  if (error || isError) {
-    return (
-      <Error
-        statusCode={((error || isError) as FetchBaseQueryError).status as number}
-        withDarkMode={colorMode === 'dark'}
-      />
-    );
-  }
 
   return (
-    <Box p="2">
-      <Breadcrumbs path={directoryPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
-      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">{filePath || repoName} </Heading>
-        <Tooltip label="Go to History to view all revisions">
-          <Tag borderRadius="full" colorScheme="blue">
-            Revision {revision} <InfoIcon ml={2} />
-          </Tag>
-        </Tooltip>
-      </Flex>
-      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={handleTabChange}>
-        <TabList>
-          <Tab>
-            <Heading size="sm">Files</Heading>
-          </Tab>
-          <Tab>
-            <Heading size="sm">History</Heading>
-          </Tab>
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <Flex gap={2}>
-              <Spacer />
-              <MetadataButton
-                href={`/app/projects/metadata/${projectName}/${repoName}`}
-                props={{ size: 'sm' }}
-              />
-              <Button
-                as={Link}
-                href={`/app/projects/${projectName}/repos/${repoName}/new_file/head${filePath}`}
-                size="sm"
-                rightIcon={<AiOutlinePlus />}
-                colorScheme="teal"
-              >
-                New File
-              </Button>
-            </Flex>
-            <FileList
-              data={fileData || []}
-              projectName={projectName}
-              repoName={repoName}
-              path={filePath}
-              directoryPath={directoryPath}
-              revision={revision}
-              copySupport={clipboardCopySupport as CopySupport}
-            />
-          </TabPanel>
-          <TabPanel>
-            <HistoryList
-              projectName={projectName}
-              repoName={repoName}
-              handleTabChange={handleTabChange}
-              totalRevision={revisionData?.revision || 0}
-            />
-          </TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Box>
+    <Deferred
+      isLoading={isGetFilesLoading || isNormalRevisionLoading}
+      error={isGetFilesError || isNormalRevisionError}
+    >
+      {() => (
+        <Box p="2">
+          <Breadcrumbs path={directoryPath} omitIndexList={[0, 3, 5, 6]} suffixes={{ 4: '/list/head' }} />
+          <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+            <Heading size="lg">{filePath || repoName} </Heading>
+            <Tooltip label="Go to History to view all revisions">
+              <Tag borderRadius="full" colorScheme="blue">
+                Revision {revision} <InfoIcon ml={2} />
+              </Tag>
+            </Tooltip>
+          </Flex>
+          <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={handleTabChange}>
+            <TabList>
+              <Tab>
+                <Heading size="sm">Files</Heading>
+              </Tab>
+              <Tab>
+                <Heading size="sm">History</Heading>
+              </Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <Flex gap={2}>
+                  <Spacer />
+                  <MetadataButton
+                    href={`/app/projects/metadata/${projectName}/${repoName}`}
+                    props={{ size: 'sm' }}
+                  />
+                  <Button
+                    as={Link}
+                    href={`/app/projects/${projectName}/repos/${repoName}/new_file/head${filePath}`}
+                    size="sm"
+                    rightIcon={<AiOutlinePlus />}
+                    colorScheme="teal"
+                  >
+                    New File
+                  </Button>
+                </Flex>
+                <FileList
+                  data={fileData || []}
+                  projectName={projectName}
+                  repoName={repoName}
+                  path={filePath}
+                  directoryPath={directoryPath}
+                  revision={revision}
+                  copySupport={clipboardCopySupport as CopySupport}
+                />
+              </TabPanel>
+              <TabPanel>
+                <HistoryList
+                  projectName={projectName}
+                  repoName={repoName}
+                  handleTabChange={handleTabChange}
+                  totalRevision={revisionData?.revision || 0}
+                />
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Box>
+      )}
+    </Deferred>
   );
 };
 

--- a/webapp/src/pages/app/projects/metadata/[projectName]/[repoName].tsx
+++ b/webapp/src/pages/app/projects/metadata/[projectName]/[repoName].tsx
@@ -46,9 +46,6 @@ const RepoMetadata = () => {
       setTabIndex(index);
     }
   }, [tab, tabIndex]);
-  if (isLoading) {
-    return <>Loading...</>;
-  }
   return (
     <Deferred isLoading={isLoading} error={error}>
       {() => (

--- a/webapp/src/pages/app/projects/metadata/[projectName]/[repoName].tsx
+++ b/webapp/src/pages/app/projects/metadata/[projectName]/[repoName].tsx
@@ -13,11 +13,18 @@ import { UserPermission } from 'dogma/features/repo/permissions/UserPermission';
 import { useRouter } from 'next/router';
 import { PerUserPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
 import { NewRepoTokenPermission } from 'dogma/features/repo/permissions/NewRepoTokenPermission';
+import Link from 'next/link';
+import { useState, useEffect } from 'react';
+
+let tabs = ['role', 'user', 'token'];
 
 const RepoMetadata = () => {
   const router = useRouter();
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
   const repoName = router.query.repoName ? (router.query.repoName as string) : '';
+  if (repoName === 'meta') {
+    tabs = ['user', 'token'];
+  }
   const { data: metadata, isLoading } = useGetMetadataByProjectNameQuery(projectName, {
     refetchOnFocus: true,
     skip: false,
@@ -26,6 +33,14 @@ const RepoMetadata = () => {
   const [deleteUserPermission, { isLoading: isDeleteUserLoading }] = useDeleteUserPermissionMutation();
   const [addTokenPermission, { isLoading: isAddTokenLoading }] = useAddTokenPermissionMutation();
   const [deleteTokenPermission, { isLoading: isDeleteTokenLoading }] = useDeleteTokenPermissionMutation();
+  const [tabIndex, setTabIndex] = useState(0);
+  const tab = router.query.tab ? (router.query.tab as string) : '';
+  useEffect(() => {
+    const index = tabs.findIndex((tabName) => tabName === tab);
+    if (index !== -1 && index !== tabIndex) {
+      setTabIndex(index);
+    }
+  }, [tab, tabIndex]);
   if (isLoading) {
     return <>Loading...</>;
   }
@@ -35,19 +50,21 @@ const RepoMetadata = () => {
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
         <Heading size="lg">Repository {repoName} - Permissions</Heading>
       </Flex>
-      <Tabs variant="enclosed-colored" size="lg">
+      <Tabs variant="enclosed-colored" size="lg" index={tabIndex}>
         <TabList>
-          {repoName !== 'meta' && (
-            <Tab key="role">
-              <Heading size="sm">Role</Heading>
+          {tabs.map((tabName) => (
+            <Tab
+              as={Link}
+              key={tabName}
+              replace
+              href={{ pathname: `/app/projects/metadata/${projectName}/${repoName}`, query: { tab: tabName } }}
+            >
+              <Heading size="sm">
+                {tabName.charAt(0).toUpperCase()}
+                {tabName.slice(1)}
+              </Heading>
             </Tab>
-          )}
-          <Tab key="user">
-            <Heading size="sm">User</Heading>
-          </Tab>
-          <Tab key="token">
-            <Heading size="sm">Token</Heading>
-          </Tab>
+          ))}
         </TabList>
         <TabPanels>
           {repoName !== 'meta' && (

--- a/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
@@ -13,6 +13,7 @@ import { DeleteProject } from 'dogma/features/project/DeleteProject';
 import { NewMember } from 'dogma/features/metadata/NewMember';
 import { NewAppToken } from 'dogma/features/metadata/NewAppToken';
 import { useAppSelector } from 'dogma/store';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 let tabs = ['repositories', 'permissions', 'members', 'tokens', 'mirror'];
 
@@ -23,7 +24,11 @@ const ProjectMetadataPage = () => {
   }
   const router = useRouter();
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
-  const { data: metadata, isLoading } = useGetMetadataByProjectNameQuery(projectName, {
+  const {
+    data: metadata,
+    isLoading,
+    error,
+  } = useGetMetadataByProjectNameQuery(projectName, {
     refetchOnFocus: true,
     skip: false,
   });
@@ -39,76 +44,86 @@ const ProjectMetadataPage = () => {
     return <>Loading...</>;
   }
   return (
-    <Box p="2">
-      <Breadcrumbs path={router.asPath.split('?')[0]} omitIndexList={[0, 2]} suffixes={{ 4: '/list/head' }} />
-      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">Project {projectName} - Metadata</Heading>
-      </Flex>
-      <Tabs variant="enclosed-colored" size="lg" index={tabIndex}>
-        <TabList>
-          {tabs.map((tabName) => (
-            <Tab
-              as={Link}
-              key={tabName}
-              replace
-              href={{ pathname: `/app/projects/metadata/${projectName}`, query: { tab: tabName } }}
-            >
-              <Heading size="sm">
-                {tabName.charAt(0).toUpperCase()}
-                {tabName.slice(1)}
-              </Heading>
-            </Tab>
-          ))}
-        </TabList>
-        <TabPanels>
-          <TabPanel>
-            <Flex gap={3}>
-              <Spacer />
-              <DeleteProject projectName={projectName} />
-              <NewRepo projectName={projectName} />
-            </Flex>
-            <RepoMetaList
-              data={metadata ? Array.from(Object.values(metadata.repos)) : []}
-              projectName={projectName}
-            />
-          </TabPanel>
-          {user && (
-            <TabPanel>
-              <RepoPermissionList
-                data={metadata ? Array.from(Object.values(metadata.repos).filter((repo) => !repo.removal)) : []}
-                projectName={projectName}
-                members={metadata ? Array.from(Object.values(metadata.members)) : []}
-              />
-            </TabPanel>
-          )}
-          {user && (
-            <TabPanel>
-              <Flex>
-                <Spacer />
-                <NewMember projectName={projectName} />
-              </Flex>
-              <AppMemberList
-                data={metadata ? Array.from(Object.values(metadata.members)) : []}
-                projectName={projectName}
-              />
-            </TabPanel>
-          )}
-          {user && (
-            <TabPanel>
-              <Flex>
-                <Spacer />
-                <NewAppToken projectName={projectName} />
-              </Flex>
-              <AppTokenList
-                data={metadata ? Array.from(Object.values(metadata.tokens)) : []}
-                projectName={projectName}
-              />
-            </TabPanel>
-          )}
-          <TabPanel>Coming soon</TabPanel>
-        </TabPanels>
-      </Tabs>
-    </Box>
+    <Deferred isLoading={isLoading} error={error}>
+      {() => (
+        <Box p="2">
+          <Breadcrumbs
+            path={router.asPath.split('?')[0]}
+            omitIndexList={[0, 2]}
+            suffixes={{ 4: '/list/head' }}
+          />
+          <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+            <Heading size="lg">Project {projectName} - Metadata</Heading>
+          </Flex>
+          <Tabs variant="enclosed-colored" size="lg" index={tabIndex}>
+            <TabList>
+              {tabs.map((tabName) => (
+                <Tab
+                  as={Link}
+                  key={tabName}
+                  replace
+                  href={{ pathname: `/app/projects/metadata/${projectName}`, query: { tab: tabName } }}
+                >
+                  <Heading size="sm">
+                    {tabName.charAt(0).toUpperCase()}
+                    {tabName.slice(1)}
+                  </Heading>
+                </Tab>
+              ))}
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <Flex gap={3}>
+                  <Spacer />
+                  <DeleteProject projectName={projectName} />
+                  <NewRepo projectName={projectName} />
+                </Flex>
+                <RepoMetaList
+                  data={metadata ? Array.from(Object.values(metadata.repos)) : []}
+                  projectName={projectName}
+                />
+              </TabPanel>
+              {user && (
+                <TabPanel>
+                  <RepoPermissionList
+                    data={
+                      metadata ? Array.from(Object.values(metadata.repos).filter((repo) => !repo.removal)) : []
+                    }
+                    projectName={projectName}
+                    members={metadata ? Array.from(Object.values(metadata.members)) : []}
+                  />
+                </TabPanel>
+              )}
+              {user && (
+                <TabPanel>
+                  <Flex>
+                    <Spacer />
+                    <NewMember projectName={projectName} />
+                  </Flex>
+                  <AppMemberList
+                    data={metadata ? Array.from(Object.values(metadata.members)) : []}
+                    projectName={projectName}
+                  />
+                </TabPanel>
+              )}
+              {user && (
+                <TabPanel>
+                  <Flex>
+                    <Spacer />
+                    <NewAppToken projectName={projectName} />
+                  </Flex>
+                  <AppTokenList
+                    data={metadata ? Array.from(Object.values(metadata.tokens)) : []}
+                    projectName={projectName}
+                  />
+                </TabPanel>
+              )}
+              <TabPanel>Coming soon</TabPanel>
+            </TabPanels>
+          </Tabs>
+        </Box>
+      )}
+    </Deferred>
   );
 };
 

--- a/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
@@ -40,9 +40,6 @@ const ProjectMetadataPage = () => {
       setTabIndex(index);
     }
   }, [tab, tabIndex]);
-  if (isLoading) {
-    return <>Loading...</>;
-  }
   return (
     <Deferred isLoading={isLoading} error={error}>
       {() => (

--- a/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/metadata/[projectName]/index.tsx
@@ -28,16 +28,13 @@ const ProjectMetadataPage = () => {
     skip: false,
   });
   const [tabIndex, setTabIndex] = useState(0);
-  const switchTab = (index: number) => {
-    setTabIndex(index);
-    window.location.hash = tabs[index];
-  };
+  const tab = router.query.tab ? (router.query.tab as string) : '';
   useEffect(() => {
-    const index = tabs.findIndex((tab) => tab === window.location.hash?.slice(1));
-    if (index !== -1) {
+    const index = tabs.findIndex((tabName) => tabName === tab);
+    if (index !== -1 && index !== tabIndex) {
       setTabIndex(index);
     }
-  }, []);
+  }, [tab, tabIndex]);
   if (isLoading) {
     return <>Loading...</>;
   }
@@ -47,13 +44,18 @@ const ProjectMetadataPage = () => {
       <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
         <Heading size="lg">Project {projectName} - Metadata</Heading>
       </Flex>
-      <Tabs variant="enclosed-colored" size="lg" index={tabIndex} onChange={switchTab}>
+      <Tabs variant="enclosed-colored" size="lg" index={tabIndex}>
         <TabList>
-          {tabs.map((tab) => (
-            <Tab as={Link} key={tab} href={`#${tab}`} shallow={true}>
+          {tabs.map((tabName) => (
+            <Tab
+              as={Link}
+              key={tabName}
+              replace
+              href={{ pathname: `/app/projects/metadata/${projectName}`, query: { tab: tabName } }}
+            >
               <Heading size="sm">
-                {tab.charAt(0).toUpperCase()}
-                {tab.slice(1)}
+                {tabName.charAt(0).toUpperCase()}
+                {tabName.slice(1)}
               </Heading>
             </Tab>
           ))}

--- a/webapp/src/pages/app/settings/tokens.tsx
+++ b/webapp/src/pages/app/settings/tokens.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import { DeactivateToken } from 'dogma/features/token/DeactivateToken';
 import { ActivateToken } from 'dogma/features/token/ActivateToken';
 import { DeleteToken } from 'dogma/features/token/DeleteToken';
+import { Deferred } from 'dogma/common/components/Deferred';
 
 const TokenPage = () => {
   const columnHelper = createColumnHelper<TokenDto>();
@@ -60,23 +61,21 @@ const TokenPage = () => {
     [columnHelper],
   );
   const { data, error, isLoading } = useGetTokensQuery();
-  if (isLoading) {
-    return <>Loading...</>;
-  }
-  if (error) {
-    return <>{JSON.stringify(error)}</>;
-  }
   return (
-    <Box p="2">
-      <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
-        <Heading size="lg">Application Tokens</Heading>
-      </Flex>
-      <Flex>
-        <Spacer />
-        <NewToken />
-      </Flex>
-      <DataTableClientPagination columns={columns} data={data || []} />
-    </Box>
+    <Deferred isLoading={isLoading} error={error}>
+      {() => (
+        <Box p="2">
+          <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
+            <Heading size="lg">Application Tokens</Heading>
+          </Flex>
+          <Flex>
+            <Spacer />
+            <NewToken />
+          </Flex>
+          <DataTableClientPagination columns={columns} data={data || []} />
+        </Box>
+      )}
+    </Deferred>
   );
 };
 


### PR DESCRIPTION
## Motivation
Clean up and fix multiple issues. 

## Modification
- Clean up link button. Fix the issue when `Application tokens` was  occasionally not redirecting. 
<img width="274" alt="Screen Shot 2023-02-22 at 12 03 03" src="https://user-images.githubusercontent.com/5079588/220526791-6aebf3d2-f946-40d3-9a7e-da4e2e358e3f.png" />

- Update linkable tabs from hash to query param. Fix the cancel rendering route error issue when changing tabs too quickly. 

- Add linkable tabs for repo permission page.

- Use a generalised `Deferred` for `error` and `isLoading`. 
- Add a spinner. 

- Display a generic error page instead of raw json. Address [https://github.com/line/centraldogma/pull/796#discussion_r1099786793](https://github.com/line/centraldogma/pull/796#discussion_r1099786793)

- Exclude deleted projects from the jump dropdown as we won't be able to jump to the project. 

- Rename `ready` to `isLoading`. Hopefully it's less confusing. Address https://github.com/line/centraldogma/pull/760#discussion_r1030093920

- When navigating to an unknown page, the 404 page looks broken in light mode. Add a customised 404 page.

## Result
- `npm run develop`

### Linkable tabs
<img width="738" alt="Screen Shot 2023-02-22 at 12 05 06" src="https://user-images.githubusercontent.com/5079588/220527138-19a0076d-f8fb-4e1b-989b-69866964bbe8.png">

### Generic error page - light
<img width="1252" alt="Screen Shot 2023-02-17 at 14 19 19" src="https://user-images.githubusercontent.com/5079588/220530849-3da75e38-1ec7-457d-8db1-bedaf05e7b11.png">

### Generic error page - dark
<img width="1247" alt="Screen Shot 2023-02-17 at 13 44 17" src="https://user-images.githubusercontent.com/5079588/220530872-071e8f50-b53b-46b3-85c6-6f0cb5656e01.png">

### Dropdown with active projects only
<img width="983" alt="Screen Shot 2023-02-22 at 12 57 03" src="https://user-images.githubusercontent.com/5079588/220535443-c46f177d-040e-4d7f-ba32-c0f8a30509d0.png">

### 404 light
#### before
<img width="996" alt="Screen Shot 2023-02-22 at 13 45 41" src="https://user-images.githubusercontent.com/5079588/220544869-53264cad-b7e7-4779-a816-fce21d1bfedc.png">

#### after
<img width="998" alt="Screen Shot 2023-02-22 at 13 53 00" src="https://user-images.githubusercontent.com/5079588/220545105-01596edf-f1ce-436c-b22b-9f27db5c7ab7.png">


