### PR TITLE
Add `AdministrativeCommand`s

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
@@ -26,6 +26,9 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.MoreObjects;
 
 import com.linecorp.armeria.common.util.Exceptions;
@@ -35,6 +38,8 @@ import com.linecorp.armeria.common.util.StartStopSupport;
  * Helps to implement a concrete {@link CommandExecutor}.
  */
 public abstract class AbstractCommandExecutor implements CommandExecutor {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractCommandExecutor.class);
 
     @Nullable
     private final Consumer<CommandExecutor> onTakeLeadership;
@@ -97,8 +102,24 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
     @Override
     public final <T> CompletableFuture<T> execute(Command<T> command) {
         requireNonNull(command, "command");
-        if (!isWritable()) {
-            throw new IllegalStateException("running in read-only mode");
+        if (!isWritable() && !(command instanceof AdministrativeCommand)) {
+            // Reject all commands except for AdministrativeCommand when the replica is in read-only mode.
+            // AdministrativeCommand is allowed because it is used to change the read-only mode or migrate
+            // metadata under maintenance mode.
+            throw new IllegalStateException("running in read-only mode. command: " + command);
+        }
+
+        if (command.type() == CommandType.UPDATE_SERVER_STATUS) {
+            final UpdateServerStatusCommand command0 = (UpdateServerStatusCommand) command;
+            final boolean writable0 = command0.writable();
+            if (writable0 != writable) {
+                setWritable(writable0);
+                if (writable0) {
+                    logger.warn("Left read-only mode.");
+                } else {
+                    logger.warn("Entered read-only mode.");
+                }
+            }
         }
 
         try {

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AdministrativeCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AdministrativeCommand.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.centraldogma.common.Author;
+
+abstract class AdministrativeCommand<T> extends RootCommand<T> {
+    AdministrativeCommand(CommandType commandType, @Nullable Long timestamp,
+                          @Nullable Author author) {
+        super(commandType, timestamp, author);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.command;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
@@ -52,6 +53,8 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
         @Type(value = PushAsIsCommand.class, name = "PUSH"),
         @Type(value = CreateSessionCommand.class, name = "CREATE_SESSIONS"),
         @Type(value = RemoveSessionCommand.class, name = "REMOVE_SESSIONS"),
+        @Type(value = UpdateServerStatusCommand.class, name = "UPDATE_SERVER_STATUS"),
+        @Type(value = ForcePushCommand.class, name = "FORCE_PUSH_COMMAND"),
 })
 public interface Command<T> {
 
@@ -353,6 +356,26 @@ public interface Command<T> {
      */
     static Command<Void> removeSession(String sessionId) {
         return new RemoveSessionCommand(null, null, sessionId);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to update the status of the server.
+     */
+    static Command<Void> updateServerStatus(boolean writable) {
+        return new UpdateServerStatusCommand(null, null, writable);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to force-push the push {@link Command} even the server is in
+     * read-only mode. This command is useful for migrating the repository content during maintenance mode.
+     *
+     * <p>Note that {@link CommandType#NORMALIZING_PUSH} and {@link CommandType#PUSH} are allowed as the
+     * delegate.
+     */
+    static <T> Command<T> forcePush(Command<T> delegate) {
+        checkArgument(delegate.type() == CommandType.NORMALIZING_PUSH || delegate.type() == CommandType.PUSH,
+                      "delegate: %s (expected: NORMALIZING_PUSH or PUSH)", delegate);
+        return new ForcePushCommand<>(delegate);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -366,13 +366,14 @@ public interface Command<T> {
     }
 
     /**
-     * Returns a new {@link Command} which is used to force-push the push {@link Command} even the server is in
+     * Returns a new {@link Command} which is used to force-push {@link Command} even the server is in
      * read-only mode. This command is useful for migrating the repository content during maintenance mode.
      *
      * <p>Note that {@link CommandType#NORMALIZING_PUSH} and {@link CommandType#PUSH} are allowed as the
      * delegate.
      */
     static <T> Command<T> forcePush(Command<T> delegate) {
+        requireNonNull(delegate, "delegate");
         checkArgument(delegate.type() == CommandType.NORMALIZING_PUSH || delegate.type() == CommandType.PUSH,
                       "delegate: %s (expected: NORMALIZING_PUSH or PUSH)", delegate);
         return new ForcePushCommand<>(delegate);

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
@@ -37,7 +37,10 @@ public enum CommandType {
     CREATE_SESSION(Void.class),
     REMOVE_SESSION(Void.class),
     PURGE_PROJECT(Void.class),
-    PURGE_REPOSITORY(Void.class);
+    PURGE_REPOSITORY(Void.class),
+    UPDATE_SERVER_STATUS(Void.class),
+    // The result type of FORCE_PUSH is Object because it can be any type.
+    FORCE_PUSH(Object.class);
 
     /**
      * The type of an object which is returned as a result after executing the command.

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/ForcePushCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/ForcePushCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+/**
+ * A {@link Command} which is used to force-push {@code delegate} even the server is in read-only mode.
+ * This command is useful for migrating the repository content during maintenance mode.
+ */
+public final class ForcePushCommand<T> extends AdministrativeCommand<T> {
+
+    private final Command<T> delegate;
+
+    @JsonCreator
+    ForcePushCommand(@JsonProperty("delegate") Command<T> delegate) {
+        super(CommandType.FORCE_PUSH, requireNonNull(delegate, "delegate").timestamp(), delegate.author());
+        this.delegate = delegate;
+    }
+
+    /**
+     * Returns the {@link Command} to be force-pushed.
+     */
+    @JsonProperty("delegate")
+    public Command<T> delegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ForcePushCommand)) {
+            return false;
+        }
+        final ForcePushCommand<?> that = (ForcePushCommand<?>) o;
+        return super.equals(that) && delegate.equals(that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() * 31 + delegate.hashCode();
+    }
+
+    @Override
+    ToStringHelper toStringHelper() {
+        return super.toStringHelper().add("delegate", delegate);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutor.java
@@ -187,6 +187,15 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
             return (CompletableFuture<T>) removeSession((RemoveSessionCommand) command);
         }
 
+        if (command instanceof UpdateServerStatusCommand) {
+            return (CompletableFuture<T>) updateServerStatus((UpdateServerStatusCommand) command);
+        }
+
+        if (command instanceof ForcePushCommand) {
+            //noinspection TailRecursion
+            return doExecute(((ForcePushCommand<T>) command).delegate());
+        }
+
         throw new UnsupportedOperationException(command.toString());
     }
 
@@ -349,5 +358,10 @@ public class StandaloneCommandExecutor extends AbstractCommandExecutor {
             logger.warn("Failed to replicate a session removal: {}", sessionId, cause);
             return null;
         });
+    }
+
+    private CompletableFuture<Void> updateServerStatus(UpdateServerStatusCommand c) {
+        setWritable(c.writable());
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/UpdateServerStatusCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/UpdateServerStatusCommand.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
+
+/**
+ * A {@link Command} which is used to update the status of all servers in the cluster.
+ */
+public final class UpdateServerStatusCommand extends AdministrativeCommand<Void> {
+
+    private final boolean writable;
+
+    @JsonCreator
+    UpdateServerStatusCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                              @JsonProperty("author") @Nullable Author author,
+                              @JsonProperty("writable") boolean writable) {
+        super(CommandType.UPDATE_SERVER_STATUS, timestamp, author);
+        this.writable = writable;
+    }
+
+    /**
+     * Returns whether the cluster is writable.
+     */
+    @JsonProperty("writable")
+    public boolean writable() {
+        return writable;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UpdateServerStatusCommand)) {
+            return false;
+        }
+        final UpdateServerStatusCommand that = (UpdateServerStatusCommand) o;
+
+        return super.equals(that) && writable == that.writable;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), writable);
+    }
+
+    @Override
+    ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                    .add("writable", writable);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLog.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLog.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.replication;
 
+import static com.linecorp.centraldogma.internal.Util.unsafeCast;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
@@ -28,7 +29,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandType;
 import com.linecorp.centraldogma.server.command.ForcePushCommand;
@@ -60,10 +60,12 @@ public final class ReplicationLog<T> {
             result = null;
         }
 
+        final Class<T> resultType;
         if (command.type() == CommandType.FORCE_PUSH) {
-            command = ((ForcePushCommand<T>) command).delegate();
+            resultType = unsafeCast(((ForcePushCommand<?>) command).delegate().type().resultType());
+        } else {
+            resultType = unsafeCast(command.type().resultType());
         }
-        final Class<T> resultType = Util.unsafeCast(command.type().resultType());
         if (resultType == Void.class) {
             if (result != null) {
                 rejectIncompatibleResult(result, Void.class);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLog.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ReplicationLog.java
@@ -30,6 +30,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.CommandType;
+import com.linecorp.centraldogma.server.command.ForcePushCommand;
 import com.linecorp.centraldogma.server.command.NormalizingPushCommand;
 
 public final class ReplicationLog<T> {
@@ -58,6 +60,9 @@ public final class ReplicationLog<T> {
             result = null;
         }
 
+        if (command.type() == CommandType.FORCE_PUSH) {
+            command = ((ForcePushCommand<T>) command).delegate();
+        }
         final Class<T> resultType = Util.unsafeCast(command.type().resultType());
         if (resultType == Void.class) {
             if (result != null) {
@@ -77,7 +82,12 @@ public final class ReplicationLog<T> {
                 : NormalizingPushCommand.class.getSimpleName() + " cannot be replicated.";
         this.command = requireNonNull(command, "command");
 
-        final Class<?> resultType = command.type().resultType();
+        final Class<?> resultType;
+        if (command.type() == CommandType.FORCE_PUSH) {
+            resultType = ((ForcePushCommand<?>) command).delegate().type().resultType();
+        } else {
+            resultType = command.type().resultType();
+        }
         if (resultType == Void.class) {
             if (result != null) {
                 rejectIncompatibleResult(result, Void.class);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -107,6 +107,7 @@ import com.linecorp.centraldogma.server.command.CommitResult;
 import com.linecorp.centraldogma.server.command.ForcePushCommand;
 import com.linecorp.centraldogma.server.command.NormalizingPushCommand;
 import com.linecorp.centraldogma.server.command.RemoveRepositoryCommand;
+import com.linecorp.centraldogma.server.command.UpdateServerStatusCommand;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.RepositoryMetadata;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -1098,6 +1099,20 @@ public final class ZooKeeperCommandExecutor
                 final Command<Revision> command0 = Command.forcePush(delegated.asIs(commitResult));
                 log = new ReplicationLog<>(replicaId(), command0, commitResult.revision());
             } else {
+                if (command.type() == CommandType.UPDATE_SERVER_STATUS) {
+                    final UpdateServerStatusCommand command0 = (UpdateServerStatusCommand) command;
+                    final boolean writable = command0.writable();
+                    final boolean wasWritable = isWritable();
+                    setWritable(writable);
+                    if (writable != wasWritable) {
+                        if (writable) {
+                            logger.warn("Left read-only mode.");
+                        } else {
+                            logger.warn("Entered read-only mode.");
+                        }
+                    }
+                }
+
                 log = new ReplicationLog<>(replicaId(), command, result);
             }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -1109,12 +1109,6 @@ public final class ZooKeeperCommandExecutor
         }
     }
 
-    private <T> ReplicationLog<?> newReplicationLogForPush(NormalizingPushCommand command, CommitResult
-            result) {
-        final Command<Revision> pushAsIsCommand = command.asIs(result);
-        return new ReplicationLog<>(replicaId(), pushAsIsCommand, result.revision());
-    }
-
     private void createParentNodes() throws Exception {
         if (createdParentNodes) {
             return;

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
@@ -58,13 +58,18 @@ class StandaloneCommandExecutorTest {
         executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO)).join();
         executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO2)).join();
         executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO3)).join();
+
+        final MetadataService mds = new MetadataService(extension.projectManager(), executor);
+        // Metadata should be created before entering read-only mode.
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO).join();
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO2).join();
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO3).join();
     }
 
     @Test
     void setWriteQuota() {
         final StandaloneCommandExecutor executor = (StandaloneCommandExecutor) extension.executor();
         final MetadataService mds = new MetadataService(extension.projectManager(), executor);
-        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO).join();
 
         final RateLimiter rateLimiter1 = executor.writeRateLimiters.get("test_prj/test_repo");
         assertThat(rateLimiter1).isNull();
@@ -122,12 +127,6 @@ class StandaloneCommandExecutorTest {
     @Test
     void shouldPerformAdministrativeCommandWithReadOnly() throws JsonParseException {
         final StandaloneCommandExecutor executor = (StandaloneCommandExecutor) extension.executor();
-        final MetadataService mds = new MetadataService(extension.projectManager(), executor);
-        // Metadata should be created before entering read-only mode.
-        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO).join();
-        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO2).join();
-        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO3).join();
-
         executor.execute(Command.updateServerStatus(false)).join();
         assertThat(executor.isWritable()).isFalse();
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.command;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 
@@ -25,7 +26,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.RateLimiter;
 
@@ -42,6 +45,7 @@ class StandaloneCommandExecutorTest {
     private static final String TEST_PRJ = "test_prj";
     private static final String TEST_REPO = "test_repo";
     private static final String TEST_REPO2 = "test_repo2";
+    private static final String TEST_REPO3 = "test_repo3";
 
     @RegisterExtension
     static ProjectManagerExtension extension = new ProjectManagerExtension();
@@ -53,6 +57,7 @@ class StandaloneCommandExecutorTest {
         executor.execute(Command.createProject(Author.SYSTEM, TEST_PRJ)).join();
         executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO)).join();
         executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO2)).join();
