### PR TITLE
Fix yarn lock CI issue in Windows

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12, windows-latest]
-        java: [11]
+        java: [17]
         include:
           - java: 11
             os: ubuntu-latest

--- a/server-auth/webapp/build.gradle
+++ b/server-auth/webapp/build.gradle
@@ -49,4 +49,11 @@ node {
     version = '16.1.0'
     yarnVersion = '1.22.10'
     download = true
+    npmInstallCommand = "ci"
+
+    // Change the cache location under Gradle user home directory so that it's cached by CI.
+    if (System.getenv('CI') != null) {
+        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
+        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
+    }
 }


### PR DESCRIPTION
The oldest occurrence I could find was this dependency update CI, but no idea how the failure is related to this change 😅 
- https://github.com/line/centraldogma/actions/runs/5286886253