### PR TITLE
Allow configuring CORS origins in config file

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class CorsPolicyTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.corsAllowedOrigins("SomeOrigin","SomeOtherOrigin");
+        }
+    };
+
+    @Test
+    void testCorsHeadersAvailable() throws Exception {
+        final WebClient client = dogma.httpClient();
+
+        final AggregatedHttpResponse res = client.blocking().prepare()
+                           .header(HttpHeaderNames.ORIGIN.toString(), "SomeOrigin")
+                           .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD.toString(), "GET")
+                                                 .options("/api/v1/projects").execute();
+        final ResponseHeaders headers = res.headers();
+        Assertions.assertTrue(headers.contains("access-control-allow-origin", "SomeOrigin"));
+        Assertions.assertTrue(headers.contains("access-control-allow-credentials", "true"));
+        Assertions.assertTrue(headers.contains("access-control-max-age", "1800"));
+    }
+
+    @Test
+    void testCorsHeadersUnAvailable() throws Exception {
+        final WebClient client = dogma.httpClient();
+
+        final AggregatedHttpResponse res = client.blocking().prepare()
+                                                 .header(HttpHeaderNames.ORIGIN.toString(),
+                                                         "SomeOriginNotIncluded")
+                                                 .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD
+                                                                 .toString(), "GET")
+                                                 .options("/api/v1/projects").execute();
+        final ResponseHeaders headers = res.headers();
+        Assertions.assertFalse(headers.contains("access-control-allow-origin", "SomeOrigin"));
+        Assertions.assertFalse(headers.contains("access-control-allow-credentials", "true"));
+        Assertions.assertFalse(headers.contains("access-control-max-age", "1800"));
+    }
+}

--- a/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
@@ -40,7 +40,7 @@ class CorsPolicyTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.cors(new CorsConfig(ImmutableList.of("SomeOrigin", "AnotherOrigin"), 1800));
+            builder.cors(new CorsConfig(ImmutableList.of("SomeOrigin"), 1800));
         }
     };
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/CorsPolicyTest.java
@@ -19,10 +19,10 @@ package com.linecorp.centraldogma.it;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -40,7 +40,7 @@ class CorsPolicyTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.cors(new CorsConfig(Arrays.asList("SomeOrigin", "AnotherOrigin"), 1800));
+            builder.cors(new CorsConfig(ImmutableList.of("SomeOrigin", "AnotherOrigin"), 1800));
         }
     };
 
