### PR TITLE
Slow delete token

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -47,6 +47,7 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.api.auth.RequiresAdministrator;
 import com.linecorp.centraldogma.server.internal.api.converter.CreateApiResponseConverter;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.Token;
@@ -150,13 +151,14 @@ public class TokenService extends AbstractService {
      *
      * <p>Purges a token of the specified ID that was deleted before.
      */
-    @Delete("/tokens/{appId}/deleted")
+    @Delete("/tokens/{appId}/removed")
+    @RequiresAdministrator
     public CompletableFuture<Token> purgeToken(ServiceRequestContext ctx,
                                                @Param String appId,
                                                Author author, User loginUser) {
-        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
+        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenComposeAsync(
                 token -> mds.purgeToken(author, appId)
-                            .thenApply(unused -> token.withoutSecret()));
+                            .thenApply(unused -> token.withoutSecret()), ctx.blockingTaskExecutor());
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -157,8 +157,10 @@ public class TokenService extends AbstractService {
                                                @Param String appId,
                                                Author author, User loginUser) {
         return getTokenOrRespondForbidden(ctx, appId, loginUser).thenComposeAsync(
-                token -> mds.purgeToken(author, appId)
-                            .thenApply(unused -> token.withoutSecret()), ctx.blockingTaskExecutor());
+                token -> {
+                    mds.purgeToken(author, appId);
+                    return CompletableFuture.supplyAsync(token::withoutSecret);
+                },ctx.blockingTaskExecutor());
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -156,10 +156,10 @@ public class TokenService extends AbstractService {
     public CompletableFuture<Token> purgeToken(ServiceRequestContext ctx,
                                                @Param String appId,
                                                Author author, User loginUser) {
-        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenComposeAsync(
+        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenApplyAsync(
                 token -> {
                     mds.purgeToken(author, appId);
-                    return CompletableFuture.supplyAsync(token::withoutSecret);
+                    return token.withoutSecret();
                 }, ctx.blockingTaskExecutor());
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -146,6 +146,20 @@ public class TokenService extends AbstractService {
     }
 
     /**
+     * DELETE /tokens/{appId}/removed
+     *
+     * <p>Purges a token of the specified ID that was deleted before.
+     */
+    @Delete("/tokens/{appId}/deleted")
+    public CompletableFuture<Token> purgeToken(ServiceRequestContext ctx,
+                                               @Param String appId,
+                                               Author author, User loginUser) {
+        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
+                token -> mds.purgeToken(author, appId)
+                            .thenApply(unused -> token.withoutSecret()));
+    }
+
+    /**
      * PATCH /tokens/{appId}
      *
      * <p>Activates or deactivates the token of the specified {@code appId}.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -177,7 +177,7 @@ public class TokenService extends AbstractService {
                 token -> {
                     if (token.isDeleted()) {
                         throw new IllegalArgumentException(
-                                "The token is deleting. You can not update the token's status");
+                                "You can't update the status of the token scheduled for deletion.");
                     }
                     if (node.equals(activation)) {
                         return mds.activateToken(author, appId)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingService.java
@@ -16,10 +16,12 @@
 package com.linecorp.centraldogma.server.internal.storage;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -148,12 +150,16 @@ public class PurgeSchedulingService {
 
     private static void purgeToken(MetadataService metadataService) {
         final Tokens tokens = metadataService.getTokens().join();
+        final List<String> purging = tokens.appIds().values()
+                                           .stream()
+                                           .filter(Token::isDeleted)
+                                           .map(Token::appId)
+                                           .collect(toImmutableList());
 
-        tokens.appIds().values()
-              .stream()
-              .filter(token -> token.isDeleted())
-              .map(Token::appId)
-              .forEach(appId -> metadataService.purgeToken(Author.SYSTEM, appId));
+        if (!purging.isEmpty()) {
+            logger.info("Purging {} tokens: {}", purging.size(), purging);
+            purging.forEach(appId -> metadataService.purgeToken(Author.SYSTEM, appId));
+        }
     }
 
     private boolean isDisabled() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -888,6 +888,9 @@ public class MetadataService {
                                       }));
     }
 
+    /**
+     * Purges the {@link Token} of the specified {@code appId} that was removed before.
+     */
     public CompletableFuture<Revision> purgeToken(Author author, String appId) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -147,7 +147,7 @@ public final class Token implements Identifiable {
     }
 
     /**
-     * Returns who delete this token when.
+     * Returns who deleted this token when.
      */
     @Nullable
     @JsonProperty

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -174,7 +174,7 @@ public final class Token implements Identifiable {
     @Override
     public String toString() {
         // Do not add "secret" to prevent it from logging.
-        return MoreObjects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this).omitNullValues()
                           .add("appId", appId())
                           .add("isAdmin", isAdmin())
                           .add("creation", creation())

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -167,7 +167,9 @@ public final class Token implements Identifiable {
      * Returns whether this token is deleted.
      */
     @JsonIgnore
-    public boolean isDeleted() {return deletion != null;}
+    public boolean isDeleted() {
+        return deletion != null;
+    }
 
     @Override
     public String toString() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -64,8 +64,11 @@ public final class Token implements Identifiable {
     @Nullable
     private final UserAndTimestamp deactivation;
 
+    @Nullable
+    private final UserAndTimestamp deletion;
+
     Token(String appId, String secret, boolean isAdmin, UserAndTimestamp creation) {
-        this(appId, secret, isAdmin, creation, null);
+        this(appId, secret, isAdmin, creation, null, null);
     }
 
     /**
@@ -76,20 +79,23 @@ public final class Token implements Identifiable {
                  @JsonProperty("secret") String secret,
                  @JsonProperty("admin") boolean isAdmin,
                  @JsonProperty("creation") UserAndTimestamp creation,
-                 @JsonProperty("deactivation") @Nullable UserAndTimestamp deactivation) {
+                 @JsonProperty("deactivation") @Nullable UserAndTimestamp deactivation,
+                 @JsonProperty("deletion") @Nullable UserAndTimestamp deletion) {
         this.appId = Util.validateFileName(appId, "appId");
         this.secret = Util.validateFileName(secret, "secret");
         this.isAdmin = isAdmin;
         this.creation = requireNonNull(creation, "creation");
         this.deactivation = deactivation;
+        this.deletion = deletion;
     }
 
     private Token(String appId, boolean isAdmin, UserAndTimestamp creation,
-                  @Nullable UserAndTimestamp deactivation) {
+                  @Nullable UserAndTimestamp deactivation, @Nullable UserAndTimestamp deletion) {
         this.appId = Util.validateFileName(appId, "appId");
         this.isAdmin = isAdmin;
         this.creation = requireNonNull(creation, "creation");
         this.deactivation = deactivation;
+        this.deletion = deletion;
         secret = null;
     }
 
@@ -141,12 +147,27 @@ public final class Token implements Identifiable {
     }
 
     /**
+     * Returns who delete this token when.
+     */
+    @Nullable
+    @JsonProperty
+    public UserAndTimestamp deletion() {
+        return deletion;
+    }
+
+    /**
      * Returns whether this token is activated.
      */
     @JsonIgnore
     public boolean isActive() {
         return deactivation == null;
     }
+
+    /**
+     * Returns whether this token is deleted.
+     */
+    @JsonIgnore
+    public boolean isDeleted() {return deletion != null;}
 
     @Override
     public String toString() {
@@ -156,6 +177,7 @@ public final class Token implements Identifiable {
                           .add("isAdmin", isAdmin())
                           .add("creation", creation())
                           .add("deactivation", deactivation())
+                          .add("deletion", deletion())
                           .toString();
     }
 
@@ -163,6 +185,6 @@ public final class Token implements Identifiable {
      * Returns a new {@link Token} instance without its secret.
      */
     public Token withoutSecret() {
-        return new Token(appId(), isAdmin(), creation(), deactivation());
+        return new Token(appId(), isAdmin(), creation(), deactivation(), deletion());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -160,7 +160,7 @@ public final class Token implements Identifiable {
      */
     @JsonIgnore
     public boolean isActive() {
-        return deactivation == null;
+        return deactivation == null && deletion == null;
     }
 
     /**

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -32,7 +32,7 @@
           <div ng-switch-when="false">
             <div ng-switch="token.isDeleted">
               <div ng-switch-when="true">Deleting</div>
-              <div ng-switch-default>InActive</div>
+              <div ng-switch-default>Inactive</div>
             </div>
           </div>
           <div ng-switch-default>Active</div>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -37,7 +37,6 @@
           </div>
           <div ng-switch-default>Active</div>
         </div>
-
       </td>
     </tr>
     </tbody>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -31,7 +31,7 @@
         <div ng-switch="token.isActive">
           <div ng-switch-when="false">
             <div ng-switch="token.isDeleted">
-              <div ng-switch-when="true">Deleting</div>
+              <div ng-switch-when="true">Scheduled for deletion</div>
               <div ng-switch-default>Inactive</div>
             </div>
           </div>

--- a/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
+++ b/server/src/main/resources/webapp/scripts/app/settings/tokens/tokens.html
@@ -29,9 +29,15 @@
       <td>{{token.creationTimeStr}}</td>
       <td>
         <div ng-switch="token.isActive">
-          <div ng-switch-when="true">Active</div>
-          <div ng-switch-default>Inactive</div>
+          <div ng-switch-when="false">
+            <div ng-switch="token.isDeleted">
+              <div ng-switch-when="true">Deleting</div>
+              <div ng-switch-default>InActive</div>
+            </div>
+          </div>
+          <div ng-switch-default>Active</div>
         </div>
+
       </td>
     </tr>
     </tbody>

--- a/server/src/main/resources/webapp/scripts/components/entities/settings.service.js
+++ b/server/src/main/resources/webapp/scripts/components/entities/settings.service.js
@@ -12,6 +12,7 @@ angular.module('CentralDogmaAdmin')
             for (i in tokens) {
               tokens[i].creationTimeStr = moment(tokens[i].creation.timestamp).fromNow();
               tokens[i].isActive = !angular.isDefined(tokens[i].deactivation);
+              tokens[i].isDeleted = angular.isDefined(tokens[i].deletion);
             }
             defer.resolve(tokens);
           } else {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -67,7 +67,7 @@ class SerializationTest {
         final Member member = new Member(userLogin, ProjectRole.MEMBER, newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.ofDefault());
-        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
+        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null, null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),
@@ -141,7 +141,7 @@ class SerializationTest {
                                          newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.ofDefault());
-        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null);
+        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null, null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -122,7 +122,7 @@ class TokenServiceTest {
                     assertThat(t.appId()).isEqualTo(token.appId());
                     assertThat(t.isAdmin()).isEqualTo(token.isAdmin());
                     assertThat(t.creation()).isEqualTo(token.creation());
-                    assertThat(t.deactivation()).isEqualTo(token.deactivation());
+                    assertThat(t.isDeleted()).isTrue();
                 });
         assertThat(tokenService.listTokens(admin).join().size()).isEqualTo(0);
         assertThat(metadataService.getProject("myPro").join().tokens().size()).isEqualTo(0);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -71,7 +71,8 @@ class TokenServiceTest {
                                              .join())
                 .hasCauseInstanceOf(HttpResponseException.class);
 
-        assertThat(tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).join()).satisfies(t -> {
+        assertThat(tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).thenCompose(
+                unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(token.appId());
             assertThat(t.isAdmin()).isEqualTo(token.isAdmin());
             assertThat(t.creation()).isEqualTo(token.creation());
@@ -92,13 +93,15 @@ class TokenServiceTest {
         assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
                 .isEqualTo(0);
 
-        assertThat(tokenService.deleteToken(ctx, "forUser1", adminAuthor, admin).join()).satisfies(t -> {
+        assertThat(tokenService.deleteToken(ctx, "forUser1", adminAuthor, admin).thenCompose(
+                unused -> tokenService.purgeToken(ctx, "forUser1", adminAuthor, admin)).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(userToken1.appId());
             assertThat(t.isAdmin()).isEqualTo(userToken1.isAdmin());
             assertThat(t.creation()).isEqualTo(userToken1.creation());
             assertThat(t.deactivation()).isEqualTo(userToken1.deactivation());
         });
-        assertThat(tokenService.deleteToken(ctx, "forUser2", guestAuthor, guest).join()).satisfies(t -> {
+        assertThat(tokenService.deleteToken(ctx, "forUser2", guestAuthor, guest).thenCompose(
+                unused -> tokenService.purgeToken(ctx, "forUser2", guestAuthor, guest)).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(userToken2.appId());
             assertThat(t.isAdmin()).isEqualTo(userToken2.isAdmin());
             assertThat(t.creation()).isEqualTo(userToken2.creation());
@@ -120,6 +123,7 @@ class TokenServiceTest {
                                                           guest)
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
-        tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).join();
+        tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).thenCompose(
+                unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -81,11 +81,10 @@ class TokenServiceTest {
                                              .join())
                 .hasCauseInstanceOf(HttpResponseException.class);
 
-        when(ctx.blockingTaskExecutor()).thenReturn(ContextAwareScheduledExecutorService.of(
-                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"))
-                                     .build(), Executors.newSingleThreadScheduledExecutor()));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"));
 
-        assertThat(tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).thenCompose(
+        assertThat(tokenService.deleteToken(this.ctx, "forAdmin1", adminAuthor, admin).thenCompose(
                 unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join()).satisfies(
                 t -> {
                     assertThat(t.appId()).isEqualTo(token.appId());
@@ -108,18 +107,17 @@ class TokenServiceTest {
         assertThat(tokens.stream().filter(token -> !StringUtil.isNullOrEmpty(token.secret())).count())
                 .isEqualTo(0);
 
-        when(ctx.blockingTaskExecutor()).thenReturn(ContextAwareScheduledExecutorService.of(
-                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"))
-                                     .build(), Executors.newSingleThreadScheduledExecutor()));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"));
 
-        assertThat(tokenService.deleteToken(ctx, "forUser1", adminAuthor, admin).thenCompose(
+        assertThat(tokenService.deleteToken(this.ctx, "forUser1", adminAuthor, admin).thenCompose(
                 unused -> tokenService.purgeToken(ctx, "forUser1", adminAuthor, admin)).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(userToken1.appId());
             assertThat(t.isAdmin()).isEqualTo(userToken1.isAdmin());
             assertThat(t.creation()).isEqualTo(userToken1.creation());
             assertThat(t.deactivation()).isEqualTo(userToken1.deactivation());
         });
-        assertThat(tokenService.deleteToken(ctx, "forUser2", guestAuthor, guest).thenCompose(
+        assertThat(tokenService.deleteToken(this.ctx, "forUser2", guestAuthor, guest).thenCompose(
                 unused -> tokenService.purgeToken(ctx, "forUser2", guestAuthor, guest)).join()).satisfies(t -> {
             assertThat(t.appId()).isEqualTo(userToken2.appId());
             assertThat(t.isAdmin()).isEqualTo(userToken2.isAdmin());
@@ -143,11 +141,10 @@ class TokenServiceTest {
                                              .join())
                 .isInstanceOf(IllegalArgumentException.class);
 
-        when(ctx.blockingTaskExecutor()).thenReturn(ContextAwareScheduledExecutorService.of(
-                ServiceRequestContext.builder(HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"))
-                                     .build(), Executors.newSingleThreadScheduledExecutor()));
+        final ServiceRequestContext ctx = ServiceRequestContext.of(
+                HttpRequest.of(HttpMethod.DELETE, "/tokens/{appId}/removed"));
 
-        tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).thenCompose(
+        tokenService.deleteToken(this.ctx, "forAdmin1", adminAuthor, admin).thenCompose(
                 unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.mock;
 import java.util.Collection;
 import java.util.concurrent.CompletionException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -41,6 +42,7 @@ import com.linecorp.centraldogma.server.command.StandaloneCommandExecutor;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.ProjectRole;
 import com.linecorp.centraldogma.server.metadata.Token;
+import com.linecorp.centraldogma.server.metadata.Tokens;
 import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
@@ -77,6 +79,17 @@ class TokenServiceTest {
                                               manager.executor());
         tokenService = new TokenService(manager.projectManager(), manager.executor(),
                                         metadataService);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        final Tokens tokens = metadataService.getTokens().join();
+        tokens.appIds().forEach((appId, token) -> {
+            if (!token.isDeleted()) {
+                metadataService.destroyToken(adminAuthor, appId);
+            }
+            metadataService.purgeToken(adminAuthor, appId);
+        });
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -72,12 +72,13 @@ class TokenServiceTest {
                 .hasCauseInstanceOf(HttpResponseException.class);
 
         assertThat(tokenService.deleteToken(ctx, "forAdmin1", adminAuthor, admin).thenCompose(
-                unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join()).satisfies(t -> {
-            assertThat(t.appId()).isEqualTo(token.appId());
-            assertThat(t.isAdmin()).isEqualTo(token.isAdmin());
-            assertThat(t.creation()).isEqualTo(token.creation());
-            assertThat(t.deactivation()).isEqualTo(token.deactivation());
-        });
+                unused -> tokenService.purgeToken(ctx, "forAdmin1", adminAuthor, admin)).join()).satisfies(
+                t -> {
+                    assertThat(t.appId()).isEqualTo(token.appId());
+                    assertThat(t.isAdmin()).isEqualTo(token.isAdmin());
+                    assertThat(t.creation()).isEqualTo(token.creation());
+                    assertThat(t.deactivation()).isEqualTo(token.deactivation());
+                });
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -20,14 +20,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.util.Collection;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.linecorp.armeria.common.ContextAwareScheduledExecutorService;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.server.HttpResponseException;
@@ -53,10 +50,6 @@ class TokenServiceTest {
     private static TokenService tokenService;
 
     private final ServiceRequestContext ctx = mock(ServiceRequestContext.class);
-
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
-    private final ContextAwareScheduledExecutorService blockingExecutor =
-            ContextAwareScheduledExecutorService.of(ctx, executor);
 
     @BeforeAll
     static void setUp() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.server.internal.api;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 import java.util.concurrent.Executors;

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -355,7 +355,9 @@ class MetadataServiceTest {
                 .containsExactly(Permission.READ);
 
         // Remove 'app1' from the system completely.
-        mds.destroyToken(author, app1).join();
+        mds.destroyToken(author, app1)
+           .thenCompose(unused -> mds.purgeToken(author, app1))
+           .join();
 
         // Remove per-token permission of 'app1', too.
         assertThat(mds.findPermissions(project1, repo1, app1).join())

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -355,9 +355,8 @@ class MetadataServiceTest {
                 .containsExactly(Permission.READ);
 
         // Remove 'app1' from the system completely.
-        mds.destroyToken(author, app1)
-           .thenCompose(unused -> mds.purgeToken(author, app1))
-           .join();
+        mds.destroyToken(author, app1).join();
+        mds.purgeToken(author, app1);
 
         // Remove per-token permission of 'app1', too.
         assertThat(mds.findPermissions(project1, repo1, app1).join())


### PR DESCRIPTION
### motivation:
* Resolve https://github.com/line/centraldogma/issues/797
* It takes a long time to delete a token when central dogma have many project.

### modification:
* Add deletion field to `Token`
* Mark deletion at `appId` Path in `/token.json` when get requested delete token
* Add `purgeToken` feature at `PurgeSchedulingService`
### result:
* When a token deletion request is received, mark deletion and purge it with a background job.
#### create a token:
<img width="1173" alt="image" src="https://user-images.githubusercontent.com/19267206/221561458-538d8f93-04b8-4169-9f71-17a9277b092b.png">
<img width="573" alt="image" src="https://user-images.githubusercontent.com/19267206/221561388-e8ef9ad6-a773-4e77-9738-44ff7fb271b6.png">

#### deactivate a token:
<img width="1192" alt="image" src="https://user-images.githubusercontent.com/19267206/221561582-2f5abec6-a380-42cd-a066-a0cf5c475264.png">
<img width="532" alt="image" src="https://user-images.githubusercontent.com/19267206/221561625-f08f8b88-2c16-47b5-a668-02a2658dbb51.png">

#### delete a token:
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/19267206/221561769-d4f6e4d7-60af-4a8b-a7c1-ca28d3702580.png">
<img width="534" alt="image" src="https://user-images.githubusercontent.com/19267206/221561827-2f8dcc6d-fe13-4aee-b9b7-aaf2418310cd.png">

#### purge a token by scheduling service:
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/19267206/221561948-5417615c-7e9a-4e1e-96a6-5b797ff7bb74.png">
<img width="251" alt="image" src="https://user-images.githubusercontent.com/19267206/221562057-fcbdc4e8-d876-4273-a39f-43486e59f115.png">

#### Activate a token that is deleting
<img width="1061" alt="image" src="https://user-images.githubusercontent.com/19267206/224533859-0f0e44a6-b2d0-405a-a87c-a9a6828a1b59.png">
