### PR TITLE
Add Snappy dependency

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -49,6 +49,9 @@ quartz = "2.3.2"
 shadow-gradle-plugin = "7.1.2"
 shiro = "1.3.2"
 slf4j = "1.7.36"
+# Ensure that we use the same Snappy version as what Curator depends on.
+# See: https://github.com/apache/curator/blob/master/pom.xml
+snappy = "1.1.10.1"
 sphinx = "2.10.1"
 spring-boot2 = "2.7.12"
 spring-boot3 = "3.1.0"
@@ -305,6 +308,10 @@ version.ref = "slf4j"
 [libraries.slf4j-log4j-over-slf4j]
 module = "org.slf4j:log4j-over-slf4j"
 version.ref = "slf4j"
+
+[libraries.snappy]
+module = "org.xerial.snappy:snappy-java"
+version.ref = "snappy"
 
 [libraries.spring-boot2-autoconfigure]
 module = "org.springframework.boot:spring-boot-autoconfigure"

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -51,6 +51,9 @@ dependencies {
     // Quartz
     implementation libs.quartz
 
+    // Snappy
+    implementation libs.snappy
+
     // Mockito for mocking a Project
     jmh libs.mockito.core
     // Logging


### PR DESCRIPTION
Motivation:
Snappy is removed from ZooKeeper 3.6.0
https://github.com/apache/zookeeper/commit/b787770b9920a7ae99f9ed2dbe583ece1b2665cc#diff-237e154d86dc584115184b6d4b8bfda7ef88fe934a67ae796c6856badc0cacbf Our test didn't fail because curator-test has the dependencies. Related #584

Modifications:
- Add Snappy 1.1.10.1

Result:
- No more `ClassNotFoundException`