### PR TITLE
Publish a docker image when a new tag is created

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,8 +1,9 @@
 name: Publish Docker image
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - centraldogma-*
 
 env:
   LC_ALL: 'en_US.UTF-8'


### PR DESCRIPTION
Motivation:

`on.release.published` on which `publish-docker.yml` depends is not triggired when GitHub Actions bot creates a release note automatically.

Modifications:

- Use `on.push.tags` event to trigger `publish-docker.yml`

Result:

A Docker image is correctly published when a new Central Dogma version is released.