### PR TITLE
Apply ConfigValueConverter to Mirroring configuration temporarily

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/DefaultConfigValueConverter.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
@@ -28,9 +29,10 @@ enum DefaultConfigValueConverter implements ConfigValueConverter {
 
     private static final String PLAINTEXT = "plaintext";
     private static final String FILE = "file";
+    private static final String BASE64 = "base64";
 
     // TODO(minwoox): Add more prefixes such as classpath, url, etc.
-    private static final List<String> SUPPORTED_PREFIXES = ImmutableList.of(PLAINTEXT, FILE);
+    private static final List<String> SUPPORTED_PREFIXES = ImmutableList.of(PLAINTEXT, FILE, BASE64);
 
     @Override
     public List<String> supportedPrefixes() {
@@ -48,6 +50,8 @@ enum DefaultConfigValueConverter implements ConfigValueConverter {
                 } catch (IOException e) {
                     throw new RuntimeException("failed to read a file: " + value, e);
                 }
+            case BASE64:
+                return new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8).trim();
             default:
                 // Should never reach here.
                 throw new Error();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/AccessTokenMirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/AccessTokenMirrorCredential.java
@@ -16,11 +16,15 @@
 
 package com.linecorp.centraldogma.server.internal.mirror.credential;
 
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static com.linecorp.centraldogma.server.internal.mirror.credential.MirrorCredentialUtil.requireNonEmpty;
 
 import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -28,6 +32,8 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
 public final class AccessTokenMirrorCredential extends AbstractMirrorCredential {
+
+    private static final Logger logger = LoggerFactory.getLogger(AccessTokenMirrorCredential.class);
 
     private final String accessToken;
 
@@ -38,12 +44,17 @@ public final class AccessTokenMirrorCredential extends AbstractMirrorCredential 
                                        Iterable<Pattern> hostnamePatterns,
                                        @JsonProperty("accessToken") String accessToken) {
         super(id, hostnamePatterns);
-
         this.accessToken = requireNonEmpty(accessToken, "accessToken");
     }
 
     public String accessToken() {
-        return accessToken;
+        try {
+            return convertValue(accessToken, "credentials.accessToken");
+        } catch (Throwable t) {
+            // The accessToken probably has `:` without prefix. Just return it as is for backward compatibility.
+            logger.debug("Failed to convert the access token of the credential: {}", id(), t);
+            return accessToken;
+        }
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/MirrorCredentialUtil.java
@@ -18,30 +18,7 @@ package com.linecorp.centraldogma.server.internal.mirror.credential;
 
 import static java.util.Objects.requireNonNull;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
-
-import javax.annotation.Nullable;
-
 final class MirrorCredentialUtil {
-    private static final String BASE64_PREFIX = "base64:";
-
-    static byte[] decodeBase64(String value, String name) {
-        requireNonNull(value, name);
-        return Base64.getDecoder().decode(value);
-    }
-
-    @Nullable
-    static String maybeDecodeBase64(@Nullable String value, String name) {
-        if (value == null) {
-            return null;
-        }
-        if (value.startsWith(BASE64_PREFIX)) {
-            return new String(decodeBase64(value.substring(BASE64_PREFIX.length()), name),
-                              StandardCharsets.UTF_8);
-        }
-        return value;
-    }
 
     static String requireNonEmpty(String value, String name) {
         requireNonNull(value, name);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredential.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/credential/PasswordMirrorCredential.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.mirror.credential;
 
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static com.linecorp.centraldogma.server.internal.mirror.credential.MirrorCredentialUtil.requireNonEmpty;
 import static java.util.Objects.requireNonNull;
 
@@ -23,12 +24,17 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.MoreObjects.ToStringHelper;
 
 public final class PasswordMirrorCredential extends AbstractMirrorCredential {
+
+    private static final Logger logger = LoggerFactory.getLogger(PasswordMirrorCredential.class);
 
     private final String username;
     private final String password;
@@ -51,7 +57,14 @@ public final class PasswordMirrorCredential extends AbstractMirrorCredential {
     }
 
     public String password() {
-        return password;
+        try {
+            return convertValue(password, "credentials.password");
+        } catch (Throwable t) {
+            // The password probably has `:` without prefix. Just return it as is for backward compatibility.
+            logger.debug("Failed to convert the password of the credential. username: {}, id: {}",
+                         username, id(), t);
+            return password;
+        }
     }
 
     @Override

--- a/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
+++ b/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
@@ -1,1 +1,2 @@
 com.linecorp.centraldogma.server.ConfigDeserializationTest$KeyConfigValueConverter
+com.linecorp.centraldogma.server.internal.mirror.credential.PublicKeyMirrorCredentialTest$PasswordConfigValueConverter


### PR DESCRIPTION
Motivation:
Before we support content encryption within CentralDogma, we need a way to secure sensitive information in mirroring configuration. We can do this using `ConfigValueConverter` that is introduced via #890 as a temporary workaround.

Modifications:
- Apply `ConfigValueConverter` to mirroring configuration.

Result:
- You can temporarily hide sensitive information in mirroring configuration using `ConfigValueConverter`. Please note that this feature will be deprecated after we implement #755.