### PR TITLE
Format code with Prettier

### DIFF
--- a/webapp/.prettierignore
+++ b/webapp/.prettierignore
@@ -1,0 +1,8 @@
+# Ignore everything recursively
+*
+
+# But not the .ts* files
+!*.ts*
+
+# Check subdirectories too
+!*/

--- a/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
+++ b/webapp/__tests__/dogma/feature/history/HistoryList.test.tsx
@@ -5,7 +5,7 @@ import HistoryList from 'dogma/features/history/HistoryList';
 // import { setupServer } from 'msw/node';
 // import { http, HttpResponse } from 'msw';
 import { apiSlice } from 'dogma/features/api/apiSlice';
-import { ApiProvider } from "@reduxjs/toolkit/query/react";
+import { ApiProvider } from '@reduxjs/toolkit/query/react';
 const expectedProps = {
   projectName: 'ProjectAlpha',
   repoName: 'RepoGamma',

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -70,9 +70,21 @@ if (!rootProject.hasProperty('noLint')) {
         outputs.upToDateWhen { true }
     }
 
+    task prettier(type: NpmTask) {
+        dependsOn tasks.eslint
+
+        args = ['run', 'format']
+
+        inputs.dir('src')
+        inputs.file('package.json')
+        inputs.file('package-lock.json')
+        inputs.file('next.config.js')
+        outputs.upToDateWhen { true }
+    }
+
     Task lintTask = project.ext.getLintTask()
-    lintTask.dependsOn(tasks.eslint)
-    tasks.buildWeb.dependsOn(tasks.eslint)
+    lintTask.dependsOn(tasks.prettier)
+    tasks.buildWeb.dependsOn(tasks.prettier)
 }
 
 task testWeb(type: NpmTask) {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -11,6 +11,8 @@
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix --ext .json,.js,.jsx,.ts,.tsx .",
+    "format": "prettier --check .",
+    "format:fix": "prettier --write .",
     "pretest": "npm run lint",
     "analyze": "ANALYZE=true next build"
   },

