### PR TITLE
Clean up HTTP service configuration with new Armeria API

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -817,23 +817,21 @@ public class CentralDogma implements AutoCloseable {
                                .annotatedService(new CredentialServiceV1(projectApiManager, executor));
         }
 
-        // TODO(ikhoon): Use context-path API once https://github.com/line/armeria/pull/5797 is fixed.
-        sb.annotatedService()
-          .pathPrefix(API_V1_PATH_PREFIX)
-          .defaultServiceNaming(new ServiceNaming() {
-              private final String serviceName = ContentServiceV1.class.getName();
-              private final String watchServiceName =
-                      serviceName.replace("ContentServiceV1", "WatchContentServiceV1");
+        apiV1ServiceBuilder.annotatedService()
+                           .defaultServiceNaming(new ServiceNaming() {
+                               private final String serviceName = ContentServiceV1.class.getName();
+                               private final String watchServiceName =
+                                       serviceName.replace("ContentServiceV1", "WatchContentServiceV1");
 
-              @Override
-              public String serviceName(ServiceRequestContext ctx) {
-                  if (ctx.request().headers().contains(HttpHeaderNames.IF_NONE_MATCH)) {
-                      return watchServiceName;
-                  }
-                  return serviceName;
-              }
-          })
-          .build(new ContentServiceV1(executor, watchService, meterRegistry));
+                               @Override
+                               public String serviceName(ServiceRequestContext ctx) {
+                                   if (ctx.request().headers().contains(HttpHeaderNames.IF_NONE_MATCH)) {
+                                       return watchServiceName;
+                                   }
+                                   return serviceName;
+                               }
+                           })
+                           .build(new ContentServiceV1(executor, watchService, meterRegistry));
 
         sb.annotatedService()
           .decorator(decorator)

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/RepositoryService.java
@@ -36,12 +36,12 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Default;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Path;
 import com.linecorp.armeria.server.annotation.Post;
 import com.linecorp.armeria.server.annotation.Put;
+import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Markup;
@@ -57,8 +57,8 @@ import com.linecorp.centraldogma.server.internal.admin.dto.CommitDto;
 import com.linecorp.centraldogma.server.internal.admin.dto.CommitMessageDto;
 import com.linecorp.centraldogma.server.internal.admin.dto.EntryDto;
 import com.linecorp.centraldogma.server.internal.admin.dto.RevisionDto;
+import com.linecorp.centraldogma.server.internal.admin.util.RestfulJsonResponseConverter;
 import com.linecorp.centraldogma.server.internal.api.AbstractService;
-import com.linecorp.centraldogma.server.internal.api.HttpApiExceptionHandler;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresReadPermission;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresWritePermission;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager;
@@ -68,7 +68,7 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
  * Annotated service object for managing repositories.
  */
 @RequiresReadPermission
