### PR TITLE
Fix incorrect `spring-boot` artifact name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,7 @@ configure(projectsWithFlags('java')) {
     // Add common JVM options such as max memory and leak detection.
     tasks.withType(JavaForkOptions) {
         // Use larger heap when test coverage is enabled.
-        maxHeapSize = hasFlags('coverage') ? '384m' : '128m'
+        maxHeapSize = hasFlags('coverage') ? '512m' : '384m'
 
         // Enable leak detection when '-Pleak' option is specified.
         if (project.hasProperty('leak')) {

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -567,6 +567,11 @@ Spring Boot integration
 If you are using `Spring Framework <https://spring.io/>`_, you can inject :api:`com.linecorp.centraldogma.client.CentralDogma`
 client very easily. First, add ``centraldogma-client-spring-boot3-starter`` into your dependencies.
 
+.. tip::
+
+    Use the ``centraldogma-client-spring-boot2-starter`` dependency if you are using Spring Boot 2 or running your application with
+    a Java version lower than 17.
+
 Gradle:
 
 .. parsed-literal::

--- a/site/src/sphinx/client-java.rst
+++ b/site/src/sphinx/client-java.rst
@@ -565,7 +565,7 @@ client profile JAR again.
 Spring Boot integration
 -----------------------
 If you are using `Spring Framework <https://spring.io/>`_, you can inject :api:`com.linecorp.centraldogma.client.CentralDogma`
-client very easily. First, add ``centraldogma-client-spring-boot-starter`` into your dependencies.
+client very easily. First, add ``centraldogma-client-spring-boot3-starter`` into your dependencies.
 
 Gradle:
 
@@ -573,7 +573,7 @@ Gradle:
     :class: highlight-gradle
 
     dependencies {
-        compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot-starter:\ |release|\ '
+        compile 'com.linecorp.centraldogma:centraldogma-client-spring-boot3-starter:\ |release|\ '
     }
 
 Maven:
@@ -584,7 +584,7 @@ Maven:
     <dependencies>
       <dependency>
         <groupId>com.linecorp.centraldogma</groupId>
-        <artifactId>centraldogma-client-spring-boot-starter</artifactId>
+        <artifactId>centraldogma-client-spring-boot3-starter</artifactId>
         <version>\ |release|\ </version>
       </dependency>
     </dependencies>

--- a/site/src/sphinx/setup-installation.rst
+++ b/site/src/sphinx/setup-installation.rst
@@ -52,10 +52,10 @@ To stop the server, use the ``bin/shutdown`` script:
 
 Running on Docker
 -----------------
-You can also pull Central Dogma image from `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_
+You can also pull Central Dogma image from `Github Packages registry <https://github.com/line/centraldogma/pkgs/container/centraldogma>`_
 and then run it on your Docker:
 
 .. code-block:: shell
 
-    $ docker run -p 36462:36462 line/centraldogma
+    $ docker run -p 36462:36462 ghcr.io/line/centraldogma
 


### PR DESCRIPTION
**Modifications**

- Updated documentation to reflect changes in the most recent release
- Increase the max heap per java fork since the build seems unstable
  - https://github.com/line/centraldogma/actions/runs/4664557189/jobs/8256924556