### PR TITLE
Reject invalid mirroring URI

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
@@ -99,6 +99,9 @@ public final class MirrorConfig {
         this.localRepo = requireNonNull(localRepo, "localRepo");
         this.localPath = firstNonNull(localPath, "/");
         this.remoteUri = requireNonNull(remoteUri, "remoteUri");
+        // Validate the remote URI.
+        RepositoryUri.parse(remoteUri, direction == MirrorDirection.REMOTE_TO_LOCAL ? "git" : "dogma");
+
         if (gitignore != null) {
             if (gitignore instanceof Iterable &&
                 Streams.stream((Iterable<?>) gitignore).allMatch(String.class::isInstance)) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
@@ -18,6 +18,7 @@
 package com.linecorp.centraldogma.server.internal.storage.repository;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.linecorp.centraldogma.server.mirror.MirrorSchemes.SCHEME_DOGMA;
 import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
@@ -99,8 +100,10 @@ public final class MirrorConfig {
         this.localRepo = requireNonNull(localRepo, "localRepo");
         this.localPath = firstNonNull(localPath, "/");
         this.remoteUri = requireNonNull(remoteUri, "remoteUri");
+
         // Validate the remote URI.
-        RepositoryUri.parse(remoteUri, direction == MirrorDirection.REMOTE_TO_LOCAL ? "git" : "dogma");
+        final String suffix = remoteUri.getScheme().equals(SCHEME_DOGMA) ? "dogma" : "git";
+        RepositoryUri.parse(remoteUri, suffix);
 
         if (gitignore != null) {
             if (gitignore instanceof Iterable &&

--- a/webapp/src/dogma/common/components/form/FieldErrorMessage.tsx
+++ b/webapp/src/dogma/common/components/form/FieldErrorMessage.tsx
@@ -20,14 +20,15 @@ import { FormErrorMessage } from '@chakra-ui/react';
 interface FieldErrorMessageProps {
   error?: FieldError;
   fieldName?: string;
+  errorMessage?: string;
 }
 
-const FieldErrorMessage = ({ error, fieldName }: FieldErrorMessageProps) => {
+const FieldErrorMessage = ({ error, fieldName, errorMessage }: FieldErrorMessageProps) => {
   if (error == null) {
     return null;
   }
 
-  let message = error.message;
+  let message = errorMessage || error.message;
   if (!message) {
     // Fill the message for known errors.
     if (error.type === 'required') {

--- a/webapp/src/dogma/features/auth/ProjectRole.tsx
+++ b/webapp/src/dogma/features/auth/ProjectRole.tsx
@@ -2,7 +2,6 @@ import { useAppSelector } from 'dogma/hooks';
 import { useGetMetadataByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import { ReactNode } from 'react';
 import { UserDto } from './UserDto';
-import { AppMemberDto } from '../project/settings/members/AppMemberDto';
 import { ProjectMetadataDto } from '../project/ProjectMetadataDto';
 
 type ProjectRole = 'OWNER' | 'MEMBER' | 'GUEST' | 'ANONYMOUS';

--- a/webapp/src/dogma/features/auth/ProjectRole.tsx
+++ b/webapp/src/dogma/features/auth/ProjectRole.tsx
@@ -1,6 +1,9 @@
 import { useAppSelector } from 'dogma/hooks';
 import { useGetMetadataByProjectNameQuery } from 'dogma/features/api/apiSlice';
 import { ReactNode } from 'react';
+import { UserDto } from './UserDto';
+import { AppMemberDto } from '../project/settings/members/AppMemberDto';
+import { ProjectMetadataDto } from '../project/ProjectMetadataDto';
 
 type ProjectRole = 'OWNER' | 'MEMBER' | 'GUEST' | 'ANONYMOUS';
 
@@ -10,13 +13,8 @@ type WithProjectRoleProps = {
   children: () => ReactNode;
 };
 
-export const WithProjectRole = ({ projectName, roles, children }: WithProjectRoleProps) => {
-  const { data: metadata } = useGetMetadataByProjectNameQuery(projectName, {
-    refetchOnFocus: true,
-  });
-
+export function findUserRole(user: UserDto, metadata: ProjectMetadataDto) {
   let role: ProjectRole;
-  const { user } = useAppSelector((state) => state.auth);
   if (metadata && user) {
     if (user.admin) {
       role = 'OWNER';
@@ -27,6 +25,16 @@ export const WithProjectRole = ({ projectName, roles, children }: WithProjectRol
   if (!role) {
     role = 'GUEST';
   }
+  return role;
+}
+
+export const WithProjectRole = ({ projectName, roles, children }: WithProjectRoleProps) => {
+  const { data: metadata } = useGetMetadataByProjectNameQuery(projectName, {
+    refetchOnFocus: true,
+  });
+
+  const { user } = useAppSelector((state) => state.auth);
+  const role = findUserRole(user, metadata);
 
   if (roles.find((r) => r === role)) {
     return <>{children()}</>;

--- a/webapp/src/dogma/features/project/settings/ProjectSettingsView.tsx
+++ b/webapp/src/dogma/features/project/settings/ProjectSettingsView.tsx
@@ -27,6 +27,7 @@ import { AppMemberDetailDto } from 'dogma/features/project/settings/members/AppM
 import { FiBox } from 'react-icons/fi';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { HttpStatusCode } from 'dogma/features/api/HttpStatusCode';
+import { findUserRole } from '../../auth/ProjectRole';
 
 interface ProjectSettingsViewProps {
   projectName: string;
@@ -83,14 +84,7 @@ const ProjectSettingsView = ({ projectName, currentTab, children }: ProjectSetti
     // 403 Forbidden means the user has a GUEST role
     queryError = null;
   } else {
-    if (metadata && user) {
-      const appUser = Array.from(Object.values(metadata.members)).find(
-        (m: AppMemberDetailDto) => m.login === user.email,
-      );
-      if (appUser != null) {
-        accessRole = appUser.role;
-      }
-    }
+    accessRole = findUserRole(user, metadata);
   }
   return (
     <Deferred isLoading={isLoading} error={queryError}>

--- a/webapp/src/dogma/features/project/settings/ProjectSettingsView.tsx
+++ b/webapp/src/dogma/features/project/settings/ProjectSettingsView.tsx
@@ -23,7 +23,6 @@ import Link from 'next/link';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
 import { useRouter } from 'next/router';
 import { useAppSelector } from 'dogma/hooks';
-import { AppMemberDetailDto } from 'dogma/features/project/settings/members/AppMemberDto';
 import { FiBox } from 'react-icons/fi';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { HttpStatusCode } from 'dogma/features/api/HttpStatusCode';

--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
@@ -43,7 +43,7 @@ import { GoArrowBoth, GoArrowDown, GoArrowUp, GoKey, GoRepo } from 'react-icons/
 import { Select } from 'chakra-react-select';
 import { IoBanSharp } from 'react-icons/io5';
 import { useGetCredentialsQuery, useGetReposQuery } from 'dogma/features/api/apiSlice';
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo } from 'react';
 import FieldErrorMessage from 'dogma/common/components/form/FieldErrorMessage';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
 import { MirrorDto } from 'dogma/features/project/settings/mirrors/MirrorDto';

--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
@@ -43,7 +43,7 @@ import { GoArrowBoth, GoArrowDown, GoArrowUp, GoKey, GoRepo } from 'react-icons/
 import { Select } from 'chakra-react-select';
 import { IoBanSharp } from 'react-icons/io5';
 import { useGetCredentialsQuery, useGetReposQuery } from 'dogma/features/api/apiSlice';
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import FieldErrorMessage from 'dogma/common/components/form/FieldErrorMessage';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
 import { MirrorDto } from 'dogma/features/project/settings/mirrors/MirrorDto';
@@ -300,9 +300,13 @@ const MirrorForm = ({ projectName, defaultValue, onSubmit, isWaitingResponse }: 
                 type="text"
                 defaultValue={defaultValue.remoteUrl}
                 placeholder="my.git.com/org/myrepo.git"
-                {...register('remoteUrl', { required: true, pattern: /^.*\.git$/ })}
+                {...register('remoteUrl', { required: true, pattern: /^[\w.-]+(:[0-9]+)?\/[\w.-\/]+.git$/ })}
               />
-              <FieldErrorMessage error={errors.remoteUrl} fieldName="remote URL" />
+              <FieldErrorMessage
+                error={errors.remoteUrl}
+                fieldName="remote URL"
+                errorMessage="Invalid remote URL. (expected format: 'my.git.com/org/myrepo.git')"
+              />
             </FormControl>
             <FormControl width="50%" isRequired isInvalid={errors.remoteBranch != null}>
               <FormLabel>branch</FormLabel>


### PR DESCRIPTION
Motivation:

An expected remote URI for mirroring is `<domain.com>/<org>/<repo>.git`. However, both the mirror UI and REST API didn't validate the input.

For example, a SSH URL, `github.com:line/centraldogma.git` is not valid in Central Dogma but can be committed. Exceptions are raised later when it is used.

Additionally, I also fixed a bug where settings tabs are not visible to admin that I found while fixing this bug.

Modifications:

- Improved the regular expression for `remoteUri` to strictly check the input.
- Validate a remote URI in the mirror REST API.
- Always set the project role of adminstrator to `OWNER`

Result:

Invalid remote URIs are now rejected by the mirror UI and API.