### PR TITLE
Add `project` and `repository` tags to `api` metrics

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -407,13 +407,13 @@ public class CentralDogma implements AutoCloseable {
                 logger.info("Starting plugins on the leader replica ..");
                 pluginsForLeaderOnly
                         .start(cfg, pm, exec, meterRegistry, purgeWorker).handle((unused, cause) -> {
-                    if (cause == null) {
-                        logger.info("Started plugins on the leader replica.");
-                    } else {
-                        logger.error("Failed to start plugins on the leader replica..", cause);
-                    }
-                    return null;
-                });
+                            if (cause == null) {
+                                logger.info("Started plugins on the leader replica.");
+                            } else {
+                                logger.error("Failed to start plugins on the leader replica..", cause);
+                            }
+                            return null;
+                        });
             }
         };
 
@@ -561,7 +561,8 @@ public class CentralDogma implements AutoCloseable {
                                                                  "Bearer " + CsrfToken.ANONYMOUS))
                                   .build());
 
-        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager);
+        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager,
+                         meterRegistry);
 
         configureMetrics(sb, meterRegistry);
 
@@ -683,7 +684,7 @@ public class CentralDogma implements AutoCloseable {
                                   ProjectApiManager projectApiManager, CommandExecutor executor,
                                   WatchService watchService, MetadataService mds,
                                   @Nullable AuthProvider authProvider,
-                                  @Nullable SessionManager sessionManager) {
+                                  @Nullable SessionManager sessionManager, MeterRegistry meterRegistry) {
         Function<? super HttpService, ? extends HttpService> decorator;
 
         if (authProvider != null) {
@@ -751,7 +752,7 @@ public class CentralDogma implements AutoCloseable {
           .decorator(decorator)
           .requestConverters(v1RequestConverter, jacksonRequestConverterFunction)
           .responseConverters(v1ResponseConverter)
-          .build(new ContentServiceV1(executor, watchService));
+          .build(new ContentServiceV1(executor, watchService, meterRegistry));
 
         if (authProvider != null) {
             final AuthConfig authCfg = cfg.authConfig();

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -407,13 +407,13 @@ public class CentralDogma implements AutoCloseable {
                 logger.info("Starting plugins on the leader replica ..");
                 pluginsForLeaderOnly
                         .start(cfg, pm, exec, meterRegistry, purgeWorker).handle((unused, cause) -> {
-                            if (cause == null) {
-                                logger.info("Started plugins on the leader replica.");
-                            } else {
-                                logger.error("Failed to start plugins on the leader replica..", cause);
-                            }
-                            return null;
-                        });
+                    if (cause == null) {
+                        logger.info("Started plugins on the leader replica.");
+                    } else {
+                        logger.error("Failed to start plugins on the leader replica..", cause);
+                    }
+                    return null;
+                });
             }
         };
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -561,8 +561,7 @@ public class CentralDogma implements AutoCloseable {
                                                                  "Bearer " + CsrfToken.ANONYMOUS))
                                   .build());
 
-        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager,
-                         meterRegistry);
+        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager);
 
         configureMetrics(sb, meterRegistry);
 
