### PR TITLE
Try to configure authentication for command from `GitWithAuth`

### DIFF
--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
@@ -37,9 +37,6 @@ import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.jgit.api.FetchCommand;
-import org.eclipse.jgit.api.LsRemoteCommand;
-import org.eclipse.jgit.api.PushCommand;
 import org.eclipse.jgit.api.RemoteSetUrlCommand;
 import org.eclipse.jgit.api.RemoteSetUrlCommand.UriType;
 import org.eclipse.jgit.api.TransportCommand;
@@ -225,11 +222,11 @@ abstract class AbstractGitMirror extends AbstractMirror {
             updateRef(gitRepository, revWalk, headBranchRefName, nextCommitId);
         }
 
-        final PushCommand push = git.push();
-        push.setRefSpecs(new RefSpec(headBranchRefName))
-            .setAtomic(true)
-            .setTimeout(GIT_TIMEOUT_SECS)
-            .call();
+        git.push()
+           .setRefSpecs(new RefSpec(headBranchRefName))
+           .setAtomic(true)
+           .setTimeout(GIT_TIMEOUT_SECS)
+           .call();
     }
 
     void mirrorRemoteToLocal(
@@ -393,11 +390,11 @@ abstract class AbstractGitMirror extends AbstractMirror {
 
     private static Collection<Ref> lsRemote(GitWithAuth git,
                                            boolean setHeads) throws GitAPIException {
-        final LsRemoteCommand lsRemoteCommand = git.lsRemote();
-        return lsRemoteCommand.setTags(false)
-                              .setTimeout(GIT_TIMEOUT_SECS)
-                              .setHeads(setHeads)
-                              .call();
+        return git.lsRemote()
+                  .setTags(false)
+                  .setTimeout(GIT_TIMEOUT_SECS)
+                  .setHeads(setHeads)
+                  .call();
     }
 
     private static Ref findHeadBranchRef(GitWithAuth git, String headBranchRefName, Collection<Ref> refs) {
@@ -456,12 +453,13 @@ abstract class AbstractGitMirror extends AbstractMirror {
 
     private static ObjectId fetchRemoteHeadAndGetCommitId(
             GitWithAuth git, String headBranchRefName) throws GitAPIException, IOException {
-        final FetchCommand fetch = git.fetch().setDepth(1);
-        final FetchResult fetchResult = fetch.setRefSpecs(new RefSpec(headBranchRefName))
-                                             .setRemoveDeletedRefs(true)
-                                             .setTagOpt(TagOpt.NO_TAGS)
-                                             .setTimeout(GIT_TIMEOUT_SECS)
-                                             .call();
+        final FetchResult fetchResult = git.fetch()
+                                           .setDepth(1)
+                                           .setRefSpecs(new RefSpec(headBranchRefName))
+                                           .setRemoveDeletedRefs(true)
+                                           .setTagOpt(TagOpt.NO_TAGS)
+                                           .setTimeout(GIT_TIMEOUT_SECS)
+                                           .call();
         final ObjectId commitId = fetchResult.getAdvertisedRef(headBranchRefName).getObjectId();
         final RefUpdate refUpdate = git.getRepository().updateRef(headBranchRefName);
         refUpdate.setNewObjectId(commitId);

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -136,21 +135,21 @@ abstract class AbstractGitMirror extends AbstractMirror {
         }
     }
 
-    GitWithAuth openGit(File workDir, String jGitUri,
-                        URIish remoteUri) throws IOException, URISyntaxException, GitAPIException {
+    GitWithAuth openGit(File workDir,
+                        URIish remoteUri,
+                        Consumer<TransportCommand<?, ?>> configurator) throws IOException, GitAPIException {
         // Now create and open the repository.
         final File repoDir = new File(
                 workDir,
                 CONSECUTIVE_UNDERSCORES.matcher(DISALLOWED_CHARS.matcher(
                         remoteRepoUri().toASCIIString()).replaceAll("_")).replaceAll("_"));
-        final GitWithAuth git = new GitWithAuth(this, repoDir, remoteUri);
+        final GitWithAuth git = new GitWithAuth(this, repoDir, remoteUri, configurator);
         boolean success = false;
         try {
             // Set the remote URLs.
-            final URIish uri = new URIish(jGitUri);
             final RemoteSetUrlCommand remoteSetUrl = git.remoteSetUrl();
             remoteSetUrl.setRemoteName(Constants.DEFAULT_REMOTE_NAME);
-            remoteSetUrl.setRemoteUri(uri);
+            remoteSetUrl.setRemoteUri(remoteUri);
 
             remoteSetUrl.setUriType(UriType.FETCH);
             remoteSetUrl.call();
@@ -174,12 +173,11 @@ abstract class AbstractGitMirror extends AbstractMirror {
     }
 
     void mirrorLocalToRemote(
-            GitWithAuth git, int maxNumFiles, long maxNumBytes,
-            Consumer<TransportCommand<?, ?>> configurator) throws GitAPIException, IOException {
+            GitWithAuth git, int maxNumFiles, long maxNumBytes) throws GitAPIException, IOException {
         // TODO(minwoox): Early return if the remote does not have any updates.
-        final Ref headBranchRef = getHeadBranchRef(git, configurator);
+        final Ref headBranchRef = getHeadBranchRef(git);
         final String headBranchRefName = headBranchRef.getName();
-        final ObjectId headCommitId = fetchRemoteHeadAndGetCommitId(git, headBranchRefName, configurator);
+        final ObjectId headCommitId = fetchRemoteHeadAndGetCommitId(git, headBranchRefName);
 
         final org.eclipse.jgit.lib.Repository gitRepository = git.getRepository();
         try (ObjectReader reader = gitRepository.newObjectReader();
@@ -228,7 +226,6 @@ abstract class AbstractGitMirror extends AbstractMirror {
         }
 
         final PushCommand push = git.push();
-        configurator.accept(push);
         push.setRefSpecs(new RefSpec(headBranchRefName))
             .setAtomic(true)
             .setTimeout(GIT_TIMEOUT_SECS)
@@ -236,12 +233,11 @@ abstract class AbstractGitMirror extends AbstractMirror {
     }
 
     void mirrorRemoteToLocal(
-            GitWithAuth git, CommandExecutor executor, int maxNumFiles, long maxNumBytes,
-            Consumer<TransportCommand<?,?>> configurator) throws Exception {
+            GitWithAuth git, CommandExecutor executor, int maxNumFiles, long maxNumBytes) throws Exception {
         final String summary;
         final String detail;
         final Map<String, Change<?>> changes = new HashMap<>();
-        final Ref headBranchRef = getHeadBranchRef(git, configurator);
+        final Ref headBranchRef = getHeadBranchRef(git);
 
         final String mirrorStatePath = localPath() + MIRROR_STATE_FILE_NAME;
         final Revision localRev = localRepo().normalizeNow(Revision.HEAD);
@@ -251,7 +247,7 @@ abstract class AbstractGitMirror extends AbstractMirror {
 
         // Update the head commit ID again because there's a chance a commit is pushed between the
         // getHeadBranchRefName and fetchRemoteHeadAndGetCommitId calls.
-        final ObjectId headCommitId = fetchRemoteHeadAndGetCommitId(git, headBranchRef.getName(), configurator);
+        final ObjectId headCommitId = fetchRemoteHeadAndGetCommitId(git, headBranchRef.getName());
         try (ObjectReader reader = git.getRepository().newObjectReader();
              TreeWalk treeWalk = new TreeWalk(reader);
              RevWalk revWalk = new RevWalk(reader)) {
@@ -369,17 +365,16 @@ abstract class AbstractGitMirror extends AbstractMirror {
         return true;
     }
 
-    private Ref getHeadBranchRef(
-            GitWithAuth git, Consumer<TransportCommand<?,?>> configurator) throws GitAPIException {
+    private Ref getHeadBranchRef(GitWithAuth git) throws GitAPIException {
         if (remoteBranch() != null) {
             final String headBranchRefName = Constants.R_HEADS + remoteBranch();
-            final Collection<Ref> refs = lsRemote(git, configurator, true);
+            final Collection<Ref> refs = lsRemote(git, true);
             return findHeadBranchRef(git, headBranchRefName, refs);
         }
 
         // Otherwise, we need to figure out which branch we should fetch.
         // Fetch the remote reference list to determine the default branch.
-        final Collection<Ref> refs = lsRemote(git, configurator, false);
+        final Collection<Ref> refs = lsRemote(git, false);
 
         // Find and resolve 'HEAD' reference, which leads us to the default branch.
         final Optional<String> headRefNameOptional = refs.stream()
@@ -396,10 +391,9 @@ abstract class AbstractGitMirror extends AbstractMirror {
         return findHeadBranchRef(git, headBranchRefName, refs);
     }
 
-    private static Collection<Ref> lsRemote(GitWithAuth git, Consumer<TransportCommand<?, ?>> configurator,
+    private static Collection<Ref> lsRemote(GitWithAuth git,
                                            boolean setHeads) throws GitAPIException {
         final LsRemoteCommand lsRemoteCommand = git.lsRemote();
-        configurator.accept(lsRemoteCommand);
         return lsRemoteCommand.setTags(false)
                               .setTimeout(GIT_TIMEOUT_SECS)
                               .setHeads(setHeads)
@@ -461,10 +455,8 @@ abstract class AbstractGitMirror extends AbstractMirror {
     }
 
     private static ObjectId fetchRemoteHeadAndGetCommitId(
-            GitWithAuth git, String headBranchRefName,
-            Consumer<TransportCommand<?,?>> configurator) throws GitAPIException, IOException {
+            GitWithAuth git, String headBranchRefName) throws GitAPIException, IOException {
         final FetchCommand fetch = git.fetch().setDepth(1);
-        configurator.accept(fetch);
         final FetchResult fetchResult = fetch.setRefSpecs(new RefSpec(headBranchRefName))
                                              .setRemoveDeletedRefs(true)
                                              .setTagOpt(TagOpt.NO_TAGS)

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultGitMirror.java
@@ -52,8 +52,8 @@ final class DefaultGitMirror extends AbstractGitMirror {
 
     @Override
     protected void mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes) throws Exception {
-        try (GitWithAuth git = openGit(workDir)) {
-            mirrorLocalToRemote(git, maxNumFiles, maxNumBytes, transportCommandConfigurator());
+        try (GitWithAuth git = openGit(workDir, transportCommandConfigurator())) {
+            mirrorLocalToRemote(git, maxNumFiles, maxNumBytes);
         }
     }
 
@@ -80,12 +80,12 @@ final class DefaultGitMirror extends AbstractGitMirror {
     @Override
     protected void mirrorRemoteToLocal(File workDir, CommandExecutor executor,
                                        int maxNumFiles, long maxNumBytes) throws Exception {
-        try (GitWithAuth git = openGit(workDir)) {
-            mirrorRemoteToLocal(git, executor, maxNumFiles, maxNumBytes, transportCommandConfigurator());
+        try (GitWithAuth git = openGit(workDir, transportCommandConfigurator())) {
+            mirrorRemoteToLocal(git, executor, maxNumFiles, maxNumBytes);
         }
     }
 
-    private GitWithAuth openGit(File workDir) throws Exception {
+    private GitWithAuth openGit(File workDir, Consumer<TransportCommand<?, ?>> configurator) throws Exception {
         final String scheme = remoteRepoUri().getScheme();
         final String jGitUri;
         if (scheme.startsWith("git+")) {
@@ -94,6 +94,6 @@ final class DefaultGitMirror extends AbstractGitMirror {
         } else {
             jGitUri = remoteRepoUri().toASCIIString();
         }
-        return openGit(workDir, jGitUri, new URIish(jGitUri));
+        return openGit(workDir, new URIish(jGitUri), configurator);
     }
 }

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
@@ -88,18 +88,13 @@ final class SshGitMirror extends AbstractGitMirror {
 
     @Override
     protected void mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes) throws Exception {
-        final SshClient sshClient = createSshClient();
         final URIish remoteUri = remoteUri();
-        final ClientSession session = createSession(sshClient, remoteUri);
-        final DefaultGitSshdSessionFactory sessionFactory =
-                new DefaultGitSshdSessionFactory(sshClient, session);
-        try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
-            mirrorLocalToRemote(git, maxNumFiles, maxNumBytes);
-        } finally {
-            try {
-                session.close(true);
-            } finally {
-                sshClient.stop();
+        try (SshClient sshClient = createSshClient();
+             ClientSession session = createSession(sshClient, remoteUri)) {
+            final DefaultGitSshdSessionFactory sessionFactory =
+                    new DefaultGitSshdSessionFactory(sshClient, session);
+            try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
+                mirrorLocalToRemote(git, maxNumFiles, maxNumBytes);
             }
         }
     }
@@ -107,18 +102,13 @@ final class SshGitMirror extends AbstractGitMirror {
     @Override
     protected void mirrorRemoteToLocal(File workDir, CommandExecutor executor,
                                        int maxNumFiles, long maxNumBytes) throws Exception {
-        final SshClient sshClient = createSshClient();
         final URIish remoteUri = remoteUri();
-        final ClientSession session = createSession(sshClient, remoteUri);
-        final DefaultGitSshdSessionFactory sessionFactory =
-                new DefaultGitSshdSessionFactory(sshClient, session);
-        try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
-            mirrorRemoteToLocal(git, executor, maxNumFiles, maxNumBytes);
-        } finally {
-            try {
-                session.close(true);
-            } finally {
-                sshClient.stop();
+        try (SshClient sshClient = createSshClient();
+             ClientSession session = createSession(sshClient, remoteUri)) {
+            final DefaultGitSshdSessionFactory sessionFactory =
+                    new DefaultGitSshdSessionFactory(sshClient, session);
+            try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
+                mirrorRemoteToLocal(git, executor, maxNumFiles, maxNumBytes);
             }
         }
     }

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
@@ -89,12 +89,25 @@ final class SshGitMirror extends AbstractGitMirror {
     @Override
     protected void mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes) throws Exception {
         final URIish remoteUri = remoteUri();
-        try (SshClient sshClient = createSshClient();
-             ClientSession session = createSession(sshClient, remoteUri)) {
+        SshClient sshClient = null;
+        ClientSession session = null;
+        try {
+            sshClient = createSshClient();
+            session = createSession(sshClient, remoteUri);
             final DefaultGitSshdSessionFactory sessionFactory =
                     new DefaultGitSshdSessionFactory(sshClient, session);
             try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
                 mirrorLocalToRemote(git, maxNumFiles, maxNumBytes);
+            }
+        } finally {
+            try {
+                if (session != null) {
+                    session.close(true);
+                }
+            } finally {
+                if (sshClient != null) {
+                    sshClient.stop();
+                }
             }
         }
     }
@@ -103,12 +116,25 @@ final class SshGitMirror extends AbstractGitMirror {
     protected void mirrorRemoteToLocal(File workDir, CommandExecutor executor,
                                        int maxNumFiles, long maxNumBytes) throws Exception {
         final URIish remoteUri = remoteUri();
-        try (SshClient sshClient = createSshClient();
-             ClientSession session = createSession(sshClient, remoteUri)) {
+        SshClient sshClient = null;
+        ClientSession session = null;
+        try {
+            sshClient = createSshClient();
+            session = createSession(sshClient, remoteUri);
             final DefaultGitSshdSessionFactory sessionFactory =
                     new DefaultGitSshdSessionFactory(sshClient, session);
             try (GitWithAuth git = openGit(workDir, remoteUri, sessionFactory::configureCommand)) {
                 mirrorRemoteToLocal(git, executor, maxNumFiles, maxNumBytes);
+            }
+        } finally {
+            try {
+                if (session != null) {
+                    session.close(true);
+                }
+            } finally {
+                if (sshClient != null) {
+                    sshClient.stop();
+                }
             }
         }
     }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorTest.java
@@ -29,11 +29,31 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
+import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 class GitMirrorTest {
+
+    class SimpleClass implements SafeCloseable {
+
+        SimpleClass() {
+            throw new RuntimeException();
+        }
+
+        @Override
+        public void close() {
+            System.out.println("close");
+        }
+    }
+
+    @Test
+    void asdf() {
+        try (SimpleClass sc = new SimpleClass()) {
+            System.out.println("Hello");
+        }
+    }
 
     @Test
     void testGitMirror() {

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorTest.java
@@ -29,31 +29,11 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 class GitMirrorTest {
-
-    class SimpleClass implements SafeCloseable {
-
-        SimpleClass() {
-            throw new RuntimeException();
-        }
-
-        @Override
-        public void close() {
-            System.out.println("close");
-        }
-    }
-
-    @Test
-    void asdf() {
-        try (SimpleClass sc = new SimpleClass()) {
-            System.out.println("Hello");
-        }
-    }
 
     @Test
     void testGitMirror() {


### PR DESCRIPTION
**Motivation**

- Goes well with the name `GitWithAuth` which implies that authentication is done from the object implicitly
- We don't have to pass a `Consumer` around for each location where we want to execute a git command