### PR TITLE
Fix Bouncy Castle version conflict in SAML module

### DIFF
--- a/server-auth/saml/build.gradle
+++ b/server-auth/saml/build.gradle
@@ -1,4 +1,8 @@
 dependencies {
     implementation project(':server')
-    implementation libs.armeria.saml
+    implementation(libs.armeria.saml) {
+        exclude group: 'org.bouncycastle'
+    }
+
+    implementation libs.bouncycastle.bcprov
 }

--- a/server-auth/saml/build.gradle
+++ b/server-auth/saml/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     implementation project(':server')
     implementation(libs.armeria.saml) {
-        exclude group: 'org.bouncycastle'
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
     }
 
     implementation libs.bouncycastle.bcprov


### PR DESCRIPTION
Motivation:
- Armeria saml uses Bouncy Castle jdk15on which conflicts with the version jdk18on that CD uses

Modification:
- Exclude Bouncy Castle jdk15on from SAML module

Result:
- Fixed version conflict