### PR TITLE
Retry the ZooKeeper lock operation to avoid entering read-only mode unwantedly

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -999,7 +999,7 @@ public final class ZooKeeperCommandExecutor
 
         @JsonCreator
         LogMeta(@JsonProperty(value = "replicaId", required = true) int replicaId,
-                @JsonProperty(value = "timestamp", defaultValue = "0") @Nullable Long timestamp,
+                @JsonProperty(value = "timestamp", defaultValue = "0") Long timestamp,
                 @JsonProperty("size") int size) {
             this.replicaId = replicaId;
             if (timestamp == null) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
@@ -91,6 +91,7 @@ final class Replica {
             }
         }, meterRegistry, mock(ProjectManager.class), writeQuota, null, null);
         commandExecutor.setMetadataService(mockMetaService());
+        commandExecutor.setLockTimeoutMillis(10000);
 
         startFuture = start ? commandExecutor.start() : null;
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -34,11 +34,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -48,7 +46,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreV2;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.function.ThrowingConsumer;
@@ -425,7 +422,9 @@ class ZooKeeperCommandExecutorTest {
                 return CompletableFuture.supplyAsync(() -> {
                     try {
                         Thread.sleep(15000);
-                    } catch (InterruptedException ignored) {}
+                    } catch (InterruptedException ignored) {
+                        // Ignore
+                    }
                     return null;
                 }, CommonPools.blockingTaskExecutor());
             } else {


### PR DESCRIPTION
Motivation:

Although not frequent, ZooKeeper seems to fail when `ZooKeeperCommandExecutor.safeLock()` attempts to acquire a lock when the system is under load, leading into read-only mode.

Modifications:

- Retry up to 1 minute to acquire a lock.
- Log what command is causing the problem.
- Miscellaneous:
  - Fix the problem where `ZooKeeperCommandExecutorTest.lockTimeout()` doesn't terminate.

Result:

- Central Dogma does not enter read-only mode unexpectedly under load.