@@ -684,7 +683,7 @@ public class CentralDogma implements AutoCloseable {
                                   ProjectApiManager projectApiManager, CommandExecutor executor,
                                   WatchService watchService, MetadataService mds,
                                   @Nullable AuthProvider authProvider,
-                                  @Nullable SessionManager sessionManager, MeterRegistry meterRegistry) {
+                                  @Nullable SessionManager sessionManager) {
         Function<? super HttpService, ? extends HttpService> decorator;
 
         if (authProvider != null) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -89,8 +89,6 @@ import com.linecorp.centraldogma.server.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.storage.repository.FindOptions;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
-import io.micrometer.core.instrument.MeterRegistry;
-
 /**
  * Annotated service object for managing and watching contents.
  */
@@ -103,12 +101,10 @@ public class ContentServiceV1 extends AbstractService {
     private static final String MIRROR_LOCAL_REPO = "localRepo";
 
     private final WatchService watchService;
-    private final MeterRegistry meterRegistry;
 
-    public ContentServiceV1(CommandExecutor executor, WatchService watchService, MeterRegistry meterRegistry) {
+    public ContentServiceV1(CommandExecutor executor, WatchService watchService) {
         super(executor);
         this.watchService = requireNonNull(watchService, "watchService");
-        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
     }
 
     /**
@@ -193,8 +189,6 @@ public class ContentServiceV1 extends AbstractService {
             CommitMessageDto commitMessage,
             @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
         checkPush(repository.name(), changes);
-        meterRegistry.counter("commits.push", "project", repository.parent().name(), "repository", repository.name())
-                     .increment();
 
         final long commitTimeMillis = System.currentTimeMillis();
         return push(commitTimeMillis, author, repository, new Revision(revision), commitMessage, changes)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -89,6 +89,8 @@ import com.linecorp.centraldogma.server.storage.repository.FindOption;
 import com.linecorp.centraldogma.server.storage.repository.FindOptions;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
+import io.micrometer.core.instrument.MeterRegistry;
+
 /**
  * Annotated service object for managing and watching contents.
  */
@@ -101,10 +103,12 @@ public class ContentServiceV1 extends AbstractService {
     private static final String MIRROR_LOCAL_REPO = "localRepo";
 
     private final WatchService watchService;
+    private final MeterRegistry meterRegistry;
 
-    public ContentServiceV1(CommandExecutor executor, WatchService watchService) {
+    public ContentServiceV1(CommandExecutor executor, WatchService watchService, MeterRegistry meterRegistry) {
         super(executor);
         this.watchService = requireNonNull(watchService, "watchService");
+        this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
     }
 
     /**
@@ -189,6 +193,8 @@ public class ContentServiceV1 extends AbstractService {
             CommitMessageDto commitMessage,
             @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
         checkPush(repository.name(), changes);
+        meterRegistry.counter("commits.push", "project", repository.parent().name(), "repository", repository.name())
+                     .increment();
 
         final long commitTimeMillis = System.currentTimeMillis();
         return push(commitTimeMillis, author, repository, new Revision(revision), commitMessage, changes)

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
@@ -53,12 +53,12 @@ class PushMetricTest {
               .commit("Add a file", Change.ofTextUpsert("/a.txt", "a"))
               .push().join();
 
-        final Counter pushCounter1 =
-                meterRegistry.find("api.requests")
-                             .tags("service", ContentServiceV1.class.getName(), "method", "push")
-                             .tags("project", projectName, "repository", repoName)
-                             .counter();
         await().untilAsserted(() -> {
+            final Counter pushCounter1 =
+                    meterRegistry.find("api.requests")
+                                 .tags("service", ContentServiceV1.class.getName(), "method", "push")
+                                 .tags("project", projectName, "repository", repoName)
+                                 .counter();
             // Check whether the push counter is increased by one.
             assertThat(pushCounter1.count()).isEqualTo(before + 1);
         });

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
@@ -59,6 +59,7 @@ class PushMetricTest {
                                  .tags("service", ContentServiceV1.class.getName(), "method", "push")
                                  .tags("project", projectName, "repository", repoName)
                                  .counter();
+            assertThat(pushCounter1).isNotNull();
             // Check whether the push counter is increased by one.
             assertThat(pushCounter1.count()).isEqualTo(before + 1);
         });

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+class PushMetricTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    @Test
+    void shouldIncreasePushCounter() {
+        String projectName = "myPro";
+        String repoName = "myRepo";
+        final MeterRegistry meterRegistry = dogma.dogma().meterRegistry().get();
+        Counter pushCounter = meterRegistry.find("commits.push")
+                                           .tags("project", projectName, "repository", repoName)
+                                           .counter();
+        final double before = pushCounter != null ? pushCounter.count() : 0;
+        final CentralDogma client = dogma.client();
+        client.createProject(projectName).join();
+        client.createRepository(projectName, repoName).join();
+        client.forRepo(projectName, repoName)
+              .commit("Add a file", Change.ofTextUpsert("/a.txt", "a"))
+              .push().join();
+
+        pushCounter = meterRegistry.find("commits.push")
+                                   .tags("project", projectName, "repository", repoName)
+                                   .counter();
+        // Check whether the push counter is increased by one.
+        assertThat(pushCounter.count()).isEqualTo(before + 1);
+    }
+}


### PR DESCRIPTION
Motivation:

It is difficult to check how many commits have been pushed to a specific repository without looking at log files.

Modifications:

- Add `project` and `repository` tags to `api` metrics.
  - `projectName` and `repoName` path params are used to extract the values.

Result:

Central Dogma metrics for REST API now provide project and repository information as tags.