### PR TITLE
Support Git clone over HTTP in Central Dogma.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -97,6 +97,7 @@ import com.linecorp.armeria.server.auth.AuthService;
 import com.linecorp.armeria.server.auth.Authorizer;
 import com.linecorp.armeria.server.cors.CorsService;
 import com.linecorp.armeria.server.docs.DocService;
+import com.linecorp.armeria.server.encoding.DecodingService;
 import com.linecorp.armeria.server.encoding.EncodingService;
 import com.linecorp.armeria.server.file.FileService;
 import com.linecorp.armeria.server.file.HttpFile;
@@ -130,6 +131,7 @@ import com.linecorp.centraldogma.server.internal.admin.service.UserService;
 import com.linecorp.centraldogma.server.internal.admin.util.RestfulJsonResponseConverter;
 import com.linecorp.centraldogma.server.internal.api.AdministrativeService;
 import com.linecorp.centraldogma.server.internal.api.ContentServiceV1;
+import com.linecorp.centraldogma.server.internal.api.GitHttpService;
 import com.linecorp.centraldogma.server.internal.api.MetadataApiService;
 import com.linecorp.centraldogma.server.internal.api.ProjectServiceV1;
 import com.linecorp.centraldogma.server.internal.api.RepositoryServiceV1;
@@ -781,6 +783,10 @@ public class CentralDogma implements AutoCloseable {
           .responseConverters(v1ResponseConverter)
           .build(new ContentServiceV1(executor, watchService));
 
+        sb.annotatedService().decorator(decorator)
+          .decorator(DecodingService.newDecorator())
+          .build(new GitHttpService(projectApiManager));
+
         if (authProvider != null) {
             final AuthConfig authCfg = cfg.authConfig();
             assert authCfg != null : "authCfg";
@@ -860,6 +866,8 @@ public class CentralDogma implements AutoCloseable {
                             case "json":
                             case "xml":
                             case "x-thrift":
+                            case "x-git-upload-pack-advertisement":
+                            case "x-git-upload-pack-result":
                                 return true;
                             default:
                                 return subtype.endsWith("+json") ||

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
@@ -24,6 +24,7 @@ import static org.eclipse.jgit.transport.GitProtocolConstants.VERSION_2_REQUEST;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.UploadPack;
@@ -192,7 +193,7 @@ public final class GitHttpService {
 
         // https://git-scm.com/docs/protocol-common#_pkt_line_format
         void put(String line) {
-            lineLength(sb, line.length() + 5);
+            lineLength(sb, line.getBytes(StandardCharsets.UTF_8).length + 5);
             sb.append(line).append('\n');
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
@@ -120,7 +120,7 @@ public final class GitHttpService {
     }
 
     private static String maybeRemoveGitSuffix(String repoName) {
-        if (repoName.length() > 5 && repoName.endsWith(".git")) {
+        if (repoName.length() >= 5 && repoName.endsWith(".git")) {
             repoName = repoName.substring(0, repoName.length() - 4);
         }
         return repoName;
@@ -211,7 +211,7 @@ public final class GitHttpService {
         }
 
         void flush() {
-            https: //git-scm.com/docs/protocol-v2/2.31.0#_packet_line_framing
+            // https: //git-scm.com/docs/protocol-v2/2.31.0#_packet_line_framing
             sb.append("0000");
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
@@ -24,7 +24,6 @@ import static org.eclipse.jgit.transport.GitProtocolConstants.VERSION_2_REQUEST;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.transport.UploadPack;
@@ -193,7 +192,7 @@ public final class GitHttpService {
 
         // https://git-scm.com/docs/protocol-common#_pkt_line_format
         void put(String line) {
-            lineLength(sb, line.getBytes(StandardCharsets.UTF_8).length + 5);
+            lineLength(sb, line.length() + 5);
             sb.append(line).append('\n');
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/GitHttpService.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.jgit.transport.GitProtocolConstants.COMMAND_FETCH;
+import static org.eclipse.jgit.transport.GitProtocolConstants.COMMAND_LS_REFS;
+import static org.eclipse.jgit.transport.GitProtocolConstants.OPTION_SHALLOW;
+import static org.eclipse.jgit.transport.GitProtocolConstants.OPTION_WAIT_FOR_DONE;
+import static org.eclipse.jgit.transport.GitProtocolConstants.VERSION_2_REQUEST;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.transport.UploadPack;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.common.AggregatedHttpRequest;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpData;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.ServerCacheControl;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.common.stream.ByteStreamMessage;
+import com.linecorp.armeria.common.stream.StreamMessage;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Header;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.Post;
+import com.linecorp.centraldogma.server.internal.api.auth.RequiresReadPermission;
+import com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager;
+
+@RequiresReadPermission
+public final class GitHttpService {
+
+    private static final Logger logger = LoggerFactory.getLogger(GitHttpService.class);
+
+    private static final char[] HEX_DIGITS = "0123456789abcdef".toCharArray();
+
+    // TODO(minwoox): Add the headers in this class to Armeria.
+    private static final AggregatedHttpResponse CAPABILITY_ADVERTISEMENT_RESPONSE = AggregatedHttpResponse.of(
+            ResponseHeaders.builder(200)
+                           .add(HttpHeaderNames.CONTENT_TYPE, "application/x-git-upload-pack-advertisement")
+                           .add(HttpHeaderNames.CACHE_CONTROL, ServerCacheControl.REVALIDATED.asHeaderValue())
+                           .build(),
+            HttpData.ofUtf8(capabilityAdvertisement()));
+
+    private static String capabilityAdvertisement() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("001e# service=git-upload-pack\n0000");
+        pktLine(sb, "version 2");
+        pktLine(sb, COMMAND_LS_REFS);
+        pktLine(sb, COMMAND_FETCH + '=' + OPTION_WAIT_FOR_DONE + ' ' + OPTION_SHALLOW);
+        // TODO(minwoox): Migrate hash function https://git-scm.com/docs/hash-function-transition
+        pktLine(sb, "object-format=sha1");
+        sb.append("0000"); // flush-pkt
+        return sb.toString();
+    }
+
+    static void pktLine(StringBuilder sb, String line) {
+        lineLength(sb, line.length() + 5);
+        sb.append(line).append('\n');
+    }
+
+    private static void lineLength(StringBuilder sb, int length) {
+        for (int i = 3; i >= 0; i--) {
+            sb.append(HEX_DIGITS[(length >>> (4 * i)) & 0xf]);
+        }
+    }
+
+    private final ProjectApiManager projectApiManager;
+
+    public GitHttpService(ProjectApiManager projectApiManager) {
+        this.projectApiManager = requireNonNull(projectApiManager, "projectApiManager");
+    }
+
+    // https://www.git-scm.com/docs/gitprotocol-http#_smart_clients
+    @Get("/{projectName}/{repoName}/info/refs")
+    public HttpResponse advertiseCapability(@Header("git-protocol") @Nullable String gitProtocol,
+                                            @Param String service,
+                                            @Param String projectName, @Param String repoName) {
+        if (!"git-upload-pack".equals(service)) {
+            // Return 403 https://www.git-scm.com/docs/http-protocol#_smart_server_response
+            return HttpResponse.of(403);
+        }
+        repoName = maybeRemoveGitSuffix(repoName);
+        if (gitProtocol == null || !gitProtocol.contains(VERSION_2_REQUEST)) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Unsupported git-protocol: " + gitProtocol);
+        }
+
+        if (!projectApiManager.getProject(projectName).repos().exists(repoName)) {
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        }
+        return CAPABILITY_ADVERTISEMENT_RESPONSE.toHttpResponse();
+    }
+
+    private static String maybeRemoveGitSuffix(String repoName) {
+        if (repoName.length() > 5 && repoName.endsWith(".git")) {
+            repoName = repoName.substring(0, repoName.length() - 4);
+        }
+        return repoName;
+    }
+
+    // https://www.git-scm.com/docs/gitprotocol-http#_smart_service_git_upload_pack
+    @Post("/{projectName}/{repoName}/git-upload-pack")
+    public HttpResponse gitUploadPack(AggregatedHttpRequest req,
+                                      @Param String projectName, @Param String repoName) {
+        repoName = maybeRemoveGitSuffix(repoName);
+        final String gitProtocol = req.headers().get("git-protocol");
+        if (gitProtocol == null || !gitProtocol.contains(VERSION_2_REQUEST)) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Unsupported git-protocol: " + gitProtocol);
+        }
+
+        final MediaType contentType = req.headers().contentType();
+        if (contentType == null || !"application/x-git-upload-pack-request".equals(contentType.toString())) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Unsupported content-type: " + contentType);
+        }
+
+        if (!projectApiManager.getProject(projectName).repos().exists(repoName)) {
+            return HttpResponse.of(HttpStatus.NOT_FOUND);
+        }
+
+        final Repository jGitRepository =
+                projectApiManager.getProject(projectName).repos().get(repoName).jGitRepository();
+
+        final ByteStreamMessage body = StreamMessage.fromOutputStream(os -> {
+            // Don't need to close the input stream.
+            final ByteArrayInputStream inputStream = new ByteArrayInputStream(req.content().byteBuf().array());
+            // Don't need to close because we don't use the timer inside it.
+            final UploadPack uploadPack = new UploadPack(jGitRepository);
+            uploadPack.setTimeout(0); // Disable timeout because Armeria server will handle it.
+            // HTTP does not use bidirectional pipe.
+            uploadPack.setBiDirectionalPipe(false);
+            uploadPack.setExtraParameters(ImmutableList.of(VERSION_2_REQUEST));
+            try {
+                uploadPack.upload(inputStream, os, null);
+            } catch (IOException e) {
+                // Log until https://github.com/line/centraldogma/pull/719 is implemented.
+                logger.debug("Failed to respond git-upload-pack-request: {}", req, e);
+                throw new RuntimeException("failed to respond git-upload-pack-request: " + req, e);
+            }
+            try {
+                os.close();
+            } catch (IOException e) {
+                // Should never reach here because StreamWriterOutputStream.close() never throws an exception.
+                logger.warn("Failed to close the output stream. request: {}", req, e);
+            }
+        });
+        return HttpResponse.of(
+                ResponseHeaders.builder(200)
+                               .add(HttpHeaderNames.CONTENT_TYPE, "application/x-git-upload-pack-result")
+                               .add(HttpHeaderNames.CACHE_CONTROL,
+                                    ServerCacheControl.REVALIDATED.asHeaderValue())
+                               .build(), body);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresPermissionDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresPermissionDecorator.java
@@ -35,6 +35,7 @@ import com.linecorp.armeria.server.SimpleDecoratingHttpService;
 import com.linecorp.armeria.server.annotation.Decorator;
 import com.linecorp.armeria.server.annotation.DecoratorFactoryFunction;
 import com.linecorp.centraldogma.server.internal.admin.auth.AuthUtil;
+import com.linecorp.centraldogma.server.internal.api.GitHttpService;
 import com.linecorp.centraldogma.server.internal.api.HttpApiUtil;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.MetadataServiceInjector;
@@ -70,7 +71,7 @@ public final class RequiresPermissionDecorator extends SimpleDecoratingHttpServi
             }
             return unwrap().serve(ctx, req);
         }
-        return serveUserRepo(ctx, req, mds, user, projectName, repoName);
+        return serveUserRepo(ctx, req, mds, user, projectName, maybeRemoveGitSuffix(repoName));
     }
 
     private static HttpResponse throwForbiddenResponse(ServiceRequestContext ctx, String projectName,
@@ -78,6 +79,17 @@ public final class RequiresPermissionDecorator extends SimpleDecoratingHttpServi
         return HttpApiUtil.throwResponse(ctx, HttpStatus.FORBIDDEN,
                                          "Repository '%s/%s' can be accessed only by an %s.",
                                          projectName, repoName, adminOrOwner);
+    }
+
+    /**
+     * Removes the trailing ".git" suffix from the repository name if it exists. This is added for
+     * GitHttpService. See {@link GitHttpService}.
+     */
+    private static String maybeRemoveGitSuffix(String repoName) {
+        if (repoName.length() > 5 && repoName.endsWith(".git")) {
+            repoName = repoName.substring(0, repoName.length() - 4);
+        }
+        return repoName;
     }
 
     private HttpResponse serveUserRepo(ServiceRequestContext ctx, HttpRequest req,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresPermissionDecorator.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresPermissionDecorator.java
@@ -86,7 +86,7 @@ public final class RequiresPermissionDecorator extends SimpleDecoratingHttpServi
      * GitHttpService. See {@link GitHttpService}.
      */
     private static String maybeRemoveGitSuffix(String repoName) {
-        if (repoName.length() > 5 && repoName.endsWith(".git")) {
+        if (repoName.length() >= 5 && repoName.endsWith(".git")) {
             repoName = repoName.substring(0, repoName.length() - 4);
         }
         return repoName;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/ProjectApiManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/ProjectApiManager.java
@@ -124,4 +124,11 @@ public final class ProjectApiManager {
         }
         return projectManager.get(projectName);
     }
+
+    public boolean exists(String projectName) {
+        if (INTERNAL_PROJECT_DOGMA.equals(projectName) && !isAdmin()) {
+            throw new IllegalArgumentException("Cannot access " + projectName);
+        }
+        return projectManager.exists(projectName);
+    }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -68,6 +68,11 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
     }
 
     @Override
+    public org.eclipse.jgit.lib.Repository jGitRepository() {
+        return unwrap().jGitRepository();
+    }
+
+    @Override
     public Set<Mirror> mirrors() {
         mirrorLock.lock();
         try {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -52,6 +52,11 @@ public class RepositoryWrapper implements Repository {
     }
 
     @Override
+    public org.eclipse.jgit.lib.Repository jGitRepository() {
+        return unwrap().jGitRepository();
+    }
+
+    @Override
     public Project parent() {
         return unwrap().parent();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
@@ -63,6 +63,11 @@ final class CachingRepository implements Repository {
     }
 
     @Override
+    public org.eclipse.jgit.lib.Repository jGitRepository() {
+        return repo.jGitRepository();
+    }
+
+    @Override
     public long creationTimeMillis() {
         return repo.creationTimeMillis();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -386,6 +386,11 @@ class GitRepository implements Repository {
     }
 
     @Override
+    public org.eclipse.jgit.lib.Repository jGitRepository() {
+        return jGitRepository;
+    }
+
+    @Override
     public Project parent() {
         return parent;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -69,6 +69,11 @@ public interface Repository {
     String ALL_PATH = "/**";
 
     /**
+     * Returns the jGit {@link org.eclipse.jgit.lib.Repository}.
+     */
+    org.eclipse.jgit.lib.Repository jGitRepository();
+
+    /**
      * Returns the parent {@link Project} of this {@link Repository}.
      */
     Project parent();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.centraldogma.server.internal.api;
 
+import static com.linecorp.centraldogma.server.internal.api.GitHttpService.pktFlush;
 import static com.linecorp.centraldogma.server.internal.api.GitHttpService.pktLine;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.jgit.transport.GitProtocolConstants.VERSION_2_REQUEST;
@@ -283,7 +284,7 @@ class GitHttpServiceTest {
         pktLine(sb, "ref-prefix HEAD");
         pktLine(sb, "ref-prefix refs/heads/");
         pktLine(sb, "ref-prefix refs/tags/");
-        sb.append("0000");
+        pktFlush(sb);
         return sb.toString();
     }
 
@@ -299,7 +300,7 @@ class GitHttpServiceTest {
         }
         pktLine(sb, "want " + oid);
         pktLine(sb, "done");
-        sb.append("0000");
+        pktFlush(sb);
         return sb.toString();
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
@@ -78,12 +78,8 @@ class GitHttpServiceTest {
         }
     };
 
-    @Test
-    void advertiseCapability() {
-        advertiseCapability("bar.git");
-        advertiseCapability("bar");
-    }
-
+    @CsvSource({ "bar.git", "bar" })
+    @ParameterizedTest
     void advertiseCapability(String repoName) {
         final RequestHeaders headers =
                 RequestHeaders.of(HttpMethod.GET, "/foo/" + repoName + "/info/refs?service=git-upload-pack",

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
@@ -200,6 +200,7 @@ class GitHttpServiceTest {
              .commit("push", Change.ofTextUpsert("/bar.txt", "hello bar!"))
              .push()
              .join();
+        git.close();
         // Clone again.
         final Git git1 = Git.cloneRepository().setURI("http://127.0.0.1:" +
                                                       dogma.serverAddress().getPort() + "/foo/bar.git")
@@ -218,6 +219,7 @@ class GitHttpServiceTest {
         assertThat(new String(fileContent).trim()).isEqualTo("hello foo!");
         fileContent = getFileContent(git1, ref1.getObjectId(), "/bar.txt");
         assertThat(new String(fileContent).trim()).isEqualTo("hello bar!");
+        git1.close();
     }
 
     private static Ref assertRefs(Git git) throws IOException {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.server.internal.api.GitHttpService.pktLine;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.jgit.transport.GitProtocolConstants.VERSION_2_REQUEST;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.FileMode;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.transport.TransportHttp;
+import org.eclipse.jgit.treewalk.TreeWalk;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ServerCacheControl;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class GitHttpServiceTest {
+
+    @TempDir
+    static File temporaryFolder;
+
+    @TempDir
+    static File temporaryFolder2;
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("foo").join();
+            client.createRepository("foo", "bar").join();
+            client.forRepo("foo", "bar").commit("push", Change.ofTextUpsert("/foo.txt", "hello foo!")).push()
+                  .join();
+        }
+    };
+
+    @Test
+    void advertiseCapability() {
+        advertiseCapability("bar.git");
+        advertiseCapability("bar");
+    }
+
+    void advertiseCapability(String repoName) {
+        final RequestHeaders headers =
+                RequestHeaders.of(HttpMethod.GET, "/foo/" + repoName + "/info/refs?service=git-upload-pack",
+                                  "git-protocol", VERSION_2_REQUEST,
+                                  HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        final AggregatedHttpResponse res = dogma.httpClient().execute(headers).aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.headers().get("content-type")).isEqualTo("application/x-git-upload-pack-advertisement");
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo(ServerCacheControl.REVALIDATED.asHeaderValue());
+        assertThat(res.contentUtf8()).isEqualTo("001e# service=git-upload-pack\n0000" +
+                                                "000eversion 2\n" +
+                                                "000cls-refs\n" +
+                                                "0020fetch=wait-for-done shallow\n" +
+                                                "0017object-format=sha1\n" +
+                                                "0000");
+    }
+
+    @Test
+    void invalidRequestAdvertiseCapability() {
+        RequestHeaders headers =
+                RequestHeaders.of(HttpMethod.GET, "/foo/non-exist-repo/info/refs?service=git-upload-pack",
+                                  "git-protocol", VERSION_2_REQUEST,
+                                  HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.NOT_FOUND);
+
+        headers = RequestHeaders.of(HttpMethod.GET, "/foo/bar.git/info/refs?service=no-such-service",
+                                    HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.FORBIDDEN);
+
+        headers = RequestHeaders.of(HttpMethod.GET, "/foo/bar.git/info/refs?service=git-upload-pack",
+                                    "git-protocol", "invalid-version",
+                                    HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void gitUploadPackRequest() {
+        final RequestHeaders headers =
+                RequestHeaders.of(HttpMethod.POST, "/foo/bar.git/git-upload-pack",
+                                  HttpHeaderNames.CONTENT_TYPE, "application/x-git-upload-pack-request",
+                                  "git-protocol", VERSION_2_REQUEST,
+                                  HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        AggregatedHttpResponse res = dogma.httpClient().execute(headers, lsRefsCommand())
+                                          .aggregate().join();
+        assertThat(res.status()).isSameAs(HttpStatus.OK);
+        assertThat(res.headers().get("content-type")).isEqualTo("application/x-git-upload-pack-result");
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo(ServerCacheControl.REVALIDATED.asHeaderValue());
+        final List<String> lines = Splitter.on('\n').trimResults().splitToList(res.contentUtf8());
+        assertThat(lines.size()).isEqualTo(3);
+        final Splitter splitter = Splitter.on(' ').trimResults();
+        final List<String> headLineSplit = splitter.splitToList(lines.get(0));
+        assertThat(headLineSplit.size()).isEqualTo(3);
+        assertThat(headLineSplit.get(1)).isEqualTo("HEAD");
+        assertThat(headLineSplit.get(2)).isEqualTo("symref-target:refs/heads/master");
+
+        final List<String> masterLineSplit = splitter.splitToList(lines.get(1));
+        assertThat(masterLineSplit.size()).isEqualTo(2);
+        assertThat(masterLineSplit.get(1)).isEqualTo("refs/heads/master");
+
+        // same oid
+        assertThat(headLineSplit.get(0).substring(4)).isEqualTo(masterLineSplit.get(0).substring(4));
+
+        res = dogma.httpClient().execute(headers, fetchCommand(headLineSplit.get(0).substring(4)))
+                   .aggregate().join();
+        assertThat(res.headers().get("content-type")).isEqualTo("application/x-git-upload-pack-result");
+        assertThat(res.headers().get(HttpHeaderNames.CACHE_CONTROL))
+                .isEqualTo(ServerCacheControl.REVALIDATED.asHeaderValue());
+        // We will verify the contents under the gitClone test so check the first line.
+        assertThat(res.contentUtf8().split("\n")[0].trim()).isEqualTo("000dpackfile");
+    }
+
+    @Test
+    void invalidGitUploadPackRequest() {
+        RequestHeaders headers =
+                RequestHeaders.of(HttpMethod.POST, "/foo/non-exist-repo/git-upload-pack",
+                                  HttpHeaderNames.CONTENT_TYPE, "application/x-git-upload-pack-request",
+                                  "git-protocol", VERSION_2_REQUEST,
+                                  HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.NOT_FOUND);
+
+        headers = RequestHeaders.of(HttpMethod.POST, "/foo/bar.git/git-upload-pack",
+                                    HttpHeaderNames.CONTENT_TYPE, MediaType.PLAIN_TEXT_UTF_8,
+                                    HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.BAD_REQUEST);
+
+        headers = RequestHeaders.of(HttpMethod.POST, "/foo/bar.git/git-upload-pack",
+                                    HttpHeaderNames.CONTENT_TYPE, "application/x-git-upload-pack-request",
+                                    "git-protocol", "invalid-version",
+                                    HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        assertThat(dogma.httpClient().execute(headers).aggregate().join().status())
+                .isSameAs(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void gitClone() throws Exception {
+        final Git git = Git.cloneRepository().setURI("http://127.0.0.1:" +
+                                                     dogma.serverAddress().getPort() + "/foo/bar.git")
+                           .setDirectory(temporaryFolder)
+                           .setTransportConfigCallback(transport -> {
+                               if (transport instanceof TransportHttp) {
+                                   ((TransportHttp) transport).setAdditionalHeaders(
+                                           ImmutableMap.of(HttpHeaderNames.AUTHORIZATION.toString(),
+                                                           "Bearer anonymous"));
+                               }
+                           }).call();
+        final Ref ref = assertRefs(git);
+
+        byte[] fileContent = getFileContent(git, ref.getObjectId(), "/foo.txt");
+        assertThat(new String(fileContent).trim()).isEqualTo("hello foo!");
+        fileContent = getFileContent(git, ref.getObjectId(), "/bar.txt");
+        assertThat(fileContent).isNull();
+
+        // Commit another file.
+        dogma.client().forRepo("foo", "bar")
+             .commit("push", Change.ofTextUpsert("/bar.txt", "hello bar!"))
+             .push()
+             .join();
+        // Clone again.
+        final Git git1 = Git.cloneRepository().setURI("http://127.0.0.1:" +
+                                                      dogma.serverAddress().getPort() + "/foo/bar.git")
+                            .setDirectory(temporaryFolder2)
+                            .setTransportConfigCallback(transport -> {
+                                if (transport instanceof TransportHttp) {
+                                    ((TransportHttp) transport).setAdditionalHeaders(
+                                            ImmutableMap.of(HttpHeaderNames.AUTHORIZATION.toString(),
+                                                            "Bearer anonymous"));
+                                }
+                            }).call();
+        final Ref ref1 = assertRefs(git1);
+        assertThat(ref).isNotEqualTo(ref1);
+
+        fileContent = getFileContent(git1, ref1.getObjectId(), "/foo.txt");
+        assertThat(new String(fileContent).trim()).isEqualTo("hello foo!");
+        fileContent = getFileContent(git1, ref1.getObjectId(), "/bar.txt");
+        assertThat(new String(fileContent).trim()).isEqualTo("hello bar!");
+    }
+
+    private static Ref assertRefs(Git git) throws IOException {
+        final List<Ref> refs = git.getRepository().getRefDatabase().getRefs();
+        assertThat(refs.size()).isEqualTo(3);
+        final Ref headRef = refs.get(0);
+        assertThat(headRef.isSymbolic()).isTrue();
+        assertThat(headRef.getName()).isEqualTo("HEAD");
+
+        final Ref masterRef = refs.get(1);
+        assertThat(masterRef.getName()).isEqualTo("refs/heads/master");
+        assertThat(headRef.getTarget()).isEqualTo(masterRef);
+
+        final Ref originMasterRef = refs.get(2);
+        assertThat(originMasterRef.getName()).isEqualTo("refs/remotes/origin/master");
+        assertThat(masterRef.getObjectId()).isEqualTo(masterRef.getObjectId());
+        assertThat(masterRef.getObjectId()).isEqualTo(originMasterRef.getObjectId());
+        return masterRef;
+    }
+
+    private static String lsRefsCommand() {
+        final StringBuilder sb = new StringBuilder();
+        pktLine(sb, "command=ls-refs");
+        pktLine(sb, "object-format=sha1");
+        sb.append("0001"); // delim-pkt
+        pktLine(sb, "peel");
+        pktLine(sb, "symrefs");
+        pktLine(sb, "ref-prefix HEAD");
+        pktLine(sb, "ref-prefix refs/heads/");
+        pktLine(sb, "ref-prefix refs/tags/");
+        sb.append("0000");
+        return sb.toString();
+    }
+
+    private static String fetchCommand(String oid) {
+        final StringBuilder sb = new StringBuilder();
+        pktLine(sb, "command=fetch");
+        pktLine(sb, "object-format=sha1");
+        sb.append("0001"); // delim-pkt
+        pktLine(sb, "thin-pack");
+        pktLine(sb, "ofs-delta");
+        pktLine(sb, "want " + oid);
+        pktLine(sb, "done");
+        sb.append("0000");
+        return sb.toString();
+    }
+
+    @Nullable
+    private static byte[] getFileContent(Git git, ObjectId commitId, String fileName) throws IOException {
+        try (ObjectReader reader = git.getRepository().newObjectReader();
+             TreeWalk treeWalk = new TreeWalk(reader);
+             RevWalk revWalk = new RevWalk(reader)) {
+            treeWalk.addTree(revWalk.parseTree(commitId).getId());
+
+            while (treeWalk.next()) {
+                if (treeWalk.getFileMode() == FileMode.TREE) {
+                    treeWalk.enterSubtree();
+                    continue;
+                }
+                if (fileName.equals('/' + treeWalk.getPathString())) {
+                    final ObjectId objectId = treeWalk.getObjectId(0);
+                    return reader.open(objectId).getBytes();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/GitHttpServiceTest.java
@@ -242,8 +242,8 @@ class GitHttpServiceTest {
 
     private static Git clone(File directory) throws GitAPIException {
         final CloneCommand cloneCommand = Git.cloneRepository().setURI("http://127.0.0.1:" +
-                                                                       dogma.serverAddress().getPort()
-                                                                       + "/foo/bar.git")
+                                                                       dogma.serverAddress().getPort() +
+                                                                       "/foo/bar.git")
                                              .setDirectory(directory);
         addAuthHeader(cloneCommand);
         return cloneCommand.call();


### PR DESCRIPTION
Motivation:
Adding support for Git clone over HTTP in Central Dogma server would enhance its capabilities and make it more user-friendly. This PR partially addressed #543.
Please note that I didn't impelent Git over HTTP fully because:
- We have APIs for commit separately.
- The underlying Git repository could be changed to another format instead of Git.

Modifications:
- Added support for Git clone over HTTP to Central Dogma.

Result:
- You can now clone your repositories via Git clone over HTTP.
  ```
  git clone -c http.extraHeader="Authorization: Bearer your-token" https://your-dogma.com/foo/bar.git
  ```

References:
- https://git-scm.com/docs/protocol-v2/
- https://git-scm.com/docs/protocol-capabilities/
- https://www.git-scm.com/docs/http-protocol
- https://www.git-scm.com/docs/git-upload-pack
- https://git-scm.com/docs/protocol-common
- https://git-scm.com/docs/pack-format/

The CLI command that allows you to view the packets being sent and received:
```
GIT_TRACE=2 GIT_CURL_VERBOSE=2 GIT_TRACE_PERFORMANCE=2 GIT_TRACE_PACK_ACCESS=2 GIT_TRACE_PACKET=2 GIT_TRACE_PACKFILE=2 GIT_TRACE_SETUP=2 GIT_TRACE_SHALLOW=2  git clone --depth=1 https://github.com/line/armeria.git
```