### PR TITLE
Parse text to JSON before committing content in an editor

### DIFF
--- a/webapp/src/dogma/common/components/CommitForm.tsx
+++ b/webapp/src/dogma/common/components/CommitForm.tsx
@@ -39,7 +39,16 @@ export const CommitForm = ({
   const { register, handleSubmit, reset } = useForm<FormData>();
   const dispatch = useAppDispatch();
   const onSubmit = async (formData: FormData) => {
-    const newContent = content();
+    let newContent = content();
+    if (name.endsWith('.json')) {
+      try {
+        newContent = JSON.parse(newContent);
+      } catch (error) {
+        dispatch(newNotification(`Failed to format json content.`, ErrorMessageParser.parse(error), 'error'));
+        return;
+      }
+    }
+
     const data = {
       commitMessage: {
         summary: formData.summary,
@@ -53,14 +62,6 @@ export const CommitForm = ({
         },
       ],
     };
-    if (name.endsWith('.json')) {
-      try {
-        JSON.parse(newContent);
-      } catch (error) {
-        dispatch(newNotification(`Failed to format json content.`, ErrorMessageParser.parse(error), 'error'));
-        return;
-      }
-    }
     try {
       const response = await updateFile({ projectName, repoName, data }).unwrap();
       if ((response as { error: FetchBaseQueryError | SerializedError }).error) {

--- a/webapp/src/dogma/features/file/NewFile.tsx
+++ b/webapp/src/dogma/features/file/NewFile.tsx
@@ -59,6 +59,16 @@ export const NewFile = ({
   const [prefixes] = useState(initialPrefixes);
   const onSubmit = async (formData: FormData) => {
     const path = `${prefixes.join('/')}/${formData.name}`;
+    let content = editorRef.current.getValue();
+    if (formData.name.endsWith('.json')) {
+      try {
+        content = JSON.parse(content);
+      } catch (error) {
+        dispatch(newNotification(`Failed to format json content.`, ErrorMessageParser.parse(error), 'error'));
+        return;
+      }
+    }
+
     const data = {
       commitMessage: {
         summary: formData.summary,
@@ -69,7 +79,7 @@ export const NewFile = ({
         {
           path: path.startsWith('/') ? path : `/${path}`,
           type: formData.name.endsWith('.json') ? 'UPSERT_JSON' : 'UPSERT_TEXT',
-          content: editorRef.current.getValue(),
+          content: content,
         },
       ],
     };


### PR DESCRIPTION
Motivation:

I found that the content of an editor is submitted as is. If the content is JSON, we need to parse and embed it in the JSON payload.

Modifications:

- Apply `JSON.parse()` before creating commit changes.

Result:

JSON content is correctly submitted without trailing `\n`