### PR TITLE
Fix flaky ServerStatusManagerIntegrationTest (2)

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/management/ServerStatusManagerIntegrationTest.java
@@ -31,9 +31,7 @@ import com.linecorp.centraldogma.server.internal.api.UpdateServerStatusRequest;
 import com.linecorp.centraldogma.server.internal.api.UpdateServerStatusRequest.Scope;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
-import com.linecorp.centraldogma.testing.internal.FlakyTest;
 
-@FlakyTest
 class ServerStatusManagerIntegrationTest {
     @RegisterExtension
     final CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
@@ -87,8 +85,6 @@ class ServerStatusManagerIntegrationTest {
         assertThatThrownBy(() -> getServerStatus(client))
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
-        // Wait for the ports acquired to be released.
-        Thread.sleep(5000);
 
         // Restart the cluster with the same configuration.
         cluster.start();
@@ -113,8 +109,6 @@ class ServerStatusManagerIntegrationTest {
         assertThatThrownBy(() -> getServerStatus(client))
                 .isInstanceOf(UnprocessedRequestException.class)
                 .hasCauseInstanceOf(ConnectException.class);
-        // Wait for the ports acquired to be released.
-        Thread.sleep(5000);
 
         cluster.start();
         serverStatus = getServerStatus(client);

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -190,7 +190,7 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
                 } catch (IOException e) {
                     throw new CompletionException(e);
                 }
-            });
+            }).join();
         }
     }
 

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -230,8 +230,8 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
             }
         }
         if (!success) {
-            throw new IllegalStateException("Failed to find available ports for the Central Dogma cluster. candidates: " +
-                                            ports);
+            throw new IllegalStateException("Failed to find available ports for the Central Dogma cluster. " +
+                                            "candidates: " + ports);
         }
 
         dogmaCluster.stream().map(CentralDogmaRuleDelegate::dogma)

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -215,7 +215,7 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
 
         // This logic won't completely prevent port duplication, but it is best efforts to reduce flakiness.
         boolean success = true;
-        for (int i = 0; i < MAX_RETRIES; i++) {
+        for (int i = 0; i < MAX_RETRIES * 2; i++) {
             success = true;
             for (Integer port : ports) {
                 if (!isTcpPortAvailable(port)) {

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -213,7 +213,7 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
             }
         }
 
-        // This logic won't completely prevent port duplication, but it is best efforts to reduce flaky.
+        // This logic won't completely prevent port duplication, but it is best efforts to reduce flakiness.
         boolean success = true;
         for (int i = 0; i < MAX_RETRIES; i++) {
             success = true;

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -64,7 +64,7 @@ import io.netty.util.NetUtil;
  */
 public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension {
 
-    private static final int MAX_RETRIES = 10;
+    private static final int MAX_RETRIES = 16;
 
     private final TemporaryFolder tmpDir = new TemporaryFolder();
     private final AuthProviderFactory factory = new TestAuthProviderFactory();
@@ -226,11 +226,12 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
             if (success) {
                 break;
             } else if (i < MAX_RETRIES - 1) {
-                Thread.sleep(1000);
+                Thread.sleep(1500);
             }
         }
         if (!success) {
-            throw new IllegalStateException("Failed to find available ports for the Central Dogma cluster");
+            throw new IllegalStateException("Failed to find available ports for the Central Dogma cluster. candidates: " +
+                                            ports);
         }
 
         dogmaCluster.stream().map(CentralDogmaRuleDelegate::dogma)


### PR DESCRIPTION
Motivation:

This PR tries to solve the flakiness of `ServerStatusManagerIntegrationTest` in a different way. See #948

This workaround minimizes port collisions by ensuring that all ports are available when a Central Dogma cluster starts.

Modifications:

- Check if all ports are open when restarting `CentralDogmaReplicationExtension`.

Result:

Less flakiness