### PR TITLE
Update documentation as using Github Packages registry instead of Dockerhub

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
@@ -115,12 +115,6 @@ public final class MirrorConfig {
     @Nullable
     Mirror toMirror(Project parent, Iterable<MirrorCredential> credentials) {
         if (!enabled || localRepo == null || !parent.repos().exists(localRepo)) {
-            final String localRepoStatus = localRepo == null ? "not specified" : "does not exist";
-            logger.warn("Mirroring is not possible because one or more conditions are not met: " +
-                            "mirroring enabled={}, localRepo={}, localRepo status={}. " +
-                            "Please ensure mirroring is enabled, a local repository name is specified, " +
-                            "and the local repository exists.",
-                    enabled, localRepo == null ? "null" : localRepo, localRepoStatus);
             return null;
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
@@ -115,6 +115,12 @@ public final class MirrorConfig {
     @Nullable
     Mirror toMirror(Project parent, Iterable<MirrorCredential> credentials) {
         if (!enabled || localRepo == null || !parent.repos().exists(localRepo)) {
+            final String localRepoStatus = localRepo == null ? "not specified" : "does not exist";
+            logger.warn("Mirroring is not possible because one or more conditions are not met: " +
+                            "mirroring enabled={}, localRepo={}, localRepo status={}. " +
+                            "Please ensure mirroring is enabled, a local repository name is specified, " +
+                            "and the local repository exists.",
+                    enabled, localRepo == null ? "null" : localRepo, localRepoStatus);
             return null;
         }
 

--- a/site/src/sphinx/index.rst
+++ b/site/src/sphinx/index.rst
@@ -40,11 +40,11 @@ Give it a try!
     $ bin/startup
     <Open http://127.0.0.1:36462/ in your browser for administrative console.>
 
-Using Docker? Launch our image at `Docker Hub <https://hub.docker.com/r/line/centraldogma/>`_:
+Using Docker? Launch our image at `Github Packages registry <https://github.com/line/centraldogma/pkgs/container/centraldogma>`_:
 
 .. code-block:: shell
 
-    $ docker run -p 36462:36462 line/centraldogma
+    $ docker run -p 36462:36462 ghcr.io/line/centraldogma
 
 Repository service for textual configuration
 --------------------------------------------


### PR DESCRIPTION
### Motivation
We must also update the document since centraldogma used [Github Packages registry](https://github.com/line/centraldogma/pkgs/container/centraldogma).
Related: https://github.com/line/centraldogma/issues/926