### PR TITLE
Restrict prefix value in `CentralDogmaConfig`

### DIFF
--- a/it/server/src/test/java/com/linecorp/centraldogma/it/ConfigValueConverterTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/ConfigValueConverterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.it;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+
+class ConfigValueConverterTest {
+
+    @Test
+    void convert() {
+        assertThat(CentralDogmaConfig.convertValue("-invalid-prefix:invalid", "property"))
+                .isEqualTo("-invalid-prefix:invalid");
+        assertThat(CentralDogmaConfig.convertValue("valid_prefix:value", "property"))
+                .isEqualTo("valid_value");
+    }
+}

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/ConfigValueConverterTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/ConfigValueConverterTest.java
@@ -25,8 +25,8 @@ class ConfigValueConverterTest {
 
     @Test
     void convert() {
-        assertThat(CentralDogmaConfig.convertValue("-invalid-prefix:invalid", "property"))
-                .isEqualTo("-invalid-prefix:invalid");
+        assertThat(CentralDogmaConfig.convertValue("invalid space prefix:invalid", "property"))
+                .isEqualTo("invalid space prefix:invalid");
         assertThat(CentralDogmaConfig.convertValue("valid_prefix:value", "property"))
                 .isEqualTo("valid_value");
     }

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/InvalidConfigValueConverter.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/InvalidConfigValueConverter.java
@@ -25,7 +25,7 @@ public final class InvalidConfigValueConverter implements ConfigValueConverter {
 
     @Override
     public List<String> supportedPrefixes() {
-        return ImmutableList.of("-invalid-prefix");
+        return ImmutableList.of("invalid space prefix");
     }
 
     @Override

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/InvalidConfigValueConverter.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/InvalidConfigValueConverter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.it;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.server.ConfigValueConverter;
+
+public final class InvalidConfigValueConverter implements ConfigValueConverter {
+
+    @Override
+    public List<String> supportedPrefixes() {
+        return ImmutableList.of("-invalid-prefix");
+    }
+
+    @Override
+    public String convert(String prefix, String value) {
+        throw new IllegalStateException("should not reach here because this is an invalid converter.");
+    }
+}

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/ValidConfigValueConverter.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/ValidConfigValueConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.it;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.server.ConfigValueConverter;
+
+public final class ValidConfigValueConverter implements ConfigValueConverter {
+
+    @Override
+    public List<String> supportedPrefixes() {
+        return ImmutableList.of("valid_prefix");
+    }
+
+    @Override
+    public String convert(String prefix, String value) {
+        if ("valid_prefix".equals(prefix)) {
+            return "valid_" + value;
+        }
+        throw new IllegalStateException("should not reach here.");
+    }
+}

--- a/it/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
+++ b/it/server/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.ConfigValueConverter
@@ -1,0 +1,2 @@
+com.linecorp.centraldogma.it.InvalidConfigValueConverter
+com.linecorp.centraldogma.it.ValidConfigValueConverter

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -87,7 +87,7 @@ public final class CentralDogmaConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(CentralDogmaConfig.class);
 
-    private static final Pattern PREFIX_PATTERN = Pattern.compile("^[a-z0-9_]+$");
+    private static final Pattern PREFIX_PATTERN = Pattern.compile("^[a-z0-9_-]+$");
 
     private static final Map<String, ConfigValueConverter> CONFIG_VALUE_CONVERTERS;
 


### PR DESCRIPTION
Motivation:
The current implementation of `CentralDogmaConfig` strips the prefix separated by a colon from the configuration value. This causes issues when the configuration value, without a prefix, contains a colon. For instance, the following configuration value:
```
-----BEGIN EC PRIVATE KEY-----
Proc-Type: 4,ENCRYPTED
DEK-Info: ...
...
```
In this case, `CentralDogmaConfig` throws an exception because there is no `ConfigValueConverter` for converting the value after the colon. This can be avoided by restricting the prefix value to only valid characters.

Modifications:
- Restrict the prefix value to the regular expression pattern `^[a-z0-9_]+$`.
- Use the configuration value as is if `CentralDogmaConfig` fails to find a proper `ConfigValueConverter` for the prefix.

Result:
- `CentralDogmaConfig` will no longer fail due to configuration values with colons.