### PR TITLE
Fix history displays irrelevant changes

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
@@ -34,6 +34,8 @@ public final class HttpApiV1Constants {
 
     public static final String REPOS = "/repos";
 
+    public static final String REPOSITORIES = "/repositories";
+
     public static final String COMMITS = "/commits";
 
     public static final String COMPARE = "/compare";

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/HttpApiV1Constants.java
@@ -30,6 +30,8 @@ public final class HttpApiV1Constants {
 
     public static final String PROJECTS_PREFIX = API_V1_PATH_PREFIX + PROJECTS;
 
+    public static final String PROJECTS_VO_PREFIX = API_V0_PATH_PREFIX + PROJECTS;
+
     public static final String REPOS = "/repos";
 
     public static final String COMMITS = "/commits";

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -177,10 +177,11 @@ public class RepositoryService extends AbstractService {
                                                        @Param String path,
                                                        @Param @Default("-1") String from,
                                                        @Param @Default("1") String to) {
+        final String pathPattern = "/".equals(path) ? "/**" : path + "/**";
         return projectApiManager.getProject(projectName).repos().get(repoName)
                                 .history(new Revision(from),
                                          new Revision(to),
-                                         path + "**")
+                                        pathPattern)
                                 .thenApply(commits -> commits.stream()
                                                              .map(DtoConverter::convert)
                                                              .collect(toList()));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -181,7 +181,7 @@ public class RepositoryService extends AbstractService {
         return projectApiManager.getProject(projectName).repos().get(repoName)
                                 .history(new Revision(from),
                                          new Revision(to),
-                                        pathPattern)
+                                         pathPattern)
                                 .thenApply(commits -> commits.stream()
                                                              .map(DtoConverter::convert)
                                                              .collect(toList()));

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryServiceTest.java
@@ -1,36 +1,151 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
 package com.linecorp.centraldogma.server.internal.admin.service;
 
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_VO_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOSITORIES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.stream.StreamSupport;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
 import com.fasterxml.jackson.databind.JsonNode;
+
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
-import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
-import org.junit.ClassRule;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
-
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.*;
 
 class RepositoryServiceTest {
 
     @RegisterExtension
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.webAppEnabled(true);
+        }
+
+        @Override
         protected void configureHttpClient(WebClientBuilder builder) {
             builder.addHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
         }
     };
 
+    private static final String REPOS_PREFIX = PROJECTS_PREFIX + "/myPro" + REPOS;
+    private static final String REPOSITORIES_PREFIX = PROJECTS_VO_PREFIX + "/myPro" + REPOSITORIES;
+    private static final String FILES_PATH = "/files/revisions/head";
+
+    @BeforeAll
+    static void setUp() {
+        createProject(dogma);
+    }
+
     @Test
-    void getUsersInfo() throws IOException {
+    void getHistory() throws IOException {
         final WebClient client = dogma.httpClient();
-        final AggregatedHttpResponse userInfo = client.get("/api/v0/users/me").aggregate().join();
-        final JsonNode jsonNode = Jackson.readTree(userInfo.contentUtf8());
-        assertThat(jsonNode.get("login").asText()).isEqualTo("admin@localhost.localdomain");
+        final String repoName = "myRepo";
+        final AggregatedHttpResponse repoResponse = createRepository(client, repoName);
+        final ResponseHeaders repoResponseHeaders = ResponseHeaders.of(repoResponse.headers());
+        assertThat(repoResponseHeaders.status()).isEqualTo(HttpStatus.CREATED);
+
+        final String repoNamePrefix = "/myRepo";
+        final AggregatedHttpResponse fileResponse1 = createFile(client,
+                repoNamePrefix,
+                "/foo/bar.txt",
+                "bar.txt",
+                "Bar");
+        final ResponseHeaders fileResponseHeader1 = ResponseHeaders.of(fileResponse1.headers());
+        assertThat(fileResponseHeader1.status()).isEqualTo(HttpStatus.CREATED);
+
+        final AggregatedHttpResponse fileResponse2 = createFile(client,
+                repoNamePrefix,
+                "/foo2/bar2.txt",
+                "bar2.txt",
+                "Bar 2");
+        final ResponseHeaders file2ResponseHeaders = ResponseHeaders.of(fileResponse2.headers());
+        assertThat(file2ResponseHeaders.status()).isEqualTo(HttpStatus.CREATED);
+
+        final AggregatedHttpResponse historyResponse1 = getHistory(client, repoNamePrefix, "/foo");
+        final JsonNode fooHistory = Jackson.readTree(historyResponse1.contentUtf8());
+        assertThat(fooHistory.get(0).get("summary").asText()).isEqualTo("Add /foo/bar.txt");
+        final boolean containsUndesiredString = StreamSupport.stream(fooHistory.spliterator(), false)
+                .anyMatch(node -> "Add /foo2/bar2.txt".equals(node.get("summary").asText()));
+        assertThat(containsUndesiredString).isFalse();
+    }
+
+    private static AggregatedHttpResponse getHistory(WebClient client, String repoName, String childRepoName) {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.GET,
+                REPOSITORIES_PREFIX + repoName + "/history" + childRepoName + "?from=head&to=1",
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        return client.execute(headers).aggregate().join();
+    }
+
+    private static AggregatedHttpResponse createRepository(WebClient client, String repoName) {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, REPOS_PREFIX,
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final String body = "{\"name\": \"" + repoName + "\"}";
+        return client.execute(headers, body).aggregate().join();
+    }
+
+    private static AggregatedHttpResponse createFile(WebClient client,
+                                                     String repoName,
+                                                     String path,
+                                                     String fileName,
+                                                     String content) {
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
+                REPOSITORIES_PREFIX + repoName + FILES_PATH,
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final String body = "{\n" +
+                "  \"file\": {\n" +
+                "    \"name\": \"" + fileName + "\",\n" +
+                "    \"type\": \"TEXT\",\n" +
+                "    \"content\": \"" + content + "\",\n" +
+                "    \"path\": \"" + path + "\"\n" +
+                "  },\n" +
+                "  \"commitMessage\": {\n" +
+                "    \"summary\": \"Add " + path + "\",\n" +
+                "    \"detail\": {\n" +
+                "      \"content\": \"\",\n" +
+                "      \"markup\": \"PLAINTEXT\"\n" +
+                "    }\n" +
+                "  }\n" +
+                '}';
+        return client.execute(headers, body).aggregate().join();
+    }
+
+    private static void createProject(CentralDogmaExtension dogma) {
+        final String body = "{\"name\": \"myPro\"}";
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, PROJECTS_PREFIX,
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final WebClient client = dogma.httpClient();
+        client.execute(headers, body).aggregate().join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryServiceTest.java
@@ -1,0 +1,36 @@
+package com.linecorp.centraldogma.server.internal.admin.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+import com.linecorp.centraldogma.testing.junit4.CentralDogmaRule;
+import org.junit.ClassRule;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.*;
+
+class RepositoryServiceTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configureHttpClient(WebClientBuilder builder) {
+            builder.addHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        }
+    };
+
+    @Test
+    void getUsersInfo() throws IOException {
+        final WebClient client = dogma.httpClient();
+        final AggregatedHttpResponse userInfo = client.get("/api/v0/users/me").aggregate().join();
+        final JsonNode jsonNode = Jackson.readTree(userInfo.contentUtf8());
+        assertThat(jsonNode.get("login").asText()).isEqualTo("admin@localhost.localdomain");
+    }
+}


### PR DESCRIPTION
Motivate: 
The history of a directory includes changes in directories share the name. For instance: the history of `/foo` displays changes for `/foo2`, `/foo3`, `/foobar` ...

Modifications:
Add a slash `(/)` before `**` in the path `(path + "/**")`. The pattern `foo/**` matches `/foo/anything`, `/foo/subdir/file`, but it does not match anything that isn't a subpath of `/foo`.

Result
Fixes https://github.com/line/centraldogma/issues/902