### PR TITLE
Migrate Docker registry from Docker Hub to GitHub container registry

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -27,7 +27,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Build Docker image
-        run: ./gradlew :dist:docker
+        run: ./gradlew :dist:docker --stacktrace
         shell: bash
 
       - name: Extract release version
@@ -45,14 +45,11 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push Docker image
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags:
-            - ${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.result }}
-            - ${{ env.IMAGE_NAME }}:latest
+        run: |
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.result }}
+          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        shell: bash

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,8 @@ on:
 
 env:
   LC_ALL: 'en_US.UTF-8'
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   push_to_registry:
@@ -39,14 +41,18 @@ jobs:
             return version
           result-encoding: string
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v1
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
         with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push Docker image
-        run: |
-          docker push line/centraldogma:${{ steps.release-version.outputs.result }}
-          docker push line/centraldogma:latest
-        shell: bash
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags:
+            - ${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.result }}
+            - ${{ env.IMAGE_NAME }}:latest

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -153,7 +153,7 @@ task docker(group: 'Build',
             dependsOn: tasks.distDir,
             type: DockerBuildImage) {
     inputDir = file('.')
-    def name = 'line/centraldogma:'
+    def name = 'ghcr.io/line/centraldogma:'
     images = [name + "${project.version}"]
     if (!(project.version =~ /-SNAPSHOT$/)) {
         images.add(name + "latest")

--- a/gradle/scripts/.gitrepo
+++ b/gradle/scripts/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/line/gradle-scripts.git
 	branch = main
-	commit = ff1ff69b0f37a613b6b139936174c6caa2b31cb7
-	parent = bda3beca0308c537fcc776400d42b7bf7a9f25c5
-	cmdver = 0.4.3
+	commit = 966b563aa4e42523c8194f988aacd061c3bcf358
+	parent = 7e3d7c2169189215b5f91ccd371597e7a30a5633
+	cmdver = 0.4.5
 	method = merge

--- a/gradle/scripts/lib/java.gradle
+++ b/gradle/scripts/lib/java.gradle
@@ -39,19 +39,19 @@ configure(rootProject) {
 /**
  * Checks each flag of the specified project for flags of format "java(\\d+)".
  * If such a flag exists, the minimum Java version is extracted and returned.
- * Otherwise, {@code defaultVersion} is returned.
+ * Otherwise, {@code null} is returned.
  */
-static def extractTargetJavaVersion(Project project, int defaultVersion) {
+static def extractTargetJavaVersion(Project project) {
     def pattern = Pattern.compile('^java(\\d+)$')
     def flags = project.ext.flags
-    for (def flag: flags) {
+    for (def flag : flags) {
         def matcher = pattern.matcher(flag)
         if (!matcher.matches()) {
             continue
         }
-        return Integer.parseInt(matcher.group(1))
+        return Integer.valueOf(matcher.group(1))
     }
-    return defaultVersion
+    return null
 }
 
 configure(projectsWithFlags('java')) {
@@ -70,14 +70,9 @@ configure(projectsWithFlags('java')) {
         delete project.ext.genSrcDir
     }
 
-    // the default targetJavaVersion is 'javaTargetCompatibility'
-    String defaultTargetJavaVersionStr = project.findProperty('javaTargetCompatibility') ?: '1.8'
-    def defaultTargetJavaVersion = Integer.parseInt(
-            JavaVersion.toVersion(defaultTargetJavaVersionStr).majorVersion)
-
-    // parse flags for the targetJavaVersion or return the default version
-    def targetJavaVersion = extractTargetJavaVersion(project, defaultTargetJavaVersion)
-    if (targetJavaVersion < 8) {
+    // parse flags for the targetJavaVersion
+    def targetJavaVersion = extractTargetJavaVersion(project)
+    if (targetJavaVersion != null && targetJavaVersion < 8) {
         throw new IllegalArgumentException("The minimum target Java version ${version} specified " +
                 "for '${project.name}' cannot be smaller than 8")
     }
@@ -123,12 +118,16 @@ configure(projectsWithFlags('java')) {
 
     // Set the sensible compiler options.
     tasks.withType(JavaCompile) {
-        def targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
-        sourceCompatibility = project.findProperty('javaSourceCompatibility') ?: targetJavaVersionStr
-        targetCompatibility = project.findProperty('javaTargetCompatibility') ?: targetJavaVersionStr
+        def targetJavaVersionStr = null
+        if (targetJavaVersion != null) {
+            targetJavaVersionStr = JavaVersion.toVersion(targetJavaVersion).toString()
+        }
+        sourceCompatibility = targetJavaVersionStr ?: project.findProperty('javaSourceCompatibility') ?: '1.8'
+        // the default targetJavaVersion is 'javaTargetCompatibility'
+        targetCompatibility = targetJavaVersionStr ?: project.findProperty('javaTargetCompatibility') ?: '1.8'
         if (buildJdkVersion >= 9) {
             // Supported since java 9 https://openjdk.org/jeps/247
-            options.release.set(targetJavaVersion)
+            options.release.set(Integer.valueOf(JavaVersion.toVersion(targetCompatibility).majorVersion))
         }
         options.encoding = 'UTF-8'
         options.warnings = false

--- a/gradle/scripts/settings-flags.gradle
+++ b/gradle/scripts/settings-flags.gradle
@@ -118,6 +118,11 @@ static def addFlags(Set<String> actualFlags, ...flags) {
         }
     }
 
+    // 'kotlin' implies 'java'
+    if (actualFlags.contains('kotlin')) {
+        actualFlags.add('java')
+    }
+
     return Collections.unmodifiableSet(actualFlags)
 }
 


### PR DESCRIPTION
Motivation:

Although Docker decided to [revert sunset the “Docker Free Team” plan](https://www.docker.com/blog/we-apologize-we-did-a-terrible-job-announcing-the-end-of-docker-free-teams/),
we still think it is worth migrating our container registry to GitHub.
Because users will easily check out the images on our GitHub repository.

Modifications:

- Fixed to publish docker images to `ghcr.io`

Result:

- You can now get Central Dogma docker images from `ghrc.io`
```sh
docker pull ghrc.io/line/centraldogma:latest
```
- Closes #823