### PR TITLE
Use LinkedBlockingQueue instead of LinkedTransferQueue for ThreadPoolExecutor

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -45,7 +45,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -360,7 +360,8 @@ public class CentralDogma implements AutoCloseable {
 
             final ThreadPoolExecutor repositoryWorkerImpl = new ThreadPoolExecutor(
                     cfg.numRepositoryWorkers(), cfg.numRepositoryWorkers(),
-                    60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
+                    // TODO(minwoox): Use LinkedTransferQueue when we upgrade to JDK 21.
+                    60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
                     new DefaultThreadFactory("repository-worker", true));
             repositoryWorkerImpl.allowCoreThreadTimeOut(true);
             repositoryWorker = ExecutorServiceMetrics.monitor(meterRegistry, repositoryWorkerImpl,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -46,7 +46,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.LinkedTransferQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -409,7 +409,8 @@ public final class ZooKeeperCommandExecutor
             // Get the command executor threads ready.
             final ThreadPoolExecutor executor = new ThreadPoolExecutor(
                     cfg.numWorkers(), cfg.numWorkers(),
-                    60, TimeUnit.SECONDS, new LinkedTransferQueue<>(),
+                    // TODO(minwoox): Use LinkedTransferQueue when we upgrade to JDK 21.
+                    60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(),
                     new DefaultThreadFactory("zookeeper-command-executor", true));
             executor.allowCoreThreadTimeOut(true);
 


### PR DESCRIPTION
Motivation:
The use of `LinkedTransferQueue` in JDK 17 has a bug causing a thread to consume all of a CPU's usage: https://bugs.openjdk.org/browse/JDK-8301341. Although this bug has been fixed, the patch has not been backported to JDK 17. Since copying the code from JDK 11 poses licensing issues (https://github.com/openhab/openhab-core/pull/3756), we need a different solution.

Switching to `LinkedBlockingQueue` offers a feasible workaround. While `LinkedTransferQueue` is typically efficient under high multi-thread contention due to its use of CAS, our current usage does not exhibit significant contention as the queue tasks' size remains close to 0.

Modifications:
- Replaced the use of `LinkedTransferQueue` with `LinkedBlockingQueue` in `ThreadPoolExecutor`.

Result:
- You no longer see an excessive CPU usage by a single thread.