### PR TITLE
Gracefully shut down watches when server is shutting down

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractWatcher.java
@@ -48,7 +48,6 @@ import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.common.ShuttingDownException;
 
 abstract class AbstractWatcher<T> implements Watcher<T> {
 
@@ -274,9 +273,6 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
                      } else if (cause instanceof RepositoryNotFoundException) {
                          logger.info("{}/{} does not exist yet; trying again",
                                      projectName, repositoryName);
-                         logged = true;
-                     } else if (cause instanceof ShuttingDownException) {
-                         logger.info("Central Dogma is shutting down; trying again");
                          logged = true;
                      }
                  }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -594,7 +594,8 @@ public interface CentralDogma {
      * {@link CompletableFuture} will be completed with {@code null}.
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
-     *         {@code null} if the files were not changed for 1 minute since the invocation of this method.
+     *         {@code null} if the files were not changed for 1 minute since the invocation of this method,
+     *         or the server is shut down during the watch.
      *
      * @deprecated Use {@link WatchFilesRequest#start(Revision)} via
      *             {@link CentralDogmaRepository#watch(PathPattern)}.
@@ -615,7 +616,7 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method.
+     *         since the invocation of this method, or the server is shut down during the watch.
      *
      * @deprecated Use {@link CentralDogmaRepository#watch(PathPattern)} and
      *             {@link WatchFilesRequest#start(Revision)}.
@@ -645,8 +646,8 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method. {@link EntryNotFoundException} is raised if the
-     *         target does not exist.
+     *         since the invocation of this method, or the server is shut down during the watch.
+     *         {@link EntryNotFoundException} is raised if the target does not exist.
      */
     CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                 Revision lastKnownRevision, PathPattern pathPattern,
@@ -658,7 +659,8 @@ public interface CentralDogma {
      * {@link CompletableFuture} will be completed with {@code null}.
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
-     *         {@code null} if the file was not changed for 1 minute since the invocation of this method.
+     *         {@code null} if the file was not changed for 1 minute since the invocation of this method,
+     *         or the server is shut down during the watch.
      *
      * @deprecated Use {@link WatchRequest#start(Revision)} via {@link CentralDogmaRepository#watch(Query)}.
      */
@@ -678,7 +680,7 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method.
+     *         since the invocation of this method, or the server is shut down during the watch.
      *
      * @deprecated Use {@link WatchRequest#start(Revision)} via {@link CentralDogmaRepository#watch(Query)}.
      */
@@ -709,8 +711,8 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method. {@link EntryNotFoundException} is raised if the
-     *         target does not exist.
+     *         since the invocation of this method, or the server is shut down during the watch.
+     *         {@link EntryNotFoundException} is raised if the target does not exist.
      */
     <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,
                                               Revision lastKnownRevision, Query<T> query,

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -594,8 +594,8 @@ public interface CentralDogma {
      * {@link CompletableFuture} will be completed with {@code null}.
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
-     *         {@code null} if the files were not changed for 1 minute since the invocation of this method,
-     *         or the server is shut down during the watch.
+     *         {@code null} if the files were not changed for 1 minute since the invocation of this method.
+     *         Even before the timeout, the watch may return null earlier due to issues such as server restart.
      *
      * @deprecated Use {@link WatchFilesRequest#start(Revision)} via
      *             {@link CentralDogmaRepository#watch(PathPattern)}.
@@ -616,7 +616,8 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method, or the server is shut down during the watch.
+     *         since the invocation of this method. Even before the timeout, the watch may return null
+     *         earlier due to issues such as server restart.
      *
      * @deprecated Use {@link CentralDogmaRepository#watch(PathPattern)} and
      *             {@link WatchFilesRequest#start(Revision)}.
@@ -646,8 +647,9 @@ public interface CentralDogma {
      *
      * @return the latest known {@link Revision} which contains the changes for the matched files.
      *         {@code null} if the files were not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method, or the server is shut down during the watch.
-     *         {@link EntryNotFoundException} is raised if the target does not exist.
+     *         since the invocation of this method. Even before the timeout, the watch may return null
+     *         earlier due to issues such as server restart. {@link EntryNotFoundException} is raised
+     *         if the target does not exist.
      */
     CompletableFuture<Revision> watchRepository(String projectName, String repositoryName,
                                                 Revision lastKnownRevision, PathPattern pathPattern,
@@ -659,8 +661,8 @@ public interface CentralDogma {
      * {@link CompletableFuture} will be completed with {@code null}.
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
-     *         {@code null} if the file was not changed for 1 minute since the invocation of this method,
-     *         or the server is shut down during the watch.
+     *         {@code null} if the file was not changed for 1 minute since the invocation of this method.
+     *         Even before the timeout, the watch may return null earlier due to issues such as server restart.
      *
      * @deprecated Use {@link WatchRequest#start(Revision)} via {@link CentralDogmaRepository#watch(Query)}.
      */
@@ -680,7 +682,8 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method, or the server is shut down during the watch.
+     *         since the invocation of this method. Even before the timeout, the watch may return null
+     *         earlier due to issues such as server restart.
      *
      * @deprecated Use {@link WatchRequest#start(Revision)} via {@link CentralDogmaRepository#watch(Query)}.
      */
@@ -711,7 +714,8 @@ public interface CentralDogma {
      *
      * @return the {@link Entry} which contains the latest known {@link Query} result.
      *         {@code null} if the file was not changed for {@code timeoutMillis} milliseconds
-     *         since the invocation of this method, or the server is shut down during the watch.
+     *         since the invocation of this method. Even before the timeout, the watch may return null
+     *         earlier due to issues such as server restart.
      *         {@link EntryNotFoundException} is raised if the target does not exist.
      */
     <T> CompletableFuture<Entry<T>> watchFile(String projectName, String repositoryName,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -66,6 +66,7 @@ import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.RevisionRange;
+import com.linecorp.centraldogma.common.ShuttingDownException;
 import com.linecorp.centraldogma.internal.api.v1.ChangeDto;
 import com.linecorp.centraldogma.internal.api.v1.CommitMessageDto;
 import com.linecorp.centraldogma.internal.api.v1.EntryDto;
@@ -313,7 +314,8 @@ public class ContentServiceV1 extends AbstractService {
     }
 
     private static Object handleWatchFailure(Throwable thrown) {
-        if (Throwables.getRootCause(thrown) instanceof CancellationException) {
+        final Throwable rootCause = Throwables.getRootCause(thrown);
+        if (rootCause instanceof CancellationException || rootCause instanceof ShuttingDownException) {
             // timeout happens
             return HttpResponse.of(HttpStatus.NOT_MODIFIED);
         }


### PR DESCRIPTION
**Motivation**

When `CentralDogma` is shutting down, clients watching the server inevitably receive a 500 HTTP response code.

While for most requests I think this behavior makes sense, watch requests by nature are expected to continuously watch the server and are probably not interested in shut down notifications.

To minimize noise while monitoring CentralDogma servers, I propose that we return a 304 status code for watch requests when the server is shutting down

**Modifications**
- Return a 304 for watch requests when `ShuttingDownException` is bubbled up

**Result**
- Central Dogma Server maintainers can monitor with less noise
- Closes https://github.com/line/centraldogma/issues/928