### PR TITLE
Do not use a global cache for Node.js

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -7,12 +7,6 @@ node {
     npmVersion = '10.8.1'
     download = true
     npmInstallCommand = "ci"
-
-    // Change the cache location under Gradle user home directory so that it's cached by CI.
-    if (System.getenv('CI') != null) {
-        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
-        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
-    }
 }
 
 dependencies {

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -8,12 +8,6 @@ node {
     npmVersion = '10.8.1'
     download = true
     npmInstallCommand = "ci"
-
-    // Change the cache location under Gradle user home directory so that it's cached by CI.
-    if (System.getenv('CI') != null) {
-        workDir = file("${gradle.gradleUserHomeDir}/caches/nodejs/${project.name}")
-        npmWorkDir = file("${gradle.gradleUserHomeDir}/caches/npm/${project.name}")
-    }
 }
 
 dependencies {


### PR DESCRIPTION
Motivation:

We have seen a weird error message in CI builds.
```
Couldn't follow symbolic link '/home/runner/.gradle/caches/nodejs/server/node-v16.14.0-linux-x64/bin/npx'.
```
We used to use a custom gradle cache key in the CI build workflow. But in the end, we removed it and delegated a cache logic to `gradle/gradle-build-action`. So I think we will use the cached node.js without referring to the glocal cache location.

Modification:

- Remove the custom cache location for Node.js

Result:

Stable CI builds