### PR TITLE
Fix to enable changing the permission of internal repositories.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -407,8 +407,11 @@ public class MetadataService {
         requireNonNull(perRolePermissions, "perRolePermissions");
 
         if (Project.isReservedRepoName(repoName)) {
-            throw new UnsupportedOperationException(
-                    "can't update the per role permission for internal repository: " + repoName);
+            final Set<Permission> guest = perRolePermissions.guest();
+            if (!guest.isEmpty()) {
+                throw new UnsupportedOperationException(
+                        "can't give a permission to guest for internal repository: " + repoName);
+            }
         }
 
         final JsonPointer path = JsonPointer.compile("/repos" + encodeSegment(repoName) +

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -406,11 +406,16 @@ public class MetadataService {
         requireNonNull(repoName, "repoName");
         requireNonNull(perRolePermissions, "perRolePermissions");
 
-        if (Project.isReservedRepoName(repoName)) {
+        if (Project.REPO_DOGMA.equals(repoName)) {
+            throw new UnsupportedOperationException(
+                    "Can't update the per role permission for internal repository: " + repoName);
+        }
+
+        if (Project.REPO_META.equals(repoName)) {
             final Set<Permission> guest = perRolePermissions.guest();
             if (!guest.isEmpty()) {
                 throw new UnsupportedOperationException(
-                        "can't give a permission to guest for internal repository: " + repoName);
+                        "Can't give a permission to guest for internal repository: " + repoName);
             }
         }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -44,6 +44,7 @@ import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 class MetadataServiceTest {
 
+    @SuppressWarnings("JUnitMalformedDeclaration")
     @RegisterExtension
     final ProjectManagerExtension manager = new ProjectManagerExtension() {
         @Override
@@ -199,8 +200,9 @@ class MetadataServiceTest {
 
         for (String internalRepo : Project.internalRepos()) {
             assertThatThrownBy(() -> mds.updatePerRolePermissions(
-                    author, project1, internalRepo, PerRolePermissions.ofDefault()).join())
-                    .isInstanceOf(UnsupportedOperationException.class);
+                    author, project1, internalRepo, PerRolePermissions.ofPublic()).join())
+                    .isInstanceOf(UnsupportedOperationException.class)
+                    .hasMessageContaining("can't give a permission to guest for internal repository");
         }
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.metadata;
 import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.NO_PERMISSION;
 import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_ONLY;
 import static com.linecorp.centraldogma.server.metadata.PerRolePermissions.READ_WRITE;
+import static com.linecorp.centraldogma.server.storage.project.Project.REPO_DOGMA;
 import static com.linecorp.centraldogma.server.storage.project.Project.REPO_META;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,7 +40,6 @@ import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.server.QuotaConfig;
 import com.linecorp.centraldogma.server.command.Command;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 class MetadataServiceTest {
@@ -198,12 +198,14 @@ class MetadataServiceTest {
         assertThat(mds.findPermissions(project1, repo1, guest).join())
                 .containsExactlyElementsOf(NO_PERMISSION);
 
-        for (String internalRepo : Project.internalRepos()) {
-            assertThatThrownBy(() -> mds.updatePerRolePermissions(
-                    author, project1, internalRepo, PerRolePermissions.ofPublic()).join())
-                    .isInstanceOf(UnsupportedOperationException.class)
-                    .hasMessageContaining("can't give a permission to guest for internal repository");
-        }
+        assertThatThrownBy(() -> mds.updatePerRolePermissions(
+                author, project1, REPO_DOGMA, PerRolePermissions.ofPublic()).join())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Can't update the per role permission for internal repository");
+        assertThatThrownBy(() -> mds.updatePerRolePermissions(
+                author, project1, REPO_META, PerRolePermissions.ofPublic()).join())
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Can't give a permission to guest for internal repository");
     }
 
     @Test


### PR DESCRIPTION
Motivation:
Internal repositories are initially created with the [internal](https://github.com/line/centraldogma/blob/0cf273402d70773e0aab1e2b858111a1c1c0f22c/server/src/main/java/com/linecorp/centraldogma/server/metadata/PerRolePermissions.java#L61) permission, and I previously restricted the ability to modify this permission. However, users may have valid reasons to adjust the permission settings.

Modifications:
- Implemented functionality to change the permission of internal repositories.
  - Note: The guest role remains restricted from having any permission on internal repositories.

Result:
- You can now have the capability to modify the permission settings for internal repositories, excluding the guest role.