### PR TITLE
Fix to route a link to the specified page with client-side rendering

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -755,7 +755,7 @@ public class CentralDogma implements AutoCloseable {
                                                .cacheControl(ServerCacheControl.REVALIDATED)
                                                .build().orElse(fallbackFileService));
 
-            // Service all web resources except for '/app'
+            // Serve all web resources except for '/app'.
             sb.route()
               .pathPrefix("/")
               .exclude("/app")

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -744,11 +744,15 @@ public class CentralDogma implements AutoCloseable {
                 sb.service(LOGOUT_PATH, authProvider.webLogoutService());
             }
 
+            final HttpService fallbackFile = HttpFile.of(CentralDogma.class.getClassLoader(),
+                                                         "com/linecorp/centraldogma/webapp/index.html")
+                                                     .asService();
             sb.serviceUnder("/",
                             FileService.builder(CentralDogma.class.getClassLoader(),
                                                 "com/linecorp/centraldogma/webapp")
                                        .cacheControl(ServerCacheControl.REVALIDATED)
-                                       .build());
+                                       .build()
+                                       .orElse(fallbackFile));
 
             sb.serviceUnder("/legacy-web",
                             FileService.builder(CentralDogma.class.getClassLoader(), "webapp")

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -744,7 +744,7 @@ public class CentralDogma implements AutoCloseable {
                 sb.service(LOGOUT_PATH, authProvider.webLogoutService());
             }
 
-            final HttpService fallbackFile = HttpFile.of(CentralDogma.class.getClassLoader(),
+            final HttpService fallbackFileService = HttpFile.of(CentralDogma.class.getClassLoader(),
                                                          "com/linecorp/centraldogma/webapp/index.html")
                                                      .asService();
             sb.serviceUnder("/",
@@ -752,7 +752,7 @@ public class CentralDogma implements AutoCloseable {
                                                 "com/linecorp/centraldogma/webapp")
                                        .cacheControl(ServerCacheControl.REVALIDATED)
                                        .build()
-                                       .orElse(fallbackFile));
+                                       .orElse(fallbackFileService));
 
             sb.serviceUnder("/legacy-web",
                             FileService.builder(CentralDogma.class.getClassLoader(), "webapp")

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -4,8 +4,8 @@ import { Provider } from 'react-redux';
 import { ChakraProvider, theme } from '@chakra-ui/react';
 import { Authorized } from 'dogma/features/auth/Authorized';
 import { NextPage } from 'next';
-import { ReactElement, ReactNode } from 'react';
-import { useRouter } from 'next/router';
+import {ReactElement, ReactNode, useEffect} from 'react';
+import Router, { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
 import { ErrorWrapper } from 'dogma/common/components/ErrorWrapper';
 import dynamic from 'next/dynamic';
@@ -20,8 +20,18 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
 
-const DogmaApp = ({ Component, pageProps }: AppPropsWithLayout) => {
+const DogmaApp = ({Component, pageProps}: AppPropsWithLayout) => {
   const router = useRouter();
+  useEffect(() => {
+    // Path patterns are used folder structures in Next.js such as '/app/projects/[projectNames]'.
+    // If '/app/projects/myProj' is requested to Central Dogma server, the server fails to find
+    // 'app/projects/myProj/index.html' file and returns 'index.html' as a fallback and the landing page is
+    // rendered instead. As a workaround, this triggers Next.js router to route to the desired page when a page
+    // is loaded for the first time.
+    if (router.asPath !== "/") {
+      Router.push(router.asPath);
+    }
+  }, []);
   const getLayout =
     router.pathname === WEB_AUTH_LOGIN
       ? (page: ReactElement) => page

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { ChakraProvider, theme } from '@chakra-ui/react';
 import { Authorized } from 'dogma/features/auth/Authorized';
 import { NextPage } from 'next';
-import {ReactElement, ReactNode, useEffect} from 'react';
+import { ReactElement, ReactNode, useEffect } from 'react';
 import Router, { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
 import { ErrorWrapper } from 'dogma/common/components/ErrorWrapper';
@@ -20,15 +20,17 @@ type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
 };
 
-const DogmaApp = ({Component, pageProps}: AppPropsWithLayout) => {
+const DogmaApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const router = useRouter();
   useEffect(() => {
-    // Path patterns are used folder structures in Next.js such as '/app/projects/[projectNames]'.
-    // If '/app/projects/myProj' is requested to Central Dogma server, the server fails to find
-    // 'app/projects/myProj/index.html' file and returns 'index.html' as a fallback and the landing page is
-    // rendered instead. As a workaround, this triggers Next.js router to route to the desired page when a page
-    // is loaded for the first time.
-    if (router.asPath !== "/") {
+    // Next.js uses a path pattern to dynamically match the request path to a specific HTML file.
+    // For example, `/app/projects/[projectNames]/index.html' is generated to render `/app/projects/myProj`
+    // page. `FileService` serving the static resources for Central Dogma webapp does not understand the
+    // path pattern syntax in the folder names. If `/ap/projects/myProj` is requested, the FileService will try
+    // to find '/app/projects/myProj/index.html' as is, and 'index.html' is returned as a fallback. As a
+    // workaround, this triggers Next.js router to route to the desired page when a page is loaded for the
+    // first time.
+    if (router.asPath !== '/') {
       Router.push(router.asPath);
     }
   }, []);

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -5,7 +5,7 @@ import { ChakraProvider, theme } from '@chakra-ui/react';
 import { Authorized } from 'dogma/features/auth/Authorized';
 import { NextPage } from 'next';
 import { ReactElement, ReactNode, useEffect } from 'react';
-import Router, { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { Layout } from 'dogma/common/components/Layout';
 import { ErrorWrapper } from 'dogma/common/components/ErrorWrapper';
 import dynamic from 'next/dynamic';
@@ -26,12 +26,12 @@ const DogmaApp = ({ Component, pageProps }: AppPropsWithLayout) => {
     // Next.js uses a path pattern to dynamically match the request path to a specific HTML file.
     // For example, `/app/projects/[projectNames]/index.html' is generated to render `/app/projects/myProj`
     // page. `FileService` serving the static resources for Central Dogma webapp does not understand the
-    // path pattern syntax in the folder names. If `/ap/projects/myProj` is requested, the FileService will try
-    // to find '/app/projects/myProj/index.html' as is, and 'index.html' is returned as a fallback. As a
-    // workaround, this triggers Next.js router to route to the desired page when a page is loaded for the
-    // first time.
+    // path pattern syntax in the folder names. If `/app/projects/myProj` is requested, the `FileService` will
+    // try to find '/app/projects/myProj/index.html' as is and fails, which in turn 'index.html' is returned as
+    // a fallback. As a workaround, this triggers Next.js router to route to the desired page when a page is
+    // loaded for the first time.
     if (router.asPath !== '/') {
-      Router.push(router.asPath);
+      router.replace(router.asPath);
     }
   }, []);
   const getLayout =


### PR DESCRIPTION
Motivation:

Path patterns are used folder structures in Next.js such as '/app/projects/[projectNames]'. If '/app/projects/myProj' is requested to Central Dogma server, the server fails to find
'app/projects/myProj/index.html' file and returns 404 not found. This does not happen if a client app starts with `npm run xxx` commands because the links are handled by Next.js server and only REST APIs are requested to a Central Dogma server.

Modifications:

- Return `index.html` file as a fallback if the `FileService` for new webapp fails to find a file.
- Trigger Next.js router to route to the desired page when a page is loaded for the first time.

Result:

You can now visit a Central Dogma webapp with a deep link.