### PR TITLE
Add JsonProperty to ControlPlanePluginConfig constructor parameter

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - "**"
     tags-ignore:
       # The release versions will be verified by 'publish-release.yml'
       - centraldogma-*

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
@@ -17,6 +17,8 @@ package com.linecorp.centraldogma.xds.internal;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
 
 /**
@@ -26,7 +28,7 @@ public final class ControlPlanePluginConfig extends AbstractPluginConfig {
     /**
      * Creates a new instance.
      */
-    public ControlPlanePluginConfig(@Nullable Boolean enabled) {
+    public ControlPlanePluginConfig(@JsonProperty("enabled") @Nullable Boolean enabled) {
         super(enabled);
     }
 }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfig.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.xds.internal;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
@@ -25,9 +26,11 @@ import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
  * A plugin configuration for the control plane.
  */
 public final class ControlPlanePluginConfig extends AbstractPluginConfig {
+
     /**
      * Creates a new instance.
      */
+    @JsonCreator
     public ControlPlanePluginConfig(@JsonProperty("enabled") @Nullable Boolean enabled) {
         super(enabled);
     }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfigTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/ControlPlanePluginConfigTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.plugin.PluginConfig;
+
+class ControlPlanePluginConfigTest {
+
+    @Test
+    void duplicatePluginConfigs() throws Exception {
+        final CentralDogmaConfig config =
+                CentralDogmaConfig.load("{\n" +
+                                        "  \"dataDir\": \"./data\",\n" +
+                                        "  \"ports\": [\n" +
+                                        "    {\n" +
+                                        "      \"localAddress\": {\n" +
+                                        "        \"host\": \"*\",\n" +
+                                        "        \"port\": 36462\n" +
+                                        "      },\n" +
+                                        "      \"protocols\": [\n" +
+                                        "        \"https\",\n" +
+                                        "        \"http\",\n" +
+                                        "        \"proxy\"\n" +
+                                        "      ]\n" +
+                                        "    }\n" +
+                                        "  ],\n" +
+                                        "  \"pluginConfigs\": [" +
+                                        "    {\n" +
+                                        "      \"type\": \"com.linecorp.centraldogma.xds.internal" +
+                                        ".ControlPlanePluginConfig\",\n" +
+                                        "      \"enabled\": false" +
+                                        "    }" +
+                                        "  ]\n" +
+                                        '}');
+        final PluginConfig pluginConfig = config.pluginConfigMap().get(ControlPlanePluginConfig.class);
+        assertThat(pluginConfig).isNotNull();
+        assertThat(pluginConfig.enabled()).isFalse();
+    }
+}


### PR DESCRIPTION
Modification:
- Add `JsonProperty` to `ControlPlanePluginConfig` constructor parameter

Result:
- You can now configure `ControlPlanePluginConfig` via configuration file properly.