### PR TITLE
Provide ConfigValueConverter to hide secret properties in Central Dog…

### DIFF
--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
@@ -16,6 +16,7 @@
 package com.linecorp.centraldogma.server.auth.saml;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
@@ -210,7 +211,7 @@ final class SamlAuthProperties {
                  @JsonProperty("signatureAlgorithm") @Nullable String signatureAlgorithm) {
             this.type = firstNonNull(type, java.security.KeyStore.getDefaultType());
             this.path = requireNonNull(path, "path");
-            this.password = password;
+            this.password = convertValue(password, "keyStore.password");
             this.keyPasswords = sanitizePasswords(keyPasswords);
             this.signatureAlgorithm = firstNonNull(signatureAlgorithm, DEFAULT_SIGNATURE_ALGORITHM);
         }
@@ -220,7 +221,8 @@ final class SamlAuthProperties {
                 return ImmutableMap.of();
             }
             final ImmutableMap.Builder<String, String> builder = new Builder<>();
-            keyPasswords.forEach((key, password) -> builder.put(key, firstNonNull(password, "")));
+            keyPasswords.forEach((key, password) -> builder.put(key, firstNonNull(
+                    convertValue(password, "keyStore.keyPasswords"), "")));
             return builder.build();
         }
 

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
@@ -193,6 +193,7 @@ final class SamlAuthProperties {
         /**
          * A map of the key name and its password.
          */
+        @Nullable
         private final Map<String, String> keyPasswords;
 
         /**
@@ -211,19 +212,9 @@ final class SamlAuthProperties {
                  @JsonProperty("signatureAlgorithm") @Nullable String signatureAlgorithm) {
             this.type = firstNonNull(type, java.security.KeyStore.getDefaultType());
             this.path = requireNonNull(path, "path");
-            this.password = convertValue(password, "keyStore.password");
-            this.keyPasswords = sanitizePasswords(keyPasswords);
+            this.password = password;
+            this.keyPasswords = keyPasswords;
             this.signatureAlgorithm = firstNonNull(signatureAlgorithm, DEFAULT_SIGNATURE_ALGORITHM);
-        }
-
-        private static Map<String, String> sanitizePasswords(@Nullable Map<String, String> keyPasswords) {
-            if (keyPasswords == null) {
-                return ImmutableMap.of();
-            }
-            final ImmutableMap.Builder<String, String> builder = new Builder<>();
-            keyPasswords.forEach((key, password) -> builder.put(key, firstNonNull(
-                    convertValue(password, "keyStore.keyPasswords"), "")));
-            return builder.build();
         }
 
         @JsonProperty
@@ -239,12 +230,22 @@ final class SamlAuthProperties {
         @Nullable
         @JsonProperty
         public String password() {
-            return password;
+            return convertValue(password, "keyStore.password");
         }
 
         @JsonProperty
         public Map<String, String> keyPasswords() {
-            return keyPasswords;
+            return sanitizePasswords(keyPasswords);
+        }
+
+        private static Map<String, String> sanitizePasswords(@Nullable Map<String, String> keyPasswords) {
+            if (keyPasswords == null) {
+                return ImmutableMap.of();
+            }
+            final ImmutableMap.Builder<String, String> builder = new Builder<>();
+            keyPasswords.forEach((key, password) -> builder.put(key, firstNonNull(
+                    convertValue(password, "keyStore.keyPasswords"), "")));
+            return builder.build();
         }
 
         @JsonProperty

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 LINE Corporation
+ * Copyright 2023 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.auth.saml;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.ConfigValueConverter;
+import com.linecorp.centraldogma.server.auth.AuthConfig;
+
+class AuthenticationDeserializationTest {
+
+    @Test
+    void authConfigValueConverter() throws Exception {
+        final String jsonConfig =
+                String.format("{\"authentication\": {" +
+                              "   \"factoryClassName\": \"%s\", " +
+                              "   \"properties\": {" +
+                              "     \"entityId\": \"https://dogma.com\", " +
+                              "     \"hostname\": \"dogma.com\", " +
+                              "     \"keyStore\": {" +
+                              "       \"path\": \"somewhere\", " +
+                              "       \"password\": \"encryption:foo\", " +
+                              "       \"keyPasswords\": {" +
+                              "         \"dogma\": \"encryption:bar\"" +
+                              "        }" +
+                              "      }," +
+                              "     \"idp\": {" +
+                              "       \"entityId\": \"dogma-saml\", " +
+                              "       \"uri\": \"https://dogma.com/signon\"" +
+                              "}}}}", SamlAuthProviderFactory.class.getName());
+        final AuthConfig authConfig = Jackson.readValue(jsonConfig, ParentConfig.class).authConfig;
+        final SamlAuthProperties properties = authConfig.properties(SamlAuthProperties.class);
+        assertThat(properties.keyStore().password()).isEqualTo("foo1");
+        assertThat(properties.keyStore().keyPasswords()).containsOnly(Maps.immutableEntry("dogma", "bar1"));
+    }
+
+    public static class KeyConfigValueConverter implements ConfigValueConverter {
+
+        @Override
+        public List<String> supportedPrefixes() {
+            return ImmutableList.of("encryption");
+        }
+
+        @Override
+        public String convert(String prefix, String value) {
+            if ("foo".equals(value)) {
+                return "foo1";
+            }
+            if ("bar".equals(value)) {
+                return "bar1";
+            }
+            throw new IllegalArgumentException("unsupported prefix: " + prefix + ", value: " + value);
+        }
+    }
+
+    static class ParentConfig {
+        private final AuthConfig authConfig;
+
+        @JsonCreator
+        ParentConfig(@JsonProperty("authentication") AuthConfig authConfig) {
+            this.authConfig = authConfig;
+        }
+    }
+}

--- a/server-auth/saml/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
+++ b/server-auth/saml/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
@@ -1,0 +1,1 @@
+com.linecorp.centraldogma.server.auth.saml.AuthenticationDeserializationTest$KeyConfigValueConverter

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.util.Collections;
 import java.util.List;
@@ -501,7 +502,10 @@ public class CentralDogma implements AutoCloseable {
             try {
                 final TlsConfig tlsConfig = cfg.tls();
                 if (tlsConfig != null) {
-                    sb.tls(tlsConfig.keyCertChainFile(), tlsConfig.keyFile(), tlsConfig.keyPassword());
+                    try (InputStream keyCertChainInputStream = tlsConfig.keyCertChainInputStream();
+                         InputStream keyInputStream = tlsConfig.keyInputStream()) {
+                        sb.tls(keyCertChainInputStream, keyInputStream, tlsConfig.keyPassword());
+                    }
                 } else {
                     logger.warn(
                             "Missing TLS configuration. Generating a self-signed certificate for TLS support.");

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -110,8 +110,12 @@ public final class CentralDogmaConfig {
         logger.debug("Available {}s: {}", ConfigValueConverter.class.getName(), sb);
     }
 
+    /**
+     * Converts the specified {@code value} using {@link ConfigValueConverter} if the specified {@code value}
+     * starts with a prefix followed by a colon {@code ':'}.
+     */
     @Nullable
-    static String convertValue(@Nullable String value, String propertyName) {
+    public static String convertValue(@Nullable String value, String propertyName) {
         if (value == null) {
             return null;
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -94,14 +94,14 @@ public final class CentralDogmaConfig {
     }
 
     @Nullable
-    static String convertValue(@Nullable String value) {
+    static String convertValue(@Nullable String value, String propertyName) {
         if (value == null) {
             return null;
         }
 
         final int index = value.indexOf(':');
-        if (index < 0) {
-            // no prefix
+        if (index <= 0) {
+            // no prefix or starts with ':'.
             return value;
         }
 
@@ -114,9 +114,7 @@ public final class CentralDogmaConfig {
             }
         }
 
-        // return the value as is instead of rest because the value might contain ':' without prefix.
-        // e.g. "@#$:@#$_is_not_prefix"
-        return value;
+        throw new IllegalArgumentException("failed to convert " + propertyName + ". value: " + value);
     }
 
     private final File dataDir;

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -103,7 +103,7 @@ public final class CentralDogmaConfig {
         CONFIG_VALUE_CONVERTERS.entrySet().stream().sorted(Entry.comparingByKey()).forEach(
                 entry -> sb.append(entry.getKey())
                            .append('=')
-                           .append(entry.getValue().getClass().getSimpleName()).append(", "));
+                           .append(entry.getValue().getClass().getName()).append(", "));
         sb.setLength(sb.length() - 2);
         sb.append('}');
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import java.util.List;
+
+/**
+ * A converter that converts a value of certain configuration properties in {@link CentralDogmaConfig}.
+ * Currently, it is used to convert a value of {@code replication.secret},
+ * {@code tls.keyCertChain} and {@code tls.key} properties.
+ * Implement this interface and register it via SPI to convert a value of the properties.
+ */
+public interface ConfigValueConverter {
+
+    /**
+     * Returns the list of prefixes of the properties that this converter supports.
+     */
+    List<String> supportedPrefixes();
+
+    /**
+     * Returns the converted value of the property. It must not return {@code null}.
+     */
+    String convert(String prefix, String value);
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * A converter that converts a value of certain configuration properties in {@link CentralDogmaConfig}.
  * Currently, it is used to convert a value of {@code replication.secret},
- * {@code tls.keyCertChain} and {@code tls.key} properties.
+ * {@code tls.keyCertChain}, {@code tls.key} and {@code tls.keyPassword} properties.
  * Implement this interface and register it via SPI to convert a value of the properties.
  */
 public interface ConfigValueConverter {

--- a/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ConfigValueConverter.java
@@ -19,8 +19,14 @@ import java.util.List;
 
 /**
  * A converter that converts a value of certain configuration properties in {@link CentralDogmaConfig}.
- * Currently, it is used to convert a value of {@code replication.secret},
- * {@code tls.keyCertChain}, {@code tls.key} and {@code tls.keyPassword} properties.
+ * Here is the list of the properties that this converter supports:
+ * <ul>
+ *     <li>{@code replication.secret}</li>
+ *     <li>{@code tls.keyCertChain}</li>
+ *     <li>{@code tls.key}</li>
+ *     <li>{@code authentication.properties.keyStore.password} (when SAML is used)</li>
+ *     <li>{@code authentication.properties.keyStore.keyPasswords} (when SAML is used)</li>
+ * </ul>
  * Implement this interface and register it via SPI to convert a value of the properties.
  */
 public interface ConfigValueConverter {

--- a/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
@@ -26,10 +26,11 @@ import com.google.common.collect.ImmutableList;
 enum DefaultConfigValueConverter implements ConfigValueConverter {
     INSTANCE;
 
+    private static final String PLAIN = "plain";
     private static final String FILE = "file";
 
     // TODO(minwoox): Add more prefixes such as classpath, url, etc.
-    private static final List<String> SUPPORTED_PREFIX = ImmutableList.of(FILE);
+    private static final List<String> SUPPORTED_PREFIX = ImmutableList.of(PLAIN, FILE);
 
     @Override
     public List<String> supportedPrefixes() {
@@ -38,10 +39,10 @@ enum DefaultConfigValueConverter implements ConfigValueConverter {
 
     @Override
     public String convert(String prefix, String value) {
-        if (!FILE.equals(prefix)) {
-            throw new IllegalArgumentException("unsupported prefix: " + prefix + ", value: " + value);
+        if (PLAIN.equals(prefix)) {
+            return value;
         }
-
+        assert FILE.equals(prefix);
         try {
             return new String(Files.readAllBytes(Paths.get(value)), StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
@@ -30,23 +30,27 @@ enum DefaultConfigValueConverter implements ConfigValueConverter {
     private static final String FILE = "file";
 
     // TODO(minwoox): Add more prefixes such as classpath, url, etc.
-    private static final List<String> SUPPORTED_PREFIX = ImmutableList.of(PLAIN, FILE);
+    private static final List<String> SUPPORTED_PREFIXES = ImmutableList.of(PLAIN, FILE);
 
     @Override
     public List<String> supportedPrefixes() {
-        return SUPPORTED_PREFIX;
+        return SUPPORTED_PREFIXES;
     }
 
     @Override
     public String convert(String prefix, String value) {
-        if (PLAIN.equals(prefix)) {
-            return value;
-        }
-        assert FILE.equals(prefix);
-        try {
-            return new String(Files.readAllBytes(Paths.get(value)), StandardCharsets.UTF_8);
-        } catch (IOException e) {
-            throw new RuntimeException("failed to read a file: " + value, e);
+        switch (prefix) {
+            case PLAIN:
+                return value;
+            case FILE:
+                try {
+                    return new String(Files.readAllBytes(Paths.get(value)), StandardCharsets.UTF_8);
+                } catch (IOException e) {
+                    throw new RuntimeException("failed to read a file: " + value, e);
+                }
+            default:
+                // Should never reach here.
+                throw new Error();
         }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
@@ -26,11 +26,11 @@ import com.google.common.collect.ImmutableList;
 enum DefaultConfigValueConverter implements ConfigValueConverter {
     INSTANCE;
 
-    private static final String PLAIN = "plain";
+    private static final String PLAINTEXT = "plaintext";
     private static final String FILE = "file";
 
     // TODO(minwoox): Add more prefixes such as classpath, url, etc.
-    private static final List<String> SUPPORTED_PREFIXES = ImmutableList.of(PLAIN, FILE);
+    private static final List<String> SUPPORTED_PREFIXES = ImmutableList.of(PLAINTEXT, FILE);
 
     @Override
     public List<String> supportedPrefixes() {
@@ -40,7 +40,7 @@ enum DefaultConfigValueConverter implements ConfigValueConverter {
     @Override
     public String convert(String prefix, String value) {
         switch (prefix) {
-            case PLAIN:
+            case PLAINTEXT:
                 return value;
             case FILE:
                 try {

--- a/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+enum DefaultConfigValueConverter implements ConfigValueConverter {
+    INSTANCE;
+
+    private static final String FILE = "file";
+
+    // TODO(minwoox): Add more prefixes such as classpath, url, etc.
+    private static final List<String> SUPPORTED_PREFIX = ImmutableList.of(FILE);
+
+    @Override
+    public List<String> supportedPrefixes() {
+        return SUPPORTED_PREFIX;
+    }
+
+    @Override
+    public String convert(String prefix, String value) {
+        if (!FILE.equals(prefix)) {
+            throw new IllegalArgumentException("unsupported prefix: " + prefix + ", value: " + value);
+        }
+
+        try {
+            return new String(Files.readAllBytes(Paths.get(value)), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("failed to read a file: " + value, e);
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
@@ -66,7 +66,7 @@ public final class TlsConfig {
         // keyCertChain and key are converted later when it's used.
         this.keyCertChain = keyCertChain;
         this.key = key;
-        this.keyPassword = convertValue(keyPassword, "tls.keyPassword");
+        this.keyPassword = keyPassword;
     }
 
     private static void validate(@Nullable File fileName, @Nullable String name,
@@ -144,7 +144,7 @@ public final class TlsConfig {
     @JsonProperty
     @Nullable
     public String keyPassword() {
-        return keyPassword;
+        return convertValue(keyPassword, "tls.keyPassword");
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/TlsConfig.java
@@ -15,23 +15,35 @@
  */
 package com.linecorp.centraldogma.server;
 
-import static java.util.Objects.requireNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.errorprone.annotations.MustBeClosed;
 
 /**
  * TLS configuration.
  */
 public final class TlsConfig {
 
+    @Nullable
     private final File keyCertChainFile;
+    @Nullable
     private final File keyFile;
+    @Nullable
+    private final String keyCertChain;
+    @Nullable
+    private final String key;
     @Nullable
     private final String keyPassword;
 
@@ -40,28 +52,78 @@ public final class TlsConfig {
      * {@code keyPassword}.
      */
     @JsonCreator
-    public TlsConfig(@JsonProperty(value = "keyCertChainFile", required = true) File keyCertChainFile,
-                     @JsonProperty(value = "keyFile", required = true) File keyFile,
+    public TlsConfig(@JsonProperty(value = "keyCertChainFile") @Nullable File keyCertChainFile,
+                     @JsonProperty(value = "keyFile") @Nullable File keyFile,
+                     @JsonProperty(value = "keyCertChain") @Nullable String keyCertChain,
+                     @JsonProperty(value = "key") @Nullable String key,
                      @JsonProperty("keyPassword") @Nullable String keyPassword) {
-        this.keyCertChainFile = requireNonNull(keyCertChainFile, "keyCertChainFile");
-        this.keyFile = requireNonNull(keyFile, "keyFile");
+        checkArgument(keyCertChainFile != null || keyCertChain != null,
+                      "keyCertChainFile and keyCertChain cannot be null at the same time.");
+        checkArgument(keyFile != null || key != null,
+                      "keyFile and key cannot be null at the same time.");
+        this.keyCertChainFile = keyCertChainFile;
+        this.keyFile = keyFile;
+        this.keyCertChain = keyCertChain;
+        this.key = key;
         this.keyPassword = keyPassword;
     }
 
     /**
      * Returns a certificates file which is created with the given {@code keyCertChainFilePath}.
+     *
+     * @deprecated Use {@link #keyCertChainInputStream()}.
      */
+    @Nullable
     @JsonProperty
+    @Deprecated
     public File keyCertChainFile() {
         return keyCertChainFile;
     }
 
     /**
      * Returns a private key file which is created with the given {@code keyFilePath}.
+     *
+     * @deprecated Use {@link #keyInputStream()}.
      */
+    @Nullable
     @JsonProperty
+    @Deprecated
     public File keyFile() {
         return keyFile;
+    }
+
+    /**
+     * Returns an {@link InputStream} of the certificate chain.
+     */
+    @MustBeClosed
+    public InputStream keyCertChainInputStream() {
+        return inputStream(keyCertChainFile, keyCertChain, "keyCertChain");
+    }
+
+    /**
+     * Returns an {@link InputStream} of the private key.
+     */
+    @MustBeClosed
+    public InputStream keyInputStream() {
+        return inputStream(keyFile, key, "key");
+    }
+
+    private static InputStream inputStream(@Nullable File file,
+                                           @Nullable String property, String propertyName) {
+        if (file != null) {
+            try {
+                return Files.newInputStream(file.toPath());
+            } catch (IOException e) {
+                throw new RuntimeException("failed to create an input stream from " + file, e);
+            }
+        }
+
+        assert property != null;
+        final String converted = convertValue(property);
+        if (converted == null) {
+            throw new NullPointerException(propertyName + '(' + property + ") is converted to null.");
+        }
+        return new ByteArrayInputStream(converted.getBytes());
     }
 
     /**
@@ -75,10 +137,11 @@ public final class TlsConfig {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this).omitNullValues()
                           .add("keyCertChainFile", keyCertChainFile)
                           .add("keyFile", keyFile)
-                          .add("keyPassword", keyPassword)
+                          .add("keyCertChain", keyCertChain)
+                          .add("key", key)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
@@ -98,7 +98,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
         this.serverId = serverId != null ? serverId : findServerId(servers);
         checkArgument(this.serverId > 0, "serverId: %s (expected: > 0)", serverId);
 
-        this.secret = firstNonNull(convertValue(secret), DEFAULT_SECRET);
+        this.secret = firstNonNull(convertValue(secret, "replication.secret"), DEFAULT_SECRET);
         checkArgument(!this.secret.isEmpty(), "secret is empty.");
 
         servers.forEach((id, server) -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
@@ -54,6 +54,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
 
     private final int serverId;
     private final Map<Integer, ZooKeeperServerConfig> servers;
+    @Nullable
     private final String secret;
     private final Map<String, String> additionalProperties;
     private final int timeoutMillis;
@@ -97,9 +98,8 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
         requireNonNull(servers, "servers");
         this.serverId = serverId != null ? serverId : findServerId(servers);
         checkArgument(this.serverId > 0, "serverId: %s (expected: > 0)", serverId);
-
-        this.secret = firstNonNull(convertValue(secret, "replication.secret"), DEFAULT_SECRET);
-        checkArgument(!this.secret.isEmpty(), "secret is empty.");
+        this.secret = secret;
+        checkArgument(!secret().isEmpty(), "secret is empty.");
 
         servers.forEach((id, server) -> {
             checkArgument(id > 0, "'servers' contains non-positive server ID: %s (expected: > 0)", id);
@@ -211,7 +211,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
      * Returns the secret string used for authenticating the ZooKeeper peers.
      */
     public String secret() {
-        return secret;
+        return firstNonNull(convertValue(secret, "replication.secret"), DEFAULT_SECRET);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZooKeeperReplicationConfig.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static java.util.Objects.requireNonNull;
 
 import java.net.InetAddress;
@@ -97,7 +98,7 @@ public final class ZooKeeperReplicationConfig implements ReplicationConfig {
         this.serverId = serverId != null ? serverId : findServerId(servers);
         checkArgument(this.serverId > 0, "serverId: %s (expected: > 0)", serverId);
 
-        this.secret = firstNonNull(secret, DEFAULT_SECRET);
+        this.secret = firstNonNull(convertValue(secret), DEFAULT_SECRET);
         checkArgument(!this.secret.isEmpty(), "secret is empty.");
 
         servers.forEach((id, server) -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
@@ -101,6 +101,7 @@ public final class AuthConfig {
              firstNonNull(sessionCacheSpec, DEFAULT_SESSION_CACHE_SPEC),
              firstNonNull(sessionTimeoutMillis, DEFAULT_SESSION_TIMEOUT_MILLIS),
              firstNonNull(sessionValidationSchedule, DEFAULT_SESSION_VALIDATION_SCHEDULE),
+             // TODO(minwoox): Refactor properties to a type to use ConfigValueConverter for secrets.
              properties);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/auth/AuthConfig.java
@@ -101,7 +101,6 @@ public final class AuthConfig {
              firstNonNull(sessionCacheSpec, DEFAULT_SESSION_CACHE_SPEC),
              firstNonNull(sessionTimeoutMillis, DEFAULT_SESSION_TIMEOUT_MILLIS),
              firstNonNull(sessionValidationSchedule, DEFAULT_SESSION_VALIDATION_SCHEDULE),
-             // TODO(minwoox): Refactor properties to a type to use ConfigValueConverter for secrets.
              properties);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -67,7 +67,7 @@ class ConfigDeserializationTest {
         final String cert = Jackson.escapeText("file:" + certFile.toAbsolutePath());
         final String jsonConfig = String.format("{\"tls\": {" +
                                                 "\"keyCertChain\": \"%s\", " +
-                                                "\"key\": \"plain:bar\", " +
+                                                "\"key\": \"plaintext:bar\", " +
                                                 "\"keyPassword\": \"sesame\"" +
                                                 "}}", cert);
         checkContent(jsonConfig);

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -18,13 +18,21 @@ package com.linecorp.centraldogma.server;
 import static java.nio.file.Files.createTempFile;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.internal.Jackson;
 
@@ -35,24 +43,82 @@ class ConfigDeserializationTest {
 
     @Test
     void tlsConfig() throws Exception {
-        final String cert = Jackson.escapeText(createTempFile(tempDir, "", "").toAbsolutePath().toString());
-        final String key = Jackson.escapeText(createTempFile(tempDir, "", "").toAbsolutePath().toString());
+        final Path certFile = createTempFile(tempDir, "", "");
+        Files.write(certFile, "foo".getBytes(StandardCharsets.UTF_8));
+        final Path keyFile = createTempFile(tempDir, "", "");
+        Files.write(keyFile, "bar".getBytes(StandardCharsets.UTF_8));
+
+        final String cert = Jackson.escapeText(certFile.toAbsolutePath().toString());
+        final String key = Jackson.escapeText(keyFile.toAbsolutePath().toString());
 
         final String jsonConfig = String.format("{\"tls\": {" +
                                                 "\"keyCertChainFile\": \"%s\", " +
                                                 "\"keyFile\": \"%s\", " +
                                                 "\"keyPassword\": null " +
                                                 "}}", cert, key);
-        final ParentConfig parentConfig = Jackson.readValue(jsonConfig, ParentConfig.class);
-        final TlsConfig tlsConfig = parentConfig.tlsConfig;
+        checkContent(jsonConfig);
+    }
 
-        assertThat(tlsConfig.keyCertChainFile()).isNotNull();
-        assertThat(tlsConfig.keyCertChainFile().canRead()).isTrue();
+    @Test
+    void tlsConfigFilePrefix() throws Exception {
+        final Path certFile = createTempFile(tempDir, "", "");
+        Files.write(certFile, "foo".getBytes(StandardCharsets.UTF_8));
+        final Path keyFile = createTempFile(tempDir, "", "");
+        Files.write(keyFile, "bar".getBytes(StandardCharsets.UTF_8));
 
-        assertThat(tlsConfig.keyFile()).isNotNull();
-        assertThat(tlsConfig.keyFile().canRead()).isTrue();
+        final String cert = Jackson.escapeText("file:" + certFile.toAbsolutePath());
+        final String key = Jackson.escapeText("file:" + keyFile.toAbsolutePath());
 
+        final String jsonConfig = String.format("{\"tls\": {" +
+                                                "\"keyCertChain\": \"%s\", " +
+                                                "\"key\": \"%s\", " +
+                                                "\"keyPassword\": null " +
+                                                "}}", cert, key);
+        checkContent(jsonConfig);
+    }
+
+    @Test
+    void tlsConfigConvigValueConverter() throws Exception {
+        final String jsonConfig = "{\"tls\": {" +
+                                  "\"keyCertChain\": \"encryption:chain\", " +
+                                  "\"key\": \"encryption:key\", " +
+                                  "\"keyPassword\": null " +
+                                  "}}";
+        checkContent(jsonConfig);
+    }
+
+    private static void checkContent(String jsonConfig) throws IOException {
+        final TlsConfig tlsConfig = Jackson.readValue(jsonConfig, ParentConfig.class).tlsConfig;
+
+        readStream(tlsConfig.keyCertChainInputStream(), "foo");
+        readStream(tlsConfig.keyInputStream(), "bar");
         assertThat(tlsConfig.keyPassword()).isNull();
+    }
+
+    private static void readStream(InputStream inputStream, String content) throws IOException {
+        try (InputStream inputStream0 = inputStream;
+             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream0))) {
+            assertThat(bufferedReader.readLine()).isEqualTo(content);
+        }
+    }
+
+    public static class KeyConfigValueConverter implements ConfigValueConverter {
+
+        @Override
+        public List<String> supportedPrefixes() {
+            return ImmutableList.of("encryption");
+        }
+
+        @Override
+        public String convert(String prefix, String value) {
+            if ("chain".equals(value)) {
+                return "foo";
+            }
+            if ("key".equals(value)) {
+                return "bar";
+            }
+            throw new IllegalArgumentException("unsupported prefix: " + prefix + ", value: " + value);
+        }
     }
 
     static class ParentConfig {

--- a/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ConfigDeserializationTest.java
@@ -54,7 +54,7 @@ class ConfigDeserializationTest {
         final String jsonConfig = String.format("{\"tls\": {" +
                                                 "\"keyCertChainFile\": \"%s\", " +
                                                 "\"keyFile\": \"%s\", " +
-                                                "\"keyPassword\": null " +
+                                                "\"keyPassword\": \"sesame\"" +
                                                 "}}", cert, key);
         checkContent(jsonConfig);
     }
@@ -63,26 +63,22 @@ class ConfigDeserializationTest {
     void tlsConfigFilePrefix() throws Exception {
         final Path certFile = createTempFile(tempDir, "", "");
         Files.write(certFile, "foo".getBytes(StandardCharsets.UTF_8));
-        final Path keyFile = createTempFile(tempDir, "", "");
-        Files.write(keyFile, "bar".getBytes(StandardCharsets.UTF_8));
 
         final String cert = Jackson.escapeText("file:" + certFile.toAbsolutePath());
-        final String key = Jackson.escapeText("file:" + keyFile.toAbsolutePath());
-
         final String jsonConfig = String.format("{\"tls\": {" +
                                                 "\"keyCertChain\": \"%s\", " +
-                                                "\"key\": \"%s\", " +
-                                                "\"keyPassword\": null " +
-                                                "}}", cert, key);
+                                                "\"key\": \"plain:bar\", " +
+                                                "\"keyPassword\": \"sesame\"" +
+                                                "}}", cert);
         checkContent(jsonConfig);
     }
 
     @Test
-    void tlsConfigConvigValueConverter() throws Exception {
+    void tlsConfigConfigValueConverter() throws Exception {
         final String jsonConfig = "{\"tls\": {" +
                                   "\"keyCertChain\": \"encryption:chain\", " +
                                   "\"key\": \"encryption:key\", " +
-                                  "\"keyPassword\": null " +
+                                  "\"keyPassword\": \"encryption:password\"" +
                                   "}}";
         checkContent(jsonConfig);
     }
@@ -92,7 +88,7 @@ class ConfigDeserializationTest {
 
         readStream(tlsConfig.keyCertChainInputStream(), "foo");
         readStream(tlsConfig.keyInputStream(), "bar");
-        assertThat(tlsConfig.keyPassword()).isNull();
+        assertThat(tlsConfig.keyPassword()).isEqualTo("sesame");
     }
 
     private static void readStream(InputStream inputStream, String content) throws IOException {
@@ -116,6 +112,9 @@ class ConfigDeserializationTest {
             }
             if ("key".equals(value)) {
                 return "bar";
+            }
+            if ("password".equals(value)) {
+                return "sesame";
             }
             throw new IllegalArgumentException("unsupported prefix: " + prefix + ", value: " + value);
         }

--- a/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
+++ b/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
@@ -1,0 +1,1 @@
+com.linecorp.centraldogma.server.ConfigDeserializationTest$KeyConfigValueConverter

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -411,8 +411,8 @@ in ``dogma.json`` as follows.
         }
       ],
       "tls": {
-        "keyCertChainFile": "./cert/centraldogma.crt",
-        "keyFile": "./cert/centraldogma.key",
+        "keyCertChain": "file:./cert/centraldogma.crt",
+        "key": "file:./cert/centraldogma.key",
         "keyPassword": null
       },
       "trustedProxyAddresses": null,
@@ -445,13 +445,13 @@ in ``dogma.json`` as follows.
 
   - the configuration for TLS support. It will be applied to the port which is configured with ``https``
     protocol. If ``null``, a self-signed certificate will be generated for ``https`` protocol.
-  - ``keyCertChainFile`` (string)
+  - ``keyCertChain`` (string)
 
-    - the path to the certificate chain file.
+    - the content of the certificate chain. If you want to use a file, specify ``file:<path>``.
 
-  - ``keyFile`` (string)
+  - ``key`` (string)
 
-    - the path to the private key file.
+    - the content of the private key. If you want to use a file, specify ``file:<path>``.
 
   - ``keyPassword`` (string)
 

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -94,7 +94,8 @@ public class CentralDogmaRuleDelegate {
         if (useTls) {
             try {
                 final SelfSignedCertificate ssc = new SelfSignedCertificate();
-                builder.tls(new TlsConfig(ssc.certificate(), ssc.privateKey(), null));
+                builder.tls(new TlsConfig(null, null,
+                                          "file:" + ssc.certificate(), "file:" + ssc.privateKey(), null));
             } catch (Exception e) {
                 Exceptions.throwUnsafely(e);
             }


### PR DESCRIPTION
…ma configuration file.

Motivation:
We can enhance the security of the Central Dogma configuration by allowing users to specify sensitive secret values using a variable in the configuration file and converting them using the `ConfigValueConverter`. This will help in safeguarding sensitive information and prevent accidental exposure of secrets.

Modifications:
- Added `ConfigValueConverter` that can be loaded via SPI.
  - `replication.secret`, `tls.keyCertChain`, `tls.key` and `tls.keyPassword` can now be converted using the converter.

Result:
- You can now easily specify secret values with variables, in the configuration file, that are converted using `ConfigValueConverter`. This enhances the security of Central Dogma configuration, reducing the risk of sensitive information exposure.
- (Deprecation) `tls.keyCertChainFile` and `tls.keyFile` in the configuration are deprecated.
  - Use `tls.keyCertChain` and `tls.key` with the `file:` prefix or `ConfigValueConverter` instead.