### PR TITLE
Record metrics when INIT revision or an old revision is used

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -22,5 +22,7 @@ if (tasks.findByName('trimShadedJar')) {
         keep "class com.linecorp.centraldogma.internal.shaded.caffeine.** { *; }"
         // Prevent ProGuard from removing all enum values from Option because otherwise it becomes a non-enum class.
         keep "class com.linecorp.centraldogma.internal.shaded.jsonpath.Option { *; }"
+
+        dontnote
     }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -23,6 +23,7 @@ if (tasks.findByName('trimShadedJar')) {
         // Prevent ProGuard from removing all enum values from Option because otherwise it becomes a non-enum class.
         keep "class com.linecorp.centraldogma.internal.shaded.jsonpath.Option { *; }"
 
+        // Reduces the verbosity of ProGuardTask when running in parallel.
         dontnote
     }
 }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -45,7 +45,7 @@ class MirroringTaskTest {
         Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
         mirror = spy(mirror);
         doNothing().when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        new MirroringTask(mirror, projectName, meterRegistry).run(null, null, 0, 0L);
+        new MirroringTask(mirror, "foo", meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
                                 "localRepo=bar,remoteBranch=,remotePath=/,success=true}", 1.0));
@@ -58,7 +58,7 @@ class MirroringTaskTest {
         mirror = spy(mirror);
         final RuntimeException e = new RuntimeException();
         doThrow(e).when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        final MirroringTask task = new MirroringTask(mirror, projectName, meterRegistry);
+        final MirroringTask task = new MirroringTask(mirror, "foo", meterRegistry);
         assertThatThrownBy(() -> task.run(null, null, 0, 0L))
                 .isSameAs(e);
         assertThat(MoreMeters.measureAll(meterRegistry))
@@ -76,7 +76,7 @@ class MirroringTaskTest {
             Thread.sleep(1000);
             return null;
         }).when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        new MirroringTask(mirror, projectName, meterRegistry).run(null, null, 0, 0L);
+        new MirroringTask(mirror, "foo", meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .hasEntrySatisfying(
                         "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -48,7 +48,7 @@ class MirroringTaskTest {
         new MirroringTask(mirror, "foo", meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
-                                "localRepo=bar,remoteBranch=,remotePath=/,success=true}", 1.0));
+                                "localRepo=bar,project=foo,remoteBranch=,remotePath=/,success=true}", 1.0));
     }
 
     @Test
@@ -63,7 +63,7 @@ class MirroringTaskTest {
                 .isSameAs(e);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
-                                "localRepo=bar,remoteBranch=main,remotePath=/," +
+                                "localRepo=bar,project=foo,remoteBranch=main,remotePath=/," +
                                 "success=false}", 1.0));
     }
 
@@ -80,7 +80,7 @@ class MirroringTaskTest {
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .hasEntrySatisfying(
                         "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +
-                        "localRepo=bar,remoteBranch=,remotePath=/}",
+                        "localRepo=bar,project=foo,remoteBranch=,remotePath=/}",
                         v -> assertThat(v).isCloseTo(1, withPercentage(30)));
     }
 }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -45,7 +45,7 @@ class MirroringTaskTest {
         Mirror mirror = newMirror("git://a.com/b.git", GitMirror.class, "foo", "bar");
         mirror = spy(mirror);
         doNothing().when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
+        new MirroringTask(mirror, projectName, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
                                 "localRepo=bar,remoteBranch=,remotePath=/,success=true}", 1.0));
@@ -58,7 +58,7 @@ class MirroringTaskTest {
         mirror = spy(mirror);
         final RuntimeException e = new RuntimeException();
         doThrow(e).when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        final MirroringTask task = new MirroringTask(mirror, meterRegistry);
+        final MirroringTask task = new MirroringTask(mirror, projectName, meterRegistry);
         assertThatThrownBy(() -> task.run(null, null, 0, 0L))
                 .isSameAs(e);
         assertThat(MoreMeters.measureAll(meterRegistry))
@@ -76,7 +76,7 @@ class MirroringTaskTest {
             Thread.sleep(1000);
             return null;
         }).when(mirror).mirror(any(), any(), anyInt(), anyLong());
