### PR TITLE
Provide a way to configure each plugin.

### DIFF
--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
@@ -49,9 +49,9 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.MirroringService;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorState;
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -73,7 +73,7 @@ class ForceRefUpdateTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.pluginConfigs(new PluginConfig("mirror", true, null));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true));
         }
     };
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
@@ -49,6 +49,7 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorState;
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -72,7 +73,7 @@ class ForceRefUpdateTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.mirroringEnabled(true);
+            builder.pluginConfigs(new PluginConfig("mirror", true, null));
         }
     };
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
@@ -40,8 +40,8 @@ import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
@@ -51,7 +51,7 @@ class GitMirrorAuthTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.pluginConfigs(new PluginConfig("mirror", true, null));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true));
         }
     };
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
@@ -38,7 +38,9 @@ import com.google.common.io.Resources;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -46,7 +48,12 @@ import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 class GitMirrorAuthTest {
 
     @RegisterExtension
-    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.pluginConfigs(new PluginConfig("mirror", true, null));
+        }
+    };
 
     // To make this test cover all supported authentication schemes, the following environment variables
     // must be set:

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorAuthTest.java
@@ -38,7 +38,6 @@ import com.google.common.io.Resources;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
 import com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -47,12 +46,7 @@ import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 class GitMirrorAuthTest {
 
     @RegisterExtension
-    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
-        @Override
-        protected void configure(CentralDogmaBuilder builder) {
-            builder.mirroringEnabled(true);
-        }
-    };
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
 
     // To make this test cover all supported authentication schemes, the following environment variables
     // must be set:

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
@@ -54,7 +54,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
@@ -66,12 +65,11 @@ import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.MirroringService;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.JGitUtil;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
@@ -88,17 +86,7 @@ class GitMirrorIntegrationTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            final JsonNode config;
-            try {
-                config = Jackson.readTree("{\"numMirroringThreads\": 1, " +
-                                          "\"maxNumFilesPerMirror\": " + MAX_NUM_FILES + ", " +
-                                          "\"maxNumBytesPerMirror\": " + MAX_NUM_BYTES + '}');
-            } catch (JsonParseException e) {
-                // Should never reach here.
-                throw new Error(e);
-            }
-
-            builder.pluginConfigs(new PluginConfig("mirror", true, config));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES));
         }
     };
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
@@ -47,8 +47,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 
 import com.linecorp.centraldogma.client.CentralDogma;
@@ -61,9 +59,9 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirrorException;
 import com.linecorp.centraldogma.server.MirroringService;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorState;
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -81,17 +79,7 @@ class LocalToRemoteGitMirrorTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            final JsonNode config;
-            try {
-                config = Jackson.readTree("{\"numMirroringThreads\": 1, " +
-                                          "\"maxNumFilesPerMirror\": " + MAX_NUM_FILES + ", " +
-                                          "\"maxNumBytesPerMirror\": " + MAX_NUM_BYTES + '}');
-            } catch (JsonParseException e) {
-                // Should never reach here.
-                throw new Error(e);
-            }
-
-            builder.pluginConfigs(new PluginConfig("mirror", true, config));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES));
         }
     };
 

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/ReplicationWriteQuotaTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/ReplicationWriteQuotaTest.java
@@ -44,10 +44,10 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.testing.internal.FlakyTest;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
@@ -132,7 +132,7 @@ class ReplicationWriteQuotaTest extends WriteQuotaTestBase {
                 .port(port, SessionProtocol.HTTP)
                 .administrators(TestAuthMessageUtil.USERNAME)
                 .authProviderFactory(factory)
-                .pluginConfigs(new PluginConfig("mirror", false, null))
+                .pluginConfigs(new MirroringServicePluginConfig(false))
                 .writeQuotaPerRepository(5, 1)
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(serverId, servers))

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/ReplicationWriteQuotaTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/ReplicationWriteQuotaTest.java
@@ -44,6 +44,7 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
@@ -131,7 +132,7 @@ class ReplicationWriteQuotaTest extends WriteQuotaTestBase {
                 .port(port, SessionProtocol.HTTP)
                 .administrators(TestAuthMessageUtil.USERNAME)
                 .authProviderFactory(factory)
-                .mirroringEnabled(false)
+                .pluginConfigs(new PluginConfig("mirror", false, null))
                 .writeQuotaPerRepository(5, 1)
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(serverId, servers))

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/TestAllReplicasPlugin.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/TestAllReplicasPlugin.java
@@ -41,4 +41,10 @@ public final class TestAllReplicasPlugin extends AllReplicasPlugin {
     public CompletionStage<Void> stop(PluginContext context) {
         return UnmodifiableFuture.completedFuture(null);
     }
+
+    @Override
+    public Class<?> configType() {
+        // Return the plugin class itself because it does not have a configuration.
+        return TestAllReplicasPlugin.class;
+    }
 }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