--- a/webapp/src/dogma/common/components/Breadcrumbs.tsx
+++ b/webapp/src/dogma/common/components/Breadcrumbs.tsx
@@ -34,7 +34,11 @@ export const Breadcrumbs = ({
           return (
             <BreadcrumbItem key={i}>
               {i < asPathNestedRoutes.length - 1 ? (
-                <BreadcrumbLink as={NextLink} href={`/${prefixes.join('/')}${suffixes[i] || ''}`} paddingBottom={1}>
+                <BreadcrumbLink
+                  as={NextLink}
+                  href={`/${prefixes.join('/')}${suffixes[i] || ''}`}
+                  paddingBottom={1}
+                >
                   {decodeURI(item)}
                 </BreadcrumbLink>
               ) : (

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -32,8 +32,8 @@ import { MirrorDto } from 'dogma/features/mirror/MirrorDto';
 import { CredentialDto } from 'dogma/features/credential/CredentialDto';
 
 export type ApiAction<Arg, Result> = {
-  (arg: Arg): { unwrap: () => Promise<Result> }
-}
+  (arg: Arg): { unwrap: () => Promise<Result> };
+};
 
 export type GetHistory = {
   projectName: string;

--- a/webapp/src/dogma/features/credential/CredentialForm.tsx
+++ b/webapp/src/dogma/features/credential/CredentialForm.tsx
@@ -141,7 +141,6 @@ const CredentialForm = ({ defaultValue, onSubmit, isWaitingResponse }: Credentia
           </FormControl>
           <Spacer />
 
-
           <FormControl isRequired isInvalid={errors.type != null}>
             <FormLabel>
               <LabelledIcon icon={GoLock} text="Authentication" />

--- a/webapp/src/dogma/features/credential/CredentialView.tsx
+++ b/webapp/src/dogma/features/credential/CredentialView.tsx
@@ -22,7 +22,8 @@ import {
   Flex,
   Heading,
   Icon,
-  Link, Spacer,
+  Link,
+  Spacer,
   Table,
   TableContainer,
   Tbody,
@@ -38,7 +39,7 @@ import { AppDispatch, useAppDispatch } from 'dogma/store';
 import { createMessage } from 'dogma/features/message/messageSlice';
 import { IconType } from 'react-icons';
 import { HiOutlineIdentification, HiOutlineUser } from 'react-icons/hi';
-import {GrOrganization} from "react-icons/gr";
+import { GrOrganization } from 'react-icons/gr';
 
 import { VscRegex } from 'react-icons/vsc';
 import { MdPublic } from 'react-icons/md';
@@ -107,13 +108,13 @@ const CredentialView = ({ projectName, credential }: CredentialViewProps) => {
         <Heading color="teal.500" size="lg" alignSelf="center" mb={4}>
           {credential.id}
         </Heading>
-        <Spacer/>
+        <Spacer />
         <TableContainer>
           <Table fontSize={'lg'} variant="unstyled">
             <Tbody>
               <Tr>
                 <HeadRow>
-                  <AlignedIcon as={GrOrganization}/> Project
+                  <AlignedIcon as={GrOrganization} /> Project
                 </HeadRow>
                 <Td fontWeight="semibold">{projectName}</Td>
               </Tr>
@@ -200,7 +201,7 @@ const CredentialView = ({ projectName, credential }: CredentialViewProps) => {
               )}
               <Tr>
                 <HeadRow>
-                  <AlignedIcon as={VscRegex}/> Hostname patterns
+                  <AlignedIcon as={VscRegex} /> Hostname patterns
                 </HeadRow>
                 <Td>
                   {credential.hostnamePatterns.length === 0 ? (

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -71,7 +71,6 @@ const HistoryList = ({ projectName, repoName, handleTabChange, totalRevision }: 
     revision: -pageIndex * pageSize - 1,
     to: Math.max(-totalRevision, -(pageIndex + 1) * pageSize),
   });
-  console.log("history data: " + data);
   return (
     <Deferred isLoading={isLoading} error={error}>
       {() => (

--- a/webapp/src/dogma/features/mirror/MirrorForm.tsx
+++ b/webapp/src/dogma/features/mirror/MirrorForm.tsx
@@ -69,20 +69,20 @@ const MIRROR_SCHEMES: OptionType[] = ['git+ssh', 'git+http', 'git+https'].map((s
 
 const INTERNAL_REPOS = new Set<string>(['dogma', 'meta']);
 
-const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: MirrorFormProps) => {
+const MirrorForm = ({ projectName, defaultValue, onSubmit, isWaitingResponse }: MirrorFormProps) => {
   const {
     register,
     handleSubmit,
     reset,
-    formState: {errors},
+    formState: { errors },
     setError,
     setValue,
     control,
   } = useForm<MirrorDto>();
 
   const isNew = defaultValue.id === '';
-  const {data: repos} = useGetReposQuery(projectName);
-  const {data: credentials} = useGetCredentialsQuery(projectName);
+  const { data: repos } = useGetReposQuery(projectName);
+  const { data: credentials } = useGetCredentialsQuery(projectName);
 
   const repoOptions: OptionType[] = (repos || [])
     .filter((repo: RepoDto) => !INTERNAL_REPOS.has(repo.name))
@@ -110,16 +110,18 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
   }, [defaultValue, setValue]);
 
   const defaultRemoteScheme: OptionType = defaultValue.remoteScheme
-    ? {value: defaultValue.remoteScheme, label: defaultValue.remoteScheme}
+    ? { value: defaultValue.remoteScheme, label: defaultValue.remoteScheme }
     : null;
   const defaultCredential: OptionType = defaultValue.credentialId
-    ? {value: defaultValue.credentialId, label: defaultValue.credentialId}
+    ? { value: defaultValue.credentialId, label: defaultValue.credentialId }
     : null;
 
   return (
-    <form onSubmit={handleSubmit((mirror) => {
-      return onSubmit(mirror, reset, setError);
-    })}>
+    <form
+      onSubmit={handleSubmit((mirror) => {
+        return onSubmit(mirror, reset, setError);
+      })}
+    >
       <Center>
         <VStack width="80%" align="left">
           <Heading color={'teal.500'} alignSelf="center">
@@ -127,7 +129,7 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
           </Heading>
           <FormControl isRequired isInvalid={errors.id != null}>
             <FormLabel>
-              <LabelledIcon icon={GiMirrorMirror} text="Mirror ID"/>
+              <LabelledIcon icon={GiMirrorMirror} text="Mirror ID" />
             </FormLabel>
             <Input
               id="id"
@@ -135,10 +137,10 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
               type="text"
               defaultValue={defaultValue.id}
               placeholder="The mirror ID"
-              {...register('id', {required: true, pattern: /^[a-zA-Z0-9-_.]+$/})}
+              {...register('id', { required: true, pattern: /^[a-zA-Z0-9-_.]+$/ })}
             />
             {errors.id ? (
-              <FieldErrorMessage error={errors.id} fieldName="ID"/>
+              <FieldErrorMessage error={errors.id} fieldName="ID" />
             ) : (
               <FormHelperText>
                 The mirror ID must be unique and contain alphanumeric characters, dashes, underscores, and
@@ -146,11 +148,11 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
               </FormHelperText>
             )}
           </FormControl>
-          <Spacer/>
+          <Spacer />
 
           <FormControl isRequired isInvalid={errors.schedule != null}>
             <FormLabel>
-              <LabelledIcon icon={BiTimer} text="Schedule"/>
+              <LabelledIcon icon={BiTimer} text="Schedule" />
             </FormLabel>
             <Input
               id="schedule"
@@ -158,11 +160,11 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
               type="text"
               placeholder="0 * * * * ?"
               defaultValue={defaultValue.schedule}
-              {...register('schedule', {required: true})}
+              {...register('schedule', { required: true })}
             />
 
             {errors.schedule ? (
-              <FieldErrorMessage error={errors.schedule}/>
+              <FieldErrorMessage error={errors.schedule} />
             ) : (
               <FormHelperText>
                 <Link
@@ -170,97 +172,97 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                   href="https://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html"
                   isExternal
                 >
-                  Quartz cron expression <ExternalLinkIcon mx="2px"/>{' '}
+                  Quartz cron expression <ExternalLinkIcon mx="2px" />{' '}
                 </Link>
                 is used to describe when the mirroring task is supposed to be triggered.
               </FormHelperText>
             )}
           </FormControl>
-          <Spacer/>
+          <Spacer />
 
           <FormControl isRequired isInvalid={errors.direction != null}>
             <FormLabel>
-              <LabelledIcon icon={GoArrowBoth} text="Direction"/>
+              <LabelledIcon icon={GoArrowBoth} text="Direction" />
             </FormLabel>
             <Controller
               name="direction"
-              rules={{required: true}}
+              rules={{ required: true }}
               control={control}
-              render={({field: {onChange, value}}) => (
+              render={({ field: { onChange, value } }) => (
                 <RadioGroup onChange={onChange} value={value} defaultValue={defaultValue.direction}>
                   <Stack direction="row">
                     <Radio value="REMOTE_TO_LOCAL" marginRight={2}>
-                      <LabelledIcon icon={GoArrowDown} text="Remote to Central Dogma"/>
+                      <LabelledIcon icon={GoArrowDown} text="Remote to Central Dogma" />
                     </Radio>
                     <Radio value="LOCAL_TO_REMOTE">
-                      <LabelledIcon icon={GoArrowUp} text="Central Dogma to Remote"/>
+                      <LabelledIcon icon={GoArrowUp} text="Central Dogma to Remote" />
                     </Radio>
                   </Stack>
                 </RadioGroup>
               )}
             />
-            <FieldErrorMessage error={errors.direction}/>
+            <FieldErrorMessage error={errors.direction} />
           </FormControl>
-          <Spacer/>
+          <Spacer />
 
-            <Stack direction="row" width="100%">
-              <FormControl isRequired isInvalid={errors.localRepo != null}>
-                <FormLabel>
-                  <LabelledIcon icon={GoRepo} text={'Local repository'}/>
-                </FormLabel>
-                <Controller
-                  control={control}
-                  name="localRepo"
-                  rules={{required: true}}
-                  render={({field: {onChange, value, name, ref}}) => (
-                    <Select
-                      ref={ref}
-                      id="localRepo"
-                      name={name}
-                      isDisabled={repoOptions.length === 0}
-                      options={repoOptions}
-                      // The default value of React Select must be null (and not undefined)
-                      value={repoOptions.find((option) => option.value === value) || null}
-                      onChange={(option) => onChange(option?.value || '')}
-                      placeholder={
-                        repoOptions.length === 0
-                          ? "No local repository is found. You need to create a local repository first."
-                          : "Enter repo name..."
-                      }
-                      closeMenuOnSelect={true}
-                      openMenuOnFocus={true}
-                      isSearchable={true}
-                      isClearable={true}
-                    />
-                  )}
-                />
-                <FieldErrorMessage error={errors.localRepo} fieldName="Local repository"/>
-              </FormControl>
-              <FormControl width="50%" isRequired isInvalid={errors.localPath != null}>
-                <FormLabel>path</FormLabel>
-                <Input
-                  id="localPath"
-                  name="localPath"
-                  type="text"
-                  defaultValue={defaultValue.localPath}
-                  placeholder="/"
-                  {...register('localPath', {required: true})}
-                />
-                <FieldErrorMessage error={errors.localPath} fieldName="Local path"/>
-              </FormControl>
-            </Stack>
-          <Spacer/>
+          <Stack direction="row" width="100%">
+            <FormControl isRequired isInvalid={errors.localRepo != null}>
+              <FormLabel>
+                <LabelledIcon icon={GoRepo} text={'Local repository'} />
+              </FormLabel>
+              <Controller
+                control={control}
+                name="localRepo"
+                rules={{ required: true }}
+                render={({ field: { onChange, value, name, ref } }) => (
+                  <Select
+                    ref={ref}
+                    id="localRepo"
+                    name={name}
+                    isDisabled={repoOptions.length === 0}
+                    options={repoOptions}
+                    // The default value of React Select must be null (and not undefined)
+                    value={repoOptions.find((option) => option.value === value) || null}
+                    onChange={(option) => onChange(option?.value || '')}
+                    placeholder={
+                      repoOptions.length === 0
+                        ? 'No local repository is found. You need to create a local repository first.'
+                        : 'Enter repo name...'
+                    }
+                    closeMenuOnSelect={true}
+                    openMenuOnFocus={true}
+                    isSearchable={true}
+                    isClearable={true}
+                  />
+                )}
+              />
+              <FieldErrorMessage error={errors.localRepo} fieldName="Local repository" />
+            </FormControl>
+            <FormControl width="50%" isRequired isInvalid={errors.localPath != null}>
+              <FormLabel>path</FormLabel>
+              <Input
+                id="localPath"
+                name="localPath"
+                type="text"
+                defaultValue={defaultValue.localPath}
+                placeholder="/"
+                {...register('localPath', { required: true })}
+              />
+              <FieldErrorMessage error={errors.localPath} fieldName="Local path" />
+            </FormControl>
+          </Stack>
+          <Spacer />
 
           <Stack direction="row" width="100%">
             <FormControl width="50%" isRequired isInvalid={errors.remoteScheme != null}>
               <FormLabel>
-                <LabelledIcon icon={GoRepo} text={'Remote'}/>
+                <LabelledIcon icon={GoRepo} text={'Remote'} />
               </FormLabel>
               <Controller
                 control={control}
                 name="remoteScheme"
-                rules={{required: true}}
-                render={({field: {onChange, value, name, ref}}) => (
+                rules={{ required: true }}
+                render={({ field: { onChange, value, name, ref } }) => (
                   <Select
                     ref={ref}
                     id="remoteScheme"
@@ -278,7 +280,7 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                   />
                 )}
               />
-              <FieldErrorMessage error={errors.remoteScheme} fieldName="scheme"/>
+              <FieldErrorMessage error={errors.remoteScheme} fieldName="scheme" />
             </FormControl>
             <FormControl isInvalid={errors.remoteUrl != null} isRequired>
               <FormLabel>repo</FormLabel>
@@ -288,9 +290,9 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                 type="text"
                 defaultValue={defaultValue.remoteUrl}
                 placeholder="my.git.com/org/myrepo.git"
-                {...register('remoteUrl', {required: true, pattern: /^.*\.git$/})}
+                {...register('remoteUrl', { required: true, pattern: /^.*\.git$/ })}
               />
-              <FieldErrorMessage error={errors.remoteUrl} fieldName="remote URL"/>
+              <FieldErrorMessage error={errors.remoteUrl} fieldName="remote URL" />
             </FormControl>
             <FormControl width="50%" isRequired isInvalid={errors.remoteBranch != null}>
               <FormLabel>branch</FormLabel>
@@ -300,9 +302,9 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                 type="text"
                 defaultValue={defaultValue.remoteBranch}
                 placeholder="main"
-                {...register('remoteBranch', {required: true})}
+                {...register('remoteBranch', { required: true })}
               />
-              <FieldErrorMessage error={errors.remoteBranch} fieldName="remote branch"/>
+              <FieldErrorMessage error={errors.remoteBranch} fieldName="remote branch" />
             </FormControl>
             <FormControl width="50%" isRequired isInvalid={errors.remotePath != null}>
               <FormLabel>path</FormLabel>
@@ -312,22 +314,22 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                 type="text"
                 defaultValue={defaultValue.remotePath}
                 placeholder="/"
-                {...register('remotePath', {required: true})}
+                {...register('remotePath', { required: true })}
               />
-              <FieldErrorMessage error={errors.remotePath} fieldName="remote path"/>
+              <FieldErrorMessage error={errors.remotePath} fieldName="remote path" />
             </FormControl>
           </Stack>
-          <Spacer/>
+          <Spacer />
 
           <FormControl width="65%" alignItems="left" isInvalid={errors.credentialId != null}>
             <FormLabel>
-              <LabelledIcon icon={GoKey} text={'Credential'}/>
+              <LabelledIcon icon={GoKey} text={'Credential'} />
             </FormLabel>
             <Controller
               control={control}
               name="credentialId"
-              rules={{required: true}}
-              render={({field: {onChange, value, name, ref}}) => (
+              rules={{ required: true }}
+              render={({ field: { onChange, value, name, ref } }) => (
                 <Select
                   ref={ref}
                   id="credentialId"
@@ -340,8 +342,8 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                   onChange={(option) => onChange(option?.value || '')}
                   placeholder={
                     credentialOptions.length === 0
-                      ? "No credential is found. You need to create credentials first."
-                      : "Enter credential ID ..."
+                      ? 'No credential is found. You need to create credentials first.'
+                      : 'Enter credential ID ...'
                   }
                   closeMenuOnSelect={true}
                   openMenuOnFocus={true}
@@ -350,13 +352,13 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
                 />
               )}
             />
-            <FieldErrorMessage error={errors.credentialId} fieldName="Credential"/>
+            <FieldErrorMessage error={errors.credentialId} fieldName="Credential" />
           </FormControl>
-          <Spacer/>
+          <Spacer />
 
           <FormControl>
             <FormLabel>
-              <LabelledIcon icon={IoBanSharp} text={'gitignore'}/>
+              <LabelledIcon icon={IoBanSharp} text={'gitignore'} />
             </FormLabel>
             <Textarea
               id="gitignore"
@@ -367,21 +369,21 @@ const MirrorForm = ({projectName, defaultValue, onSubmit, isWaitingResponse}: Mi
             />
             <FormHelperText>
               <Link color="teal.500" href="https://git-scm.com/docs/gitignore" isExternal>
-                gitignore <ExternalLinkIcon mx="2px"/>
+                gitignore <ExternalLinkIcon mx="2px" />
               </Link>{' '}
               describes files that should be excluded from the mirroring.
             </FormHelperText>
           </FormControl>
-          <Spacer/>
+          <Spacer />
 
           <FormControl display="flex" alignItems="center">
             <FormLabel htmlFor="enabled" mb="0">
-              <LabelledIcon icon={GiPowerButton} text={'Enable mirror?'}/>
+              <LabelledIcon icon={GiPowerButton} text={'Enable mirror?'} />
             </FormLabel>
             <Switch id="enabled" defaultChecked={defaultValue.enabled} {...register('enabled')} />
           </FormControl>
-          <Spacer/>
-          <Spacer/>
+          <Spacer />
+          <Spacer />
 
           {isNew ? (
             <Button

--- a/webapp/src/dogma/features/mirror/MirrorView.tsx
+++ b/webapp/src/dogma/features/mirror/MirrorView.tsx
@@ -16,15 +16,15 @@ import {
 } from '@chakra-ui/react';
 import { GiMirrorMirror, GiPowerButton } from 'react-icons/gi';
 import { BiTimer } from 'react-icons/bi';
-import { GoKey, GoMirror, GoRepo} from 'react-icons/go';
+import { GoKey, GoMirror, GoRepo } from 'react-icons/go';
 import { IoBanSharp } from 'react-icons/io5';
 import { EditIcon } from '@chakra-ui/icons';
 import React, { ReactNode } from 'react';
 import { CredentialDto } from 'dogma/features/credential/CredentialDto';
 import { MirrorDto } from 'dogma/features/mirror/MirrorDto';
 import { IconType } from 'react-icons';
-import {GrOrganization} from "react-icons/gr";
-import {VscRepoClone} from "react-icons/vsc";
+import { GrOrganization } from 'react-icons/gr';
+import { VscRepoClone } from 'react-icons/vsc';
 
 const HeadRow = ({ children }: { children: ReactNode }) => (
   <Td width="250px" fontWeight="semibold">

--- a/webapp/src/dogma/features/project/Projects.tsx
+++ b/webapp/src/dogma/features/project/Projects.tsx
@@ -50,14 +50,13 @@ export const Projects = () => {
       }),
       columnHelper.accessor((row: ProjectDto) => row.name, {
         cell: (info) =>
-          info.row.original.name === 'dogma' ? null :
-            (info.row.original.createdAt ? (
+          info.row.original.name === 'dogma' ? null : info.row.original.createdAt ? (
             <ChakraLink href={`/app/projects/${info.getValue()}/metadata`}>
               <IconButton icon={<FcServices />} variant="ghost" colorScheme="teal" aria-label="metadata" />
             </ChakraLink>
           ) : (
             <RestoreProject projectName={info.getValue()} />
-            )),
+          ),
         header: 'Action',
         enableSorting: false,
       }),

--- a/webapp/src/dogma/features/repo/permissions/ConfirmAddUserPermission.tsx
+++ b/webapp/src/dogma/features/repo/permissions/ConfirmAddUserPermission.tsx
@@ -10,12 +10,12 @@ import {
   ModalOverlay,
 } from '@chakra-ui/react';
 import { SerializedError } from '@reduxjs/toolkit';
-import { FetchBaseQueryError, } from '@reduxjs/toolkit/query';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { createMessage } from 'dogma/features/message/messageSlice';
 import ErrorHandler from 'dogma/features/services/ErrorHandler';
 import { useAppDispatch } from 'dogma/store';
-import { ApiAction } from "dogma/features/api/apiSlice";
-import { AddUserPermissionDto } from "dogma/features/repo/permissions/AddUserPermissionDto";
+import { ApiAction } from 'dogma/features/api/apiSlice';
+import { AddUserPermissionDto } from 'dogma/features/repo/permissions/AddUserPermissionDto';
 
 const constructPermissions = (permission: string): Array<'READ' | 'WRITE'> =>
   permission === 'write' ? ['READ', 'WRITE'] : permission === 'read' ? ['READ'] : [];
@@ -47,10 +47,9 @@ export const ConfirmAddUserPermission = ({
     permissions: constructPermissions(permission),
   };
 
-
   const handleUpdate = async () => {
     try {
-      const response = await addUserPermission({projectName, repoName, data}).unwrap();
+      const response = await addUserPermission({ projectName, repoName, data }).unwrap();
       if ((response as unknown as { error: FetchBaseQueryError | SerializedError }).error) {
         throw (response as unknown as { error: FetchBaseQueryError | SerializedError }).error;
       }

--- a/webapp/src/dogma/features/repo/permissions/NewRepoTokenPermission.tsx
+++ b/webapp/src/dogma/features/repo/permissions/NewRepoTokenPermission.tsx
@@ -17,16 +17,16 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react';
-import {Controller, useForm} from 'react-hook-form';
-import {IoMdArrowDropdown} from 'react-icons/io';
-import {useState} from 'react';
-import {OptionBase, Select} from 'chakra-react-select';
-import {ConfirmAddUserPermission} from 'dogma/features/repo/permissions/ConfirmAddUserPermission';
-import {ChakraLink} from 'dogma/common/components/ChakraLink';
-import {PerUserPermissionDto} from 'dogma/features/repo/RepoPermissionDto';
-import {AppTokenDetailDto} from "dogma/features/metadata/AppTokenDto";
-import { AddUserPermissionDto } from "dogma/features/repo/permissions/AddUserPermissionDto";
-import { ApiAction } from "dogma/features/api/apiSlice";
+import { Controller, useForm } from 'react-hook-form';
+import { IoMdArrowDropdown } from 'react-icons/io';
+import { useState } from 'react';
+import { OptionBase, Select } from 'chakra-react-select';
+import { ConfirmAddUserPermission } from 'dogma/features/repo/permissions/ConfirmAddUserPermission';
+import { ChakraLink } from 'dogma/common/components/ChakraLink';
+import { PerUserPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
+import { AppTokenDetailDto } from 'dogma/features/metadata/AppTokenDto';
+import { AddUserPermissionDto } from 'dogma/features/repo/permissions/AddUserPermissionDto';
+import { ApiAction } from 'dogma/features/api/apiSlice';
 
 interface TokenOptionType extends OptionBase {
   value: string;
@@ -145,7 +145,7 @@ export const NewRepoTokenPermission = ({
                 repoName={repoName}
                 loginId={appId}
                 permission={permission}
-                     isOpen={isConfirmAddOpen}
+                isOpen={isConfirmAddOpen}
                 onClose={onConfirmAddClose}
                 resetForm={reset}
                 addUserPermission={addTokenPermission}

--- a/webapp/src/dogma/features/repo/permissions/NewRepoUserPermission.tsx
+++ b/webapp/src/dogma/features/repo/permissions/NewRepoUserPermission.tsx
@@ -17,16 +17,16 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react';
-import {Controller, useForm} from 'react-hook-form';
-import {IoMdArrowDropdown} from 'react-icons/io';
-import {useState} from 'react';
-import {OptionBase, Select} from 'chakra-react-select';
-import {AppMemberDetailDto} from 'dogma/features/metadata/AppMemberDto';
-import {ConfirmAddUserPermission} from 'dogma/features/repo/permissions/ConfirmAddUserPermission';
-import {AddUserPermissionDto} from 'dogma/features/repo/permissions/AddUserPermissionDto';
-import {PerUserPermissionDto} from 'dogma/features/repo/RepoPermissionDto';
-import {ChakraLink} from 'dogma/common/components/ChakraLink';
-import { ApiAction } from "dogma/features/api/apiSlice";
+import { Controller, useForm } from 'react-hook-form';
+import { IoMdArrowDropdown } from 'react-icons/io';
+import { useState } from 'react';
+import { OptionBase, Select } from 'chakra-react-select';
+import { AppMemberDetailDto } from 'dogma/features/metadata/AppMemberDto';
+import { ConfirmAddUserPermission } from 'dogma/features/repo/permissions/ConfirmAddUserPermission';
+import { AddUserPermissionDto } from 'dogma/features/repo/permissions/AddUserPermissionDto';
+import { PerUserPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
+import { ChakraLink } from 'dogma/common/components/ChakraLink';
+import { ApiAction } from 'dogma/features/api/apiSlice';
 
 interface MemberOptionType extends OptionBase {
   value: string;

--- a/webapp/src/dogma/features/repo/permissions/RolePermissionForm.tsx
+++ b/webapp/src/dogma/features/repo/permissions/RolePermissionForm.tsx
@@ -8,8 +8,8 @@ const getPermission = (permissions: Array<'READ' | 'WRITE'>) => {
   return permissions.find((permission) => permission === 'WRITE')
     ? 'write'
     : permissions.find((permission) => permission === 'READ')
-    ? 'read'
-    : 'none';
+      ? 'read'
+      : 'none';
 };
 const constructPermissions = (permission: string): Array<'READ' | 'WRITE'> =>
   permission === 'write' ? ['READ', 'WRITE'] : permission === 'read' ? ['READ'] : [];

--- a/webapp/src/dogma/features/repo/permissions/UserPermission.tsx
+++ b/webapp/src/dogma/features/repo/permissions/UserPermission.tsx
@@ -5,7 +5,7 @@ import { DeleteMember } from 'dogma/features/metadata/DeleteMember';
 import { DeleteUserPermissionDto } from 'dogma/features/repo/permissions/DeleteUserPermissionDto';
 import { PerUserPermissionDto } from 'dogma/features/repo/RepoPermissionDto';
 import { useMemo } from 'react';
-import { ApiAction } from "dogma/features/api/apiSlice";
+import { ApiAction } from 'dogma/features/api/apiSlice';
 
 type UserAndPermission = [string, string[]];
 

--- a/webapp/src/pages/api/v1/projects/[projectName]/credentials/[index]/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/credentials/[index]/index.ts
@@ -14,9 +14,9 @@
  * under the License.
  */
 
-import {NextApiRequest, NextApiResponse} from 'next';
-import {CredentialDto} from "dogma/features/credential/CredentialDto";
-import {newRandomCredential} from "pages/api/v1/projects/[projectName]/credentials/index";
+import { NextApiRequest, NextApiResponse } from 'next';
+import { CredentialDto } from 'dogma/features/credential/CredentialDto';
+import { newRandomCredential } from 'pages/api/v1/projects/[projectName]/credentials/index';
 
 const credentials: Map<number, CredentialDto> = new Map();
 

--- a/webapp/src/pages/app/projects/[projectName]/credentials/[id]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/credentials/[id]/index.tsx
@@ -20,7 +20,7 @@ import { Deferred } from 'dogma/common/components/Deferred';
 import React from 'react';
 import CredentialView from 'dogma/features/credential/CredentialView';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
-import {Flex, Spacer} from "@chakra-ui/react";
+import { Flex, Spacer } from '@chakra-ui/react';
 
 const CredentialViewPage = () => {
   const router = useRouter();
@@ -33,8 +33,8 @@ const CredentialViewPage = () => {
         return (
           <>
             <Flex>
-            <Breadcrumbs path={router.asPath} omitIndexList={[0]} replaces={{ 4: data.id }} />
-              <Spacer/>
+              <Breadcrumbs path={router.asPath} omitIndexList={[0]} replaces={{ 4: data.id }} />
+              <Spacer />
             </Flex>
             <CredentialView projectName={projectName} credential={data} />
           </>

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -36,13 +36,13 @@ const ProjectDetailPage = () => {
               <TabPanel>
                 <Flex gap={2}>
                   <Spacer />
-                  {
-                    projectName === 'dogma' ? null : (
-                      <MetadataButton
-                        href={`/app/projects/${projectName}/metadata`} props={{size: 'sm'}}
-                        text={'Project settings'}/>
-                    )
-                  }
+                  {projectName === 'dogma' ? null : (
+                    <MetadataButton
+                      href={`/app/projects/${projectName}/metadata`}
+                      props={{ size: 'sm' }}
+                      text={'Project settings'}
+                    />
+                  )}
                   <NewRepo projectName={projectName} />
                 </Flex>
                 <RepoList data={repoData || []} projectName={projectName} />


### PR DESCRIPTION
Motivation:

`next lint` checks only violations but does not perform code formatting.

Modifications:

- Make Gradle `lint` task depend on `prettier` task.
- Add the following scripts to `package.json` 
  ```
  npm run format
  npm run format:fix
  ```

Result:

CI builds now check the code format of webapp.