### PR TITLE
Do not read user SSH config / Fix GitMirrorAuthTest

### DIFF
--- a/server-jgit6/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git6WithAuth.java
+++ b/server-jgit6/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git6WithAuth.java
@@ -72,7 +72,7 @@ final class Git6WithAuth extends GitWithAuth {
     }
 
     @Override
-    public  <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PasswordMirrorCredential cred) {
+    public <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PasswordMirrorCredential cred) {
         cmd.setTransportConfigCallback(transport -> {
             final SshTransport sshTransport = (SshTransport) transport;
             final JschConfigSessionFactory sessionFactory = new JschConfigSessionFactory() {
@@ -98,10 +98,10 @@ final class Git6WithAuth extends GitWithAuth {
     /**
      * Returns an empty {@link OpenSshConfig}.
      *
-     * <p>The default {@link OpenSshConfig} reads the SSH config in `~/.ssh/config` and converts the identity files into
-     * {@code com.jcraft.jsch.KeyPair}. Since JSch does not support Ed25519, `KeyPair.load()` raise an exception if
-     * Ed25519 is used locally. Plus, Central Dogma uses {@link PublicKeyMirrorCredential}, we need to provide an empty
-     * config for isolated environment.
+     * <p>The default {@link OpenSshConfig} reads the SSH config in `~/.ssh/config` and converts the identity
+     * files into {@code com.jcraft.jsch.KeyPair}. Since JSch does not support Ed25519, `KeyPair.load()`
+     * raise an exception if Ed25519 is used locally. Plus, Central Dogma uses
+     * {@link PublicKeyMirrorCredential}, we need to provide an empty config for an isolated environment.
      */
     private static OpenSshConfig emptySshConfig() {
         final File emptyConfigFile;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git5WithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git5WithAuth.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import com.linecorp.armeria.common.annotation.Nullable;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
@@ -32,6 +31,7 @@ import org.eclipse.jgit.transport.SshTransport;
 
 import com.jcraft.jsch.Session;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.internal.mirror.credential.PasswordMirrorCredential;
 import com.linecorp.centraldogma.server.internal.mirror.credential.PublicKeyMirrorCredential;
@@ -46,7 +46,8 @@ final class Git5WithAuth extends GitWithAuth {
     static {
         Method setConfigMethod = null;
         try {
-            setConfigMethod = JschConfigSessionFactory.class.getDeclaredMethod("setConfig", OpenSshConfig.class);
+            setConfigMethod =
+                    JschConfigSessionFactory.class.getDeclaredMethod("setConfig", OpenSshConfig.class);
             setConfigMethod.setAccessible(true);
         } catch (NoSuchMethodException ignored) {
         }
@@ -87,7 +88,7 @@ final class Git5WithAuth extends GitWithAuth {
     }
 
     @Override
-    public  <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PasswordMirrorCredential cred) {
+    public <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PasswordMirrorCredential cred) {
         cmd.setTransportConfigCallback(transport -> {
             final SshTransport sshTransport = (SshTransport) transport;
             final JschConfigSessionFactory sessionFactory = new JschConfigSessionFactory() {
@@ -125,9 +126,12 @@ final class Git5WithAuth extends GitWithAuth {
     /**
      * Returns an empty {@link OpenSshConfig}.
      *
-     * <p>The default {@link OpenSshConfig} reads the SSH config in `~/.ssh/config` and converts the identity files into
-     * {@code com.jcraft.jsch.KeyPair}. Since JSch does not support Ed25519, `KeyPair.load()` raise an exception if
-     * Ed25519 is used locally. Plus, Central Dogma uses {@link PublicKeyMirrorCredential}, we need to provide an empty
+     * <p>The default {@link OpenSshConfig} reads the SSH config in `~/.ssh/config` and converts the identity
+     * files into
+     * {@code com.jcraft.jsch.KeyPair}. Since JSch does not support Ed25519, `KeyPair.load()` raise an
+     * exception if
+     * Ed25519 is used locally. Plus, Central Dogma uses {@link PublicKeyMirrorCredential}, we need to
+     * provide an empty
      * config for isolated environment.
      */
     private static OpenSshConfig emptySshConfig() {
@@ -140,7 +144,8 @@ final class Git5WithAuth extends GitWithAuth {
         }
 
         try {
-            final Constructor<OpenSshConfig> ctor = OpenSshConfig.class.getDeclaredConstructor(File.class, File.class);
+            final Constructor<OpenSshConfig> ctor =
+                    OpenSshConfig.class.getDeclaredConstructor(File.class, File.class);
             ctor.setAccessible(true);
             return ctor.newInstance(emptyConfigFile.getParentFile(), emptyConfigFile);
         } catch (ReflectiveOperationException e) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git5WithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/Git5WithAuth.java
@@ -18,10 +18,15 @@ package com.linecorp.centraldogma.server.internal.mirror;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
+import com.linecorp.armeria.common.annotation.Nullable;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.TransportCommand;
 import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.OpenSshConfig.Host;
 import org.eclipse.jgit.transport.SshTransport;
 
@@ -32,6 +37,22 @@ import com.linecorp.centraldogma.server.internal.mirror.credential.PasswordMirro
 import com.linecorp.centraldogma.server.internal.mirror.credential.PublicKeyMirrorCredential;
 
 final class Git5WithAuth extends GitWithAuth {
+
+    private static final OpenSshConfig EMPTY_CONFIG = emptySshConfig();
+
+    @Nullable
+    private static final Method SET_CONFIG_METHOD;
+
+    static {
+        Method setConfigMethod = null;
+        try {
+            setConfigMethod = JschConfigSessionFactory.class.getDeclaredMethod("setConfig", OpenSshConfig.class);
+            setConfigMethod.setAccessible(true);
+        } catch (NoSuchMethodException ignored) {
+        }
+        SET_CONFIG_METHOD = setConfigMethod;
+    }
+
     Git5WithAuth(GitMirror mirror, File repoDir) throws IOException {
         super(mirror, repoDir);
     }
@@ -45,7 +66,7 @@ final class Git5WithAuth extends GitWithAuth {
     public <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PublicKeyMirrorCredential cred) {
         cmd.setTransportConfigCallback(transport -> {
             final SshTransport sshTransport = (SshTransport) transport;
-            sshTransport.setSshSessionFactory(new JschConfigSessionFactory() {
+            final JschConfigSessionFactory sessionFactory = new JschConfigSessionFactory() {
                 @Override
                 protected void configure(Host host, Session session) {
                     try {
@@ -59,7 +80,9 @@ final class Git5WithAuth extends GitWithAuth {
                         throw new MirrorException(e);
                     }
                 }
-            });
+            };
+            setEmptyConfig(sessionFactory);
+            sshTransport.setSshSessionFactory(sessionFactory);
         });
     }
 
@@ -67,7 +90,7 @@ final class Git5WithAuth extends GitWithAuth {
     public  <T extends TransportCommand<?, ?>> void configureSsh(T cmd, PasswordMirrorCredential cred) {
         cmd.setTransportConfigCallback(transport -> {
             final SshTransport sshTransport = (SshTransport) transport;
-            sshTransport.setSshSessionFactory(new JschConfigSessionFactory() {
+            final JschConfigSessionFactory sessionFactory = new JschConfigSessionFactory() {
                 @Override
                 protected void configure(Host host, Session session) {
                     try {
@@ -80,7 +103,48 @@ final class Git5WithAuth extends GitWithAuth {
                         throw new MirrorException(e);
                     }
                 }
-            });
+            };
+            setEmptyConfig(sessionFactory);
+            sshTransport.setSshSessionFactory(sessionFactory);
         });
+    }
+
+    /**
+     * Disables the default SSH config file lookup.
+     */
+    private static void setEmptyConfig(JschConfigSessionFactory sessionFactory) {
+        try {
+            if (SET_CONFIG_METHOD != null) {
+                SET_CONFIG_METHOD.invoke(sessionFactory, EMPTY_CONFIG);
+            }
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    /**
+     * Returns an empty {@link OpenSshConfig}.
+     *
+     * <p>The default {@link OpenSshConfig} reads the SSH config in `~/.ssh/config` and converts the identity files into
+     * {@code com.jcraft.jsch.KeyPair}. Since JSch does not support Ed25519, `KeyPair.load()` raise an exception if
+     * Ed25519 is used locally. Plus, Central Dogma uses {@link PublicKeyMirrorCredential}, we need to provide an empty
+     * config for isolated environment.
+     */
+    private static OpenSshConfig emptySshConfig() {
+        final File emptyConfigFile;
+        try {
+            emptyConfigFile = File.createTempFile("dogma", "empty-ssh-config");
+            emptyConfigFile.deleteOnExit();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        try {
+            final Constructor<OpenSshConfig> ctor = OpenSshConfig.class.getDeclaredConstructor(File.class, File.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(emptyConfigFile.getParentFile(), emptyConfigFile);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -30,7 +30,6 @@ import java.util.Vector;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.jcraft.jsch.*;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.GarbageCollectCommand;
 import org.eclipse.jgit.api.Git;
@@ -44,6 +43,16 @@ import org.eclipse.jgit.lib.RepositoryBuilder;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.jcraft.jsch.Buffer;
+import com.jcraft.jsch.HostKey;
+import com.jcraft.jsch.HostKeyRepository;
+import com.jcraft.jsch.Identity;
+import com.jcraft.jsch.IdentityRepository;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.KeyPair;
+import com.jcraft.jsch.UserInfo;
 
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.internal.IsolatedSystemReader;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -30,6 +30,7 @@ import java.util.Vector;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.jcraft.jsch.*;
 import org.eclipse.jgit.api.FetchCommand;
 import org.eclipse.jgit.api.GarbageCollectCommand;
 import org.eclipse.jgit.api.Git;
@@ -43,16 +44,6 @@ import org.eclipse.jgit.lib.RepositoryBuilder;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.jcraft.jsch.Buffer;
-import com.jcraft.jsch.HostKey;
-import com.jcraft.jsch.HostKeyRepository;
-import com.jcraft.jsch.Identity;
-import com.jcraft.jsch.IdentityRepository;
-import com.jcraft.jsch.JSch;
-import com.jcraft.jsch.JSchException;
-import com.jcraft.jsch.KeyPair;
-import com.jcraft.jsch.UserInfo;
 
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.internal.IsolatedSystemReader;


### PR DESCRIPTION
Motivation:

When JGit creates a session JSch, it obtains user's configuration first.
https://github.com/eclipse-mirrors/org.eclipse.jgit/blob/master/org.eclipse.jgit.ssh.jsch/src/org/eclipse/jgit/transport/ssh/jsch/OpenSshConfig.java#L69-L77
Although the SSH config is not actually used to Git mirror, JSch tries to parse the SSH identity files.

JSch does not support Ed25519 public-key signature algorithm. If Ed25519 key is used configured in a user's SSH key, `KeyPair.load()` raises `JSchException: invalid privatekey ...`.

Consequently, GitMirrorAuthTest fails due to the exception.

Modifications:

- Set an empty `OpenSshConfig` to `JschConfigSessionFactory` when a Git mirroring repository is initialized to disable the default SSH config file lookup.

Result:

- The Central Dogma operates consistently across different environments.
- `GitMirrorAuthTest` no longer fails when Ed25519 key is configured in the SSH config file.