### PR TITLE
Allow adding `@` prefix for internal projects

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -55,9 +55,20 @@ public final class Util {
      * Start with an alphanumeric character.
      * An alphanumeric character, minus, plus, underscore and dot are allowed in the middle.
      * End with an alphanumeric character.
+     * Use this pattern for project and repository names that are entered by users.
      */
-    private static final Pattern PROJECT_AND_REPO_NAME_PATTERN =
+    public static final Pattern USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN =
             Pattern.compile("^(?!.*\\.git$)[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$");
+
+    public static final String INTERNAL_PROJECT_PREFIX = "_dogma_";
+
+    /**
+     * The difference between this and {@link #USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN} is that this
+     * allows an underscore at the beginning for internal projects.
+     */
+    public static final Pattern PROJECT_AND_REPO_NAME_PATTERN =
+            Pattern.compile("^(?!.*\\.git$)(" + INTERNAL_PROJECT_PREFIX +
+                            "|[0-9A-Za-z])(?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$");
 
     public static String validateFileName(String name, String paramName) {
         requireNonNull(name, paramName);
@@ -148,25 +159,26 @@ public final class Util {
     public static String validateProjectName(String projectName, String paramName) {
         requireNonNull(projectName, paramName);
         checkArgument(isValidProjectName(projectName),
-                      "%s: %s (expected: %s)", paramName, projectName, PROJECT_AND_REPO_NAME_PATTERN);
+                      "%s: %s (expected: %s)", paramName, projectName,
+                      USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN);
         return projectName;
     }
 
     public static boolean isValidProjectName(String projectName) {
         requireNonNull(projectName, "projectName");
-        return PROJECT_AND_REPO_NAME_PATTERN.matcher(projectName).matches();
+        return USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN.matcher(projectName).matches();
     }
 
     public static String validateRepositoryName(String repoName, String paramName) {
         requireNonNull(repoName, paramName);
         checkArgument(isValidRepositoryName(repoName),
-                      "%s: %s (expected: %s)", paramName, repoName, PROJECT_AND_REPO_NAME_PATTERN);
+                      "%s: %s (expected: %s)", paramName, repoName, USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN);
         return repoName;
     }
 
     public static boolean isValidRepositoryName(String repoName) {
         requireNonNull(repoName, "repoName");
-        return PROJECT_AND_REPO_NAME_PATTERN.matcher(repoName).matches();
+        return USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN.matcher(repoName).matches();
     }
 
     public static String validateEmailAddress(String emailAddr, String paramName) {

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -60,7 +60,7 @@ public final class Util {
     public static final Pattern USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN =
             Pattern.compile("^(?!.*\\.git$)[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$");
 
-    public static final String INTERNAL_PROJECT_PREFIX = "_dogma_";
+    public static final String INTERNAL_PROJECT_PREFIX = "@";
 
     /**
      * The difference between this and {@link #USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN} is that this

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -64,7 +64,7 @@ public final class Util {
 
     /**
      * The difference between this and {@link #USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN} is that this
-     * allows an underscore at the beginning for internal projects.
+     * allows {@value INTERNAL_PROJECT_PREFIX} at the beginning for internal projects.
      */
     public static final Pattern PROJECT_AND_REPO_NAME_PATTERN =
             Pattern.compile("^(?!.*\\.git$)(" + INTERNAL_PROJECT_PREFIX +

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.storage;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.linecorp.centraldogma.internal.Util.PROJECT_AND_REPO_NAME_PATTERN;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -37,7 +38,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
-import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
@@ -56,13 +56,6 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
 
     private static final Logger logger = LoggerFactory.getLogger(DirectoryBasedStorageManager.class);
 
-    /**
-     * Start with an alphanumeric character.
-     * An alphanumeric character, minus, plus, underscore and dot are allowed in the middle.
-     * End with an alphanumeric character.
-     */
-    private static final Pattern CHILD_NAME =
-            Pattern.compile("^[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$");
     private static final String SUFFIX_REMOVED = ".removed";
     private static final String SUFFIX_PURGED = ".purged";
     private static final String GIT_EXTENSION = ".git";
@@ -434,7 +427,7 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
             return false;
         }
 
-        if (!CHILD_NAME.matcher(name).matches()) {
+        if (!PROJECT_AND_REPO_NAME_PATTERN.matcher(name).matches()) {
             return false;
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.common.Author;
@@ -45,7 +46,6 @@ import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository;
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
 import com.linecorp.centraldogma.server.internal.storage.repository.cache.CachingRepositoryManager;
@@ -240,6 +240,10 @@ public class DefaultProject implements Project {
 
     @Override
     public String toString() {
-        return Util.simpleTypeName(getClass()) + '(' + repos + ')';
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name)
+                          .add("author", author)
+                          .add("repos", repos)
+                          .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -19,7 +19,7 @@ package com.linecorp.centraldogma.server.metadata;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation.asJsonArray;
 import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchUtil.encodeSegment;
-import static com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager.listProjectsWithoutDogma;
+import static com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager.listProjectsWithoutInternal;
 import static com.linecorp.centraldogma.server.metadata.RepositorySupport.convertWithJackson;
 import static com.linecorp.centraldogma.server.metadata.Tokens.SECRET_PREFIX;
 import static com.linecorp.centraldogma.server.metadata.Tokens.validateSecret;
@@ -911,7 +911,7 @@ public class MetadataService {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
-        final Collection<Project> projects = listProjectsWithoutDogma(projectManager.list()).values();
+        final Collection<Project> projects = listProjectsWithoutInternal(projectManager.list()).values();
         // Remove the token from projects that only have the token.
         for (Project project : projects) {
             final ProjectMetadata projectMetadata = fetchMetadata(project.name()).join().object();

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
@@ -153,7 +153,7 @@ class StandaloneCommandExecutorTest {
     @Test
     void createInternalProject() {
         final CommandExecutor executor = extension.executor();
-        final String internalProjectName = "_dogma_project";
+        final String internalProjectName = "@project";
         executor.execute(Command.createProject(Author.SYSTEM, internalProjectName)).join();
         final MetadataService mds = new MetadataService(extension.projectManager(), executor);
         mds.addRepo(Author.SYSTEM, internalProjectName, TEST_REPO).join();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -76,7 +76,7 @@ class ProjectServiceV1ListProjectTest {
     @Test
     void listProjects() {
         // Create an internal project.
-        dogma.projectManager().create("_dogma_foo", Author.SYSTEM);
+        dogma.projectManager().create("@foo", Author.SYSTEM);
 
         createProject(normalClient, "trustin");
         createProject(normalClient, "hyangtack");
@@ -123,12 +123,12 @@ class ProjectServiceV1ListProjectTest {
         assertThatJson(aRes.contentUtf8()).isEqualTo(
                 String.format(withoutDogma,
                               "   {" +
-                              "       \"name\": \"_dogma_foo\"," +
+                              "       \"name\": \"@foo\"," +
                               "       \"creator\": {" +
                               "           \"name\": \"System\"," +
                               "           \"email\": \"system@localhost.localdomain\"" +
                               "        }," +
-                              "        \"url\": \"/api/v1/projects/_dogma_foo\"," +
+                              "        \"url\": \"/api/v1/projects/@foo\"," +
                               "        \"createdAt\": \"${json-unit.ignore}\"" +
                               "   }," +
                               "   {" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -36,6 +36,7 @@ import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
@@ -74,6 +75,9 @@ class ProjectServiceV1ListProjectTest {
 
     @Test
     void listProjects() {
+        // Create an internal project.
+        dogma.projectManager().create("_dogma_foo", Author.SYSTEM);
+
         createProject(normalClient, "trustin");
         createProject(normalClient, "hyangtack");
         createProject(normalClient, "minwoox");
@@ -118,6 +122,15 @@ class ProjectServiceV1ListProjectTest {
         assertThat(aRes.headers().status()).isEqualTo(HttpStatus.OK);
         assertThatJson(aRes.contentUtf8()).isEqualTo(
                 String.format(withoutDogma,
+                              "   {" +
+                              "       \"name\": \"_dogma_foo\"," +
+                              "       \"creator\": {" +
+                              "           \"name\": \"System\"," +
+                              "           \"email\": \"system@localhost.localdomain\"" +
+                              "        }," +
+                              "        \"url\": \"/api/v1/projects/_dogma_foo\"," +
+                              "        \"createdAt\": \"${json-unit.ignore}\"" +
+                              "   }," +
                               "   {" +
                               "       \"name\": \"dogma\"," +
                               "       \"creator\": {" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -110,8 +110,8 @@ class ProjectServiceV1Test {
 
     @Test
     void createInvalidProject() throws IOException {
-        // Underscore is only allowed for internal projects.
-        final AggregatedHttpResponse aRes = createProject(normalClient, "_myPro");
+        // @ is only allowed for internal projects.
+        final AggregatedHttpResponse aRes = createProject(normalClient, "@myPro");
         final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
         assertThat(headers.status()).isEqualTo(HttpStatus.BAD_REQUEST);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -109,6 +109,14 @@ class ProjectServiceV1Test {
     }
 
     @Test
+    void createInvalidProject() throws IOException {
+        // Underscore is only allowed for internal projects.
+        final AggregatedHttpResponse aRes = createProject(normalClient, "_myPro");
+        final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
+        assertThat(headers.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
     void createProjectWithSameName() {
         createProject(normalClient, "myNewPro");
         final AggregatedHttpResponse res = createProject(normalClient, "myNewPro");


### PR DESCRIPTION
Motivation:
The xDS module requires its own Central Dogma project for managing xDS resources.
While it's possible to create a project with an arbitrary name that is not currently is use,
adding a `@` prefix to the project name has several benefits:
- It allows adding other internal projects later without worrying about duplicate names
- It makes it easy to distinguish internal projects from non-internals.

Modifications:
- Split valid name pattern to `USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN` and `PROJECT_AND_REPO_NAME_PATTERN`
  - `USER_INPUT_PROJECT_AND_REPO_NAME_PATTERN` is used to validate the names entered by users.
  - `PROJECT_AND_REPO_NAME_PATTERN` is used internally.

Result:
- You can now create an internal project whose name starts with `@`.