### PR TITLE
Update Armeria version when available

### DIFF
--- a/.github/workflows/update-armeria-version.yml
+++ b/.github/workflows/update-armeria-version.yml
@@ -14,6 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Wait for Armeria artifacts to be available
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: "https://repo.maven.apache.org/maven2/com/linecorp/armeria/armeria-bom/${{ inputs.armeria_version }}/armeria-bom-${{ inputs.armeria_version }}.pom"
+          responseCode: 200
+          timeout: 60000 # 1 minute
+          interval: 60000 # 1 minute
+
       - name: Update Armeria version to ${{ inputs.armeria_version }}
         run: |
           sed -i "s/armeria = \".*\"/armeria = \"${{ inputs.armeria_version }}\"/" dependencies.toml

--- a/.github/workflows/update-armeria-version.yml
+++ b/.github/workflows/update-armeria-version.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           url: "https://repo.maven.apache.org/maven2/com/linecorp/armeria/armeria-bom/${{ inputs.armeria_version }}/armeria-bom-${{ inputs.armeria_version }}.pom"
           responseCode: 200
-          timeout: 60000 # 1 minute
+          timeout: 18000000 # Timeout before giving up in milliseconds. 5 hours
           interval: 60000 # 1 minute
 
       - name: Update Armeria version to ${{ inputs.armeria_version }}


### PR DESCRIPTION
Motivation:

Currently, `update-armeria-version.yml` is triggered right after the publication of Armeria artifacts has done. As it takes some time to replicate the artifacts to Maven Central from OSS Sonatype, the PR maded by `update-armeria-version.yml` always fails.

Modifications:

- Add a new step for waiting until Armeria artifacts are available in Maven Central.

Result:

Enhanced automation