### PR TITLE
Java features should be preferred to Guava

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialUtil.java
@@ -19,19 +19,16 @@ package com.linecorp.centraldogma.server.internal.mirror.credential;
 import static java.util.Objects.requireNonNull;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 import javax.annotation.Nullable;
-
-import com.google.common.io.BaseEncoding;
 
 final class MirrorCredentialUtil {
     private static final String BASE64_PREFIX = "base64:";
 
-    private static final BaseEncoding base64 = BaseEncoding.base64();
-
     static byte[] decodeBase64(String value, String name) {
         requireNonNull(value, name);
-        return base64.decode(value);
+        return Base64.getDecoder().decode(value);
     }
 
     @Nullable


### PR DESCRIPTION
### Motivation
It’s recommended to prefer Java 8 APIs over Guava ones to ease its maintenance

### Modification
Replace `com.google.common.io.BaseEncoding#base64()` with `java.util.Base64`

### Result
Using `java.util.Base64` instead of Guava Base64 in `MirrorCredentialUtil`