### PR TITLE
Add xds module to build.gradle in dist

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -27,6 +27,7 @@ evaluationDependsOn(':server')
 evaluationDependsOn(':server-auth:saml')
 evaluationDependsOn(':server-auth:shiro')
 evaluationDependsOn(':server-mirror-git')
+evaluationDependsOn(':xds')
 
 ext {
     distDir = "${project.buildDir}/dist"
@@ -78,6 +79,10 @@ task copyLib(group: 'Build',
     from project(':server-auth:shiro').tasks.jar
     from project(':server-mirror-git').configurations.runtimeClasspath
     from project(':server-mirror-git').tasks.jar
+    from project(':xds').configurations.runtimeClasspath {
+        exclude group: 'org.eclipse.jgit'
+    }
+    from project(':xds').tasks.jar
 
     File libDir = new File("${project.ext.distDir}/lib")
     into libDir


### PR DESCRIPTION
Here is the list of libraries added:
```
animal-sniffer-annotations-1.23.jar
annotations-4.1.1.4.jar
api-1.0.39.jar
armeria-grpc-1.27.0.jar
armeria-grpc-protocol-1.27.0.jar
armeria-protobuf-1.27.0.jar
auto-value-annotations-1.6.3.jar
byte-buddy-1.14.4.jar
cache-1.0.39.jar
centraldogma-xds-0.64.1-SNAPSHOT.jar
grpc-api-1.61.0.jar
grpc-context-1.61.0.jar
grpc-core-1.61.0.jar
grpc-protobuf-1.61.0.jar
grpc-protobuf-lite-1.61.0.jar
grpc-services-1.61.0.jar
grpc-stub-1.61.0.jar
grpc-util-1.61.0.jar
gson-2.10.1.jar
j2objc-annotations-2.8.jar
perfmark-api-0.26.0.jar
proto-google-common-protos-2.29.0.jar
protobuf-jackson-2.2.0.jar
protobuf-java-3.25.1.jar
protobuf-java-util-3.25.1.jar
server-1.0.39.jar
```