### PR TITLE
Fix flaky ServerStatusManagerIntegrationTest

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
@@ -31,7 +31,9 @@ import com.linecorp.centraldogma.server.internal.api.UpdateServerStatusRequest;
 import com.linecorp.centraldogma.server.internal.api.UpdateServerStatusRequest.Scope;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+import com.linecorp.centraldogma.testing.internal.FlakyTest;
 
+@FlakyTest
 class ServerStatusManagerIntegrationTest {
     @RegisterExtension
     final CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
@@ -86,7 +88,7 @@ class ServerStatusManagerIntegrationTest {
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
         // Wait for the ports acquired to be released.
-        Thread.sleep(3000);
+        Thread.sleep(5000);
 
         // Restart the cluster with the same configuration.
         cluster.start();
@@ -112,7 +114,7 @@ class ServerStatusManagerIntegrationTest {
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
         // Wait for the ports acquired to be released.
-        Thread.sleep(3000);
+        Thread.sleep(5000);
 
         cluster.start();
         serverStatus = getServerStatus(client);

--- a/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
@@ -85,6 +85,8 @@ class ServerStatusManagerIntegrationTest {
         assertThatThrownBy(() -> getServerStatus(client))
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
+        // Wait for the ports acquired to be released.
+        Thread.sleep(3000);
 
         // Restart the cluster with the same configuration.
         cluster.start();
@@ -109,6 +111,8 @@ class ServerStatusManagerIntegrationTest {
         assertThatThrownBy(() -> getServerStatus(client))
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
+        // Wait for the ports acquired to be released.
+        Thread.sleep(3000);
 
         cluster.start();
         serverStatus = getServerStatus(client);


### PR DESCRIPTION
Motivation:

`ServerStatusManagerIntegrationTest` reuses the acquired ports to restart the running cluster. I observed that the ports were not released after `cluster.stop()`.

![image](https://github.com/line/centraldogma/assets/1866157/e0bd2f45-61c6-41c2-8d55-59f654ccc379)

Modifications:

- Sleep 3 seconds after a cluster stop to give enough time to release the ports.

Result:

Fixes CI failures.