+        executor.execute(Command.createRepository(Author.SYSTEM, TEST_PRJ, TEST_REPO3)).join();
     }
 
     @Test
@@ -82,7 +87,8 @@ class StandaloneCommandExecutorTest {
         Change<JsonNode> change = Change.ofJsonUpsert("/foo.json", "{\"a\": \"b\"}");
         CommitResult commitResult =
                 executor.execute(Command.push(
-                        Author.SYSTEM, TEST_PRJ, TEST_REPO2, Revision.HEAD, "", "", Markup.PLAINTEXT, change))
+                                Author.SYSTEM, TEST_PRJ, TEST_REPO2, Revision.HEAD, "", "",
+                                Markup.PLAINTEXT, change))
                         .join();
         // The same json upsert.
         assertThat(commitResult).isEqualTo(CommitResult.of(new Revision(2), ImmutableList.of(change)));
@@ -91,7 +97,8 @@ class StandaloneCommandExecutorTest {
         change = Change.ofJsonUpsert("/foo.json", "{\"a\": \"c\"}");
         commitResult =
                 executor.execute(Command.push(
-                        Author.SYSTEM, TEST_PRJ, TEST_REPO2, Revision.HEAD, "", "", Markup.PLAINTEXT, change))
+                                Author.SYSTEM, TEST_PRJ, TEST_REPO2, Revision.HEAD, "", "",
+                                Markup.PLAINTEXT, change))
                         .join();
 
         assertThat(commitResult.revision()).isEqualTo(new Revision(3));
