### PR TITLE
Downgrade cron-utils to 9.2.0

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -10,7 +10,8 @@ bouncycastle = "1.76"
 caffeine = "2.9.3"
 checkstyle = "10.3.3"
 curator = "5.5.0"
-cron-utils = "9.2.1"
+# Do not upgrade cron-utils until there's another CVE or Armeria's SLF4J and Logback are upgraded.
+cron-utils = "9.2.0"
 diffutils = "1.3.0"
 docker = "9.3.2"
 download = "5.4.0"
@@ -110,7 +111,6 @@ version.ref = "checkstyle"
 [libraries.cron-utils]
 module = "com.cronutils:cron-utils"
 version.ref = "cron-utils"
-exclusions = 'org.slf4j:slf4j-api' # cron-utils brings in slf4j2
 relocations = { from = "com.cronutils", to = "com.linecorp.centraldogma.internal.shaded.cronutils" }
 
 # Ensure that we use the same ZooKeeper version as what Curator depends on.

--- a/dist/src/conf/logback.xml
+++ b/dist/src/conf/logback.xml
@@ -37,7 +37,7 @@
   <logger name="com.github.benmanes.caffeine.cache" level="ERROR" />
   <logger name="com.linecorp" level="INFO" />
   <logger name="com.linecorp.centraldogma" level="DEBUG" />
-  <logger name="com.linecorp.centraldogma.server.internal.mirror" level="INFO" />
+  <logger name="com.linecorp.centraldogma.server.internal.mirror.GitWithAuth$DefaultGitSshdSessionFactory" level="INFO" />
   <logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
     <appender-ref ref="ACCESS"/>
   </logger>

--- a/dist/src/conf/logback.xml
+++ b/dist/src/conf/logback.xml
@@ -37,6 +37,7 @@
   <logger name="com.github.benmanes.caffeine.cache" level="ERROR" />
   <logger name="com.linecorp" level="INFO" />
   <logger name="com.linecorp.centraldogma" level="DEBUG" />
+  <logger name="com.linecorp.centraldogma.server.internal.mirror" level="INFO" />
   <logger name="com.linecorp.armeria.logging.access" level="INFO" additivity="false">
     <appender-ref ref="ACCESS"/>
   </logger>


### PR DESCRIPTION
Motivation:
We have upgraded cron-utils to 9.2.1 to address [CVE-2021-41269](https://github.com/advisories/GHSA-p9m8-27x8-rg87). The 9.2.1 version uses slf4j2 that must be used with logback 1.3 or 1.4. Because we use logback 1.2 version in Armeria, we need to exclude slf4j2: https://github.com/line/centraldogma/pull/872.
Just excluding slf4j should be okay because cron-utils isn't using any APIs that are introduced after slf4j 2.0: https://github.com/search?q=repo%3Ajmrozanec%2Fcron-utils+slf4j&type=code
However, there's no guarantee that cron-utils won't use the new APIs in the future. So, I think we should stop upgrading it until there's another CVE is found or Armeria uses higher version of Logback and Slf4j.\

While, I'm working on this I found out that cron-utils 9.2.0, which is one micro version eariler, uses Slf4j 1.x which is compatible with Armeria so it's better to use that version.

Modification:
- Downgrade cron-utils to 9.2.0

Result:
- Resovle dependency conflict for server module.