### PR TITLE
Do not run auto-GC against any repositories

### DIFF
--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -404,7 +404,7 @@ class GitMirrorTest {
         // Add files whose total size exceeds the allowed maximum.
         long remainder = MAX_NUM_BYTES + 1;
         final int defaultFileSize = (int) (MAX_NUM_BYTES / MAX_NUM_FILES * 2);
-        for (int i = 0; ; i++) {
+        for (int i = 0;; i++) {
             final int fileSize;
             if (remainder > defaultFileSize) {
                 remainder -= defaultFileSize;

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -431,7 +431,7 @@ class GitMirrorTest {
 
     @Test
     void remoteToLocal_cloneDefaultSettings() throws Exception {
-        // Perform a mirroring task so that the remote Git repository is fetched into `data/_mirrors/`.
+        // Perform a mirroring task so that the remote Git repository is fetched into `<dataDir>/_mirrors/`.
         pushMirrorSettings(null, null, null);
         mirroringService.mirror().join();
 

--- a/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
+++ b/it/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorTest.java
@@ -25,6 +25,8 @@ import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_GPGSIGN;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -40,7 +42,9 @@ import org.eclipse.jgit.lib.Constants;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
+import org.eclipse.jgit.util.FS;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,7 +56,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
-import com.google.common.io.Files;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.CentralDogmaException;
@@ -64,6 +68,7 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.internal.JGitUtil;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
@@ -353,9 +358,9 @@ class GitMirrorTest {
         createGitRepo(gitSubmoduleRepo);
         final Git gitSubmodule = Git.wrap(gitSubmoduleRepo);
         final String gitSubmoduleUri = "file://" +
-                 (gitSubmoduleWorkTree.getPath().startsWith(File.separator) ? "" : "/") +
-                 gitSubmoduleWorkTree.getPath().replace(File.separatorChar, '/') +
-                 "/.git";
+                                       (gitSubmoduleWorkTree.getPath().startsWith(File.separator) ? "" : "/") +
+                                       gitSubmoduleWorkTree.getPath().replace(File.separatorChar, '/') +
+                                       "/.git";
 
         // Prepare the master branch of the submodule repository.
         addToGitIndex(gitSubmodule, gitSubmoduleWorkTree,
@@ -399,7 +404,7 @@ class GitMirrorTest {
         // Add files whose total size exceeds the allowed maximum.
         long remainder = MAX_NUM_BYTES + 1;
         final int defaultFileSize = (int) (MAX_NUM_BYTES / MAX_NUM_FILES * 2);
-        for (int i = 0;; i++) {
+        for (int i = 0; ; i++) {
             final int fileSize;
             if (remainder > defaultFileSize) {
                 remainder -= defaultFileSize;
@@ -422,6 +427,39 @@ class GitMirrorTest {
                 .hasCauseInstanceOf(MirrorException.class)
                 .hasMessageContaining("contains more than")
                 .hasMessageContaining("byte");
+    }
+
+    @Test
+    void remoteToLocal_cloneDefaultSettings() throws Exception {
+        // Perform a mirroring task so that the remote Git repository is fetched into `data/_mirrors/`.
+        pushMirrorSettings(null, null, null);
+        mirroringService.mirror().join();
+
+        // Find the Git config files.
+        final List<File> configFiles = Files.list(dogma.dataDir().resolve("_mirrors"))
+                                            .map(p -> p.resolve("config"))
+                                            .filter(Files::isRegularFile)
+                                            .map(Path::toFile)
+                                            .collect(ImmutableList.toImmutableList());
+
+        // We should find at least one.
+        assertThat(configFiles).isNotEmpty();
+
+        for (File configFile : configFiles) {
+            // Load the Git config file.
+            final FileBasedConfig config = new FileBasedConfig(configFile, FS.DETECTED);
+            config.load();
+            final String configText = config.toText();
+
+            // All properties set by JGitUtil must be set already,
+            // leading `applyDefaults()` to return `false` (means 'not modified').
+            assertThat(JGitUtil.applyDefaults(config))
+                    .withFailMessage("A mirror repository has unexpected config value(s): %s\n" +
+                                     "actual:\n%s\n\n\n" +
+                                     "expected:\n%s\n\n\n",
+                                     configFile, configText, config.toText())
+                    .isFalse();
+        }
     }
 
     @CsvSource({ "meta", "dogma" })
@@ -473,7 +511,7 @@ class GitMirrorTest {
                               String path, String content) throws IOException, GitAPIException {
         final File file = Paths.get(gitWorkTree.getAbsolutePath(), path.split("/")).toFile();
         file.getParentFile().mkdirs();
-        Files.asCharSink(file, StandardCharsets.UTF_8).write(content);
+        Files.write(file.toPath(), content.getBytes(StandardCharsets.UTF_8));
         git.add().addFilepattern(path).call();
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReader.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReader.java
@@ -15,12 +15,21 @@
  */
 package com.linecorp.centraldogma.server.internal;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.SystemReader;
 
@@ -36,6 +45,8 @@ public final class IsolatedSystemReader extends SystemReader {
             "^(?:java|os|file|path|line|user|native|jdk)\\.");
 
     private static final SystemReader INSTANCE = new IsolatedSystemReader();
+    private static final FileBasedConfig EMPTY_CONFIG = new EmptyConfig();
+    private static final String[] EMPTY_STRING_ARRAY = {};
 
     public static void install() {
         SystemReader.setInstance(INSTANCE);
@@ -68,17 +79,17 @@ public final class IsolatedSystemReader extends SystemReader {
 
     @Override
     public FileBasedConfig openUserConfig(Config parent, FS fs) {
-        return new EmptyConfig(parent, fs);
+        return EMPTY_CONFIG;
     }
 
     @Override
     public FileBasedConfig openSystemConfig(Config parent, FS fs) {
-        return new EmptyConfig(parent, fs);
+        return EMPTY_CONFIG;
     }
 
     @Override
     public FileBasedConfig openJGitConfig(Config parent, FS fs) {
-        return new EmptyConfig(parent, fs);
+        return EMPTY_CONFIG;
     }
 
     @Override
@@ -92,8 +103,8 @@ public final class IsolatedSystemReader extends SystemReader {
     }
 
     private static final class EmptyConfig extends FileBasedConfig {
-        EmptyConfig(Config base, FS fs) {
-            super(base, null, fs);
+        EmptyConfig() {
+            super(null, null, null);
         }
 
         @Override
@@ -102,8 +113,130 @@ public final class IsolatedSystemReader extends SystemReader {
         }
 
         @Override
+        public void save() throws IOException {
+            // Do nothing.
+        }
+
+        @Override
         public boolean isOutdated() {
             return false;
+        }
+
+        @Override
+        public int getInt(String section, String name, int defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public int getInt(String section, String subsection, String name, int defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public long getLong(String section, String name, long defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public long getLong(String section, String subsection, String name, long defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public boolean getBoolean(String section, String name, boolean defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public boolean getBoolean(String section, String subsection, String name, boolean defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public <T extends Enum<?>> T getEnum(String section, String subsection, String name, T defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public <T extends Enum<?>> T getEnum(T[] all, String section, String subsection, String name,
+                                             T defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        @Nullable
+        public String getString(String section, String subsection, String name) {
+            return null;
+        }
+
+        @Override
+        public String[] getStringList(String section, String subsection, String name) {
+            return EMPTY_STRING_ARRAY;
+        }
+
+        @Override
+        public long getTimeUnit(String section, String subsection, String name, long defaultValue,
+                                TimeUnit wantUnit) {
+            return defaultValue;
+        }
+
+        @Override
+        public Path getPath(String section, String subsection, String name, FS fs, File resolveAgainst,
+                            Path defaultValue) {
+            return defaultValue;
+        }
+
+        @Override
+        public List<RefSpec> getRefSpecs(String section, String subsection, String name) {
+            // We return a mutable list to match the original behavior.
+            return new ArrayList<>();
+        }
+
+        @Override
+        public Set<String> getSubsections(String section) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getSections() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getNames(String section) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getNames(String section, String subsection) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getNames(String section, boolean recursive) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public Set<String> getNames(String section, String subsection, boolean recursive) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public <T> T get(SectionParser<T> parser) {
+            return parser.parse(this);
+        }
+
+        @Override
+        public String toText() {
+            return "";
+        }
+
+        @Override
+        public String toString() {
+            // super.toString() triggers a NullPointerException because it assumes getFile() returns non-null,
+            // which is not the case for us.
+            return getClass().getSimpleName();
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReader.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReader.java
@@ -33,6 +33,8 @@ import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.util.FS;
 import org.eclipse.jgit.util.SystemReader;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import com.linecorp.armeria.common.util.SystemInfo;
 
 /**
@@ -44,8 +46,9 @@ public final class IsolatedSystemReader extends SystemReader {
     private static final Pattern allowedSystemPropertyNamePattern = Pattern.compile(
             "^(?:java|os|file|path|line|user|native|jdk)\\.");
 
+    @VisibleForTesting
+    static final FileBasedConfig EMPTY_CONFIG = new EmptyConfig();
     private static final SystemReader INSTANCE = new IsolatedSystemReader();
-    private static final FileBasedConfig EMPTY_CONFIG = new EmptyConfig();
     private static final String[] EMPTY_STRING_ARRAY = {};
 
     public static void install() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/JGitUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/JGitUtil.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.eclipse.jgit.lib.Config;
-import org.eclipse.jgit.lib.ConfigConstants;
 import org.eclipse.jgit.lib.StoredConfig;
 
 public final class JGitUtil {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/JGitUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/JGitUtil.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_COMMIT_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_CORE_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_DIFF_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_GC_SECTION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_ALGORITHM;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_AUTO;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_AUTOGC;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_AUTOPACKLIMIT;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_FILEMODE;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_GPGSIGN;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_HIDEDOTFILES;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_LOGALLREFUPDATES;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_PRECOMPOSEUNICODE;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_RENAMES;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_REPO_FORMAT_VERSION;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_KEY_SYMLINKS;
+import static org.eclipse.jgit.lib.ConfigConstants.CONFIG_RECEIVE_SECTION;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.lib.ConfigConstants;
+import org.eclipse.jgit.lib.StoredConfig;
+
+public final class JGitUtil {
+
+    public static final int REPO_FORMAT_VERSION = 1;
+
+    private static final String REPO_FORMAT_VERSION_STR = String.valueOf(REPO_FORMAT_VERSION);
+
+    public static void applyDefaultsAndSave(StoredConfig config) throws IOException {
+        if (applyDefaults(config)) {
+            config.save();
+        }
+    }
+
+    public static boolean applyDefaults(Config config) {
+        boolean updated = false;
+        // Update the repository settings to upgrade to format version 1 and reftree.
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_REPO_FORMAT_VERSION, REPO_FORMAT_VERSION_STR);
+
+        // Disable hidden files, symlinks and file modes we do not use.
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_HIDEDOTFILES, "false");
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_SYMLINKS, "false");
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_FILEMODE, "false");
+
+        // Don't log ref updates.
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_LOGALLREFUPDATES, "false");
+
+        // Do not decompose file names in macOS.
+        updated |= set(config, CONFIG_CORE_SECTION, CONFIG_KEY_PRECOMPOSEUNICODE, "true");
+
+        // Disable GPG signing.
+        updated |= set(config, CONFIG_COMMIT_SECTION, CONFIG_KEY_GPGSIGN, "false");
+
+        // Set the diff algorithm.
+        updated |= set(config, CONFIG_DIFF_SECTION, CONFIG_KEY_ALGORITHM, "histogram");
+
+        // Disable rename detection which we do not use.
+        updated |= set(config, CONFIG_DIFF_SECTION, CONFIG_KEY_RENAMES, "false");
+
+        // Disable auto-GC by default because of the following reasons:
+        // - GC can take long time affecting performance.
+        // - jGit's GC task has memory leak which adds a JVM shutdown hook for each GC task.
+        //   See https://github.com/eclipse-mirrors/org.eclipse.jgit/blob/2e3f12a0fc63deba80e725bfa985c0c5bd31de99/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/GC.java#L1769
+        updated |= set(config, CONFIG_GC_SECTION, CONFIG_KEY_AUTO, "0");
+        updated |= set(config, CONFIG_GC_SECTION, CONFIG_KEY_AUTOPACKLIMIT, "0");
+        updated |= set(config, CONFIG_RECEIVE_SECTION, CONFIG_KEY_AUTOGC, "false");
+
+        return updated;
+    }
+
+    private static boolean set(Config config, String section, String name, String value) {
+        requireNonNull(section, "section");
+        requireNonNull(name, "name");
+        requireNonNull(value, "value");
+
+        final String oldValue = config.getString(section, null, name);
+        if (Objects.equals(oldValue, value)) {
+            return false;
+        }
+
+        config.setString(section, null, name, value);
+        return true;
+    }
+
+    private JGitUtil() {}
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -56,6 +56,7 @@ import com.jcraft.jsch.UserInfo;
 
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.internal.IsolatedSystemReader;
+import com.linecorp.centraldogma.server.internal.JGitUtil;
 import com.linecorp.centraldogma.server.internal.mirror.credential.AccessTokenMirrorCredential;
 import com.linecorp.centraldogma.server.internal.mirror.credential.PasswordMirrorCredential;
 import com.linecorp.centraldogma.server.internal.mirror.credential.PublicKeyMirrorCredential;
@@ -108,6 +109,8 @@ abstract class GitWithAuth extends Git {
             if (!repo.getObjectDatabase().exists()) {
                 repo.create(true);
             }
+
+            JGitUtil.applyDefaultsAndSave(repo.getConfig());
             success = true;
             return repo;
         } finally {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReaderTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReaderTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.util.SystemReader;
+import org.junit.jupiter.api.Test;
+
+class IsolatedSystemReaderTest {
+    static {
+        IsolatedSystemReader.install();
+    }
+
+    @Test
+    void defaultSettings() throws Exception {
+        final SystemReader reader = SystemReader.getInstance();
+        assertThat(reader).isInstanceOf(IsolatedSystemReader.class);
+
+        // Make sure all the necessary properties are set.
+        final StoredConfig config = reader.getUserConfig();
+        final String configText = config.toText();
+        assertThat(configText).isEqualTo("[core]\n" +
+                "\trepositoryformatversion = 1\n" +
+                "\thidedotfiles = false\n" +
+                "\tsymlinks = false\n" +
+                "\tfilemode = false\n" +
+                "[commit]\n" +
+                "\tgpgSign = false\n" +
+                "[diff]\n" +
+                "\talgorithm = histogram\n" +
+                "\trenames = false\n" +
+                "[gc]\n" +
+                "\tautopacklimit = 0\n" +
+                "\tauto = 0\n");
+
+        // Make sure user, system and jGit configs are all same with each other.
+        assertThat(reader.getSystemConfig().toText()).isEqualTo(configText);
+        assertThat(reader.getJGitConfig().toText()).isEqualTo(configText);
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReaderTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/IsolatedSystemReaderTest.java
@@ -17,39 +17,20 @@ package com.linecorp.centraldogma.server.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.eclipse.jgit.lib.StoredConfig;
 import org.eclipse.jgit.util.SystemReader;
 import org.junit.jupiter.api.Test;
 
 class IsolatedSystemReaderTest {
-    static {
-        IsolatedSystemReader.install();
-    }
-
     @Test
     void defaultSettings() throws Exception {
+        IsolatedSystemReader.install();
         final SystemReader reader = SystemReader.getInstance();
         assertThat(reader).isInstanceOf(IsolatedSystemReader.class);
 
         // Make sure all the necessary properties are set.
-        final StoredConfig config = reader.getUserConfig();
-        final String configText = config.toText();
-        assertThat(configText).isEqualTo("[core]\n" +
-                "\trepositoryformatversion = 1\n" +
-                "\thidedotfiles = false\n" +
-                "\tsymlinks = false\n" +
-                "\tfilemode = false\n" +
-                "[commit]\n" +
-                "\tgpgSign = false\n" +
-                "[diff]\n" +
-                "\talgorithm = histogram\n" +
-                "\trenames = false\n" +
-                "[gc]\n" +
-                "\tautopacklimit = 0\n" +
-                "\tauto = 0\n");
-
-        // Make sure user, system and jGit configs are all same with each other.
-        assertThat(reader.getSystemConfig().toText()).isEqualTo(configText);
-        assertThat(reader.getJGitConfig().toText()).isEqualTo(configText);
+        assertThat(reader.getUserConfig()).isSameAs(IsolatedSystemReader.EMPTY_CONFIG);
+        assertThat(reader.getSystemConfig()).isSameAs(IsolatedSystemReader.EMPTY_CONFIG);
+        assertThat(reader.getJGitConfig()).isSameAs(IsolatedSystemReader.EMPTY_CONFIG);
+        assertThat(reader.getUserConfig()).isSameAs(IsolatedSystemReader.EMPTY_CONFIG);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -1068,8 +1068,8 @@ class GitRepositoryTest {
                                                  "}]");
 
         final Entry<JsonNode> res3 = repo.get(HEAD, Query.ofJsonPath(
-                                                 "/instances.json", "$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]"))
-                                         .join();
+                "/instances.json",
+                "$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]")).join();
 
         assertThatJson(res3.content()).isEqualTo("[{" +
                                                  "  \"name\": \"a\"," +
@@ -1178,11 +1178,11 @@ class GitRepositoryTest {
                 .isInstanceOf(TimeoutException.class);
 
         // Here comes the interesting change; make sure notification is triggered.
-        final Revision rev3 = repo.commit(
-                                          HEAD, 0L, Author.UNKNOWN, SUMMARY,
-                                          Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"jupiter\", \"goodbye\": \"mars\" }"))
-                                  .join()
-                                  .revision();
+        final Revision rev3 =
+                repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                            Change.ofJsonUpsert(jsonPaths[0],
+                                                "{ \"hello\": \"jupiter\", \"goodbye\": \"mars\" }"))
+                    .join().revision();
 
         final Entry<JsonNode> res = f.get(3, TimeUnit.SECONDS);
         assertThat(res.revision()).isEqualTo(rev3);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -52,6 +52,8 @@ import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.RefUpdate;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.util.FS;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +77,7 @@ import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.internal.Util;
+import com.linecorp.centraldogma.server.internal.JGitUtil;
 import com.linecorp.centraldogma.server.storage.StorageException;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
@@ -159,6 +162,27 @@ class GitRepositoryTest {
         }
 
         watchConsumer = null;
+    }
+
+    @Test
+    void defaultSettings() throws Exception {
+        // Make sure the Git config file has been created.
+        final File configFile = repoDir.toPath().resolve("test_repo").resolve("config").toFile();
+        assertThat(configFile).exists();
+
+        // Load the Git config file.
+        final FileBasedConfig config = new FileBasedConfig(configFile, FS.DETECTED);
+        config.load();
+        final String configText = config.toText();
+
+        // All properties set by JGitUtil must be set already,
+        // leading `applyDefaults()` to return `false` (means 'not modified').
+        assertThat(JGitUtil.applyDefaults(config))
+                .withFailMessage("A repository has unexpected config value(s): %s\n" +
+                                 "actual:\n%s\n\n\n" +
+                                 "expected:\n%s\n\n\n",
+                                 configFile, configText, config.toText())
+                .isFalse();
     }
 
     @Test
@@ -1044,7 +1068,7 @@ class GitRepositoryTest {
                                                  "}]");
 
         final Entry<JsonNode> res3 = repo.get(HEAD, Query.ofJsonPath(
-                "/instances.json", "$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]"))
+                                                 "/instances.json", "$[?(@.groups[?(@.type == 'phase' && @.name == 'alpha')] empty false)]"))
                                          .join();
 
         assertThatJson(res3.content()).isEqualTo("[{" +
@@ -1155,8 +1179,8 @@ class GitRepositoryTest {
 
         // Here comes the interesting change; make sure notification is triggered.
         final Revision rev3 = repo.commit(
-                HEAD, 0L, Author.UNKNOWN, SUMMARY,
-                Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"jupiter\", \"goodbye\": \"mars\" }"))
+                                          HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                                          Change.ofJsonUpsert(jsonPaths[0], "{ \"hello\": \"jupiter\", \"goodbye\": \"mars\" }"))
                                   .join()
                                   .revision();
 

--- a/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
+++ b/testing/junit/src/main/java/com/linecorp/centraldogma/testing/junit/CentralDogmaExtension.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.testing.junit;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
@@ -27,6 +28,7 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.common.annotation.UnstableApi;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
@@ -112,6 +114,16 @@ public class CentralDogmaExtension extends AbstractAllOrEachExtension {
                 throw new CompletionException(e);
             }
         });
+    }
+
+    /**
+     * Returns the {@link Path} to the server's data directory.
+     *
+     * @throws IllegalStateException if the data directory is not created yet
+     */
+    @UnstableApi
+    public final Path dataDir() {
+        return dataDir.getRoot();
     }
 
     /**


### PR DESCRIPTION
Motivation:

Our default jGit settings did not disable auto-GC. Auto-GC is not desirable for our use case because:

- It triggers GC at unexpected point of time, affecting performance.
- Since jGit 6.5.0, jGit acquires a filesystem lock before performing GC
  and registers a JVM shutdown hook that cleans the lock file up.
  This new behavior may be OK for short-living processes such as CLI
  tools, but it leads to memory leak for us.
  See: https://github.com/eclipse-mirrors/org.eclipse.jgit/blob/2e3f12a0fc63deba80e725bfa985c0c5bd31de99/org.eclipse.jgit/src/org/eclipse/jgit/internal/storage/file/GC.java#L1769

Modifications:

- Added a new class `JGitUtil` that sets the common Git configuration
  properties for all JGit `Config`s
- Made sure the desired default settings are enforced for all Git
  repositories, including `GitRepository` and `GitMirror`
- Optimized `EmptyConfig` so it can be used as a singleton
- Added test cases that make sure the default settings have all the
  necessary properties
- Added `CentralDogmaExtension.dataDir()` so that a user can access the
  location of the data directory, which is useful for checking the
  internal state of Central Dogma

Result:

- Automatic GC is never triggered for all repositories including both
  Central Dogma repositories and mirrored Git repositories.
- The memory leak, that occurs when jGit 6.5 is used, is gone.
- A user can now know the location of the data directory with
  `dataDir()` when using `CentralDogmaExtension`.