@@ -51,7 +51,7 @@ class CorsPolicyTest {
         final AggregatedHttpResponse res =
                 client.blocking()
                       .prepare()
-                      .header(HttpHeaderNames.ORIGIN.toString(), "SomeOrigin")
+                      .header(HttpHeaderNames.ORIGIN, "SomeOrigin")
                       .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET")
                       .options("/api/v1/projects")
                       .execute();
@@ -69,7 +69,7 @@ class CorsPolicyTest {
         final AggregatedHttpResponse res =
                 client.blocking()
                       .prepare()
-                      .header(HttpHeaderNames.ORIGIN.toString(), "SomeOriginNotIncluded")
+                      .header(HttpHeaderNames.ORIGIN, "SomeOriginNotIncluded")
                       .header(HttpHeaderNames.ACCESS_CONTROL_REQUEST_METHOD, "GET")
                       .options("/api/v1/projects")
                       .execute();

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -512,7 +512,6 @@ public class CentralDogma implements AutoCloseable {
         sb.clientAddressSources(cfg.clientAddressSourceList());
         sb.clientAddressTrustedProxyFilter(cfg.trustedProxyAddressPredicate());
 
-        // Config cors policy
         configCors(sb, config().corsConfig());
 
         cfg.numWorkers().ifPresent(

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -129,7 +128,7 @@ public final class CentralDogmaBuilder {
 
     // Cors config
     @Nullable
-    private List<String> corsAllowedOrigins;
+    private CorsConfig corsConfig;
 
     /**
      * Creates a new builder with the specified data directory.
@@ -538,10 +537,10 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Sets the list of allowed origins for CORS policy.
+     * Sets config for CORS policy.
      */
-    public CentralDogmaBuilder corsAllowedOrigins(String... corsAllowedOrigins) {
-        this.corsAllowedOrigins = Arrays.asList(corsAllowedOrigins.clone());
+    public CentralDogmaBuilder cors(CorsConfig corsConfig) {
+        this.corsConfig = corsConfig;
         return this;
     }
 
@@ -579,6 +578,6 @@ public final class CentralDogmaBuilder {
                                       webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
                                       null, accessLogFormat, authCfg, quotaConfig,
-                                      corsAllowedOrigins);
+                                      corsConfig);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -125,6 +126,10 @@ public final class CentralDogmaBuilder {
     private int writeQuota;
     private int timeWindowSeconds;
     private MeterRegistry meterRegistry = Flags.meterRegistry();
+
+    // Cors config
+    @Nullable
+    private List<String> corsAllowedOrigins;
 
     /**
      * Creates a new builder with the specified data directory.
@@ -533,6 +538,14 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Sets the list of allowed origins for CORS policy.
+     */
+    public CentralDogmaBuilder corsAllowedOrigins(String... corsAllowedOrigins) {
+        this.corsAllowedOrigins = Arrays.asList(corsAllowedOrigins.clone());
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link CentralDogma} server.
      */
     public CentralDogma build() {
@@ -565,6 +578,7 @@ public final class CentralDogmaBuilder {
                                       maxRemovedRepositoryAgeMillis, gracefulShutdownTimeout,
                                       webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
                                       maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
-                                      null, accessLogFormat, authCfg, quotaConfig);
+                                      null, accessLogFormat, authCfg, quotaConfig,
+                                      corsAllowedOrigins);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -540,7 +540,7 @@ public final class CentralDogmaBuilder {
      * Sets config for CORS policy.
      */
     public CentralDogmaBuilder cors(CorsConfig corsConfig) {
-        this.corsConfig = corsConfig;
+        this.corsConfig = requireNonNull(corsConfig, "corsConfig");
         return this;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -126,7 +126,6 @@ public final class CentralDogmaBuilder {
     private int timeWindowSeconds;
     private MeterRegistry meterRegistry = Flags.meterRegistry();
 
-    // Cors config
     @Nullable
     private CorsConfig corsConfig;
 
@@ -537,7 +536,7 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Sets config for CORS policy.
+     * Sets CORS related configurations.
      */
     public CentralDogmaBuilder cors(CorsConfig corsConfig) {
         this.corsConfig = requireNonNull(corsConfig, "corsConfig");

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -138,10 +138,8 @@ public final class CentralDogmaConfig {
     @Nullable
     private final QuotaConfig writeQuotaPerRepository;
 
-    // List of allowed origin, if there is an '*' origin, then all origins are allowed,
-    // if null, cors is disabled
     @Nullable
-    private final List<String> corsAllowedOrigins;
+    private final CorsConfig corsConfig;
 
     CentralDogmaConfig(
             @JsonProperty(value = "dataDir", required = true) File dataDir,
@@ -171,11 +169,11 @@ public final class CentralDogmaConfig {
             @JsonProperty("accessLogFormat") @Nullable String accessLogFormat,
             @JsonProperty("authentication") @Nullable AuthConfig authConfig,
             @JsonProperty("writeQuotaPerRepository") @Nullable QuotaConfig writeQuotaPerRepository,
-            @JsonProperty("corsAllowedOrigins") @Nullable List<String> corsAllowedOrigins) {
+            @JsonProperty("cors") @Nullable CorsConfig corsConfig) {
 
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
-        this.corsAllowedOrigins = corsAllowedOrigins;
+        this.corsConfig = corsConfig;
         checkArgument(!ports.isEmpty(), "ports must have at least one port.");
         this.tls = tls;
         this.trustedProxyAddresses = trustedProxyAddresses;
@@ -464,12 +462,12 @@ public final class CentralDogmaConfig {
     }
 
     /**
-     * Returns list of cors policy allowed origins.
+     * Returns the {@link CorsConfig}.
      */
     @Nullable
-    @JsonProperty("corsAllowedOrigins")
-    public List<String> corsAllowedOrigins() {
-        return corsAllowedOrigins;
+    @JsonProperty("cors")
+    public CorsConfig corsConfig() {
+        return corsConfig;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -138,6 +138,11 @@ public final class CentralDogmaConfig {
     @Nullable
     private final QuotaConfig writeQuotaPerRepository;
 
+    // List of allowed origin, if there is an '*' origin, then all origins are allowed,
+    // if null, cors is disabled
+    @Nullable
+    private final List<String> corsAllowedOrigins;
+
     CentralDogmaConfig(
             @JsonProperty(value = "dataDir", required = true) File dataDir,
             @JsonProperty(value = "ports", required = true)
@@ -165,10 +170,12 @@ public final class CentralDogmaConfig {
             @JsonProperty("csrfTokenRequiredForThrift") @Nullable Boolean csrfTokenRequiredForThrift,
             @JsonProperty("accessLogFormat") @Nullable String accessLogFormat,
             @JsonProperty("authentication") @Nullable AuthConfig authConfig,
-            @JsonProperty("writeQuotaPerRepository") @Nullable QuotaConfig writeQuotaPerRepository) {
+            @JsonProperty("writeQuotaPerRepository") @Nullable QuotaConfig writeQuotaPerRepository,
+            @JsonProperty("corsAllowedOrigins") @Nullable List<String> corsAllowedOrigins) {
 
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
+        this.corsAllowedOrigins = corsAllowedOrigins;
         checkArgument(!ports.isEmpty(), "ports must have at least one port.");
         this.tls = tls;
         this.trustedProxyAddresses = trustedProxyAddresses;
@@ -454,6 +461,15 @@ public final class CentralDogmaConfig {
     @JsonProperty("writeQuotaPerRepository")
     public QuotaConfig writeQuotaPerRepository() {
         return writeQuotaPerRepository;
+    }
+
+    /**
+     * Returns list of cors policy allowed origins.
+     */
+    @Nullable
+    @JsonProperty("corsAllowedOrigins")
+    public List<String> corsAllowedOrigins() {
+        return corsAllowedOrigins;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -33,15 +33,15 @@ public final class CorsConfig {
     private static final int DEFAULT_MAX_AGE = 7200;
 
     private final List<String> allowedOrigins;
-    private final int maxAge;
+    private final int maxAgeSeconds;
 
     /**
      * Creates an instance with the specified {@code allowedOrigins} and
-     * {@code maxAge}.
+     * {@code maxAgeSeconds}.
      */
     @JsonCreator
     public CorsConfig(@JsonProperty("allowedOrigins") Object allowedOrigins,
-                      @JsonProperty("maxAge") @Nullable Integer maxAge) {
+                      @JsonProperty("maxAgeSeconds") @Nullable Integer maxAgeSeconds) {
         if (allowedOrigins instanceof Iterable &&
             Streams.stream((Iterable<?>) allowedOrigins).allMatch(String.class::isInstance)) {
             this.allowedOrigins = ImmutableList.copyOf((Iterable<String>) allowedOrigins);
@@ -59,15 +59,15 @@ public final class CorsConfig {
                     " (expected: the list of origins must not be empty)");
         }
 
-        if (maxAge == null) {
-            maxAge = DEFAULT_MAX_AGE;
+        if (maxAgeSeconds == null) {
+            maxAgeSeconds = DEFAULT_MAX_AGE;
         }
-        if (maxAge <= 0) {
+        if (maxAgeSeconds <= 0) {
             throw new IllegalArgumentException(
-                    "maxAge: " + maxAge +
-                    " (expected: maxAge must be positive)");
+                    "maxAgeSeconds: " + maxAgeSeconds +
+                    " (expected: maxAgeSeconds must be positive)");
         }
-        this.maxAge = maxAge;
+        this.maxAgeSeconds = maxAgeSeconds;
     }
 
     /**
@@ -80,18 +80,18 @@ public final class CorsConfig {
 
     /**
      * Returns how long in seconds the results of a preflight request can be cached.
-     * If unspecified, the default of {@value #DEFAULT_MAX_AGE} is returned.
+     * If unspecified, the default of {@code 7200} seconds is returned.
      */
     @JsonProperty
-    public int maxAge() {
-        return maxAge;
+    public int maxAgeSeconds() {
+        return maxAgeSeconds;
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("allowedOrigins", allowedOrigins)
-                          .add("maxAge", maxAge)
+                          .add("maxAgeSeconds", maxAgeSeconds)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.centraldogma.server;
 
-import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -23,7 +22,7 @@ import javax.annotation.Nullable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 
 /**
@@ -45,10 +44,10 @@ public final class CorsConfig {
                       @JsonProperty("maxAge") @Nullable Integer maxAge) {
         if (allowedOrigins instanceof Iterable &&
             Streams.stream((Iterable<?>) allowedOrigins).allMatch(String.class::isInstance)) {
-            this.allowedOrigins = Lists.newArrayList((Iterable<String>) allowedOrigins);
+            this.allowedOrigins = ImmutableList.copyOf((Iterable<String>) allowedOrigins);
         } else if (allowedOrigins instanceof String) {
             final String origin = (String) allowedOrigins;
-            this.allowedOrigins = Collections.singletonList(origin);
+            this.allowedOrigins = ImmutableList.of(origin);
         } else {
             throw new IllegalArgumentException(
                     "allowedOrigins: " + allowedOrigins +
@@ -60,7 +59,16 @@ public final class CorsConfig {
                     " (expected: the list of origins must not be empty)");
         }
 
-        this.maxAge = maxAge == null || maxAge <= 0 ? DEFAULT_MAX_AGE : maxAge;
+        if (maxAge == null) {
+            this.maxAge = DEFAULT_MAX_AGE;
+            return;
+        }
+        if (maxAge <= 0) {
+            throw new IllegalArgumentException(
+                    "maxAge: " + maxAge +
+                    " (expected: maxAge must be positive)");
+        }
+        this.maxAge = maxAge;
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
@@ -60,8 +60,7 @@ public final class CorsConfig {
         }
 
         if (maxAge == null) {
-            this.maxAge = DEFAULT_MAX_AGE;
-            return;
+            maxAge = DEFAULT_MAX_AGE;
         }
         if (maxAge <= 0) {
             throw new IllegalArgumentException(

--- a/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CorsConfig.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
+
+/**
+ * CORS configuration.
+ */
+public final class CorsConfig {
+
+    private static final int DEFAULT_MAX_AGE = 7200;
+
+    private final List<String> allowedOrigins;
+    private final int maxAge;
+
+    /**
+     * Creates an instance with the specified {@code allowedOrigins} and
+     * {@code maxAge}.
+     */
+    @JsonCreator
+    public CorsConfig(@JsonProperty("allowedOrigins") Object allowedOrigins,
+                      @JsonProperty("maxAge") @Nullable Integer maxAge) {
+        if (allowedOrigins instanceof Iterable &&
+            Streams.stream((Iterable<?>) allowedOrigins).allMatch(String.class::isInstance)) {
+            this.allowedOrigins = Lists.newArrayList((Iterable<String>) allowedOrigins);
+        } else if (allowedOrigins instanceof String) {
+            final String origin = (String) allowedOrigins;
+            this.allowedOrigins = Collections.singletonList(origin);
+        } else {
+            throw new IllegalArgumentException(
+                    "allowedOrigins: " + allowedOrigins +
+                    " (expected: either a string or an array of strings)");
+        }
+        if (this.allowedOrigins.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "allowedOrigins: " + allowedOrigins +
+                    " (expected: the list of origins must not be empty)");
+        }
+
+        this.maxAge = maxAge == null || maxAge <= 0 ? DEFAULT_MAX_AGE : maxAge;
+    }
+
+    /**
+     * Returns the list of origins which are allowed a CORS policy.
+     */
+    @JsonProperty
+    public List<String> allowedOrigins() {
+        return allowedOrigins;
+    }
+
+    /**
+     * Returns how long in seconds the results of a preflight request can be cached.
+     * If unspecified, the default of {@value #DEFAULT_MAX_AGE} is returned.
+     */
+    @JsonProperty
+    public int maxAge() {
+        return maxAge;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("allowedOrigins", allowedOrigins)
+                          .add("maxAge", maxAge)
+                          .toString();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -240,4 +240,31 @@ class CentralDogmaConfigTest {
                                   CentralDogmaConfig.class)
         ).hasCauseInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    void corsAllowedOrigins() throws Exception {
+        final CentralDogmaConfig cfg =
+                Jackson.readValue("{\n" +
+                                  "  \"dataDir\": \"./data\",\n" +
+                                  "  \"ports\": [\n" +
+                                  "    {\n" +
+                                  "      \"localAddress\": {\n" +
+                                  "        \"host\": \"*\",\n" +
+                                  "        \"port\": 36462\n" +
+                                  "      },\n" +
+                                  "      \"protocols\": [\n" +
+                                  "        \"https\",\n" +
+                                  "        \"http\",\n" +
+                                  "        \"proxy\"\n" +
+                                  "      ]\n" +
+                                  "    }\n" +
+                                  "  ],\n" +
+                                  "  \"corsAllowedOrigins\": [" +
+                                  "      \"sample.com\"\n" +
+                                  "    ]" +
+                                  '}',
+                                  CentralDogmaConfig.class);
+        assertThat(cfg.corsAllowedOrigins() != null ? cfg.corsAllowedOrigins().get(0)
+                                                    : null).isEqualTo("sample.com");
+    }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -269,7 +269,7 @@ class CentralDogmaConfigTest {
             final List<String> allowedOrigins = cfg.corsConfig().allowedOrigins();
             assertThat(allowedOrigins).isNotNull();
             assertThat(allowedOrigins.get(0)).isEqualTo("foo.com");
-            assertThat(cfg.corsConfig().maxAge()).isEqualTo(7200);
+            assertThat(cfg.corsConfig().maxAgeSeconds()).isEqualTo(7200);
         } else {
             fail("corsConfig is null");
         }
@@ -295,7 +295,7 @@ class CentralDogmaConfigTest {
                                   "  ],\n" +
                                   "  \"cors\": {\n" +
                                   "    \"allowedOrigins\": [\"foo.com\", \"bar.com\"],\n" +
-                                  "    \"maxAge\": 1200\n" +
+                                  "    \"maxAgeSeconds\": 1200\n" +
                                   "  }\n" +
                                   '}',
                                   CentralDogmaConfig.class);
@@ -304,7 +304,7 @@ class CentralDogmaConfigTest {
             assertThat(allowedOrigins).isNotNull();
             assertThat(allowedOrigins.get(0)).isEqualTo("foo.com");
             assertThat(allowedOrigins.get(1)).isEqualTo("bar.com");
-            assertThat(cfg.corsConfig().maxAge()).isEqualTo(1200);
+            assertThat(cfg.corsConfig().maxAgeSeconds()).isEqualTo(1200);
         } else {
             fail("corsConfig is null");
         }
@@ -379,7 +379,7 @@ class CentralDogmaConfigTest {
                                                      "  ],\n" +
                                                      "  \"cors\": {\n" +
                                                      "    \"allowedOrigins\": \"foo.com\",\n" +
-                                                     "    \"maxAge\": -10\n" +
+                                                     "    \"maxAgeSeconds\": -10\n" +
                                                      "  }\n" +
                                                      '}',
                                                      CentralDogmaConfig.class)

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -312,8 +312,7 @@ class CentralDogmaConfigTest {
 
     @Test
     void corsConfig_withNullAllowOrigins() throws Exception {
-        assertThatThrownBy(() ->
-                                   Jackson.readValue("{\n" +
+        assertThatThrownBy(() -> Jackson.readValue("{\n" +
                                                      "  \"dataDir\": \"./data\",\n" +
                                                      "  \"ports\": [\n" +
                                                      "    {\n" +
@@ -338,8 +337,7 @@ class CentralDogmaConfigTest {
 
     @Test
     void corsConfig_withEmptyAllowOrigins() throws Exception {
-        assertThatThrownBy(() ->
-                                   Jackson.readValue("{\n" +
+        assertThatThrownBy(() -> Jackson.readValue("{\n" +
                                                      "  \"dataDir\": \"./data\",\n" +
                                                      "  \"ports\": [\n" +
                                                      "    {\n" +
@@ -356,6 +354,32 @@ class CentralDogmaConfigTest {
                                                      "  ],\n" +
                                                      "  \"cors\": {\n" +
                                                      "    \"allowedOrigins\": []" +
+                                                     "  }\n" +
+                                                     '}',
+                                                     CentralDogmaConfig.class)
+        ).hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void corsConfig_withNegatieMaxAge() throws Exception {
+        assertThatThrownBy(() -> Jackson.readValue("{\n" +
+                                                     "  \"dataDir\": \"./data\",\n" +
+                                                     "  \"ports\": [\n" +
+                                                     "    {\n" +
+                                                     "      \"localAddress\": {\n" +
+                                                     "        \"host\": \"*\",\n" +
+                                                     "        \"port\": 36462\n" +
+                                                     "      },\n" +
+                                                     "      \"protocols\": [\n" +
+                                                     "        \"https\",\n" +
+                                                     "        \"http\",\n" +
+                                                     "        \"proxy\"\n" +
+                                                     "      ]\n" +
+                                                     "    }\n" +
+                                                     "  ],\n" +
+                                                     "  \"cors\": {\n" +
+                                                     "    \"allowedOrigins\": \"foo.com\",\n" +
+                                                     "    \"maxAge\": -10\n" +
                                                      "  }\n" +
                                                      '}',
                                                      CentralDogmaConfig.class)

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -48,15 +48,15 @@ defaults:
       "maxNumFilesPerMirror": null,
       "maxNumBytesPerMirror": null,
       "writeQuotaPerRepository": {
-        "requestQuota" : 5,
+        "requestQuota": 5,
         "timeWindowSeconds": 1
       },
       "accessLogFormat": "common",
       "authentication": null,
-      "corsAllowedOrigins": [
-         "http://example1.com",
-         "http://example2.com"
-      ]
+      "cors": {
+         "allowedOrigins": ["http://example1.com", "http://example2.com"],
+         "maxAge": 1800
+      }
     }
 
 Core properties
@@ -233,10 +233,17 @@ Core properties
   - the authentication configuration. If ``null``, the authentication is disabled.
     See :ref:`auth` to learn how to configure the authentication layer.
 
-- ``corsAllowedOrigins``
+- ``cors``
 
-  - configs the list of allowed origins for CORS policy, if there is an ``*`` origin, then all origins are allowed,
-    if ``null``, CORS is disabled.
+  - ``allowedOrigins`` (string or string array)
+
+    - the list of origins which are allowed a lenient CORS policy. If the literal value ``*`` is specified then
+      all origins are allowed. Specify ``null`` to disable CORS entirely.
+
+  - ``maxAge`` (integer)
+
+    - how long in seconds the results of a preflight request can be cached, if not specified then the default
+      value ``7200`` is applied.
 
 .. _replication:
 

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -52,7 +52,11 @@ defaults:
         "timeWindowSeconds": 1
       },
       "accessLogFormat": "common",
-      "authentication": null
+      "authentication": null,
+      "corsAllowedOrigins": [
+         "http://example1.com",
+         "http://example2.com"
+      ]
     }
 
 Core properties
@@ -228,6 +232,11 @@ Core properties
 
   - the authentication configuration. If ``null``, the authentication is disabled.
     See :ref:`auth` to learn how to configure the authentication layer.
+
+- ``corsAllowedOrigins``
+
+  - configs the list of allowed origins for CORS policy, if there is an ``*`` origin, then all origins are allowed,
+    if ``null``, CORS is disabled.
 
 .. _replication:
 

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -238,9 +238,9 @@ Core properties
     - the list of origins which are allowed a lenient CORS policy. If the literal value ``*`` is specified then
       all origins are allowed.
 
-  - ``maxAge`` (integer)
+  - ``maxAgeSeconds`` (integer)
 
-    - how long in seconds the results of a preflight request can be cached, if not specified then the default
+    - how long in seconds the results of a preflight request can be cached. If not specified then the default
       value ``7200`` is applied.
 
 .. _replication:

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -53,10 +53,7 @@ defaults:
       },
       "accessLogFormat": "common",
       "authentication": null,
-      "cors": {
-         "allowedOrigins": ["http://example1.com", "http://example2.com"],
-         "maxAge": 1800
-      }
+      "cors": null
     }
 
 Core properties
@@ -235,10 +232,11 @@ Core properties
 
 - ``cors``
 
+  - specify ``null`` to disable CORS entirely.
   - ``allowedOrigins`` (string or string array)
 
     - the list of origins which are allowed a lenient CORS policy. If the literal value ``*`` is specified then
-      all origins are allowed. Specify ``null`` to disable CORS entirely.
+      all origins are allowed.
 
   - ``maxAge`` (integer)
 


### PR DESCRIPTION
This is my implementation for the issue https://github.com/line/centraldogma/issues/754.

Motivation
Provide a way to configure CORS policies, so that web applications hosted in a different origin can call Central Dogma REST API.

Modifications
- Add `corsAllowedOrigins` to `CentralDogmaConfig`
- Add Cors decorator when setting up HttpApi

Result:
- Close #754
- You can now configure CORS policies in the config file.