### PR TITLE
Use personal acesss token to trigger CI builds

### DIFF
--- a/.github/workflows/update-armeria-version.yml
+++ b/.github/workflows/update-armeria-version.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v4
         with:
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
           title: Update Armeria version to ${{ inputs.armeria_version }}
           body : ''
           commit-message: Update Armeria version to ${{ inputs.armeria_version }}


### PR DESCRIPTION
Motivation:

When a PR is created by a workflow with the deafult GITHUB_TOKEN which is given by GitHub Actions, CI builds aren't triggered. https://github.com/orgs/community/discussions/55906

Releated: #870

Modifications:

- Use PAT of our friendly bot @armerian

Result:

CI is correctly run when an Armeria version upgrade PR is made