### PR TITLE
Add @ConsumseJson to contents API.

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -51,6 +51,7 @@ import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
 import com.linecorp.armeria.server.annotation.Default;
 import com.linecorp.armeria.server.annotation.Get;
 import com.linecorp.armeria.server.annotation.Param;
@@ -187,6 +188,7 @@ public class ContentServiceV1 extends AbstractService {
      * <p>Pushes a commit.
      */
     @Post("/projects/{projectName}/repos/{repoName}/contents")
+    @ConsumesJson
     @RequiresWritePermission
     public CompletableFuture<PushResultDto> push(
             ServiceRequestContext ctx,
@@ -226,6 +228,7 @@ public class ContentServiceV1 extends AbstractService {
      * <p>Previews the actual changes which will be resulted by the given changes.
      */
     @Post("/projects/{projectName}/repos/{repoName}/preview")
+    @ConsumesJson
     public CompletableFuture<Iterable<ChangeDto<?>>> preview(
             ServiceRequestContext ctx,
             @Param @Default("-1") String revision,

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -417,7 +417,7 @@ class ContentServiceV1Test {
                 "application/xml, 415",
                 "application/x-www-form-urlencoded, 415"
         })
-        void getFileWithoutSuitableContentType(String mediaType, int expectedStatusCode) {
+        void getFileWithVariusContentType(String mediaType, int expectedStatusCode) {
             // Given:
             final WebClient client = dogma.httpClient();
             final String body =

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1Test.java
@@ -41,7 +41,6 @@ import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
-import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
@@ -442,7 +441,6 @@ class ContentServiceV1Test {
             // Then:
             assertThatJson(aRes.headers().status().code()).isEqualTo(expectedStatusCode);
         }
-
 
         @Test
         void getFileWithJsonPath() {


### PR DESCRIPTION
### Motivation:
- When a client sends a request with a JSON body but does not configure the `content-type` in header, Central Dogma returns the response`: {"exception":"java.lang.IllegalArgumentException","message":"No suitable request converter found for a @RequestObject 'CommitMessageDto'"}`. This response is quite ambiguous, making it difficult for the client to understand the problem.


### Modifications:
- Add `@ConsumesJson` to each method that uses `ChangesRequestConverter.class`. 

### FYI
1. If `@RequestConverter` is declared on method signatures, Armeria will add an object Resolver. ([link](https://github.com/line/armeria/blob/e2b298dd2f54243e8801540f13e90166f75578b5/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java#L501-L508))
2. Then, when Armeria receives a request from client, Armeria will try to resolve the request.  ([link](https://github.com/line/armeria/blob/e2b298dd2f54243e8801540f13e90166f75578b5/core/src/main/java/com/linecorp/armeria/internal/server/annotation/AnnotatedValueResolver.java#L829-L862))
3. `ChangesRequestConverter` tries to parse body from request. Actually, `ChangeRequestConverter` delegates to `JacksonRequestConvertFunction`.
4. `JacksonRequestConverter` validates contents type. ([here](https://github.com/line/armeria/blob/e2b298dd2f54243e8801540f13e90166f75578b5/core/src/main/java/com/linecorp/armeria/server/annotation/JacksonRequestConverterFunction.java#L98-L106))
5. If there is no `content-type` or `content-type` is not `application/json`, `JacksonRequestConverter` will call `RequestConverterFunction.fallthrough()`. 

With this flow, client will receive response `: {"exception":"java.lang.IllegalArgumentException","message":"No suitable request converter found for a @RequestObject 'CommitMessageDto'"}`.

If `@ConsumsJson` is delcared to each method having `ChangesRequestConverter.class` on their method signature, Armeria will not try to resolve request without header `Content-Type: application/json`.


### Result:
- Client will receive 415 response.
```sh
$ curl -X POST localhost:8080/my-post \
-d '{"name": "John Doe", "email": "john.doe@example.com"}'
>>
Status: 415
Description: Unsupported Media Type
```
- Closes #987.