-        new MirroringTask(mirror, meterRegistry).run(null, null, 0, 0L);
+        new MirroringTask(mirror, projectName, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .hasEntrySatisfying(
                         "mirroring.task#total{direction=LOCAL_TO_REMOTE,localPath=/," +

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -24,6 +24,7 @@ import static com.linecorp.centraldogma.internal.Util.isValidDirPath;
 import static com.linecorp.centraldogma.internal.Util.isValidFilePath;
 import static com.linecorp.centraldogma.server.internal.api.DtoConverter.convert;
 import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.returnOrThrow;
+import static com.linecorp.centraldogma.server.internal.api.RepositoryServiceV1.increaseCounterIfOldRevisionUsed;
 import static com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository.metaRepoFiles;
 import static java.util.Objects.requireNonNull;
 
@@ -114,11 +115,13 @@ public class ContentServiceV1 extends AbstractService {
      * <p>Returns the list of files in the path.
      */
     @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/list(?<path>(|/.*))$")
-    public CompletableFuture<List<EntryDto<?>>> listFiles(@Param String path,
+    public CompletableFuture<List<EntryDto<?>>> listFiles(ServiceRequestContext ctx,
+                                                          @Param String path,
                                                           @Param @Default("-1") String revision,
                                                           Repository repository) {
         final String normalizedPath = normalizePath(path);
         final Revision normalizedRev = repository.normalizeNow(new Revision(revision));
+        increaseCounterIfOldRevisionUsed(ctx, repository, normalizedRev);
         final CompletableFuture<List<EntryDto<?>>> future = new CompletableFuture<>();
         listFiles(repository, normalizedPath, normalizedRev, false, future);
         return future;
@@ -214,12 +217,14 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Post("/projects/{projectName}/repos/{repoName}/preview")
     public CompletableFuture<Iterable<ChangeDto<?>>> preview(
+            ServiceRequestContext ctx,
             @Param @Default("-1") String revision,
             Repository repository,
             @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
-
+        final Revision baseRevision = new Revision(revision);
+        increaseCounterIfOldRevisionUsed(ctx, repository, baseRevision);
         final CompletableFuture<Map<String, Change<?>>> changesFuture =
-                repository.previewDiff(new Revision(revision), changes);
+                repository.previewDiff(baseRevision, changes);
 
         return changesFuture.thenApply(previewDiffs -> previewDiffs.values().stream()
                                                                    .map(DtoConverter::convert)
@@ -245,6 +250,7 @@ public class ContentServiceV1 extends AbstractService {
             Repository repository,
             @RequestConverter(WatchRequestConverter.class) @Nullable WatchRequest watchRequest,
             @RequestConverter(QueryRequestConverter.class) @Nullable Query<?> query) {
+        increaseCounterIfOldRevisionUsed(ctx, repository, new Revision(revision));
         final String normalizedPath = normalizePath(path);
 
         // watch repository or a file
@@ -325,7 +331,8 @@ public class ContentServiceV1 extends AbstractService {
      * specify {@code to}, this will return the list of commits.
      */
     @Get("regex:/projects/(?<projectName>[^/]+)/repos/(?<repoName>[^/]+)/commits(?<revision>(|/.*))$")
-    public CompletableFuture<?> listCommits(@Param String revision,
+    public CompletableFuture<?> listCommits(ServiceRequestContext ctx,
+                                            @Param String revision,
                                             @Param @Default("/**") String path,
                                             @Param @Nullable String to,
                                             @Param @Nullable Integer maxCommits,
@@ -346,6 +353,10 @@ public class ContentServiceV1 extends AbstractService {
         }
 
         final RevisionRange range = repository.normalizeNow(fromRevision, toRevision).toDescending();
+
+        increaseCounterIfOldRevisionUsed(ctx, repository, range.from());
+        increaseCounterIfOldRevisionUsed(ctx, repository, range.to());
+
         final int maxCommits0 = firstNonNull(maxCommits, Repository.DEFAULT_MAX_COMMITS);
         return repository
                 .history(range.from(), range.to(), normalizePath(path), maxCommits0)
@@ -368,17 +379,21 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Get("/projects/{projectName}/repos/{repoName}/compare")
     public CompletableFuture<?> getDiff(
+            ServiceRequestContext ctx,
             @Param @Default("/**") String pathPattern,
             @Param @Default("1") String from, @Param @Default("head") String to,
             Repository repository,
             @RequestConverter(QueryRequestConverter.class) @Nullable Query<?> query) {
-
+        final Revision fromRevision = new Revision(from);
+        final Revision toRevision = new Revision(to);
+        increaseCounterIfOldRevisionUsed(ctx, repository, fromRevision);
+        increaseCounterIfOldRevisionUsed(ctx, repository, toRevision);
         if (query != null) {
-            return repository.diff(new Revision(from), new Revision(to), query)
+            return repository.diff(fromRevision, toRevision, query)
                              .thenApply(DtoConverter::convert);
         } else {
             return repository
-                    .diff(new Revision(from), new Revision(to), normalizePath(pathPattern))
+                    .diff(fromRevision, toRevision, normalizePath(pathPattern))
                     .thenApply(changeMap -> changeMap.values().stream()
                                                      .map(DtoConverter::convert).collect(toImmutableList()));
         }
@@ -402,9 +417,12 @@ public class ContentServiceV1 extends AbstractService {
      */
     @Get("/projects/{projectName}/repos/{repoName}/merge")
     public <T> CompletableFuture<MergedEntryDto<T>> mergeFiles(
+            ServiceRequestContext ctx,
             @Param @Default("-1") String revision, Repository repository,
             @RequestConverter(MergeQueryRequestConverter.class) MergeQuery<T> query) {
-        return repository.mergeFiles(new Revision(revision), query).thenApply(DtoConverter::convert);
+        final Revision rev = new Revision(revision);
+        increaseCounterIfOldRevisionUsed(ctx, repository, rev);
+        return repository.mergeFiles(rev, query).thenApply(DtoConverter::convert);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -213,13 +213,13 @@ public class RepositoryServiceV1 extends AbstractService {
         if (normalized.major() == 1) {
             ctx.log().whenComplete().thenAccept(
                     log -> ctx.meterRegistry()
-                              .counter("init.revisions", generateTags(projectName, repoName, log).build())
+                              .counter("revisions.init", generateTags(projectName, repoName, log).build())
                               .increment());
         }
         if (head.major() - normalized.major() >= 5000) {
             ctx.log().whenComplete().thenAccept(
                     log -> ctx.meterRegistry()
-                              .summary("old.revisions",
+                              .summary("revisions.old",
                                        generateTags(projectName, repoName, log)
                                                .add(Tag.of("init", Boolean.toString(normalized.major() == 1)))
                                                .build())

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringService.java
@@ -224,8 +224,7 @@ public final class DefaultMirroringService implements MirroringService {
     }
 
     private void run(Project project, Mirror m) {
-        final ListenableFuture<?> future =
-                worker.submit(() -> run(m, project.name(), true));
+        final ListenableFuture<?> future = worker.submit(() -> run(m, project.name(), true));
         Futures.addCallback(future, new FutureCallback<Object>() {
             @Override
             public void onSuccess(@Nullable Object result) {}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringService.java
@@ -22,6 +22,7 @@ import static java.util.Objects.requireNonNull;
 import java.io.File;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,7 +30,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
@@ -188,35 +188,25 @@ public final class DefaultMirroringService implements MirroringService {
         final ZonedDateTime currentLastExecutionTime = lastExecutionTime;
         lastExecutionTime = now;
 
-        projectManager.list().values().stream()
-                      .map(Project::metaRepo)
-                      .flatMap(r -> {
+        projectManager.list()
+                      .values()
+                      .forEach(project -> {
+                          final Set<Mirror> mirrors;
                           try {
-                              return r.mirrors().stream();
+                              mirrors = project.metaRepo().mirrors();
                           } catch (Exception e) {
-                              logger.warn("Failed to load the mirror list from: {}", r.parent().name(), e);
-                              return Stream.empty();
+                              logger.warn("Failed to load the mirror list from: {}", project.name(), e);
+                              return;
                           }
-                      })
-                      .filter(m -> {
-                          try {
-                              return m.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0;
-                          } catch (Exception e) {
-                              logger.warn("Failed to calculate the next execution time of: {}", m, e);
-                              return false;
-                          }
-                      })
-                      .forEach(m -> {
-                          final ListenableFuture<?> future = worker.submit(() -> run(m, true));
-                          Futures.addCallback(future, new FutureCallback<Object>() {
-                              @Override
-                              public void onSuccess(@Nullable Object result) {}
-
-                              @Override
-                              public void onFailure(Throwable cause) {
-                                  logger.warn("Unexpected Git mirroring failure: {}", m, cause);
+                          mirrors.forEach(m -> {
+                              try {
+                                  if (m.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0) {
+                                      run(project, m);
+                                  }
+                              } catch (Exception e) {
+                                  logger.warn("Unexpected exception while mirroring: {}", m, e);
                               }
-                          }, MoreExecutors.directExecutor());
+                          });
                       });
     }
 
@@ -229,14 +219,28 @@ public final class DefaultMirroringService implements MirroringService {
         return CompletableFuture.runAsync(
                 () -> projectManager.list().values()
                                     .forEach(p -> p.metaRepo().mirrors()
-                                                   .forEach(m -> run(m, false))),
+                                                   .forEach(m -> run(m, p.name(), false))),
                 worker);
     }
 
-    private void run(Mirror m, boolean logOnFailure) {
+    private void run(Project project, Mirror m) {
+        final ListenableFuture<?> future =
+                worker.submit(() -> run(m, project.name(), true));
+        Futures.addCallback(future, new FutureCallback<Object>() {
+            @Override
+            public void onSuccess(@Nullable Object result) {}
+
+            @Override
+            public void onFailure(Throwable cause) {
+                logger.warn("Unexpected Git mirroring failure: {}", m, cause);
+            }
+        }, MoreExecutors.directExecutor());
+    }
+
+    private void run(Mirror m, String projectName, boolean logOnFailure) {
         logger.info("Mirroring: {}", m);
         try {
-            new MirroringTask(m, meterRegistry)
+            new MirroringTask(m, projectName, meterRegistry)
                     .run(workDir, commandExecutor, maxNumFilesPerMirror, maxNumBytesPerMirror);
         } catch (Exception e) {
             if (logOnFailure) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
@@ -31,8 +31,9 @@ import io.micrometer.core.instrument.Tag;
 
 final class MirroringTask {
 
-    private static Iterable<Tag> generateTags(Mirror mirror) {
+    private static Iterable<Tag> generateTags(Mirror mirror, String projectName) {
         return ImmutableList.of(
+                Tag.of("project", projectName),
                 Tag.of("direction", mirror.direction().name()),
                 Tag.of("remoteBranch", firstNonNull(mirror.remoteBranch(), "")),
                 Tag.of("remotePath", mirror.remotePath()),
@@ -44,10 +45,10 @@ final class MirroringTask {
     private final Mirror mirror;
     private final Iterable<Tag> tags;
 
-    MirroringTask(Mirror mirror, MeterRegistry meterRegistry) {
+    MirroringTask(Mirror mirror, String projectName, MeterRegistry meterRegistry) {
         this.mirror = mirror;
         this.meterRegistry = meterRegistry;
-        tags = generateTags(mirror);
+        tags = generateTags(mirror, projectName);
     }
 
     private Counter counter(boolean success) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -359,6 +359,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void mergeFiles(String projectName, String repositoryName, Revision revision,
                            MergeQuery mergeQuery, AsyncMethodCallback resultHandler) {
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, revision);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .mergeFiles(convert(revision), convert(mergeQuery))
                              .thenApply(merged -> new MergedEntry(convert(merged.revision()),

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -232,8 +232,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
         final com.linecorp.centraldogma.common.Revision normalized =
                 repository.normalizeNow(convert(revision));
         final com.linecorp.centraldogma.common.Revision head = repository.normalizeNow(HEAD);
-        increaseCounterIfOldRevisionUsed(RequestContext.current(), projectName, repositoryName,
-                                         normalized, head);
+        increaseCounterIfOldRevisionUsed(RequestContext.current(), repository, normalized, head);
         return normalized;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -17,7 +17,9 @@ package com.linecorp.centraldogma.server.internal.thrift;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.centraldogma.common.Author.SYSTEM;
+import static com.linecorp.centraldogma.common.Revision.HEAD;
 import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkPush;
+import static com.linecorp.centraldogma.server.internal.api.RepositoryServiceV1.increaseCounterIfOldRevisionUsed;
 import static com.linecorp.centraldogma.server.internal.thrift.Converter.convert;
 import static com.linecorp.centraldogma.server.storage.project.Project.isReservedRepoName;
 import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FIND_ALL_WITHOUT_CONTENT;
@@ -36,6 +38,7 @@ import org.apache.thrift.async.AsyncMethodCallback;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.RequestContext;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.internal.thrift.Author;
 import com.linecorp.centraldogma.internal.thrift.CentralDogmaConstants;
@@ -218,15 +221,27 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
                                   AsyncMethodCallback resultHandler) {
 
         final com.linecorp.centraldogma.common.Revision normalized =
-                projectManager.get(projectName).repos().get(repositoryName)
-                              .normalizeNow(convert(revision));
+                normalizeRevision(projectName, repositoryName, revision);
+
         resultHandler.onComplete(convert(normalized));
+    }
+
+    private com.linecorp.centraldogma.common.Revision normalizeRevision(
+            String projectName, String repositoryName, Revision revision) {
+        final Repository repository = projectManager.get(projectName).repos().get(repositoryName);
+        final com.linecorp.centraldogma.common.Revision normalized =
+                repository.normalizeNow(convert(revision));
+        final com.linecorp.centraldogma.common.Revision head = repository.normalizeNow(HEAD);
+        increaseCounterIfOldRevisionUsed(RequestContext.current(), projectName, repositoryName,
+                                         normalized, head);
+        return normalized;
     }
 
     @Override
     public void listFiles(String projectName, String repositoryName, Revision revision, String pathPattern,
                           AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, revision);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .find(convert(revision), pathPattern, FIND_ALL_WITHOUT_CONTENT)
                              .thenApply(entries -> {
@@ -241,7 +256,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void getFiles(String projectName, String repositoryName, Revision revision, String pathPattern,
                          AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, revision);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .find(convert(revision), pathPattern)
                              .thenApply(entries -> {
@@ -257,7 +273,9 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void getHistory(String projectName, String repositoryName, Revision from, Revision to,
                            String pathPattern, AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, from);
+        normalizeRevision(projectName, repositoryName, to);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .history(convert(from), convert(to), pathPattern)
                              .thenApply(commits -> commits.stream()
@@ -269,7 +287,9 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void getDiffs(String projectName, String repositoryName, Revision from, Revision to,
                          String pathPattern, AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, from);
+        normalizeRevision(projectName, repositoryName, to);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .diff(convert(from), convert(to), pathPattern)
                              .thenApply(diffs -> convert(diffs.values(), Converter::convert)),
@@ -279,7 +299,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void getPreviewDiffs(String projectName, String repositoryName, Revision baseRevision,
                                 List<Change> changes, AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, baseRevision);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .previewDiff(convert(baseRevision), convert(changes, Converter::convert))
                              .thenApply(diffs -> convert(diffs.values(), Converter::convert)),
@@ -313,7 +334,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void getFile(String projectName, String repositoryName, Revision revision, Query query,
                         AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, revision);
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .get(convert(revision), convert(query))
                              .thenApply(res -> new GetFileResult(convert(res.type()), res.contentAsText())),
@@ -323,7 +345,9 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     @Override
     public void diffFile(String projectName, String repositoryName, Revision from, Revision to, Query query,
                          AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, from);
+        normalizeRevision(projectName, repositoryName, to);
         // FIXME(trustin): Remove the firstNonNull() on the change content once we make it optional.
         handle(projectManager.get(projectName).repos().get(repositoryName)
                              .diff(convert(from), convert(to), convert(query))
@@ -348,7 +372,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     public void watchRepository(
             String projectName, String repositoryName, Revision lastKnownRevision,
             String pathPattern, long timeoutMillis, AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, lastKnownRevision);
         if (timeoutMillis <= 0) {
             rejectInvalidWatchTimeout("watchRepository", resultHandler);
             return;
@@ -384,7 +409,8 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
     public void watchFile(
             String projectName, String repositoryName, Revision lastKnownRevision,
             Query query, long timeoutMillis, AsyncMethodCallback resultHandler) {
-
+        // Call normalizeRevision() first to check if the specified revision needs to be recorded.
+        normalizeRevision(projectName, repositoryName, lastKnownRevision);
         if (timeoutMillis <= 0) {
             rejectInvalidWatchTimeout("watchFile", resultHandler);
             return;

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -20,12 +20,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.WatchRequest;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -55,7 +59,7 @@ class MetricsTest {
         assertThat(((CompositeMeterRegistry) meterRegistry).getRegistries())
                 .hasAtLeastOneElementOfType(PrometheusMeterRegistry.class);
 
-        AggregatedHttpResponse res = dogma.httpClient().get("/monitor/metrics").aggregate().join();
+        final AggregatedHttpResponse res = dogma.httpClient().get("/monitor/metrics").aggregate().join();
         String content = res.contentUtf8();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentType()).isEqualTo(MediaType.parse(TextFormat.CONTENT_TYPE_004));
@@ -63,15 +67,19 @@ class MetricsTest {
         assertThat(content).doesNotContain(
                 "com.linecorp.centraldogma.server.internal.api.WatchContentServiceV1");
 
-        dogma.client()
-             .forRepo("foo", "bar")
-             .watch(Query.ofJson("/foo.json"))
-             .timeoutMillis(100)
-             .errorOnEntryNotFound(false)
-             .start()
-             .join();
-        res = dogma.httpClient().get("/monitor/metrics").aggregate().join();
-        content = res.contentUtf8();
+        final WatchRequest<JsonNode> jsonNodeWatchRequest = dogma.client()
+                                                                 .forRepo("foo", "bar")
+                                                                 .watch(Query.ofJson("/foo.json"))
+                                                                 .timeoutMillis(100)
+                                                                 .errorOnEntryNotFound(false);
+        jsonNodeWatchRequest.start().join();
+        content = dogma.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
         assertThat(content).contains("com.linecorp.centraldogma.server.internal.api.WatchContentServiceV1");
+        assertThat(content).doesNotContain("dogma_old_revision");
+
+        // Trigger old revision recording
+        jsonNodeWatchRequest.start(Revision.INIT).join();
+        content = dogma.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
+        assertThat(content).contains("dogma_old_revision");
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/MetricsTest.java
@@ -75,11 +75,11 @@ class MetricsTest {
         jsonNodeWatchRequest.start().join();
         content = dogma.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
         assertThat(content).contains("com.linecorp.centraldogma.server.internal.api.WatchContentServiceV1");
-        assertThat(content).doesNotContain("dogma_old_revision");
+        assertThat(content).doesNotContain("init_revisions");
 
         // Trigger old revision recording
         jsonNodeWatchRequest.start(Revision.INIT).join();
         content = dogma.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
-        assertThat(content).contains("dogma_old_revision");
+        assertThat(content).contains("init_revisions");
     }
 }


### PR DESCRIPTION
Motivation:
Before we apply https://github.com/line/centraldogma/pull/681 that removes old commits, it would be nice if we could find any usages that access data with the INIT Revision or revisions that are more than 5000 (default minimum number of commit retentions) commits ahead from the head.

Modifications:
- Add a counter that is increased when INIT Revision or revisions that are more than 5000 ahead from the head are used.

Result:
- Track the number of usages.
- This commit will be reverted after we find the usage and fix it.