### PR TITLE
Auto-detect the default branch when mirroring a Git repository

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - master
+      - main
     tags-ignore:
       # The release versions will be verified by 'publish-release.yml'
       - centraldogma-*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Please [contact us](dl_oss_dev@linecorp.com) if you need the CCLA (corporate con
 
 ### Code of conduct
 
-We expect contributors to follow [our code of conduct](https://github.com/line/centraldogma/blob/master/CODE_OF_CONDUCT.md).
+We expect contributors to follow [our code of conduct](https://github.com/line/centraldogma/blob/main/CODE_OF_CONDUCT.md).
 
 ### Setting up your IDE
 
@@ -33,7 +33,7 @@ After importing the project, import the IDE settings as well.
 
 #### IntelliJ IDEA
 
-- [`settings.jar`](https://raw.githubusercontent.com/line/centraldogma/master/settings/intellij_idea/settings.jar) -
+- [`settings.jar`](https://raw.githubusercontent.com/line/centraldogma/main/settings/intellij_idea/settings.jar) -
   See [Import settings from a ZIP archive](https://www.jetbrains.com/help/idea/sharing-your-ide-settings.html#7a4f08b8).
 - Make sure to use 'LINE OSS' code style and inspection profile.
   - Go to `Preferences` > `Editors` > `Code Style` and set `Scheme` option to `LINE OSS`.
@@ -47,15 +47,15 @@ After importing the project, import the IDE settings as well.
 
 #### Eclipse
 
-- [`formatter.xml`](https://raw.githubusercontent.com/line/centraldogma/master/settings/eclipse/formatter.xml) -
+- [`formatter.xml`](https://raw.githubusercontent.com/line/centraldogma/main/settings/eclipse/formatter.xml) -
   See [Code Formatter Preferences](https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-formatter.htm).
-- [`formatter.importorder`](https://raw.githubusercontent.com/line/centraldogma/master/settings/eclipse/formatter.importorder) -
+- [`formatter.importorder`](https://raw.githubusercontent.com/line/centraldogma/main/settings/eclipse/formatter.importorder) -
   See [Organize Imports Preferences](https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-organize-imports.htm).
-- [`cleanup.xml`](https://raw.githubusercontent.com/line/centraldogma/master/settings/eclipse/cleanup.xml) -
+- [`cleanup.xml`](https://raw.githubusercontent.com/line/centraldogma/main/settings/eclipse/cleanup.xml) -
   See [Clean Up Preferences](https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Fcodestyle%2Fref-preferences-cleanup.htm).
 - Configure [Java Save Actions Preferences](https://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.jdt.doc.user%2Freference%2Fpreferences%2Fjava%2Feditor%2Fref-preferences-save-actions.htm).
   <details><summary>Click here to see the screenshot.</summary>
-    <img src="https://raw.githubusercontent.com/line/centraldogma/master/settings/eclipse/save_actions.png">
+    <img src="https://raw.githubusercontent.com/line/centraldogma/main/settings/eclipse/save_actions.png">
   </details>
 - Although optional, if you want to run Checkstyle from Eclipse, install the
   [Eclipse Checkstyle Plugin](https://eclipse-cs.sourceforge.net/), import and activate

--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -5,7 +5,7 @@
 ;
 [subrepo]
 	remote = https://github.com/line/gradle-scripts.git
-	branch = master
+	branch = main
 	commit = ff1ff69b0f37a613b6b139936174c6caa2b31cb7
 	parent = bda3beca0308c537fcc776400d42b7bf7a9f25c5
 	cmdver = 0.4.3

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -33,6 +33,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.GarbageCollectCommand;
 import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.lib.EmptyProgressMonitor;
@@ -148,6 +149,11 @@ abstract class GitWithAuth extends Git {
     @Override
     public final GarbageCollectCommand gc() {
         return super.gc().setProgressMonitor(progressMonitor("gc"));
+    }
+
+    @Override
+    public final LsRemoteCommand lsRemote() {
+        return configure(super.lsRemote());
     }
 
     private <T extends TransportCommand<?, ?>> T configure(T command) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -75,7 +75,7 @@ public interface Mirror {
 
         switch (scheme) {
             case SCHEME_DOGMA: {
-                final String[] components = split(remoteUri, "dogma", null);
+                final String[] components = split(remoteUri, "dogma");
                 final URI remoteRepoUri = URI.create(components[0]);
                 final Matcher matcher = DOGMA_PATH_PATTERN.matcher(remoteRepoUri.getPath());
                 if (!matcher.find()) {
@@ -96,7 +96,7 @@ public interface Mirror {
             case SCHEME_GIT_HTTP:
             case SCHEME_GIT_HTTPS:
             case SCHEME_GIT_FILE: {
-                final String[] components = split(remoteUri, "git", "master");
+                final String[] components = split(remoteUri, "git");
                 return new GitMirror(schedule, direction, credential, localRepo, localPath,
                                      URI.create(components[0]), components[1], components[2],
                                      gitignore);

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
@@ -23,8 +23,6 @@ import java.net.URLDecoder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
-
 /**
  * A utility class for creating a mirroring task.
  */

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
@@ -69,7 +69,7 @@ public final class MirrorUtil {
      * - remotePath:    / (default)
      * - remoteBranch:  {@code defaultBranch}
      */
-    static String[] split(URI remoteUri, String suffix, @Nullable String defaultBranch) {
+    static String[] split(URI remoteUri, String suffix) {
         final String host = remoteUri.getHost();
         if (host == null && !remoteUri.getScheme().endsWith("+file")) {
             throw new IllegalArgumentException("no host in remoteUri: " + remoteUri);
@@ -108,8 +108,7 @@ public final class MirrorUtil {
             throw new Error(e);
         }
 
-        final String fragment = remoteUri.getFragment();
-        final String remoteBranch = fragment != null ? fragment : defaultBranch;
+        final String remoteBranch = remoteUri.getFragment();
 
         return new String[] { newRemoteUri, remotePath, remoteBranch };
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorTest.java
@@ -38,15 +38,15 @@ class MirrorTest {
     void testGitMirror() {
         // Simplest possible form
         assertMirror("git://a.com/b.git", GitMirror.class,
-                     "git://a.com/b.git", "/", "master");
+                     "git://a.com/b.git", "/", null);
 
         // Non-default port number
         assertMirror("git+ssh://a.com:8022/b.git", GitMirror.class,
-                     "git+ssh://a.com:8022/b.git", "/", "master");
+                     "git+ssh://a.com:8022/b.git", "/", null);
 
         // Non-default remotePath
         assertMirror("git+http://a.com/b.git/c", GitMirror.class,
-                     "git+http://a.com/b.git", "/c/", "master");
+                     "git+http://a.com/b.git", "/c/", null);
 
         // Non-default remoteBranch
         assertMirror("git+https://a.com/b.git#develop", GitMirror.class,
@@ -121,7 +121,7 @@ class MirrorTest {
     @Test
     void jitter() {
         final AbstractMirror mirror = assertMirror("git://a.com/b.git", AbstractMirror.class,
-                                                   "git://a.com/b.git", "/", "master");
+                                                   "git://a.com/b.git", "/", null);
 
         assertThat(mirror.schedule()).isSameAs(EVERY_MINUTE);
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -48,13 +48,13 @@ class MirroringTaskTest {
         new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
-                                "localRepo=bar,remoteBranch=master,remotePath=/,success=true}", 1.0));
+                                "localRepo=bar,remoteBranch=,remotePath=/,success=true}", 1.0));
     }
 
     @Test
     void testFailureMetrics() {
         final MeterRegistry meterRegistry = new SimpleMeterRegistry();
-        Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
+        Mirror mirror = newMirror("git://a.com/b.git#main", GitMirror.class, "foo", "bar");
         mirror = spy(mirror);
         final RuntimeException e = new RuntimeException();
         doThrow(e).when(mirror).mirror(any(), any(), anyInt(), anyLong());
@@ -63,7 +63,7 @@ class MirroringTaskTest {
                 .isSameAs(e);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
-                                "localRepo=bar,remoteBranch=master,remotePath=/," +
+                                "localRepo=bar,remoteBranch=main,remotePath=/," +
                                 "success=false}", 1.0));
     }
 
@@ -80,7 +80,7 @@ class MirroringTaskTest {
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .hasEntrySatisfying(
                         "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +
-                        "localRepo=bar,remoteBranch=master,remotePath=/}",
+                        "localRepo=bar,remoteBranch=,remotePath=/}",
                         v -> assertThat(v).isCloseTo(1, withPercentage(30)));
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepositoryTest.java
@@ -206,8 +206,8 @@ class DefaultMetaRepositoryTest {
         assertThat(bar.remotePath()).isEqualTo("/some-path/");
         assertThat(qux.remotePath()).isEqualTo("/");
 
-        assertThat(foo.remoteBranch()).isEqualTo("master");
-        assertThat(bar.remoteBranch()).isEqualTo("master");
+        assertThat(foo.remoteBranch()).isNull();
+        assertThat(bar.remoteBranch()).isNull();
         assertThat(qux.remoteBranch()).isEqualTo("develop");
 
         // Ensure the credentials are loaded correctly.

--- a/site/src/sphinx/_templates/breadcrumbs.html
+++ b/site/src/sphinx/_templates/breadcrumbs.html
@@ -3,5 +3,5 @@
 {% set github_user = 'line' %}
 {% set github_repo = 'centraldogma' %}
 {% set theme_vcs_pageview_mode = 'blob' %}
-{% set github_version = 'master' %}
+{% set github_version = 'main' %}
 {% set conf_py_path = '/site/src/sphinx/' %}

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -111,4 +111,4 @@ Read more
     Source cross-reference <xref/index.html#://>
     Questions and answers <https://github.com/line/centraldogma/issues?q=label%3Aquestion-answered>
     Fork me on GitHub <https://github.com/line/centraldogma>
-    Contributing <https://github.com/line/centraldogma/blob/master/CONTRIBUTING.md>
+    Contributing <https://github.com/line/centraldogma/blob/main/CONTRIBUTING.md>

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -100,7 +100,7 @@ You need to put two files into the ``meta`` repository of your Central Dogma pro
     the Git repository ``/foo.git`` If you want to mirror the whole content of the repository, you can simply
     end the URI with ``.git``. e.g. ``git+ssh://git.example.com/foo.git``
   - Fragment represents a branch name. e.g. ``#release`` will mirror the branch ``release``. If unspecified,
-    the branch ``master`` is mirrored.
+    the repository's default branch is mirrored.
 
 - ``credentialId`` (string, optional)
 


### PR DESCRIPTION
Motivation:

Central Dogma currently chooses the branch `master` when a user doesn't specify the branch. However, not all repositories' default branches are `master`. They are sometimes `main` or even something else.

Modifications:

- Set `null` to `remoteBranch` when a user didn't specify a branch.
- Auto-detect the default branch before mirroring when `remoteBranch` is `null`.

Result:

- Less surprising behavior.
- Fixes the failing `GitMirrorAuthTest`.