### PR TITLE
Add a metric for tracking the number of pushes

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -425,13 +425,13 @@ public class CentralDogma implements AutoCloseable {
                 logger.info("Starting plugins on the leader replica ..");
                 pluginsForLeaderOnly
                         .start(cfg, pm, exec, meterRegistry, purgeWorker).handle((unused, cause) -> {
-                            if (cause == null) {
-                                logger.info("Started plugins on the leader replica.");
-                            } else {
-                                logger.error("Failed to start plugins on the leader replica..", cause);
-                            }
-                            return null;
-                        });
+                    if (cause == null) {
+                        logger.info("Started plugins on the leader replica.");
+                    } else {
+                        logger.error("Failed to start plugins on the leader replica..", cause);
+                    }
+                    return null;
+                });
             }
         };
 
@@ -585,7 +585,8 @@ public class CentralDogma implements AutoCloseable {
                                                                  "Bearer " + CsrfToken.ANONYMOUS))
                                   .build());
 
-        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager);
+        configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, sessionManager,
+                         meterRegistry);
 
         configureMetrics(sb, meterRegistry);
 
@@ -710,7 +711,7 @@ public class CentralDogma implements AutoCloseable {
                                   ProjectApiManager projectApiManager, CommandExecutor executor,
                                   WatchService watchService, MetadataService mds,
                                   @Nullable AuthProvider authProvider,
-                                  @Nullable SessionManager sessionManager) {
+                                  @Nullable SessionManager sessionManager, MeterRegistry meterRegistry) {
         Function<? super HttpService, ? extends HttpService> decorator;
 
         if (authProvider != null) {
@@ -779,7 +780,7 @@ public class CentralDogma implements AutoCloseable {
           .decorator(decorator)
           .requestConverters(v1RequestConverter, jacksonRequestConverterFunction)
           .responseConverters(v1ResponseConverter)
-          .build(new ContentServiceV1(executor, watchService));
+          .build(new ContentServiceV1(executor, watchService, meterRegistry));
 
         if (authProvider != null) {
             final AuthConfig authCfg = cfg.authConfig();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -194,7 +194,9 @@ public class ContentServiceV1 extends AbstractService {
             CommitMessageDto commitMessage,
             @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
         checkPush(repository.name(), changes);
-        meterRegistry.counter("commits.push", "project", repository.parent().name(), "repository", repository.name())
+        meterRegistry.counter("commits.push",
+                              "project", repository.parent().name(),
+                              "repository", repository.name())
                      .increment();
 
         final long commitTimeMillis = System.currentTimeMillis();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/converter/PushMetricTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+class PushMetricTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    @Test
+    void shouldIncreasePushCounter() {
+        final String projectName = "myPro";
+        final String repoName = "myRepo";
+        final MeterRegistry meterRegistry = dogma.dogma().meterRegistry().get();
+        final Counter pushCounter = meterRegistry.find("commits.push")
+                                                 .tags("project", projectName, "repository", repoName)
+                                                 .counter();
+        final double before = pushCounter != null ? pushCounter.count() : 0;
+        final CentralDogma client = dogma.client();
+        client.createProject(projectName).join();
+        client.createRepository(projectName, repoName).join();
+        client.forRepo(projectName, repoName)
+              .commit("Add a file", Change.ofTextUpsert("/a.txt", "a"))
+              .push().join();
+
+        await().untilAsserted(() -> {
+            final Counter pushCounter0 = meterRegistry.find("commits.push")
+                                                      .tags("project", projectName, "repository", repoName)
+                                                      .counter();
+            assertThat(pushCounter0).isNotNull();
+            // Check whether the push counter is increased by one.
+            assertThat(pushCounter0.count()).isEqualTo(before + 1);
+        });
+    }
+}


### PR DESCRIPTION
Motivation:

It isn't easy to check how many commits have been pushed to a specific repository without looking at log files.

This PR is the orignal commit of #943 that tracks the number of pushes instead of adding `project` and `repo` tags to all `api` metrics. #943 has been reverted because it increased in CPU and memory usage.

Modifications:

- Add a `Counter` that is increased when a commit is pushed to a repository.
  - `project` and `repository` are added as tags.

Result:

You can monitor the number of pushes to a repository using the `commits.push` metric.