### PR TITLE
Reuse BouncyCastleRandom

### DIFF
--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -38,6 +38,7 @@ import org.apache.sshd.client.ClientBuilder;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.config.hosts.HostConfigEntryResolver;
 import org.apache.sshd.client.session.ClientSession;
+import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.common.config.keys.loader.KeyPairResourceParser;
@@ -45,7 +46,9 @@ import org.apache.sshd.common.config.keys.loader.openssh.OpenSSHKeyPairResourceP
 import org.apache.sshd.common.config.keys.loader.pem.PKCS8PEMResourceKeyPairParser;
 import org.apache.sshd.common.file.nonefs.NoneFileSystemFactory;
 import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
+import org.apache.sshd.common.random.Random;
 import org.apache.sshd.common.util.security.SecurityUtils;
+import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleRandom;
 import org.apache.sshd.git.transport.GitSshdSession;
 import org.apache.sshd.git.transport.GitSshdSessionFactory;
 import org.eclipse.jgit.api.FetchCommand;
@@ -87,6 +90,14 @@ final class GitWithAuth extends Git {
             SecurityUtils.getBouncycastleKeyPairResourceParser(),
             PKCS8PEMResourceKeyPairParser.INSTANCE,
             OpenSSHKeyPairResourceParser.INSTANCE);
+
+    // Creates BouncyCastleRandom once and reuses it.
+    // Otherwise, BouncyCastleRandom is created whenever the SSH client is created that leads to
+    // blocking the thread to get enough entropy for SecureRandom.
+    // We might create multiple BouncyCastleRandom later and poll them, if necessary.
+    private static final BouncyCastleRandom bounceCastleRandom = new BouncyCastleRandom();
+
+    private static final Factory<Random> randomFactory = () -> bounceCastleRandom;
 
     /**
      * One of the Locks in this array is locked while a Git repository is accessed so that other GitMirrors
@@ -285,6 +296,7 @@ final class GitWithAuth extends Git {
                         builder.fileSystemFactory(NoneFileSystemFactory.INSTANCE);
                         // Do not verify the server key.
                         builder.serverKeyVerifier((clientSession, remoteAddress, serverKey) -> true);
+                        builder.randomFactory(randomFactory);
                         final SshClient client = builder.build();
                         onClientCreated(client);
                         return client;

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitWithAuth.java
@@ -38,7 +38,6 @@ import org.apache.sshd.client.ClientBuilder;
 import org.apache.sshd.client.SshClient;
 import org.apache.sshd.client.config.hosts.HostConfigEntryResolver;
 import org.apache.sshd.client.session.ClientSession;
-import org.apache.sshd.common.Factory;
 import org.apache.sshd.common.NamedResource;
 import org.apache.sshd.common.config.keys.FilePasswordProvider;
 import org.apache.sshd.common.config.keys.loader.KeyPairResourceParser;
@@ -46,7 +45,6 @@ import org.apache.sshd.common.config.keys.loader.openssh.OpenSSHKeyPairResourceP
 import org.apache.sshd.common.config.keys.loader.pem.PKCS8PEMResourceKeyPairParser;
 import org.apache.sshd.common.file.nonefs.NoneFileSystemFactory;
 import org.apache.sshd.common.keyprovider.KeyIdentityProvider;
-import org.apache.sshd.common.random.Random;
 import org.apache.sshd.common.util.security.SecurityUtils;
 import org.apache.sshd.common.util.security.bouncycastle.BouncyCastleRandom;
 import org.apache.sshd.git.transport.GitSshdSession;
@@ -96,8 +94,6 @@ final class GitWithAuth extends Git {
     // blocking the thread to get enough entropy for SecureRandom.
     // We might create multiple BouncyCastleRandom later and poll them, if necessary.
     private static final BouncyCastleRandom bounceCastleRandom = new BouncyCastleRandom();
-
-    private static final Factory<Random> randomFactory = () -> bounceCastleRandom;
 
     /**
      * One of the Locks in this array is locked while a Git repository is accessed so that other GitMirrors
@@ -296,7 +292,7 @@ final class GitWithAuth extends Git {
                         builder.fileSystemFactory(NoneFileSystemFactory.INSTANCE);
                         // Do not verify the server key.
                         builder.serverKeyVerifier((clientSession, remoteAddress, serverKey) -> true);
-                        builder.randomFactory(randomFactory);
+                        builder.randomFactory(() -> bounceCastleRandom);
                         final SshClient client = builder.build();
                         onClientCreated(client);
                         return client;


### PR DESCRIPTION
Motivation:
`BouncyCastleRandom`, which creates a `SecureRandom` inside, was created whenever an SSH client is created. That blocked the thread because the instance lacks entropy for getting the seed. Instead, we could create a BouncyCastleRandome once and reuse it.

Modifications:
- Create BouncyCastleRandom once and reuse it

Result:
- Mirroring doesn't take longer anymore due to an SSH client creation.