-@ExceptionHandler(HttpApiExceptionHandler.class)
+@ResponseConverter(RestfulJsonResponseConverter.class)
 public class RepositoryService extends AbstractService {
 
     private static final Object VOID = new Object();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/service/UserService.java
@@ -21,15 +21,18 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.admin.auth.AuthUtil;
+import com.linecorp.centraldogma.server.internal.admin.util.RestfulJsonResponseConverter;
 import com.linecorp.centraldogma.server.internal.api.AbstractService;
 import com.linecorp.centraldogma.server.metadata.User;
 
 /**
  * Annotated service object for managing users.
  */
+@ResponseConverter(RestfulJsonResponseConverter.class)
 public class UserService extends AbstractService {
 
     public UserService(CommandExecutor executor) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AbstractService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/AbstractService.java
@@ -20,12 +20,21 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
 
+import com.linecorp.armeria.server.annotation.JacksonRequestConverterFunction;
+import com.linecorp.armeria.server.annotation.RequestConverter;
+import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.api.converter.HttpApiRequestConverter;
+import com.linecorp.centraldogma.server.internal.api.converter.HttpApiResponseConverter;
 
 /**
  * A base service class for HTTP API.
  */
+@RequestConverter(HttpApiRequestConverter.class)
+@RequestConverter(JacksonRequestConverterFunction.class)
+// Do not need jacksonResponseConverterFunction because HttpApiResponseConverter handles the JSON data.
+@ResponseConverter(HttpApiResponseConverter.class)
 public class AbstractService {
 
     private final CommandExecutor executor;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -52,7 +52,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Default;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
@@ -101,7 +100,6 @@ import io.micrometer.core.instrument.MeterRegistry;
 @ProducesJson
 @RequiresReadPermission
 @RequestConverter(CommitMessageRequestConverter.class)
-@ExceptionHandler(HttpApiExceptionHandler.class)
 public class ContentServiceV1 extends AbstractService {
 
     private static final String MIRROR_LOCAL_REPO = "localRepo";

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/CredentialServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/CredentialServiceV1.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.server.annotation.ConsumesJson;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
@@ -41,7 +40,6 @@ import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
  * Annotated service object for managing credential service.
  */
 @ProducesJson
-@ExceptionHandler(HttpApiExceptionHandler.class)
 public class CredentialServiceV1 extends AbstractService {
 
     private final ProjectApiManager projectApiManager;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
@@ -35,7 +35,6 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
 import com.linecorp.armeria.server.annotation.Post;
@@ -47,6 +46,7 @@ import com.linecorp.centraldogma.internal.jsonpatch.JsonPatch;
 import com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation;
 import com.linecorp.centraldogma.internal.jsonpatch.ReplaceOperation;
 import com.linecorp.centraldogma.server.QuotaConfig;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresAdministrator;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresRole;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
@@ -61,8 +61,7 @@ import com.linecorp.centraldogma.server.metadata.User;
  */
 @ProducesJson
 @RequiresRole(roles = ProjectRole.OWNER)
-@ExceptionHandler(HttpApiExceptionHandler.class)
-public class MetadataApiService {
+public class MetadataApiService extends AbstractService {
 
     private static final TypeReference<Collection<Permission>> permissionsTypeRef =
             new TypeReference<Collection<Permission>>() {};
@@ -70,7 +69,9 @@ public class MetadataApiService {
     private final MetadataService mds;
     private final Function<String, String> loginNameNormalizer;
 
-    public MetadataApiService(MetadataService mds, Function<String, String> loginNameNormalizer) {
+    public MetadataApiService(CommandExecutor executor, MetadataService mds,
+                              Function<String, String> loginNameNormalizer) {
+        super(executor);
         this.mds = requireNonNull(mds, "mds");
         this.loginNameNormalizer = requireNonNull(loginNameNormalizer, "loginNameNormalizer");
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.server.annotation.ConsumesJson;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Post;
@@ -45,7 +44,6 @@ import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
  * Annotated service object for managing mirroring service.
  */
 @ProducesJson
-@ExceptionHandler(HttpApiExceptionHandler.class)
 public class MirroringServiceV1 extends AbstractService {
 
     // TODO(ikhoon):

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -45,6 +44,7 @@ import com.linecorp.armeria.server.annotation.StatusCode;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.api.v1.CreateProjectRequest;
 import com.linecorp.centraldogma.internal.api.v1.ProjectDto;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresAdministrator;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresRole;
 import com.linecorp.centraldogma.server.internal.api.converter.CreateApiResponseConverter;
@@ -57,12 +57,12 @@ import com.linecorp.centraldogma.server.storage.project.Project;
  * Annotated service object for managing projects.
  */
 @ProducesJson
-@ExceptionHandler(HttpApiExceptionHandler.class)
-public class ProjectServiceV1 {
+public class ProjectServiceV1 extends AbstractService {
 
     private final ProjectApiManager projectApiManager;
 
-    public ProjectServiceV1(ProjectApiManager projectApiManager) {
+    public ProjectServiceV1(ProjectApiManager projectApiManager, CommandExecutor executor) {
+        super(executor);
         this.projectApiManager = requireNonNull(projectApiManager, "projectApiManager");
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -37,7 +37,6 @@ import com.linecorp.armeria.common.logging.RequestOnlyLog;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
 import com.linecorp.armeria.server.annotation.Patch;
@@ -66,7 +65,6 @@ import io.micrometer.core.instrument.Tag;
  * Annotated service object for managing repositories.
  */
 @ProducesJson
-@ExceptionHandler(HttpApiExceptionHandler.class)
 public class RepositoryServiceV1 extends AbstractService {
 
     private final MetadataService mds;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/TokenService.java
@@ -34,7 +34,6 @@ import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Delete;
-import com.linecorp.armeria.server.annotation.ExceptionHandler;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.HttpResult;
 import com.linecorp.armeria.server.annotation.Param;
@@ -58,7 +57,6 @@ import com.linecorp.centraldogma.server.metadata.User;
  * Annotated service object for managing {@link Token}s.
  */
 @ProducesJson
-@ExceptionHandler(HttpApiExceptionHandler.class)
 public class TokenService extends AbstractService {
 
     private static final JsonNode activation = Jackson.valueToTree(

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -148,7 +148,9 @@ class PermissionTest {
                                          @Param String repoName) {
                     return HttpResponse.of(HttpStatus.OK);
                 }
-            }, decorator, new HttpApiExceptionHandler());
+            }, decorator);
+
+            sb.errorHandler(new HttpApiExceptionHandler());
         }
     };
 


### PR DESCRIPTION
Motivation:

The Central Dogma HTTP service configurations used old Armeria API and had many duplicate code.

Modifications:

- Use the context-path API to register API services.
- Use a route decorator to not bind the decorator to each service
- Use `ServerErrorHandler` to apply it globally
- Use `DependencyInjector` to inject request/response converters with annotations.

Result:

Duplicate code has been removed and streamlined