@@ -110,5 +117,35 @@ class StandaloneCommandExecutorTest {
                 new PushAsIsCommand(0L, Author.SYSTEM, TEST_PRJ, TEST_REPO2, Revision.HEAD,
                                     "", "", Markup.PLAINTEXT, ImmutableList.of(change))).join();
         assertThat(revision).isEqualTo(new Revision(4));
+    }
+
+    @Test
+    void shouldPerformAdministrativeCommandWithReadOnly() throws JsonParseException {
+        final StandaloneCommandExecutor executor = (StandaloneCommandExecutor) extension.executor();
+        final MetadataService mds = new MetadataService(extension.projectManager(), executor);
+        // Metadata should be created before entering read-only mode.
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO).join();
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO2).join();
+        mds.addRepo(Author.SYSTEM, TEST_PRJ, TEST_REPO3).join();
+
+        executor.execute(Command.updateServerStatus(false)).join();
+        assertThat(executor.isWritable()).isFalse();
+
+        final Change<JsonNode> change = Change.ofJsonUpsert("/foo.json", "{\"a\": \"b\"}");
+        final Command<CommitResult> push = Command.push(
+                Author.SYSTEM, TEST_PRJ, TEST_REPO3, Revision.HEAD, "", "", Markup.PLAINTEXT, change);
+        assertThatThrownBy(() -> executor.execute(push))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("running in read-only mode.");
+        // The same json upsert.
+        final CommitResult commitResult = executor.execute(Command.forcePush(push)).join();
+        assertThat(commitResult).isEqualTo(CommitResult.of(new Revision(2), ImmutableList.of(change)));
+        final ObjectNode json = (ObjectNode) extension.projectManager()
+                                                      .get(TEST_PRJ)
+                                                      .repos().get(TEST_REPO3)
+                                                      .get(Revision.HEAD, "/foo.json")
+                                                      .join()
+                                                      .contentAsJson();
+        assertThat(json.get("a").asText()).isEqualTo("b");
     }
 }


### PR DESCRIPTION
Motivation:

While mirroring migration job is implemeted #880, read-only mode is necessary to safely migrate the legacy `mirrors.json` and `credentials.json` the HEAD revision. As the current read-only mode rejects all commands, the migration job is also unable to push commits.

A new command type is required to rejects only users requests but allows administrative cases. I propose to introduce two new command types for the smooth migration job.

Modifications:

- Add `UpdateServerStatusCommand` so as to toggle the read-only mode for the cluster.
- Add `ForcePush` so as to wrap a push `Command` to be executed even in the read-only mode.

Result:

`UpdateServerStatusCommand` and `ForcePush` have been added as new commands to update the cluster status and forcibly push commits in the read-only mode.