### PR TITLE
Update Central Dogma CLI to 0.1.0

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -73,7 +73,7 @@ task copyLib(group: 'Build',
     }
 }
 
-def cliVersion = "0.0.1"
+def cliVersion = "0.1.0"
 
 task downloadClientBinaries(group: 'Build',
         description: "Downloads client binaries into ${project.ext.cliDownloadDir}") {
@@ -81,7 +81,7 @@ task downloadClientBinaries(group: 'Build',
     outputs.dir("${project.ext.cliDownloadDir}/$cliVersion")
 
     doLast {
-        ["darwin-amd64", "linux-amd64", "windows-amd64.exe"].each { platform ->
+        ["darwin-amd64", "darwin-arm64", "linux-amd64", "windows-amd64.exe"].each { platform ->
             download.run {
                 src "https://github.com/line/centraldogma-go/releases/download/$cliVersion/dogma.$platform"
                 dest "${project.ext.cliDownloadDir}/$cliVersion/dogma.$platform"

--- a/dist/src/bin/dogma
+++ b/dist/src/bin/dogma
@@ -8,6 +8,8 @@ DOGMA_BIN="$(dirname "$0")/native"
 if [[ "${OS}" == 'Darwin' ]]; then
   if [[ "${MACH}" == 'x86_64' ]]; then
     DOGMA_BIN="${DOGMA_BIN}/dogma.darwin-amd64"
+  elif [[ "${MACH}" == 'arm64' ]]; then
+    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin-arm64"
   else
     echo "32-bit OS is not supported by default: ${OS}-${MACH}"
     exit 1


### PR DESCRIPTION
Central Dogma CLI 0.1.0 has been released.
https://github.com/line/centraldogma-go/releases/tag/0.1.0

Fixes: #779