### PR TITLE
Disable Zookeeper multi address

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/EmbeddedZooKeeper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/EmbeddedZooKeeper.java
@@ -78,6 +78,7 @@ final class EmbeddedZooKeeper extends QuorumPeer {
         setLearnerType(zkCfg.getPeerType());
         setSyncEnabled(zkCfg.getSyncEnabled());
         setQuorumListenOnAllIPs(zkCfg.getQuorumListenOnAllIPs());
+        setMultiAddressEnabled(false);
 
         configureSasl();
 


### PR DESCRIPTION
Motivation:

Zookeeper 3.6 added a new option that was ability to set multiple adders for quorum operations. https://github.com/apache/zookeeper/pull/1048 The multi address was not compatible with the old protocol used in ZooKeeper 3.5.x, so https://github.com/apache/zookeeper/pull/1251 has disabled the option.

During fixing incompatibility in https://github.com/apache/zookeeper/pull/1251, it omitted to change the default value of `QuorumPeer.multiAddressEnabled` to `false`.
https://github.com/apache/zookeeper/blob/e08cc2a782982964a57651f179a468b19e2e6010/zookeeper-server/src/main/java/org/apache/zookeeper/server/quorum/QuorumPeer.java#L174-L180
The default is correctly set to false when a Zookeeper server is used as a standalone mode. However, if a new `QuorumPeer` instance is manually created, it will remain `true.` 

Since CentralDogma directly extends `QuorumPeer`, `zookeeper.multiadress` is activated automatically and Central Dogma using Zookeeper 3.5.x can't be upgraded with a rolling deployment.

Modifications:

- Set `multiAddressEnabled` to false when creating `EmbeddedZooKeeper`

Result:

- Fixed an issue where CentralDogma does not perform rolling updates due to the invalid protocol version of Zookeeper.
  - Note that this bug affects 0.61.2, 0.61.3 and 0.61.4