### PR TITLE
Fix to read all short words for the mirror migration

### DIFF
--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
@@ -187,13 +187,13 @@ class MirroringMigrationServiceClusterTest {
                                  }
                              }, Function.identity()));
 
-        assertMirrorConfig(mirrors.get(TEST_REPO0), "mirror-" + TEST_PROJ + '-' + TEST_REPO0 + "-[a-z]+",
+        assertMirrorConfig(mirrors.get(TEST_REPO0), "mirror-" + TEST_PROJ + '-' + TEST_REPO0,
                            REPO0_MIRROR);
         assertMirrorConfig(mirrors.get(TEST_REPO1), "mirror-1", REPO1_MIRROR);
-        // "-1" suffix is added because the mirror ID is duplicated.
-        assertMirrorConfig(mirrors.get(TEST_REPO2), "mirror-1-1", REPO2_MIRROR);
-        // "-2" suffix is added because the mirror ID is duplicated.
-        assertMirrorConfig(mirrors.get(TEST_REPO3), "mirror-1-2", REPO3_MIRROR);
+        // "-khaki" suffix is added because the mirror ID is duplicated.
+        assertMirrorConfig(mirrors.get(TEST_REPO2), "mirror-1-khaki", REPO2_MIRROR);
+        // "-speakers" suffix is added because the mirror ID is duplicated.
+        assertMirrorConfig(mirrors.get(TEST_REPO3), "mirror-1-speakers", REPO3_MIRROR);
 
         final Map<String, Entry<?>> credentialEntries = repo.file(PathPattern.of("/credentials/*.json"))
                                                             .get()
@@ -210,11 +210,11 @@ class MirroringMigrationServiceClusterTest {
                                      }
                                  }, Function.identity()));
 
-        assertCredential(credentials.get("public_key"), "credential-" + TEST_PROJ + "-[a-z]+",
+        assertCredential(credentials.get("public_key"), "credential-" + TEST_PROJ + "-public_key",
                          PUBLIC_KEY_CREDENTIAL);
         assertCredential(credentials.get("password"), "credential-1", PASSWORD_CREDENTIAL);
         // "-1" suffix is added because the credential ID is duplicated.
-        assertCredential(credentials.get("access_token"), "credential-1-1", ACCESS_TOKEN_CREDENTIAL);
+        assertCredential(credentials.get("access_token"), "credential-1-slingshot", ACCESS_TOKEN_CREDENTIAL);
 
         // Make sure that the legacy files are renamed.
         assertThatThrownBy(() -> repo.file(PATH_LEGACY_MIRRORS).get().join())

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceTest.java
@@ -244,13 +244,13 @@ class MirroringMigrationServiceTest {
                            }
                        }, Function.identity()));
 
-        assertMirrorConfig(mirrors.get(TEST_REPO0), "mirror-" + TEST_PROJ + '-' + TEST_REPO0 + "-[a-z]+",
+        assertMirrorConfig(mirrors.get(TEST_REPO0), "mirror-" + TEST_PROJ + '-' + TEST_REPO0,
                            REPO0_MIRROR);
         assertMirrorConfig(mirrors.get(TEST_REPO1), "mirror-1", REPO1_MIRROR);
-        // "-1" suffix is added because the mirror ID is duplicated.
-        assertMirrorConfig(mirrors.get(TEST_REPO2), "mirror-1-1", REPO2_MIRROR);
-        // "-2" suffix is added because the mirror ID is duplicated.
-        assertMirrorConfig(mirrors.get(TEST_REPO3), "mirror-1-2", REPO3_MIRROR);
+        // "-khaki" suffix is added because the mirror ID is duplicated.
+        assertMirrorConfig(mirrors.get(TEST_REPO2), "mirror-1-khaki", REPO2_MIRROR);
+        // "-speakers" suffix is added because the mirror ID is duplicated.
+        assertMirrorConfig(mirrors.get(TEST_REPO3), "mirror-1-speakers", REPO3_MIRROR);
     }
 
     static void assertMirrorConfig(Map.Entry<String, Entry<?>> actualMirrorConfig, String mirrorId,
@@ -292,11 +292,11 @@ class MirroringMigrationServiceTest {
                            }
                        }, Function.identity()));
 
-        assertCredential(credentials.get("public_key"), "credential-" + TEST_PROJ + "-[a-z]+",
+        assertCredential(credentials.get("public_key"), "credential-" + TEST_PROJ + "-public_key",
                          PUBLIC_KEY_CREDENTIAL);
         assertCredential(credentials.get("password"), "credential-1", PASSWORD_CREDENTIAL);
-        // "-1" suffix is added because the credential ID is duplicated.
-        assertCredential(credentials.get("access_token"), "credential-1-1", ACCESS_TOKEN_CREDENTIAL);
+        // "-slingshot" suffix is added because the credential ID is duplicated.
+        assertCredential(credentials.get("access_token"), "credential-1-slingshot", ACCESS_TOKEN_CREDENTIAL);
 
         // Make sure that the migration log is written.
         final Repository dogmaRepo = projectManager.get(InternalProjectInitializer.INTERNAL_PROJECT_DOGMA)
@@ -332,7 +332,7 @@ class MirroringMigrationServiceTest {
             if ("mirror-1".equals(mirror.id())) {
                 assertThat(mirror.credential().id()).isEqualTo("credential-1");
             } else if (mirror.id().startsWith("mirror-" + TEST_PROJ + '-' + TEST_REPO0)) {
-                assertThat(mirror.credential().id()).matches("credential-" + TEST_PROJ + "-[a-z]+");
+                assertThat(mirror.credential().id()).matches("credential-" + TEST_PROJ + "-public_key");
             } else if (mirror.id().startsWith("mirror-1-")) {
                 // No matched credential was found.
                 assertThat(mirror.credential().id()).matches("");

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceTest.java
@@ -343,6 +343,15 @@ class MirroringMigrationServiceTest {
         }
     }
 
+    @Test
+    void shouldBuildShortWords() {
+        final List<String> words = MirroringMigrationService.buildShortWords();
+        final int expectedSize = 1296;
+        assertThat(words).hasSize(expectedSize);
+        assertThat(words.get(0)).isEqualTo("aardvark");
+        assertThat(words.get(expectedSize - 1)).isEqualTo("zucchini");
+    }
+
     static void assertCredential(Map.Entry<String, Entry<?>> actualCredential, String credentialId,
                                  String expectedCredential) throws JsonParseException {
         assertThat(actualCredential.getKey()).matches("/credentials/" + credentialId + "\\.json");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationService.java
@@ -48,7 +48,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.common.Author;
@@ -440,14 +439,13 @@ final class MirroringMigrationService {
         return maybeUnique;
     }
 
-    private static List<String> buildShortWords() {
+    @VisibleForTesting
+    static List<String> buildShortWords() {
         // TODO(ikhoon) Remove 'short_wordlist.txt' if Central Dogma version has been updated enough and
         //              we can assume that all users have already migrated.
         final InputStream is = MirroringMigrationService.class.getResourceAsStream("short_wordlist.txt");
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(is))) {
-            final ImmutableList.Builder<String> words = ImmutableList.builder();
-            words.add(reader.readLine());
-            return words.build();
+            return reader.lines().collect(toImmutableList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }


### PR DESCRIPTION
Motivation:

There was a bug that only the first word was read from the `short_wordlist.txt`

Modifications:

- Use `reader.lines()` to read all words

Result:

Automatically generated mirror ID and credential ID are correctly randomized.