### PR TITLE
Fix to fetch the file content with revision

### DIFF
--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -59,6 +59,7 @@ export type GetFileContent = {
   projectName: string;
   repoName: string;
   filePath: string;
+  revision: string;
 };
 
 export type TitleDto = {
@@ -233,8 +234,8 @@ export const apiSlice = createApi({
       providesTags: ['File'],
     }),
     getFileContent: builder.query<FileContentDto, GetFileContent>({
-      query: ({ projectName, repoName, filePath }) =>
-        `/api/v1/projects/${projectName}/repos/${repoName}/contents/${filePath}`,
+      query: ({ projectName, repoName, filePath, revision }) =>
+        `/api/v1/projects/${projectName}/repos/${repoName}/contents/${filePath}?revision=${revision}`,
       providesTags: ['File'],
     }),
     pushFileChanges: builder.mutation({

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -21,7 +21,7 @@ const FileContentPage = () => {
 
   const fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1);
   const { data, isLoading, error } = useGetFileContentQuery(
-    { projectName, repoName, filePath },
+    { projectName, repoName, filePath, revision },
     {
       refetchOnMountOrArgChange: true,
       skip: false,


### PR DESCRIPTION
Motiviation:

A revision number should be specified to get old data.

Modifications:

- Use the revision number specified in the path variable to fetch file content

Result:

Old content is now correctly rendered