@@ -71,6 +71,7 @@ import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
@@ -106,7 +107,7 @@ class MirroringMigrationServiceClusterTest {
                                  final int port = ports[i * 3 + 2];
                                  return new CentralDogmaBuilder(data)
                                          .port(port, SessionProtocol.HTTP)
-                                         .mirroringEnabled(false)
+                                         .pluginConfigs(new PluginConfig("mirror", false, null))
                                          .authProviderFactory(factory)
                                          .replication(replicationConfig)
                                          .administrators(TestAuthMessageUtil.USERNAME)
@@ -155,7 +156,6 @@ class MirroringMigrationServiceClusterTest {
                            server.stop().join();
                            return new CentralDogmaBuilder(server.config().dataDir())
                                    .port(port, SessionProtocol.HTTP)
-                                   .mirroringEnabled(true)
                                    .replication(server.config().replicationConfig())
                                    .build();
                        })

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringMigrationServiceClusterTest.java
@@ -71,10 +71,10 @@ import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
@@ -107,7 +107,7 @@ class MirroringMigrationServiceClusterTest {
                                  final int port = ports[i * 3 + 2];
                                  return new CentralDogmaBuilder(data)
                                          .port(port, SessionProtocol.HTTP)
-                                         .pluginConfigs(new PluginConfig("mirror", false, null))
+                                         .pluginConfigs(new MirroringServicePluginConfig(false))
                                          .authProviderFactory(factory)
                                          .replication(replicationConfig)
                                          .administrators(TestAuthMessageUtil.USERNAME)

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -213,8 +213,7 @@ public class CentralDogma implements AutoCloseable {
      */
     public static CentralDogma forConfig(File configFile) throws IOException {
         requireNonNull(configFile, "configFile");
-        return new CentralDogma(Jackson.readValue(configFile, CentralDogmaConfig.class),
-                                Flags.meterRegistry());
+        return new CentralDogma(CentralDogmaConfig.load(configFile), Flags.meterRegistry());
     }
 
     private final SettableHealthChecker serverHealth = new SettableHealthChecker(false);

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -80,6 +80,22 @@ public final class CentralDogmaBuilder {
             "maximumWeight=134217728," + // Cache up to apx. 128-megachars.
             "expireAfterAccess=5m";      // Expire on 5 minutes of inactivity.
 
+    static final boolean XDS_CONTROL_PLANE_FOUND;
+
+    static {
+        XDS_CONTROL_PLANE_FOUND =
+                exists("com.linecorp.centraldogma.xds.internal.ControlPlanePlugin");
+    }
+
+    private static boolean exists(String className) {
+        try {
+            Class.forName(className, false, CentralDogmaBuilder.class.getClassLoader());
+            return true;
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
     // Armeria properties
     // Note that we use nullable types here for optional properties.
     // When a property is null, the default value will be used implicitly.
@@ -107,9 +123,13 @@ public final class CentralDogmaBuilder {
     private int numMirroringThreads = DEFAULT_NUM_MIRRORING_THREADS;
     private int maxNumFilesPerMirror = DEFAULT_MAX_NUM_FILES_PER_MIRROR;
     private long maxNumBytesPerMirror = DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
+
+    private boolean xdsControlPlaneEnabled = XDS_CONTROL_PLANE_FOUND;
+
     @Nullable
     private GracefulShutdownTimeout gracefulShutdownTimeout;
     private ReplicationConfig replicationConfig = ReplicationConfig.NONE;
+    @Nullable
     private String accessLogFormat;
 
     // AuthConfig properties
@@ -407,6 +427,15 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Sets whether xDS control plane is enabled or not.
+     * If unspecified, xDS control plane is enabled.
+     */
+    public CentralDogmaBuilder xdsControlPlaneEnabled(boolean xdsControlPlaneEnabled) {
+        this.xdsControlPlaneEnabled = xdsControlPlaneEnabled;
+        return this;
+    }
+
+    /**
      * Sets the graceful shutdown timeout. If unspecified, graceful shutdown is disabled.
      */
     public CentralDogmaBuilder gracefulShutdownTimeout(GracefulShutdownTimeout gracefulShutdownTimeout) {
@@ -584,8 +613,8 @@ public final class CentralDogmaBuilder {
                                       numRepositoryWorkers, repositoryCacheSpec,
                                       maxRemovedRepositoryAgeMillis, gracefulShutdownTimeout,
                                       webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
-                                      maxNumFilesPerMirror, maxNumBytesPerMirror, replicationConfig,
-                                      null, accessLogFormat, authCfg, quotaConfig,
+                                      maxNumFilesPerMirror, maxNumBytesPerMirror, xdsControlPlaneEnabled,
+                                      replicationConfig, null, accessLogFormat, authCfg, quotaConfig,
                                       corsConfig);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -49,6 +49,7 @@ import com.linecorp.centraldogma.server.auth.AuthConfig;
 import com.linecorp.centraldogma.server.auth.AuthProvider;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
 import com.linecorp.centraldogma.server.auth.Session;
+import com.linecorp.centraldogma.server.plugin.PluginConfig;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 import io.micrometer.core.instrument.MeterRegistry;

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -71,42 +71,29 @@ public final class CentralDogmaBuilder {
     private static final ServerPort DEFAULT_PORT = new ServerPort(36462, SessionProtocol.HTTP);
 
     static final int DEFAULT_NUM_REPOSITORY_WORKERS = 16;
-    static final int DEFAULT_NUM_MIRRORING_THREADS = 16;
-    static final int DEFAULT_MAX_NUM_FILES_PER_MIRROR = 8192;
-    static final long DEFAULT_MAX_NUM_BYTES_PER_MIRROR = 32 * 1048576; // 32 MiB
     static final long DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS = 604_800_000;  // 7 days
 
     static final String DEFAULT_REPOSITORY_CACHE_SPEC =
             "maximumWeight=134217728," + // Cache up to apx. 128-megachars.
             "expireAfterAccess=5m";      // Expire on 5 minutes of inactivity.
 
-    static final boolean XDS_CONTROL_PLANE_FOUND;
-
-    static {
-        XDS_CONTROL_PLANE_FOUND =
-                exists("com.linecorp.centraldogma.xds.internal.ControlPlanePlugin");
-    }
-
-    private static boolean exists(String className) {
-        try {
-            Class.forName(className, false, CentralDogmaBuilder.class.getClassLoader());
-            return true;
-        } catch (Throwable t) {
-            return false;
-        }
-    }
-
     // Armeria properties
     // Note that we use nullable types here for optional properties.
     // When a property is null, the default value will be used implicitly.
     private final List<ServerPort> ports = new ArrayList<>(2);
+    @Nullable
     private TlsConfig tls;
-    private List<String> trustedProxyAddresses = new ArrayList<>();
-    private List<String> clientAddressSources = new ArrayList<>();
+    private final List<String> trustedProxyAddresses = new ArrayList<>();
+    private final List<String> clientAddressSources = new ArrayList<>();
+    @Nullable
     private Integer numWorkers;
+    @Nullable
     private Integer maxNumConnections;
+    @Nullable
     private Long requestTimeoutMillis;
+    @Nullable
     private Long idleTimeoutMillis;
+    @Nullable
     private Integer maxFrameLength;
 
     // Central Dogma properties
@@ -119,12 +106,6 @@ public final class CentralDogmaBuilder {
     private boolean webAppEnabled = true;
     @Nullable
     private String webAppTitle;
-    private boolean mirroringEnabled = true;
-    private int numMirroringThreads = DEFAULT_NUM_MIRRORING_THREADS;
-    private int maxNumFilesPerMirror = DEFAULT_MAX_NUM_FILES_PER_MIRROR;
-    private long maxNumBytesPerMirror = DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
-
-    private boolean xdsControlPlaneEnabled = XDS_CONTROL_PLANE_FOUND;
 
     @Nullable
     private GracefulShutdownTimeout gracefulShutdownTimeout;
@@ -148,6 +129,8 @@ public final class CentralDogmaBuilder {
 
     @Nullable
     private CorsConfig corsConfig;
+
+    private final List<PluginConfig> pluginConfigs = new ArrayList<>();
 
     /**
      * Creates a new builder with the specified data directory.
@@ -391,51 +374,6 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Sets whether {@link MirroringService} is enabled or not.
-     * If unspecified, {@link MirroringService} is enabled.
-     */
-    public CentralDogmaBuilder mirroringEnabled(boolean mirroringEnabled) {
-        this.mirroringEnabled = mirroringEnabled;
-        return this;
-    }
-
-    /**
-     * Sets the number of worker threads dedicated to mirroring between repositories.
-     * If unspecified, {@value #DEFAULT_NUM_MIRRORING_THREADS} threads are created at maximum.
-     */
-    public CentralDogmaBuilder numMirroringThreads(int numMirroringThreads) {
-        this.numMirroringThreads = numMirroringThreads;
-        return this;
-    }
-
-    /**
-     * Sets the maximum allowed number of files in a mirrored tree.
-     * If unspecified, {@value #DEFAULT_MAX_NUM_FILES_PER_MIRROR} files are allowed at maximum.
-     */
-    public CentralDogmaBuilder maxNumFilesPerMirror(int maxNumFilesPerMirror) {
-        this.maxNumFilesPerMirror = maxNumFilesPerMirror;
-        return this;
-    }
-
-    /**
-     * Sets the maximum allowed number of bytes in a mirrored tree.
-     * If unspecified, {@value #DEFAULT_MAX_NUM_BYTES_PER_MIRROR} bytes are allowed at maximum.
-     */
-    public CentralDogmaBuilder maxNumBytesPerMirror(long maxNumBytesPerMirror) {
-        this.maxNumBytesPerMirror = maxNumBytesPerMirror;
-        return this;
-    }
-
-    /**
-     * Sets whether xDS control plane is enabled or not.
-     * If unspecified, xDS control plane is enabled.
-     */
-    public CentralDogmaBuilder xdsControlPlaneEnabled(boolean xdsControlPlaneEnabled) {
-        this.xdsControlPlaneEnabled = xdsControlPlaneEnabled;
-        return this;
-    }
-
-    /**
      * Sets the graceful shutdown timeout. If unspecified, graceful shutdown is disabled.
      */
     public CentralDogmaBuilder gracefulShutdownTimeout(GracefulShutdownTimeout gracefulShutdownTimeout) {
@@ -582,6 +520,15 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Adds the {@link PluginConfig}s.
+     */
+    public CentralDogmaBuilder pluginConfigs(PluginConfig... pluginConfigs) {
+        requireNonNull(pluginConfigs, "pluginConfigs");
+        this.pluginConfigs.addAll(ImmutableList.copyOf(pluginConfigs));
+        return this;
+    }
+
+    /**
      * Returns a newly-created {@link CentralDogma} server.
      */
     public CentralDogma build() {
@@ -612,9 +559,8 @@ public final class CentralDogmaBuilder {
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
                                       numRepositoryWorkers, repositoryCacheSpec,
                                       maxRemovedRepositoryAgeMillis, gracefulShutdownTimeout,
-                                      webAppEnabled, webAppTitle, mirroringEnabled, numMirroringThreads,
-                                      maxNumFilesPerMirror, maxNumBytesPerMirror, xdsControlPlaneEnabled,
-                                      replicationConfig, null, accessLogFormat, authCfg, quotaConfig,
-                                      corsConfig);
+                                      webAppEnabled, webAppTitle,replicationConfig,
+                                      null, accessLogFormat, authCfg, quotaConfig,
+                                      corsConfig, pluginConfigs);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -29,6 +29,7 @@ import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_MAX_R
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_MIRRORING_THREADS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_NUM_REPOSITORY_WORKERS;
 import static com.linecorp.centraldogma.server.CentralDogmaBuilder.DEFAULT_REPOSITORY_CACHE_SPEC;
+import static com.linecorp.centraldogma.server.CentralDogmaBuilder.XDS_CONTROL_PLANE_FOUND;
 import static com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache.validateCacheSpec;
 import static java.util.Objects.requireNonNull;
 
@@ -204,6 +205,8 @@ public final class CentralDogmaConfig {
     private final int maxNumFilesPerMirror;
     private final long maxNumBytesPerMirror;
 
+    private final boolean xdsControlPlaneEnabled;
+
     // Graceful shutdown
     @Nullable
     private final GracefulShutdownTimeout gracefulShutdownTimeout;
@@ -250,7 +253,8 @@ public final class CentralDogmaConfig {
             @JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
             @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
             @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror,
-            @JsonProperty("replication") @Nullable ReplicationConfig replicationConfig,
+            @JsonProperty("xdsControlPlaneEnabled") @Nullable Boolean xdsControlPlaneEnabled,
+            @JsonProperty("replication") ReplicationConfig replicationConfig,
             @JsonProperty("csrfTokenRequiredForThrift") @Nullable Boolean csrfTokenRequiredForThrift,
             @JsonProperty("accessLogFormat") @Nullable String accessLogFormat,
             @JsonProperty("authentication") @Nullable AuthConfig authConfig,
@@ -293,6 +297,10 @@ public final class CentralDogmaConfig {
         this.maxNumBytesPerMirror = firstNonNull(maxNumBytesPerMirror, DEFAULT_MAX_NUM_BYTES_PER_MIRROR);
         checkArgument(this.maxNumBytesPerMirror > 0,
                       "maxNumBytesPerMirror: %s (expected: > 0)", this.maxNumBytesPerMirror);
+
+        this.xdsControlPlaneEnabled = XDS_CONTROL_PLANE_FOUND ? firstNonNull(xdsControlPlaneEnabled, true)
+                                                              : false;
+
         this.gracefulShutdownTimeout = gracefulShutdownTimeout;
         this.replicationConfig = firstNonNull(replicationConfig, ReplicationConfig.NONE);
         this.csrfTokenRequiredForThrift = firstNonNull(csrfTokenRequiredForThrift, true);
@@ -501,6 +509,14 @@ public final class CentralDogmaConfig {
     @JsonProperty
     public long maxNumBytesPerMirror() {
         return maxNumBytesPerMirror;
+    }
+
+    /**
+     * Returns whether the XDS control plane is enabled.
+     */
+    @JsonProperty
+    public boolean isXdsControlPlaneEnabled() {
+        return xdsControlPlaneEnabled;
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -336,7 +337,8 @@ public final class CentralDogmaConfig {
         this.writeQuotaPerRepository = writeQuotaPerRepository;
         this.corsConfig = corsConfig;
         this.pluginConfigs = firstNonNull(pluginConfigs, ImmutableList.of());
-        pluginConfigMap = this.pluginConfigs.stream().collect(toImmutableMap(PluginConfig::getClass, pc -> pc));
+        pluginConfigMap = this.pluginConfigs.stream().collect(
+                toImmutableMap(PluginConfig::getClass, Function.identity()));
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.linecorp.armeria.common.util.InetAddressPredicates.ofCidr;
 import static com.linecorp.armeria.common.util.InetAddressPredicates.ofExact;
 import static com.linecorp.armeria.server.ClientAddressSource.ofHeader;
@@ -262,6 +263,7 @@ public final class CentralDogmaConfig {
     private final CorsConfig corsConfig;
 
     private final List<PluginConfig> pluginConfigs;
+    private final Map<Class<?>, PluginConfig> pluginConfigMap;
 
     CentralDogmaConfig(
             @JsonProperty(value = "dataDir", required = true) File dataDir,
@@ -333,7 +335,8 @@ public final class CentralDogmaConfig {
 
         this.writeQuotaPerRepository = writeQuotaPerRepository;
         this.corsConfig = corsConfig;
-        this.pluginConfigs = ImmutableList.copyOf(firstNonNull(pluginConfigs, ImmutableList.of()));
+        this.pluginConfigs = firstNonNull(pluginConfigs, ImmutableList.of());
+        pluginConfigMap = this.pluginConfigs.stream().collect(toImmutableMap(PluginConfig::getClass, pc -> pc));
     }
 
     /**
@@ -554,6 +557,13 @@ public final class CentralDogmaConfig {
     @JsonProperty("plugins")
     public List<PluginConfig> pluginConfigs() {
         return pluginConfigs;
+    }
+
+    /**
+     * Returns the map of {@link PluginConfig}s.
+     */
+    public Map<Class<?>, PluginConfig> pluginConfigMap() {
+        return pluginConfigMap;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -290,7 +290,7 @@ public final class CentralDogmaConfig {
             @JsonProperty("authentication") @Nullable AuthConfig authConfig,
             @JsonProperty("writeQuotaPerRepository") @Nullable QuotaConfig writeQuotaPerRepository,
             @JsonProperty("cors") @Nullable CorsConfig corsConfig,
-            @JsonProperty("plugins") @Nullable List<PluginConfig> pluginConfigs) {
+            @JsonProperty("pluginConfigs") @Nullable List<PluginConfig> pluginConfigs) {
 
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
@@ -554,7 +554,7 @@ public final class CentralDogmaConfig {
     /**
      * Returns the list of {@link PluginConfig}s.
      */
-    @JsonProperty("plugins")
+    @JsonProperty("pluginConfigs")
     public List<PluginConfig> pluginConfigs() {
         return pluginConfigs;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginConfig.java
@@ -16,6 +16,7 @@
 package com.linecorp.centraldogma.server;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
 
@@ -38,7 +39,7 @@ public final class PluginConfig {
     public PluginConfig(@JsonProperty(value = "name", required = true) String name,
                         @JsonProperty("enabled") @Nullable Boolean enabled,
                         @JsonProperty("config") @Nullable JsonNode config) {
-        this.name = name;
+        this.name = requireNonNull(name, "name");
         this.enabled = firstNonNull(enabled, true);
         this.config = config;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginConfig.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * A configuration of a plugin.
+ */
+public final class PluginConfig {
+
+    private final String name;
+    private final boolean enabled;
+    @Nullable
+    private final JsonNode config;
+
+    /**
+     * Creates a new instance.
+     */
+    public PluginConfig(@JsonProperty(value = "name", required = true) String name,
+                        @JsonProperty("enabled") @Nullable Boolean enabled,
+                        @JsonProperty("config") @Nullable JsonNode config) {
+        this.name = name;
+        this.enabled = firstNonNull(enabled, true);
+        this.config = config;
+    }
+
+    /**
+     * Returns the name of the plugin.
+     */
+    @JsonProperty
+    public String name() {
+        return name;
+    }
+
+    /**
+     * Returns whether the plugin is enabled.
+     */
+    @JsonProperty
+    public boolean enabled() {
+        return enabled;
+    }
+
+    /**
+     * Returns the configuration of the plugin.
+     */
+    @JsonProperty
+    @Nullable
+    public JsonNode config() {
+        return config;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -84,7 +84,6 @@ final class PluginGroup {
         final ServiceLoader<Plugin> loader = ServiceLoader.load(Plugin.class, classLoader);
         final ImmutableMap.Builder<String, Plugin> plugins = new ImmutableMap.Builder<>();
         for (Plugin plugin : loader) {
-            System.err.println("plugin: " + plugin.name());
             if (target == plugin.target() && plugin.isEnabled(config)) {
                 plugins.put(plugin.name(), plugin);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -19,6 +19,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableMap;
 import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.armeria.common.util.StartStopSupport;
@@ -81,19 +82,20 @@ final class PluginGroup {
         requireNonNull(config, "config");
 
         final ServiceLoader<Plugin> loader = ServiceLoader.load(Plugin.class, classLoader);
-        final Builder<Plugin> plugins = new Builder<>();
+        final ImmutableMap.Builder<String, Plugin> plugins = new ImmutableMap.Builder<>();
         for (Plugin plugin : loader) {
             if (target == plugin.target() && plugin.isEnabled(config)) {
-                plugins.add(plugin);
+                plugins.put(plugin.name(), plugin);
             }
         }
 
-        final List<Plugin> list = plugins.build();
-        if (list.isEmpty()) {
+        // IllegalArgumentException is thrown if there are duplicate keys.
+        final Map<String, Plugin> pluginMap = plugins.build();
+        if (pluginMap.isEmpty()) {
             return null;
         }
 
-        return new PluginGroup(list, Executors.newSingleThreadExecutor(new DefaultThreadFactory(
+        return new PluginGroup(pluginMap.values(), Executors.newSingleThreadExecutor(new DefaultThreadFactory(
                 "plugins-for-" + target.name().toLowerCase().replace("_", "-"), true)));
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -82,15 +82,15 @@ final class PluginGroup {
         requireNonNull(config, "config");
 
         final ServiceLoader<Plugin> loader = ServiceLoader.load(Plugin.class, classLoader);
-        final ImmutableMap.Builder<String, Plugin> plugins = new ImmutableMap.Builder<>();
+        final ImmutableMap.Builder<Class<?>, Plugin> plugins = new ImmutableMap.Builder<>();
         for (Plugin plugin : loader) {
             if (target == plugin.target() && plugin.isEnabled(config)) {
-                plugins.put(plugin.name(), plugin);
+                plugins.put(plugin.configType(), plugin);
             }
         }
 
         // IllegalArgumentException is thrown if there are duplicate keys.
-        final Map<String, Plugin> pluginMap = plugins.build();
+        final Map<Class<?>, Plugin> pluginMap = plugins.build();
         if (pluginMap.isEmpty()) {
             return null;
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -84,6 +84,7 @@ final class PluginGroup {
         final ServiceLoader<Plugin> loader = ServiceLoader.load(Plugin.class, classLoader);
         final ImmutableMap.Builder<String, Plugin> plugins = new ImmutableMap.Builder<>();
         for (Plugin plugin : loader) {
+            System.err.println("plugin: " + plugin.name());
             if (target == plugin.target() && plugin.isEnabled(config)) {
                 plugins.put(plugin.name(), plugin);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
@@ -130,6 +130,7 @@ public final class DefaultMirroringServicePlugin implements Plugin {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
+                          .add("name", name())
                           .add("target", target())
                           .toString();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.server.internal.mirror;
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -29,7 +28,6 @@ import com.google.common.base.MoreObjects;
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.plugin.Plugin;
-import com.linecorp.centraldogma.server.plugin.PluginConfig;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
 
@@ -50,15 +48,12 @@ public final class DefaultMirroringServicePlugin implements Plugin {
         DefaultMirroringService mirroringService = this.mirroringService;
         if (mirroringService == null) {
             final CentralDogmaConfig cfg = context.config();
-            final Optional<PluginConfig> optional =
-                    cfg.pluginConfigs().stream().filter(plugin -> configType().isInstance(plugin))
-                       .findFirst();
+            final MirroringServicePluginConfig mirroringServicePluginConfig =
+                    (MirroringServicePluginConfig) cfg.pluginConfigMap().get(configType());
             final int numThreads;
             final int maxNumFilesPerMirror;
             final long maxNumBytesPerMirror;
 
-            final MirroringServicePluginConfig mirroringServicePluginConfig =
-                    (MirroringServicePluginConfig) optional.orElse(null);
             if (mirroringServicePluginConfig != null) {
                 numThreads = mirroringServicePluginConfig.numMirroringThreads();
                 maxNumFilesPerMirror = mirroringServicePluginConfig.maxNumFilesPerMirror();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringServicePluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringServicePluginConfig.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.google.common.base.Preconditions.checkArgument;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+final class MirroringServicePluginConfig {
+
+    static final int DEFAULT_NUM_MIRRORING_THREADS = 16;
+    static final int DEFAULT_MAX_NUM_FILES_PER_MIRROR = 8192;
+    static final long DEFAULT_MAX_NUM_BYTES_PER_MIRROR = 32 * 1048576; // 32 MiB
+
+    private final int numMirroringThreads;
+    private final int maxNumFilesPerMirror;
+    private final long maxNumBytesPerMirror;
+
+    MirroringServicePluginConfig(@JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
+                                 @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
+                                 @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror) {
+        this.numMirroringThreads = firstNonNull(numMirroringThreads, DEFAULT_NUM_MIRRORING_THREADS);
+        checkArgument(this.numMirroringThreads > 0,
+                      "numMirroringThreads: %s (expected: > 0)", this.numMirroringThreads);
+        this.maxNumFilesPerMirror = firstNonNull(maxNumFilesPerMirror, DEFAULT_MAX_NUM_FILES_PER_MIRROR);
+        checkArgument(this.maxNumFilesPerMirror > 0,
+                      "maxNumFilesPerMirror: %s (expected: > 0)", this.maxNumFilesPerMirror);
+        this.maxNumBytesPerMirror = firstNonNull(maxNumBytesPerMirror, DEFAULT_MAX_NUM_BYTES_PER_MIRROR);
+        checkArgument(this.maxNumBytesPerMirror > 0,
+                      "maxNumBytesPerMirror: %s (expected: > 0)", this.maxNumBytesPerMirror);
+    }
+
+    /**
+     * Returns the number of mirroring threads.
+     */
+    @JsonProperty
+    int numMirroringThreads() {
+        return numMirroringThreads;
+    }
+
+    /**
+     * Returns the maximum allowed number of files per mirror.
+     */
+    @JsonProperty
+    int maxNumFilesPerMirror() {
+        return maxNumFilesPerMirror;
+    }
+
+    /**
+     * Returns the maximum allowed number of bytes per mirror.
+     */
+    @JsonProperty
+    long maxNumBytesPerMirror() {
+        return maxNumBytesPerMirror;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("numMirroringThreads", numMirroringThreads)
+                          .add("maxNumFilesPerMirror", maxNumFilesPerMirror)
+                          .add("maxNumBytesPerMirror", maxNumBytesPerMirror)
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
@@ -75,7 +75,7 @@ public final class PurgeSchedulingServicePlugin implements Plugin {
     @Override
     public Class<?> configType() {
         // Return the plugin class itself because it does not have a configuration.
-        return PurgeSchedulingServicePlugin.class;
+        return getClass();
     }
 
     @Nullable

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
@@ -72,6 +72,12 @@ public final class PurgeSchedulingServicePlugin implements Plugin {
         return requireNonNull(config, "config").maxRemovedRepositoryAgeMillis() > 0;
     }
 
+    @Override
+    public Class<?> configType() {
+        // Return the plugin class itself because it does not have a configuration.
+        return PurgeSchedulingServicePlugin.class;
+    }
+
     @Nullable
     public PurgeSchedulingService scheduledPurgingService() {
         return purgeSchedulingService;

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
@@ -13,17 +13,26 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.centraldogma.server.internal.mirror;
+package com.linecorp.centraldogma.server.mirror;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
 
-final class MirroringServicePluginConfig {
+import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
+
+/**
+ * A mirroring service plugin configuration.
+ */
+public final class MirroringServicePluginConfig extends AbstractPluginConfig {
+
+    public static final MirroringServicePluginConfig INSTANCE =
+            new MirroringServicePluginConfig(true, null, null, null);
 
     static final int DEFAULT_NUM_MIRRORING_THREADS = 16;
     static final int DEFAULT_MAX_NUM_FILES_PER_MIRROR = 8192;
@@ -33,9 +42,23 @@ final class MirroringServicePluginConfig {
     private final int maxNumFilesPerMirror;
     private final long maxNumBytesPerMirror;
 
-    MirroringServicePluginConfig(@JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
-                                 @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
-                                 @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror) {
+    /**
+     * Creates a new instance.
+     */
+    public MirroringServicePluginConfig(boolean enabled) {
+        this(enabled, null, null, null);
+    }
+
+    /**
+     * Creates a new instance.
+     */
+    @JsonCreator
+    public MirroringServicePluginConfig(
+            @JsonProperty("enabled") @Nullable Boolean enabled,
+            @JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
+            @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
+            @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror) {
+        super(enabled);
         this.numMirroringThreads = firstNonNull(numMirroringThreads, DEFAULT_NUM_MIRRORING_THREADS);
         checkArgument(this.numMirroringThreads > 0,
                       "numMirroringThreads: %s (expected: > 0)", this.numMirroringThreads);
@@ -51,7 +74,7 @@ final class MirroringServicePluginConfig {
      * Returns the number of mirroring threads.
      */
     @JsonProperty
-    int numMirroringThreads() {
+    public int numMirroringThreads() {
         return numMirroringThreads;
     }
 
@@ -59,7 +82,7 @@ final class MirroringServicePluginConfig {
      * Returns the maximum allowed number of files per mirror.
      */
     @JsonProperty
-    int maxNumFilesPerMirror() {
+    public int maxNumFilesPerMirror() {
         return maxNumFilesPerMirror;
     }
 
@@ -67,7 +90,7 @@ final class MirroringServicePluginConfig {
      * Returns the maximum allowed number of bytes per mirror.
      */
     @JsonProperty
-    long maxNumBytesPerMirror() {
+    public long maxNumBytesPerMirror() {
         return maxNumBytesPerMirror;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/AbstractPluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/AbstractPluginConfig.java
@@ -13,59 +13,34 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.centraldogma.server;
+package com.linecorp.centraldogma.server.plugin;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static java.util.Objects.requireNonNull;
 
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
- * A configuration of a plugin.
+ * An abstract {@link PluginConfig} implementation.
  */
-public final class PluginConfig {
+public abstract class AbstractPluginConfig implements PluginConfig {
 
-    private final String name;
     private final boolean enabled;
-    @Nullable
-    private final JsonNode config;
 
     /**
      * Creates a new instance.
      */
-    public PluginConfig(@JsonProperty(value = "name", required = true) String name,
-                        @JsonProperty("enabled") @Nullable Boolean enabled,
-                        @JsonProperty("config") @Nullable JsonNode config) {
-        this.name = requireNonNull(name, "name");
+    protected AbstractPluginConfig(@Nullable Boolean enabled) {
         this.enabled = firstNonNull(enabled, true);
-        this.config = config;
-    }
-
-    /**
-     * Returns the name of the plugin.
-     */
-    @JsonProperty
-    public String name() {
-        return name;
     }
 
     /**
      * Returns whether the plugin is enabled.
      */
     @JsonProperty
+    @Override
     public boolean enabled() {
         return enabled;
-    }
-
-    /**
-     * Returns the configuration of the plugin.
-     */
-    @JsonProperty
-    @Nullable
-    public JsonNode config() {
-        return config;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
@@ -66,8 +66,8 @@ public interface Plugin {
             return true;
         }
         if (configs.size() > 1) {
-            throw new IllegalStateException("Multiple plugin configurations found for: " + name() +
-                                            ", plugin configs: " + configs);
+            throw new IllegalArgumentException("Multiple plugin configurations found for: " + name() +
+                                               ", plugin configs: " + configs);
         }
         final PluginConfig pluginConfig = configs.get(0);
         validatePluginConfig(pluginConfig);

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
@@ -15,9 +15,6 @@
  */
 package com.linecorp.centraldogma.server.plugin;
 
-import static com.google.common.collect.ImmutableList.toImmutableList;
-
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
@@ -50,18 +47,12 @@ public interface Plugin {
      * Returns {@code true} if this {@link Plugin} is enabled.
      */
     default boolean isEnabled(CentralDogmaConfig config) {
-        final List<PluginConfig> configs = config.pluginConfigs().stream()
-                                                 .filter(plugin -> configType().isInstance(plugin))
-                                                 .collect(toImmutableList());
-        if (configs.isEmpty()) {
+        final PluginConfig pluginConfig = config.pluginConfigMap().get(configType());
+        if (pluginConfig == null) {
             // Enabled if not found.
             return true;
         }
-        if (configs.size() > 1) {
-            throw new IllegalArgumentException("Multiple plugin configurations found." +
-                                               " configs: " + configs);
-        }
-        return configs.get(0).enabled();
+        return pluginConfig.enabled();
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2024 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -15,15 +15,17 @@
  */
 package com.linecorp.centraldogma.server.plugin;
 
-public class NoopPluginForAllReplicas extends AbstractNoopPlugin {
-    @Override
-    public PluginTarget target() {
-        return PluginTarget.ALL_REPLICAS;
-    }
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-    @Override
-    public Class<?> configType() {
-        // Return the plugin class itself because it does not have a configuration.
-        return NoopPluginForAllReplicas.class;
-    }
+/**
+ * A configuration of a plugin.
+ */
+@FunctionalInterface
+public interface PluginConfig {
+
+    /**
+     * Returns whether the plugin is enabled.
+     */
+    @JsonProperty
+    boolean enabled();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.server.plugin;
 import java.io.IOException;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
@@ -42,7 +41,7 @@ public final class PluginConfigDeserializer extends StdDeserializer<PluginConfig
 
     @Override
     public PluginConfig deserialize(JsonParser jp, DeserializationContext ctxt)
-            throws IOException, JsonProcessingException {
+            throws IOException {
         final JsonNode jsonNode = jp.readValueAsTree();
         final JsonNode configType = jsonNode.get("configType");
         if (configType == null || configType.asText() == null) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.plugin;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import com.linecorp.centraldogma.internal.Jackson;
+
+/**
+ * A {@link StdDeserializer} that deserializes a {@link PluginConfig}.
+ */
+public final class PluginConfigDeserializer extends StdDeserializer<PluginConfig> {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Creates a new instance.
+     */
+    public PluginConfigDeserializer() {
+        super(PluginConfig.class);
+    }
+
+    @Override
+    public PluginConfig deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        final JsonNode jsonNode = jp.readValueAsTree();
+        final JsonNode configType = jsonNode.get("configType");
+        if (configType == null || configType.asText() == null) {
+            ctxt.reportInputMismatch(PluginConfig.class, "plugin config should have a type.");
+            // should never reach here
+            throw new Error();
+        }
+
+        final String configTypeText = configType.asText();
+        try {
+            final Class<?> clazz = Class.forName(configTypeText);
+            if (!PluginConfig.class.isAssignableFrom(clazz)) {
+                ctxt.reportInputMismatch(PluginConfig.class, configTypeText + " is not a subtype of " +
+                                                             PluginConfig.class.getSimpleName());
+                // should never reach here
+                throw new Error();
+            }
+
+            assert jsonNode instanceof ObjectNode;
+            final ObjectNode objectNode = (ObjectNode) jsonNode;
+            objectNode.remove("configType");
+
+            return (PluginConfig) Jackson.treeToValue(objectNode, clazz);
+        } catch (ClassNotFoundException e) {
+            ctxt.reportInputMismatch(PluginConfig.class, configTypeText + " is not found.");
+            // should never reach here
+            throw new Error();
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginConfigDeserializer.java
@@ -43,18 +43,18 @@ public final class PluginConfigDeserializer extends StdDeserializer<PluginConfig
     public PluginConfig deserialize(JsonParser jp, DeserializationContext ctxt)
             throws IOException {
         final JsonNode jsonNode = jp.readValueAsTree();
-        final JsonNode configType = jsonNode.get("configType");
-        if (configType == null || configType.asText() == null) {
+        final JsonNode type = jsonNode.get("type");
+        if (type == null || type.asText() == null) {
             ctxt.reportInputMismatch(PluginConfig.class, "plugin config should have a type.");
             // should never reach here
             throw new Error();
         }
 
-        final String configTypeText = configType.asText();
+        final String typeText = type.asText();
         try {
-            final Class<?> clazz = Class.forName(configTypeText);
+            final Class<?> clazz = Class.forName(typeText);
             if (!PluginConfig.class.isAssignableFrom(clazz)) {
-                ctxt.reportInputMismatch(PluginConfig.class, configTypeText + " is not a subtype of " +
+                ctxt.reportInputMismatch(PluginConfig.class, typeText + " is not a subtype of " +
                                                              PluginConfig.class.getSimpleName());
                 // should never reach here
                 throw new Error();
@@ -62,11 +62,11 @@ public final class PluginConfigDeserializer extends StdDeserializer<PluginConfig
 
             assert jsonNode instanceof ObjectNode;
             final ObjectNode objectNode = (ObjectNode) jsonNode;
-            objectNode.remove("configType");
+            objectNode.remove("type");
 
             return (PluginConfig) Jackson.treeToValue(objectNode, clazz);
         } catch (ClassNotFoundException e) {
-            ctxt.reportInputMismatch(PluginConfig.class, configTypeText + " is not found.");
+            ctxt.reportInputMismatch(PluginConfig.class, typeText + " is not found.");
             // should never reach here
             throw new Error();
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -446,14 +446,14 @@ class CentralDogmaConfigTest {
                                                          "      ]\n" +
                                                          "    }\n" +
                                                          "  ],\n" +
-                                                         "  \"plugins\": [" +
+                                                         "  \"pluginConfigs\": [" +
                                                          "    {\n" +
-                                                         "      \"configType\": \"com.linecorp.centraldogma" +
+                                                         "      \"type\": \"com.linecorp.centraldogma" +
                                                          ".server.mirror.MirroringServicePluginConfig\",\n" +
                                                          "      \"numMirroringThreads\": 1" +
                                                          "    }," +
                                                          "    {\n" +
-                                                         "      \"configType\": \"com.linecorp.centraldogma" +
+                                                         "      \"type\": \"com.linecorp.centraldogma" +
                                                          ".server.mirror.MirroringServicePluginConfig\",\n" +
                                                          "      \"numMirroringThreads\": 2" +
                                                          "    }" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/CentralDogmaConfigTest.java
@@ -428,4 +428,38 @@ class CentralDogmaConfigTest {
             assertThat(caughtException).isNull();
         }
     }
+
+    @Test
+    void duplicatePluginConfigs() throws Exception {
+        assertThatThrownBy(() -> CentralDogmaConfig.load("{\n" +
+                                                         "  \"dataDir\": \"./data\",\n" +
+                                                         "  \"ports\": [\n" +
+                                                         "    {\n" +
+                                                         "      \"localAddress\": {\n" +
+                                                         "        \"host\": \"*\",\n" +
+                                                         "        \"port\": 36462\n" +
+                                                         "      },\n" +
+                                                         "      \"protocols\": [\n" +
+                                                         "        \"https\",\n" +
+                                                         "        \"http\",\n" +
+                                                         "        \"proxy\"\n" +
+                                                         "      ]\n" +
+                                                         "    }\n" +
+                                                         "  ],\n" +
+                                                         "  \"plugins\": [" +
+                                                         "    {\n" +
+                                                         "      \"configType\": \"com.linecorp.centraldogma" +
+                                                         ".server.mirror.MirroringServicePluginConfig\",\n" +
+                                                         "      \"numMirroringThreads\": 1" +
+                                                         "    }," +
+                                                         "    {\n" +
+                                                         "      \"configType\": \"com.linecorp.centraldogma" +
+                                                         ".server.mirror.MirroringServicePluginConfig\",\n" +
+                                                         "      \"numMirroringThreads\": 2" +
+                                                         "    }" +
+                                                         "  ]\n" +
+                                                         '}')
+        ).hasCauseInstanceOf(IllegalArgumentException.class)
+         .hasMessageContaining("Multiple entries with same key");
+    }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -16,6 +16,7 @@
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -69,6 +70,15 @@ class PluginGroupTest {
         final PluginGroup group3 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group3).isNotNull();
         assertThat(group3.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotPresent();
+    }
+
+    @Test
+    void duplicatePluginConfig() {
+        final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
+        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(true),
+                                                              new MirroringServicePluginConfig(true)));
+        assertThatThrownBy(() -> PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin;
 import com.linecorp.centraldogma.server.internal.storage.PurgeSchedulingServicePlugin;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.plugin.AbstractNoopPlugin;
 import com.linecorp.centraldogma.server.plugin.NoopPluginForAllReplicas;
 import com.linecorp.centraldogma.server.plugin.NoopPluginForLeader;
@@ -59,12 +60,12 @@ class PluginGroupTest {
         assertThat(group1).isNotNull();
         assertThat(group1.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
 
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new PluginConfig("mirror", null, null)));
+        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(true)));
         final PluginGroup group2 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group2).isNotNull();
         assertThat(group2.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
 
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new PluginConfig("mirror", false, null)));
+        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(false)));
         final PluginGroup group3 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group3).isNotNull();
         assertThat(group3.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotPresent();

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -16,7 +16,6 @@
 package com.linecorp.centraldogma.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +23,7 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin;
 import com.linecorp.centraldogma.server.internal.storage.PurgeSchedulingServicePlugin;
@@ -56,29 +55,22 @@ class PluginGroupTest {
     @Test
     void confirmDefaultMirroringServiceLoadedDependingOnConfig() {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of());
+        when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of());
         final PluginGroup group1 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group1).isNotNull();
         assertThat(group1.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
 
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(true)));
+        when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of(
+                MirroringServicePluginConfig.class, new MirroringServicePluginConfig(true)));
         final PluginGroup group2 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group2).isNotNull();
         assertThat(group2.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
 
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(false)));
+        when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of(
+                MirroringServicePluginConfig.class, new MirroringServicePluginConfig(false)));
         final PluginGroup group3 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group3).isNotNull();
         assertThat(group3.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotPresent();
-    }
-
-    @Test
-    void duplicatePluginConfig() {
-        final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
-        when(cfg.pluginConfigs()).thenReturn(ImmutableList.of(new MirroringServicePluginConfig(true),
-                                                              new MirroringServicePluginConfig(true)));
-        assertThatThrownBy(() -> PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg))
-                .isInstanceOf(IllegalArgumentException.class);
     }
 
     /**

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -52,6 +52,7 @@ import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.testing.internal.FlakyTest;
@@ -96,7 +97,7 @@ class ReplicatedLoginAndLogoutTest {
                 .port(port1, SessionProtocol.HTTP)
                 .authProviderFactory(factory)
                 .webAppEnabled(true)
-                .mirroringEnabled(false)
+                .pluginConfigs(new PluginConfig("mirror", false, null))
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(1, servers))
                 .build();
@@ -105,7 +106,7 @@ class ReplicatedLoginAndLogoutTest {
                 .port(port2, SessionProtocol.HTTP)
                 .authProviderFactory(factory)
                 .webAppEnabled(true)
-                .mirroringEnabled(false)
+                .pluginConfigs(new PluginConfig("mirror", false, null))
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(2, servers))
                 .build();

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/ReplicatedLoginAndLogoutTest.java
@@ -52,9 +52,9 @@ import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.testing.internal.FlakyTest;
 import com.linecorp.centraldogma.testing.internal.TemporaryFolderExtension;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
@@ -97,7 +97,7 @@ class ReplicatedLoginAndLogoutTest {
                 .port(port1, SessionProtocol.HTTP)
                 .authProviderFactory(factory)
                 .webAppEnabled(true)
-                .pluginConfigs(new PluginConfig("mirror", false, null))
+                .pluginConfigs(new MirroringServicePluginConfig(false))
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(1, servers))
                 .build();
@@ -106,7 +106,7 @@ class ReplicatedLoginAndLogoutTest {
                 .port(port2, SessionProtocol.HTTP)
                 .authProviderFactory(factory)
                 .webAppEnabled(true)
-                .pluginConfigs(new PluginConfig("mirror", false, null))
+                .pluginConfigs(new MirroringServicePluginConfig(false))
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .replication(new ZooKeeperReplicationConfig(2, servers))
                 .build();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
@@ -42,9 +42,9 @@ class DefaultMirroringServicePluginTest {
                                         "      ]\n" +
                                         "    }\n" +
                                         "  ],\n" +
-                                        "  \"plugins\": [" +
+                                        "  \"pluginConfigs\": [" +
                                         "    {\n" +
-                                        "      \"configType\": \"com.linecorp.centraldogma.server.mirror." +
+                                        "      \"type\": \"com.linecorp.centraldogma.server.mirror." +
                                                                 "MirroringServicePluginConfig\",\n" +
                                         "      \"numMirroringThreads\": 1" +
                                         "    }" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import static com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin.mirroringServicePluginConfig;
+import static com.linecorp.centraldogma.server.internal.mirror.MirroringServicePluginConfig.DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
+import static com.linecorp.centraldogma.server.internal.mirror.MirroringServicePluginConfig.DEFAULT_MAX_NUM_FILES_PER_MIRROR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+
+class DefaultMirroringServicePluginTest {
+
+    @Test
+    void pluginConfig() throws Exception {
+        final CentralDogmaConfig centralDogmaConfig = Jackson.readValue("{\n" +
+                                                                        "  \"dataDir\": \"./data\",\n" +
+                                                                        "  \"ports\": [\n" +
+                                                                        "    {\n" +
+                                                                        "      \"localAddress\": {\n" +
+                                                                        "        \"host\": \"*\",\n" +
+                                                                        "        \"port\": 36462\n" +
+                                                                        "      },\n" +
+                                                                        "      \"protocols\": [\n" +
+                                                                        "        \"https\",\n" +
+                                                                        "        \"http\",\n" +
+                                                                        "        \"proxy\"\n" +
+                                                                        "      ]\n" +
+                                                                        "    }\n" +
+                                                                        "  ],\n" +
+                                                                        "  \"plugins\": [" +
+                                                                        "    {\n" +
+                                                                        "      \"name\": \"mirror\",\n" +
+                                                                        "      \"config\": {\n" +
+                                                                        "        \"numMirroringThreads\": 1" +
+                                                                        "      }" +
+                                                                        "    }" +
+                                                                        "  ]\n" +
+                                                                        '}',
+                                                                        CentralDogmaConfig.class);
+        final MirroringServicePluginConfig mirroringServicePluginConfig = mirroringServicePluginConfig(
+                centralDogmaConfig.pluginConfigs().get(0));
+        assertThat(mirroringServicePluginConfig).isNotNull();
+        assertThat(mirroringServicePluginConfig.numMirroringThreads()).isOne();
+        assertThat(mirroringServicePluginConfig.maxNumFilesPerMirror())
+                .isEqualTo(DEFAULT_MAX_NUM_FILES_PER_MIRROR);
+        assertThat(mirroringServicePluginConfig.maxNumBytesPerMirror())
+                .isEqualTo(DEFAULT_MAX_NUM_BYTES_PER_MIRROR);
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
@@ -51,7 +51,8 @@ class DefaultMirroringServicePluginTest {
                                         "  ]\n" +
                                         '}');
         final MirroringServicePluginConfig mirroringServicePluginConfig =
-                (MirroringServicePluginConfig) centralDogmaConfig.pluginConfigs().get(0);
+                (MirroringServicePluginConfig) centralDogmaConfig.pluginConfigMap()
+                                                                 .get(MirroringServicePluginConfig.class);
         assertThat(mirroringServicePluginConfig).isNotNull();
         assertThat(mirroringServicePluginConfig.enabled()).isTrue();
         assertThat(mirroringServicePluginConfig.numMirroringThreads()).isOne();

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePluginTest.java
@@ -15,52 +15,49 @@
  */
 package com.linecorp.centraldogma.server.internal.mirror;
 
-import static com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin.mirroringServicePluginConfig;
-import static com.linecorp.centraldogma.server.internal.mirror.MirroringServicePluginConfig.DEFAULT_MAX_NUM_BYTES_PER_MIRROR;
-import static com.linecorp.centraldogma.server.internal.mirror.MirroringServicePluginConfig.DEFAULT_MAX_NUM_FILES_PER_MIRROR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
-import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 
 class DefaultMirroringServicePluginTest {
 
     @Test
     void pluginConfig() throws Exception {
-        final CentralDogmaConfig centralDogmaConfig = Jackson.readValue("{\n" +
-                                                                        "  \"dataDir\": \"./data\",\n" +
-                                                                        "  \"ports\": [\n" +
-                                                                        "    {\n" +
-                                                                        "      \"localAddress\": {\n" +
-                                                                        "        \"host\": \"*\",\n" +
-                                                                        "        \"port\": 36462\n" +
-                                                                        "      },\n" +
-                                                                        "      \"protocols\": [\n" +
-                                                                        "        \"https\",\n" +
-                                                                        "        \"http\",\n" +
-                                                                        "        \"proxy\"\n" +
-                                                                        "      ]\n" +
-                                                                        "    }\n" +
-                                                                        "  ],\n" +
-                                                                        "  \"plugins\": [" +
-                                                                        "    {\n" +
-                                                                        "      \"name\": \"mirror\",\n" +
-                                                                        "      \"config\": {\n" +
-                                                                        "        \"numMirroringThreads\": 1" +
-                                                                        "      }" +
-                                                                        "    }" +
-                                                                        "  ]\n" +
-                                                                        '}',
-                                                                        CentralDogmaConfig.class);
-        final MirroringServicePluginConfig mirroringServicePluginConfig = mirroringServicePluginConfig(
-                centralDogmaConfig.pluginConfigs().get(0));
+        final CentralDogmaConfig centralDogmaConfig =
+                CentralDogmaConfig.load("{\n" +
+                                        "  \"dataDir\": \"./data\",\n" +
+                                        "  \"ports\": [\n" +
+                                        "    {\n" +
+                                        "      \"localAddress\": {\n" +
+                                        "        \"host\": \"*\",\n" +
+                                        "        \"port\": 36462\n" +
+                                        "      },\n" +
+                                        "      \"protocols\": [\n" +
+                                        "        \"https\",\n" +
+                                        "        \"http\",\n" +
+                                        "        \"proxy\"\n" +
+                                        "      ]\n" +
+                                        "    }\n" +
+                                        "  ],\n" +
+                                        "  \"plugins\": [" +
+                                        "    {\n" +
+                                        "      \"configType\": \"com.linecorp.centraldogma.server.mirror." +
+                                                                "MirroringServicePluginConfig\",\n" +
+                                        "      \"numMirroringThreads\": 1" +
+                                        "    }" +
+                                        "  ]\n" +
+                                        '}');
+        final MirroringServicePluginConfig mirroringServicePluginConfig =
+                (MirroringServicePluginConfig) centralDogmaConfig.pluginConfigs().get(0);
         assertThat(mirroringServicePluginConfig).isNotNull();
+        assertThat(mirroringServicePluginConfig.enabled()).isTrue();
         assertThat(mirroringServicePluginConfig.numMirroringThreads()).isOne();
         assertThat(mirroringServicePluginConfig.maxNumFilesPerMirror())
-                .isEqualTo(DEFAULT_MAX_NUM_FILES_PER_MIRROR);
+                .isEqualTo(MirroringServicePluginConfig.INSTANCE.maxNumFilesPerMirror());
         assertThat(mirroringServicePluginConfig.maxNumBytesPerMirror())
-                .isEqualTo(DEFAULT_MAX_NUM_BYTES_PER_MIRROR);
+                .isEqualTo(MirroringServicePluginConfig.INSTANCE.maxNumBytesPerMirror());
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForAllReplicas.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForAllReplicas.java
@@ -24,6 +24,6 @@ public class NoopPluginForAllReplicas extends AbstractNoopPlugin {
     @Override
     public Class<?> configType() {
         // Return the plugin class itself because it does not have a configuration.
-        return NoopPluginForAllReplicas.class;
+        return getClass();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
@@ -20,4 +20,10 @@ public class NoopPluginForLeader extends AbstractNoopPlugin {
     public PluginTarget target() {
         return PluginTarget.LEADER_ONLY;
     }
+
+    @Override
+    public Class<?> configType() {
+        // Return the plugin class itself because it does not have a configuration.
+        return NoopPluginForLeader.class;
+    }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
@@ -24,6 +24,6 @@ public class NoopPluginForLeader extends AbstractNoopPlugin {
     @Override
     public Class<?> configType() {
         // Return the plugin class itself because it does not have a configuration.
-        return NoopPluginForLeader.class;
+        return getClass();
     }
 }

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -56,7 +56,7 @@ defaults:
           "enabled": true,
           "numMirroringThreads": null,
           "maxNumFilesPerMirror": null,
-          "maxNumBytesPerMirror": null,
+          "maxNumBytesPerMirror": null
         }
       ]
     }
@@ -420,10 +420,6 @@ in ``dogma.json`` as follows.
       "replication": {
         "method": "NONE"
       },
-      "mirroringEnabled": true,
-      "numMirroringThreads": null,
-      "maxNumFilesPerMirror": null,
-      "maxNumBytesPerMirror": null,
       "accessLogFormat": "common",
       "authentication": null
     }

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -50,9 +50,9 @@ defaults:
       "accessLogFormat": "common",
       "authentication": null,
       "cors": null,
-      "plugins": [
+      "pluginConfigs": [
         {
-          "configType": "com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig",
+          "type": "com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig",
           "enabled": true,
           "numMirroringThreads": null,
           "maxNumFilesPerMirror": null,
@@ -226,7 +226,7 @@ Core properties
     - how long in seconds the results of a preflight request can be cached. If not specified then the default
       value ``7200`` is applied.
 
-- ``plugins``
+- ``pluginConfigs``
 
   - the list of plugin configuration. See :ref:`plugins` for more information.
 
@@ -460,7 +460,7 @@ Java client, call the ``useTls()`` method when building a ``CentralDogma`` insta
 Configuring plugins
 -------------------
 Central Dogma supports installing a plugin that runs on Central Dogma servers. You can configure the plugin
-with ``plugins`` property in ``dogma.json`` as follows.
+with ``pluginConfigs`` property in ``dogma.json`` as follows.
 
 .. code-block:: json
 
@@ -478,9 +478,9 @@ with ``plugins`` property in ``dogma.json`` as follows.
         }
       ],
       ...
-      "plugins": [
+      "pluginConfigs": [
         {
-          "configType": "com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig",
+          "type": "com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig",
           "enabled": true,
           "numMirroringThreads": null,
           "maxNumFilesPerMirror": null,
@@ -489,7 +489,7 @@ with ``plugins`` property in ``dogma.json`` as follows.
       ]
     }
 
-Each configuration in ``plugins`` must have ``configType`` that specifies the fully qualified class name of
+Each configuration in ``pluginConfigs`` must have ``type`` that specifies the fully qualified class name of
 the plugin configuration class. The plugin configuration class must implement the ``PluginConfig`` interface
 that requires ``enabled`` property. The plugin configuration class can have additional properties that are
 specific to the plugin. The example above shows the configuration of the mirroring plugin and here are the

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -50,10 +50,10 @@ import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 import com.linecorp.centraldogma.testing.junit.AbstractAllOrEachExtension;
@@ -116,7 +116,7 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
                     builder.port(new InetSocketAddress(NetUtil.LOCALHOST4, dogmaPort), SessionProtocol.HTTP)
                            .administrators(TestAuthMessageUtil.USERNAME)
                            .authProviderFactory(factory)
-                           .pluginConfigs(new PluginConfig("mirror", false, null))
+                           .pluginConfigs(new MirroringServicePluginConfig(false))
                            .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                            .replication(new ZooKeeperReplicationConfig(serverId, zooKeeperServers));
                 }

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -50,6 +50,7 @@ import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.ZooKeeperReplicationConfig;
 import com.linecorp.centraldogma.server.ZooKeeperServerConfig;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
@@ -115,7 +116,7 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
                     builder.port(new InetSocketAddress(NetUtil.LOCALHOST4, dogmaPort), SessionProtocol.HTTP)
                            .administrators(TestAuthMessageUtil.USERNAME)
                            .authProviderFactory(factory)
-                           .mirroringEnabled(false)
+                           .pluginConfigs(new PluginConfig("mirror", false, null))
                            .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                            .replication(new ZooKeeperReplicationConfig(serverId, zooKeeperServers));
                 }

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -114,15 +114,10 @@ public class CentralDogmaRuleDelegate {
         configure(builder);
 
         final com.linecorp.centraldogma.server.CentralDogma dogma = builder.build();
-        boolean mirrorPluginConfigured = false;
-        for (PluginConfig pluginConfig : dogma.config().pluginConfigs()) {
-            if (pluginConfig instanceof MirroringServicePluginConfig) {
-                mirrorPluginConfigured = true;
-                break;
-            }
-        }
+        final PluginConfig mirroringConfig = dogma.config().pluginConfigMap().get(
+                MirroringServicePluginConfig.class);
         final com.linecorp.centraldogma.server.CentralDogma dogma0;
-        if (!mirrorPluginConfigured) {
+        if (mirroringConfig == null) {
             // Disable mirror plugin if not configured.
             dogma0 = builder.pluginConfigs(new MirroringServicePluginConfig(false)).build();
         } else {

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -42,6 +42,7 @@ import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.TlsConfig;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 
@@ -93,7 +94,7 @@ public class CentralDogmaRuleDelegate {
         final CentralDogmaBuilder builder = new CentralDogmaBuilder(dataDir)
                 .port(TEST_PORT, useTls ? SessionProtocol.HTTPS : SessionProtocol.HTTP)
                 .webAppEnabled(false)
-                .mirroringEnabled(false)
+                .pluginConfigs(new PluginConfig("mirror", false, null))
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0));
 
         if (useTls) {

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -42,8 +42,9 @@ import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
 import com.linecorp.centraldogma.server.MirroringService;
-import com.linecorp.centraldogma.server.PluginConfig;
 import com.linecorp.centraldogma.server.TlsConfig;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
+import com.linecorp.centraldogma.server.plugin.PluginConfig;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -115,7 +116,7 @@ public class CentralDogmaRuleDelegate {
         final com.linecorp.centraldogma.server.CentralDogma dogma = builder.build();
         boolean mirrorPluginConfigured = false;
         for (PluginConfig pluginConfig : dogma.config().pluginConfigs()) {
-            if ("mirror".equals(pluginConfig.name())) {
+            if (pluginConfig instanceof MirroringServicePluginConfig) {
                 mirrorPluginConfigured = true;
                 break;
             }
@@ -123,7 +124,7 @@ public class CentralDogmaRuleDelegate {
         final com.linecorp.centraldogma.server.CentralDogma dogma0;
         if (!mirrorPluginConfigured) {
             // Disable mirror plugin if not configured.
-            dogma0 = builder.pluginConfigs(new PluginConfig("mirror", false, null)).build();
+            dogma0 = builder.pluginConfigs(new MirroringServicePluginConfig(false)).build();
         } else {
             dogma0 = dogma;
         }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.MoreObjects;
 import com.google.protobuf.InvalidProtocolBufferException;
 
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
@@ -321,6 +322,14 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     public CompletionStage<Void> stop(PluginContext context) {
         stop = true;
         return UnmodifiableFuture.completedFuture(null);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("name", name())
+                          .add("target", target())
+                          .toString();
     }
 
     private static final class LoggingDiscoveryServerCallbacks implements DiscoveryServerCallbacks {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -95,11 +95,6 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     private final CentralDogmaXdsResources centralDogmaXdsResources = new CentralDogmaXdsResources();
 
     @Override
-    public String name() {
-        return "xds";
-    }
-
-    @Override
     public void init(PluginInitContext pluginInitContext) {
         final InternalProjectInitializer projectInitializer = pluginInitContext.internalProjectInitializer();
         projectInitializer.initialize(XDS_CENTRAL_DOGMA_PROJECT);
@@ -325,9 +320,14 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     }
 
     @Override
+    public Class<?> configType() {
+        return ControlPlanePluginConfig.class;
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("name", name())
+                          .add("configType", configType())
                           .add("target", target())
                           .toString();
     }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -16,8 +16,6 @@
 
 package com.linecorp.centraldogma.xds.internal;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +40,6 @@ import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.plugin.AllReplicasPlugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
@@ -97,8 +94,8 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     private final CentralDogmaXdsResources centralDogmaXdsResources = new CentralDogmaXdsResources();
 
     @Override
-    public boolean isEnabled(CentralDogmaConfig config) {
-        return requireNonNull(config, "config").isXdsControlPlaneEnabled();
+    public String name() {
+        return "xds";
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.centraldogma.xds.internal;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +42,7 @@ import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.plugin.AllReplicasPlugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
@@ -92,6 +95,11 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     // Accessed only from CONTROL_PLANE_EXECUTOR.
     private final Set<String> watchingXdsProjects = new HashSet<>();
     private final CentralDogmaXdsResources centralDogmaXdsResources = new CentralDogmaXdsResources();
+
+    @Override
+    public boolean isEnabled(CentralDogmaConfig config) {
+        return requireNonNull(config, "config").isXdsControlPlaneEnabled();
+    }
 
     @Override
     public void init(PluginInitContext pluginInitContext) {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 LINE Corporation
+ * Copyright 2024 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -13,17 +13,20 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-package com.linecorp.centraldogma.server.plugin;
+package com.linecorp.centraldogma.xds.internal;
 
-public class NoopPluginForAllReplicas extends AbstractNoopPlugin {
-    @Override
-    public PluginTarget target() {
-        return PluginTarget.ALL_REPLICAS;
-    }
+import javax.annotation.Nullable;
 
-    @Override
-    public Class<?> configType() {
-        // Return the plugin class itself because it does not have a configuration.
-        return NoopPluginForAllReplicas.class;
+import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
+
+/**
+ * A plugin configuration for the control plane.
+ */
+public final class ControlPlanePluginConfig extends AbstractPluginConfig {
+    /**
+     * Creates a new instance.
+     */
+    public ControlPlanePluginConfig(@Nullable Boolean enabled) {
+        super(enabled);
     }
 }


### PR DESCRIPTION
Motivation:
Configuring user-defined plugins is currently difficult because there is no way to configure their properties via `dogma.json`.

Modifications:
- Added `PluginConfig` interface that represents a configuration of a plugin.
- Added `pluginConfigs` to `CentralDogmaConfig` that accepts a list of `PluginConfig`.
  - Users can now configure each plugin using `PluginConfig`.
- Moved mirroring plugin properties from `CentralDogmaConfig` to `MirroringServicePluginConfig`.
  - Compatibility was not maintained as few users are running the Central Dogma server, and they can be guided directly. Let me know if a different approach is preferred.

Result:
- Users can now specify plugin configurations in the `plugins` property.
  ```json
  {
    "dataDir": "./data",
    ...
    "pluginConfigs": [
      {
        "type": "com.example.MyPlugin",
        "enabled": true, // enabled by default
        "myPluginTimeout": 10
      },
      // Other plugins
    ]
  }
  ```
- (Breaking changes) `mirroringEnabled`, `numMirroringThreads`, `maxNumFilesPerMirror`, and `maxNumBytesPerMirror` have been removed from `CentralDogmaBuilder` and `CentralDogmaConfig`.
  - These properties should now be specified in the plugins property:
    ```json
    {
      "dataDir": "./data",
      ...
      "pluginConfigs": [
        {
          "type": "com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig",
          "enabled": true,
          "numMirroringThreads": 16,
          "maxNumFilesPerMirror": 8192
        }  
      ]
    }
    ```