### PR TITLE
Fix to show project creators correctly

### DIFF
--- a/benchmarks/jmh/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
+++ b/benchmarks/jmh/src/jmh/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryBenchmark.java
@@ -41,7 +41,7 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 @State(Scope.Benchmark)
 public class GitRepositoryBenchmark {
 
-    private static final Author AUTHOR = new Author("user@example.com");
+    private static final Author AUTHOR = Author.ofEmail("user@example.com");
 
     @Param({ "0", "2000", "4000", "6000", "8000" })
     private int previousCommits;

--- a/common/src/main/java/com/linecorp/centraldogma/common/Author.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Author.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.common;
 
+import static com.linecorp.centraldogma.internal.Util.emailToUsername;
 import static java.util.Objects.requireNonNull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -43,12 +44,23 @@ public class Author {
      */
     public static final Author UNKNOWN = new Author("Unknown", "nobody@no.where");
 
+    /**
+     * Create a new {@link Author} with the {@code email}.
+     * The {@link #name()} will be set to the username of the {@code email}.
+     */
+    public static Author ofEmail(String email) {
+        return new Author(emailToUsername(email, "email"), email);
+    }
+
     private final String name;
     private final String email;
 
     /**
      * Creates a new instance with the specified e-mail address.
+     *
+     * @deprecated Use {@link #ofEmail(String)}.
      */
+    @Deprecated
     public Author(String email) {
         this(email, email);
     }

--- a/common/src/test/java/com/linecorp/centraldogma/common/AuthorTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/AuthorTest.java
@@ -42,9 +42,9 @@ class AuthorTest {
                              "  \"email\": \"homer@simpsonsworld.com\"" +
                              '}');
 
-        TestUtil.assertJsonConversion(new Author("bart@simpsonsworld.com"),
+        TestUtil.assertJsonConversion(Author.ofEmail("bart@simpsonsworld.com"),
                              '{' +
-                             "  \"name\": \"bart@simpsonsworld.com\"," +
+                             "  \"name\": \"bart\"," +
                              "  \"email\": \"bart@simpsonsworld.com\"" +
                              '}');
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -91,7 +91,7 @@ public class DefaultProject implements Project {
             createReservedRepos(System.currentTimeMillis());
             final UserAndTimestamp creation = metadataCreation();
             if (creation != null) {
-                creationTimeMillis = creation.epochMillis();
+                creationTimeMillis = creation.timestampMillis();
                 author = Author.ofEmail(creation.user());
             } else {
                 creationTimeMillis = repos.get(REPO_DOGMA).creationTimeMillis();

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserAndTimestamp.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserAndTimestamp.java
@@ -92,7 +92,7 @@ public final class UserAndTimestamp {
     /**
      * Returns the epoch milliseconds of the {@link #timestamp()}.
      */
-    public long epochMillis() {
+    public long timestampMillis() {
         return timestamp.toEpochMilli();
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserAndTimestamp.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserAndTimestamp.java
@@ -89,6 +89,13 @@ public final class UserAndTimestamp {
         return timestampAsText;
     }
 
+    /**
+     * Returns the epoch milliseconds of the {@link #timestamp()}.
+     */
+    public long epochMillis() {
+        return timestamp.toEpochMilli();
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/Project.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/Project.java
@@ -51,16 +51,12 @@ public interface Project {
     /**
      * Returns the creation time of this project, in milliseconds.
      */
-    default long creationTimeMillis() {
-        return repos().get(REPO_DOGMA).creationTimeMillis();
-    }
+    long creationTimeMillis();
 
     /**
      * Returns the author who initially created this project.
      */
-    default Author author() {
-        return repos().get(REPO_DOGMA).author();
-    }
+    Author author();
 
     /**
      * Returns the {@link MetaRepository} of this project.

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -135,8 +135,8 @@ class ProjectServiceV1Test {
                 '{' +
                 "   \"name\": \"bar\"," +
                 "   \"creator\": {" +
-                "       \"name\": \"System\"," +
-                "       \"email\": \"system@localhost.localdomain\"" +
+                "       \"name\": \"admin\"," +
+                "       \"email\": \"admin@localhost.localdomain\"" +
                 "   }," +
                 "   \"url\": \"/api/v1/projects/bar\"," +
                 "   \"createdAt\": \"${json-unit.ignore}\"" +
@@ -187,8 +187,8 @@ class ProjectServiceV1Test {
                     "   {" +
                     "       \"name\": \"hyangtack\"," +
                     "       \"creator\": {" +
-                    "           \"name\": \"System\"," +
-                    "           \"email\": \"system@localhost.localdomain\"" +
+                    "           \"name\": \"admin\"," +
+                    "           \"email\": \"admin@localhost.localdomain\"" +
                     "       }," +
                     "       \"url\": \"/api/v1/projects/hyangtack\"," +
                     "       \"createdAt\": \"${json-unit.ignore}\"" +
@@ -196,8 +196,8 @@ class ProjectServiceV1Test {
                     "   {" +
                     "       \"name\": \"minwoox\"," +
                     "       \"creator\": {" +
-                    "           \"name\": \"System\"," +
-                    "           \"email\": \"system@localhost.localdomain\"" +
+                    "           \"name\": \"admin\"," +
+                    "           \"email\": \"admin@localhost.localdomain\"" +
                     "       }," +
                     "       \"url\": \"/api/v1/projects/minwoox\"," +
                     "       \"createdAt\": \"${json-unit.ignore}\"" +
@@ -205,8 +205,8 @@ class ProjectServiceV1Test {
                     "   {" +
                     "       \"name\": \"trustin\"," +
                     "       \"creator\": {" +
-                    "           \"name\": \"System\"," +
-                    "           \"email\": \"system@localhost.localdomain\"" +
+                    "           \"name\": \"admin\"," +
+                    "           \"email\": \"admin@localhost.localdomain\"" +
                     "       }," +
                     "       \"url\": \"/api/v1/projects/trustin\"," +
                     "       \"createdAt\": \"${json-unit.ignore}\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -40,8 +40,8 @@ class TokenServiceTest {
     @RegisterExtension
     static final ProjectManagerExtension manager = new ProjectManagerExtension();
 
-    private static final Author adminAuthor = new Author("admin@localhost.com");
-    private static final Author guestAuthor = new Author("guest@localhost.com");
+    private static final Author adminAuthor = Author.ofEmail("admin@localhost.com");
+    private static final Author guestAuthor = Author.ofEmail("guest@localhost.com");
     private static final User admin = new User("admin@localhost.com", User.LEVEL_ADMIN);
     private static final User guest = new User("guest@localhost.com");
 


### PR DESCRIPTION
Motivation:
The current creator of a project is the creator of the internal `dogma` repository, consistently set as `System`. We should show the correct creator which is stored in the `metadata.json` file.

A noteworthy observation is that only the email of the creator is stored in `metadata.json` instead of the complete `Author` information. A temporary solution involves restoring the `Author` using the email, with plans to revisit this approach if issues arise.

Modifications:
- Fix to show project creators correctly using information stored in the `metadata.json` file.

Result:
- Close #908 
- The project creator is now correctly retrieved based on the information stored in the `metadata.json` file.