### PR TITLE
Add HTTP API for updating a token level

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
@@ -19,7 +19,7 @@ package com.linecorp.centraldogma.server.internal.api;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-class TokenLevelRequest {
+public final class TokenLevelRequest {
     private final String level;
 
     @JsonCreator

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
@@ -16,21 +16,19 @@
 
 package com.linecorp.centraldogma.server.internal.api;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 class TokenLevelRequest {
-    private String level;
+    private final String level;
 
-    TokenLevelRequest() {
-    }
-
-    TokenLevelRequest(String level) {
+    @JsonCreator
+    TokenLevelRequest(@JsonProperty("level") String level) {
         this.level = level;
     }
 
-    String getLevel() {
+    @JsonProperty
+    String level() {
         return level;
-    }
-
-    void setLevel(String level) {
-        this.level = level;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenLevelRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+class TokenLevelRequest {
+    private String level;
+
+    TokenLevelRequest() {
+    }
+
+    TokenLevelRequest(String level) {
+        this.level = level;
+    }
+
+    String getLevel() {
+        return level;
+    }
+
+    void setLevel(String level) {
+        this.level = level;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -201,8 +201,8 @@ public class TokenService extends AbstractService {
     @Consumes("application/json-patch+json")
     @RequiresAdministrator
     public CompletableFuture<Token> updateTokenLevel(ServiceRequestContext ctx,
-                                                          @Param String appId,
-                                                          Author author, User loginUser) {
+                                                     @Param String appId,
+                                                     Author author, User loginUser) {
         return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
                 token -> {
                     if (token.isAdmin()) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -192,6 +192,31 @@ public class TokenService extends AbstractService {
         );
     }
 
+    /**
+     * PATCH /tokens/{appId}/permission
+     *
+     * <p>Updates a permission of a token of the specified ID.
+     */
+    @Patch("/tokens/{appId}/level")
+    @Consumes("application/json-patch+json")
+    @RequiresAdministrator
+    public CompletableFuture<Token> updateTokenLevel(ServiceRequestContext ctx,
+                                                          @Param String appId,
+                                                          Author author, User loginUser) {
+        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
+                token -> {
+                    if (token.isAdmin()) {
+                        return mds.updateTokenToUser(author, appId).thenApply(
+                                unused -> mds.findTokenByAppId(appId).join().withoutSecret()
+                        );
+                    } else {
+                        return mds.updateTokenToAdmin(author, appId).thenApply(
+                                unused -> mds.findTokenByAppId(appId).join().withoutSecret()
+                        );
+                    }
+                });
+    }
+
     private CompletableFuture<Token> getTokenOrRespondForbidden(ServiceRequestContext ctx,
                                                                 String appId, User loginUser) {
         return mds.findTokenByAppId(appId).thenApply(token -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -19,7 +19,6 @@ package com.linecorp.centraldogma.server.internal.api;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 
@@ -206,14 +205,15 @@ public class TokenService extends AbstractService {
                                                      TokenLevelRequest tokenLevelRequest,
                                                      Author author, User loginUser) {
 
-        checkArgument(Arrays.asList("user", "admin").contains(tokenLevelRequest.level().toLowerCase()),
-                      "Unsupported token level: " + tokenLevelRequest.level());
+        final String newTokenLevel = tokenLevelRequest.level().toLowerCase();
+        checkArgument("user".equals(newTokenLevel) || "admin".equals(newTokenLevel),
+                      "token level: %s (expected: user or admin)" + tokenLevelRequest.level());
 
         return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
                 token -> {
                     boolean toBeAdmin = false;
 
-                    switch (tokenLevelRequest.level().toLowerCase()) {
+                    switch (newTokenLevel) {
                         case "user":
                             if (!token.isAdmin()) {
                                 throw HttpStatusException.of(HttpStatus.NOT_MODIFIED);

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1000,6 +1000,53 @@ public class MetadataService {
     }
 
     /**
+     * Update the {@link Token} of the specified {@code appId} to user.
+     */
+    public CompletableFuture<Revision> updateTokenToUser(Author author, String appId) {
+        requireNonNull(author, "author");
+        requireNonNull(appId, "appId");
+
+        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
+                              "Update the token: " + appId + " to user",
+                              () -> tokenRepo
+                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
+                                      .thenApply(tokens -> {
+                                          final JsonPointer adminPath = JsonPointer.compile(
+                                                  "/appIds" + encodeSegment(appId) +
+                                                  "/admin");
+                                          final Change<JsonNode> change = Change.ofJsonPatch(
+                                                  TOKEN_JSON,
+                                                  new ReplaceOperation(adminPath,
+                                                                       Jackson.valueToTree(
+                                                                               false)).toJsonNode());
+                                          return HolderWithRevision.of(change, tokens.revision());
+                                      }));
+    }
+
+    /**
+     * Update the {@link Token} of the specified {@code appId} to admin.
+     */
+    public CompletableFuture<Revision> updateTokenToAdmin(Author author, String appId) {
+        requireNonNull(author, "author");
+        requireNonNull(appId, "appId");
+
+        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
+                              "Update the token: " + appId + " to admin",
+                              () -> tokenRepo
+                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
+                                      .thenApply(tokens -> {
+                                          final JsonPointer adminPath = JsonPointer.compile(
+                                                  "/appIds" + encodeSegment(appId) +
+                                                  "/admin");
+                                          final Change<JsonNode> change = Change.ofJsonPatch(
+                                                  TOKEN_JSON,
+                                                  new ReplaceOperation(adminPath,
+                                                                       Jackson.valueToTree(true)).toJsonNode());
+                                          return HolderWithRevision.of(change, tokens.revision());
+                                      }));
+    }
+
+    /**
      * Returns a {@link Token} which has the specified {@code appId}.
      */
     public CompletableFuture<Token> findTokenByAppId(String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1007,20 +1007,19 @@ public class MetadataService {
         requireNonNull(appId, "appId");
 
         return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                              "Update the token level: " + appId,
-                              () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
-                                      .thenApply(tokens -> {
-                                          final JsonPointer adminPath = JsonPointer.compile(
-                                                  "/appIds" + encodeSegment(appId) +
-                                                  "/admin");
-                                          final Change<JsonNode> change = Change.ofJsonPatch(
-                                                  TOKEN_JSON,
-                                                  new ReplaceOperation(adminPath,
-                                                                       Jackson.valueToTree(
-                                                                               toBeAdmin)).toJsonNode());
-                                          return HolderWithRevision.of(change, tokens.revision());
-                                      }));
+                              "Update the token level: " + appId + " to " + (toBeAdmin ? "admin" : "user"),
+                              () -> tokenRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
+                                             .thenApply(tokens -> {
+                                                 final JsonPointer adminPath = JsonPointer.compile(
+                                                         "/appIds" + encodeSegment(appId) +
+                                                         "/admin");
+                                                 final Change<JsonNode> change = Change.ofJsonPatch(
+                                                         TOKEN_JSON,
+                                                         new ReplaceOperation(adminPath,
+                                                                              Jackson.valueToTree(
+                                                                                      toBeAdmin)).toJsonNode());
+                                                 return HolderWithRevision.of(change, tokens.revision());
+                                             }));
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1000,14 +1000,14 @@ public class MetadataService {
     }
 
     /**
-     * Update the {@link Token} of the specified {@code appId} to user.
+     * Update the {@link Token} of the specified {@code appId} to user or admin.
      */
-    public CompletableFuture<Revision> updateTokenToUser(Author author, String appId) {
+    public CompletableFuture<Revision> updateTokenLevel(Author author, String appId, boolean toBeAdmin) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
         return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                              "Update the token: " + appId + " to user",
+                              "Update the token level: " + appId,
                               () -> tokenRepo
                                       .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
                                       .thenApply(tokens -> {
@@ -1018,30 +1018,7 @@ public class MetadataService {
                                                   TOKEN_JSON,
                                                   new ReplaceOperation(adminPath,
                                                                        Jackson.valueToTree(
-                                                                               false)).toJsonNode());
-                                          return HolderWithRevision.of(change, tokens.revision());
-                                      }));
-    }
-
-    /**
-     * Update the {@link Token} of the specified {@code appId} to admin.
-     */
-    public CompletableFuture<Revision> updateTokenToAdmin(Author author, String appId) {
-        requireNonNull(author, "author");
-        requireNonNull(appId, "appId");
-
-        return tokenRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                              "Update the token: " + appId + " to admin",
-                              () -> tokenRepo
-                                      .fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON)
-                                      .thenApply(tokens -> {
-                                          final JsonPointer adminPath = JsonPointer.compile(
-                                                  "/appIds" + encodeSegment(appId) +
-                                                  "/admin");
-                                          final Change<JsonNode> change = Change.ofJsonPatch(
-                                                  TOKEN_JSON,
-                                                  new ReplaceOperation(adminPath,
-                                                                       Jackson.valueToTree(true)).toJsonNode());
+                                                                               toBeAdmin)).toJsonNode());
                                           return HolderWithRevision.of(change, tokens.revision());
                                       }));
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -246,30 +246,29 @@ class TokenServiceTest {
     }
 
     @Test
-    public void updateTokenLevel() {
-        final Token token = tokenService.createToken("forUpdate", true, null, adminAuthor, admin).join()
+    void updateTokenLevel() {
+        final Token token = tokenService.createToken("forUpdate", false, null, adminAuthor, admin).join()
                                         .content();
         assertThat(token.isActive()).isTrue();
 
-        final Token userToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("USER"),
+        final Token userToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("ADMIN"),
                                                               adminAuthor, admin)
                                             .join();
-        assertThat(userToken.isAdmin()).isFalse();
+        assertThat(userToken.isAdmin()).isTrue();
 
-        final Token adminToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("ADMIN"),
+        final Token adminToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("USER"),
                                                                adminAuthor, admin)
                                              .join();
-        assertThat(adminToken.isAdmin()).isTrue();
+        assertThat(adminToken.isAdmin()).isFalse();
 
         assertThatThrownBy(
                 () -> tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("INVALID"),
                                                     adminAuthor, admin).join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(IllegalArgumentException.class);
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void createTokenAndUpdateLevel() throws JsonParseException {
+    void createTokenAndUpdateLevel() throws JsonParseException {
         assertThat(adminClient.post(API_V1_PATH_PREFIX + "tokens",
                                     QueryParams.of("appId", "forUpdate", "isAdmin", false),
                                     HttpData.empty())

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -203,4 +203,27 @@ class TokenServiceTest {
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(IllegalArgumentException.class);
     }
+
+    @Test
+    public void updateTokenLevel() {
+        final Token token = tokenService.createToken("forUpdate", true, null, adminAuthor, admin).join()
+                                        .content();
+        assertThat(token.isActive()).isTrue();
+
+        final Token userToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("USER"),
+                                                              adminAuthor, admin)
+                                            .join();
+        assertThat(userToken.isAdmin()).isFalse();
+
+        final Token adminToken = tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("ADMIN"),
+                                                               adminAuthor, admin)
+                                             .join();
+        assertThat(adminToken.isAdmin()).isTrue();
+
+        assertThatThrownBy(
+                () -> tokenService.updateTokenLevel(ctx, "forUpdate", new TokenLevelRequest("INVALID"),
+                                                    adminAuthor, admin).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/TokenServiceTest.java
@@ -15,9 +15,11 @@
  */
 package com.linecorp.centraldogma.server.internal.api;
 
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URI;
 import java.util.Collection;
 import java.util.concurrent.CompletionException;
 
@@ -26,16 +28,29 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.armeria.server.HttpResponseException;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.AccessToken;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.StandaloneCommandExecutor;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
@@ -44,6 +59,9 @@ import com.linecorp.centraldogma.server.metadata.Token;
 import com.linecorp.centraldogma.server.metadata.Tokens;
 import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 import io.netty.util.internal.StringUtil;
 
@@ -51,6 +69,16 @@ class TokenServiceTest {
 
     @RegisterExtension
     static final ProjectManagerExtension manager = new ProjectManagerExtension();
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.administrators(TestAuthMessageUtil.USERNAME);
+            builder.authProviderFactory(new TestAuthProviderFactory());
+        }
+    };
 
     private static final Author adminAuthor = Author.ofEmail("admin@localhost.com");
     private static final Author guestAuthor = Author.ofEmail("guest@localhost.com");
@@ -69,13 +97,26 @@ class TokenServiceTest {
 
     private static TokenService tokenService;
     private static MetadataService metadataService;
+    private static WebClient adminClient;
 
     // ctx is only used for getting the blocking task executor.
     private final ServiceRequestContext ctx =
             ServiceRequestContext.builder(HttpRequest.of(HttpMethod.GET, "/")).build();
 
+    static String sessionId(WebClient webClient, String username, String password)
+            throws JsonParseException, JsonMappingException {
+        return Jackson.readValue(TestAuthMessageUtil.login(webClient, username, password).content().array(),
+                                 AccessToken.class).accessToken();
+    }
+
     @BeforeAll
-    static void setUp() {
+    static void setUp() throws JsonMappingException, JsonParseException {
+        final URI uri = dogma.httpClient().uri();
+        adminClient = WebClient.builder(uri)
+                               .auth(AuthToken.ofOAuth2(sessionId(dogma.httpClient(),
+                                                                  TestAuthMessageUtil.USERNAME,
+                                                                  TestAuthMessageUtil.PASSWORD)))
+                               .build();
         metadataService = new MetadataService(manager.projectManager(), manager.executor());
         tokenService = new TokenService(manager.executor(), metadataService);
     }
@@ -225,5 +266,30 @@ class TokenServiceTest {
                                                     adminAuthor, admin).join())
                 .isInstanceOf(CompletionException.class)
                 .hasCauseInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void createTokenAndUpdateLevel() throws JsonParseException {
+        assertThat(adminClient.post(API_V1_PATH_PREFIX + "tokens",
+                                    QueryParams.of("appId", "forUpdate", "isAdmin", false),
+                                    HttpData.empty())
+                              .aggregate()
+                              .join()
+                              .headers()
+                              .get(HttpHeaderNames.LOCATION)).isEqualTo("/tokens/forUpdate");
+
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH,
+                                                         API_V1_PATH_PREFIX + "tokens/forUpdate/level",
+                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+
+        final String body = "{\"level\":\"ADMIN\"}";
+        final AggregatedHttpResponse response = adminClient.execute(headers, body).aggregate().join();
+
+        final JsonNode jsonNode = Jackson.readTree(response.contentUtf8());
+        assertThat(jsonNode.get("appId").asText()).isEqualTo("forUpdate");
+        assertThat(jsonNode.get("admin").asBoolean()).isEqualTo(true);
+
+        final AggregatedHttpResponse response2 = adminClient.execute(headers, body).aggregate().join();
+        assertThat(response2.status()).isEqualTo(HttpStatus.NOT_MODIFIED);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -418,11 +418,11 @@ class MetadataServiceTest {
         assertThat(token).isNotNull();
         assertThat(token.isAdmin()).isFalse();
 
-        mds.updateTokenToAdmin(author, app1).join();
+        mds.updateTokenLevel(author, app1, true).join();
         token = mds.getTokens().join().get(app1);
         assertThat(token.isAdmin()).isTrue();
 
-        mds.updateTokenToUser(author, app1).join();
+        mds.updateTokenLevel(author, app1, false).join();
         token = mds.getTokens().join().get(app1);
         assertThat(token.isAdmin()).isFalse();
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -408,6 +408,26 @@ class MetadataServiceTest {
         assertThat(repoMeta.writeQuota()).isEqualTo(writeQuota2);
     }
 
+    @Test
+    void updateUser() {
+        final MetadataService mds = newMetadataService(manager);
+
+        Token token;
+        mds.createToken(author, app1).join();
+        token = mds.getTokens().join().get(app1);
+        assertThat(token).isNotNull();
+        assertThat(token.isAdmin()).isFalse();
+
+        mds.updateTokenToAdmin(author, app1).join();
+        token = mds.getTokens().join().get(app1);
+        assertThat(token.isAdmin()).isTrue();
+
+        mds.updateTokenToUser(author, app1).join();
+        token = mds.getTokens().join().get(app1);
+        assertThat(token.isAdmin()).isFalse();
+    }
+
+
     private static RepositoryMetadata getRepo1(MetadataService mds) {
         final ProjectMetadata metadata = mds.getProject(project1).join();
         return metadata.repo(repo1);

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -427,7 +427,6 @@ class MetadataServiceTest {
         assertThat(token.isAdmin()).isFalse();
     }
 
-
     private static RepositoryMetadata getRepo1(MetadataService mds) {
         final ProjectMetadata metadata = mds.getProject(project1).join();
         return metadata.repo(repo1);


### PR DESCRIPTION
Motivation:
- Resolve https://github.com/line/centraldogma/issues/906
- A lot of effort is used to change permissions.

Modification:
- Change admin from true to false or vice versa.

Result:
- You can now change the level of a token via HTTP API.
<img width="805" alt="image" src="https://github.com/line/centraldogma/assets/19267206/9c1a527e-9bb9-4995-bf36-b284e4c644a8">
<img width="796" alt="image" src="https://github.com/line/centraldogma/assets/19267206/1709909d-6b4e-48f6-b4b6-0c078388508d">
