### PR TITLE
Check if the internal project and repos exist before creating them

### DIFF
--- a/dist/src/conf/dogma.json
+++ b/dist/src/conf/dogma.json
@@ -28,10 +28,6 @@
   },
   "webAppEnabled": true,
   "webAppTitle": null,
-  "mirroringEnabled": true,
-  "numMirroringThreads": null,
-  "maxNumFilesPerMirror": null,
-  "maxNumBytesPerMirror": null,
   "replication": {
     "method": "NONE"
   },

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -496,7 +496,7 @@ public class CentralDogma implements AutoCloseable {
             default:
                 throw new Error("unknown replication method: " + replicationMethod);
         }
-        projectInitializer = new InternalProjectInitializer(executor);
+        projectInitializer = new InternalProjectInitializer(executor, pm);
 
         final ServerStatus initialServerStatus = statusManager.serverStatus();
         executor.setWritable(initialServerStatus.writable());

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -375,8 +375,11 @@ public interface Command<T> {
      */
     static <T> Command<T> forcePush(Command<T> delegate) {
         requireNonNull(delegate, "delegate");
-        checkArgument(delegate.type() == CommandType.NORMALIZING_PUSH || delegate.type() == CommandType.PUSH,
-                      "delegate: %s (expected: NORMALIZING_PUSH or PUSH)", delegate);
+        checkArgument(delegate.type() == CommandType.CREATE_PROJECT ||
+                      delegate.type() == CommandType.CREATE_REPOSITORY ||
+                      delegate.type() == CommandType.NORMALIZING_PUSH || delegate.type() == CommandType.PUSH,
+                      "delegate: %s (expected: CREATE_PROJECT, CREATE_REPOSITORY, NORMALIZING_PUSH or PUSH)",
+                      delegate);
         return new ForcePushCommand<>(delegate);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -380,6 +380,8 @@ public interface Command<T> {
                       delegate.type() == CommandType.NORMALIZING_PUSH || delegate.type() == CommandType.PUSH,
                       "delegate: %s (expected: CREATE_PROJECT, CREATE_REPOSITORY, NORMALIZING_PUSH or PUSH)",
                       delegate);
+        checkArgument(delegate.author().equals(Author.SYSTEM), "delegate.author: %s (expected: SYSTEM)",
+                      delegate.author());
         return new ForcePushCommand<>(delegate);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
@@ -25,14 +25,17 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.ProjectExistsException;
+import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.ReadOnlyException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.Revision;
@@ -49,13 +52,15 @@ public final class InternalProjectInitializer {
     public static final String INTERNAL_PROJECT_DOGMA = "dogma";
 
     private final CommandExecutor executor;
+    private final ProjectManager projectManager;
     private final CompletableFuture<Void> initialFuture = new CompletableFuture<>();
 
     /**
      * Creates a new instance.
      */
-    public InternalProjectInitializer(CommandExecutor executor) {
+    public InternalProjectInitializer(CommandExecutor executor, ProjectManager projectManager) {
         this.executor = executor;
+        this.projectManager = projectManager;
     }
 
     /**
@@ -86,17 +91,15 @@ public final class InternalProjectInitializer {
      */
     public void initialize0(String projectName) {
         final long creationTimeMillis = System.currentTimeMillis();
-        try {
-            executor.execute(createProject(creationTimeMillis, Author.SYSTEM, projectName))
-                    .get();
-        } catch (Throwable cause) {
-            final Throwable peeled = Exceptions.peel(cause);
-            if (peeled instanceof ReadOnlyException) {
-                // The executor has stopped right after starting up.
-                return;
-            }
-            if (!(peeled instanceof ProjectExistsException)) {
-                throw new Error("failed to initialize an internal project: " + projectName, peeled);
+        if (!projectManager.exists(projectName)) {
+            try {
+                executor.execute(createProject(creationTimeMillis, Author.SYSTEM, projectName))
+                        .get();
+            } catch (Throwable cause) {
+                final Throwable peeled = Exceptions.peel(cause);
+                if (!(peeled instanceof ProjectExistsException)) {
+                    throw new Error("failed to initialize an internal project: " + projectName, peeled);
+                }
             }
         }
 
@@ -106,6 +109,13 @@ public final class InternalProjectInitializer {
     }
 
     private void initializeTokens() {
+        final Entry<JsonNode> entry =
+                projectManager.get(INTERNAL_PROJECT_DOGMA).repos().get(Project.REPO_DOGMA)
+                              .getOrNull(Revision.HEAD,
+                                         Query.ofJson(MetadataService.TOKEN_JSON)).join();
+        if (entry != null && entry.hasContent()) {
+            return;
+        }
         try {
             final Change<?> change = Change.ofJsonPatch(MetadataService.TOKEN_JSON,
                                                         null, Jackson.valueToTree(new Tokens()));
@@ -116,7 +126,7 @@ public final class InternalProjectInitializer {
                     .get();
         } catch (Throwable cause) {
             final Throwable peeled = Exceptions.peel(cause);
-            if (peeled instanceof ReadOnlyException || peeled instanceof ChangeConflictException) {
+            if (peeled instanceof ChangeConflictException) {
                 return;
             }
             throw new Error("failed to initialize the token list file", peeled);
@@ -137,7 +147,12 @@ public final class InternalProjectInitializer {
     private void initializeInternalRepos(String projectName, List<String> internalRepos,
                                          long creationTimeMillis) {
         requireNonNull(internalRepos, "internalRepos");
+        final Project project = projectManager.get(projectName);
+        assert project != null;
         for (final String repo : internalRepos) {
+            if (project.repos().exists(repo)) {
+                continue;
+            }
             try {
                 executor.execute(createRepository(creationTimeMillis, Author.SYSTEM, projectName, repo))
                         .get();

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
@@ -40,6 +40,7 @@ import com.linecorp.centraldogma.common.ReadOnlyException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.Tokens;
@@ -93,7 +94,8 @@ public final class InternalProjectInitializer {
         final long creationTimeMillis = System.currentTimeMillis();
         if (!projectManager.exists(projectName)) {
             try {
-                executor.execute(createProject(creationTimeMillis, Author.SYSTEM, projectName))
+                executor.execute(Command.forcePush(
+                                createProject(creationTimeMillis, Author.SYSTEM, projectName)))
                         .get();
             } catch (Throwable cause) {
                 final Throwable peeled = Exceptions.peel(cause);
@@ -121,8 +123,9 @@ public final class InternalProjectInitializer {
                                                         null, Jackson.valueToTree(new Tokens()));
             final String commitSummary = "Initialize the token list file: /" + INTERNAL_PROJECT_DOGMA + '/' +
                                          Project.REPO_DOGMA + MetadataService.TOKEN_JSON;
-            executor.execute(push(Author.SYSTEM, INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, Revision.HEAD,
-                                  commitSummary, "", Markup.PLAINTEXT, ImmutableList.of(change)))
+            executor.execute(Command.forcePush(push(Author.SYSTEM, INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA,
+                                                    Revision.HEAD, commitSummary, "", Markup.PLAINTEXT,
+                                                    ImmutableList.of(change))))
                     .get();
         } catch (Throwable cause) {
             final Throwable peeled = Exceptions.peel(cause);
@@ -154,7 +157,8 @@ public final class InternalProjectInitializer {
                 continue;
             }
             try {
-                executor.execute(createRepository(creationTimeMillis, Author.SYSTEM, projectName, repo))
+                executor.execute(Command.forcePush(
+                                createRepository(creationTimeMillis, Author.SYSTEM, projectName, repo)))
                         .get();
             } catch (Throwable cause) {
                 final Throwable peeled = Exceptions.peel(cause);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/PermissionTest.java
@@ -98,7 +98,7 @@ class PermissionTest {
             final CommandExecutor executor = new StandaloneCommandExecutor(
                     pm, ForkJoinPool.commonPool(), statusManager, null, null, null);
             executor.start().join();
-            new InternalProjectInitializer(executor).initialize();
+            new InternalProjectInitializer(executor, pm).initialize();
 
             executor.execute(Command.createProject(AUTHOR, "project1")).join();
 

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerExtension.java
@@ -78,7 +78,7 @@ public class ProjectManagerExtension extends AbstractAllOrEachExtension {
         executor = newCommandExecutor(projectManager, repositoryWorker, dataDir);
 
         executor.start().get();
-        internalProjectInitializer = new InternalProjectInitializer(executor);
+        internalProjectInitializer = new InternalProjectInitializer(executor, projectManager);
         internalProjectInitializer.initialize();
 
         afterExecutorStarted();


### PR DESCRIPTION
Motivation:
Central Dogma server currently attempts to create internal projects and repositories during starting up, even if they already exist. This is unnecessary for most scenarios, except when setting up a new cluster.

Modifications:
- Added checks to verify if the internal project and repositories exist before attempting to create them.
- Propagated the read-only exception to the caller if it's raised while creating the internal project.
  - It doesn't make sense to continue to run the cluster because the internal project must exist when the cluster gets back to non read-only mode.

Result:
- Central Dogma servers now checks for the existence of internal projects and repos before attempting to create them.