### PR TITLE
Wait for quiet period after health check

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -326,6 +326,16 @@ public class CentralDogma implements AutoCloseable {
      */
     public CompletableFuture<Void> stop() {
         serverHealth.setHealthy(false);
+
+        final Optional<GracefulShutdownTimeout> gracefulTimeoutOpt = cfg.gracefulShutdownTimeout();
+        if (gracefulTimeoutOpt.isPresent()) {
+            try {
+                Thread.sleep(gracefulTimeoutOpt.get().quietPeriodMillis());
+            } catch (InterruptedException e) {
+                logger.debug("Interrupted while waiting for quiet period", e);
+            }
+        }
+
         numPendingStopRequests.incrementAndGet();
         return startStop.stop().thenRun(numPendingStopRequests::decrementAndGet);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -334,6 +334,7 @@ public class CentralDogma implements AutoCloseable {
                 Thread.sleep(gracefulTimeoutOpt.get().quietPeriodMillis());
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for quiet period", e);
+                Thread.currentThread().interrupt();
             }
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -330,6 +330,7 @@ public class CentralDogma implements AutoCloseable {
         final Optional<GracefulShutdownTimeout> gracefulTimeoutOpt = cfg.gracefulShutdownTimeout();
         if (gracefulTimeoutOpt.isPresent()) {
             try {
+                // Sleep so that clients have some time to redirect traffic according to the health status
                 Thread.sleep(gracefulTimeoutOpt.get().quietPeriodMillis());
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for quiet period", e);

--- a/server/src/main/java/com/linecorp/centraldogma/server/GracefulShutdownTimeout.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/GracefulShutdownTimeout.java
@@ -15,6 +15,8 @@
  */
 package com.linecorp.centraldogma.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
@@ -37,6 +39,10 @@ public final class GracefulShutdownTimeout {
     public GracefulShutdownTimeout(
             @JsonProperty(value = "quietPeriodMillis", required = true) long quietPeriodMillis,
             @JsonProperty(value = "timeoutMillis", required = true) long timeoutMillis) {
+        checkArgument(quietPeriodMillis >= 0,
+                      "quietPeriodMillis: %s (expected: >= 0)", quietPeriodMillis);
+        checkArgument(timeoutMillis >= 0,
+                      "timeoutMillis: %s (expected: >= 0)", timeoutMillis);
         this.quietPeriodMillis = quietPeriodMillis;
         this.timeoutMillis = timeoutMillis;
     }


### PR DESCRIPTION
**Motivation**

https://github.com/line/centraldogma/issues/928

When `CentralDogma` server is shutting down, we set the health check to false and then initiate the shutdown process.
However, we do this immediately so clients likely don't have time to react to the health check signal.
I propose that we wait for `quietPeriodMillis` after setting the health check for more graceful shutdown behavior.

Note that I've left the `ServerBuilder#gracefulShutdownTimeout` call as-is since if requests are correctly drained `gracefulShutdownTimeout`, won't have an effect.

**Modifications**

- It is possible that a user provides a negative `quietPeriodMillis`, so added a >= 0 validation
- Added a sleep right after setting the health check to false

**Result**
- Graceful shutdown behavior