### PR TITLE
Sleep 1 second after changing server healthy to false when shutting down

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -330,8 +330,9 @@ public class CentralDogma implements AutoCloseable {
         final Optional<GracefulShutdownTimeout> gracefulTimeoutOpt = cfg.gracefulShutdownTimeout();
         if (gracefulTimeoutOpt.isPresent()) {
             try {
-                // Sleep so that clients have some time to redirect traffic according to the health status
-                Thread.sleep(gracefulTimeoutOpt.get().quietPeriodMillis());
+                // Sleep 1 second so that clients have some time to redirect traffic according
+                // to the health status
+                Thread.sleep(1000);
             } catch (InterruptedException e) {
                 logger.debug("Interrupted while waiting for quiet period", e);
                 Thread.currentThread().interrupt();


### PR DESCRIPTION
We changed to sleep as much as graceful shutdown quiet period after changing server healthy when shutting down in https://github.com/line/centraldogma/pull/938
However, if the value is too large, it may result in an unnecessarily long wait. Let's just change the value to 1 second and add a parameter later if there's a demand.