### PR TITLE
Fix flaky ProjectServiceV1ListProjectTest

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -261,7 +261,7 @@ class ProjectServiceV1ListProjectTest {
         createProject(adminClient, "trustin");
         createProject(adminClient, "hyangtack");
 
-        Map<String, ProjectDto> projects = getProjects(normalClient);
+        final Map<String, ProjectDto> projects = getProjects(normalClient);
         assertThat(projects).hasSize(2);
         assertThat(projects).containsOnlyKeys("trustin", "hyangtack");
         assertThat(projects.values().stream().map(ProjectDto::userRole))
@@ -275,7 +275,7 @@ class ProjectServiceV1ListProjectTest {
                            .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         await().untilAsserted(() -> {
-            Map<String, ProjectDto> projects0 = getProjects(normalClient);
+            final Map<String, ProjectDto> projects0 = getProjects(normalClient);
             assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
             assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
         });
@@ -287,7 +287,7 @@ class ProjectServiceV1ListProjectTest {
                           .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         await().untilAsserted(() -> {
-            Map<String, ProjectDto> projects0 = getProjects(normalClient);
+            final Map<String, ProjectDto> projects0 = getProjects(normalClient);
             assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
             assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
         });
@@ -311,7 +311,7 @@ class ProjectServiceV1ListProjectTest {
                                                        .auth(AuthToken.ofOAuth2(token))
                                                        .build()
                                                        .blocking();
-        Map<String, ProjectDto> projects = getProjects(tokenClient);
+        final Map<String, ProjectDto> projects = getProjects(tokenClient);
         assertThat(projects).hasSize(2);
         assertThat(projects).containsOnlyKeys("trustin", "hyangtack");
         assertThat(projects.values().stream().map(ProjectDto::userRole))
@@ -324,7 +324,7 @@ class ProjectServiceV1ListProjectTest {
                             .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         await().untilAsserted(() -> {
-            Map<String, ProjectDto> projects0 = getProjects(tokenClient);
+            final Map<String, ProjectDto> projects0 = getProjects(tokenClient);
             assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
             assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
         });
@@ -335,7 +335,7 @@ class ProjectServiceV1ListProjectTest {
                            .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
         await().untilAsserted(() -> {
-            Map<String, ProjectDto> projects0 = getProjects(tokenClient);
+            final Map<String, ProjectDto> projects0 = getProjects(tokenClient);
             assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
             assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
         });

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -21,6 +21,7 @@ import static com.linecorp.centraldogma.server.internal.api.ProjectServiceV1Test
 import static com.linecorp.centraldogma.server.internal.api.ProjectServiceV1Test.sessionId;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.net.URI;
@@ -273,9 +274,11 @@ class ProjectServiceV1ListProjectTest {
                                    TestAuthMessageUtil.USERNAME2, "MEMBER"))
                            .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
-        projects = getProjects(normalClient);
-        assertThat(projects.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
-        assertThat(projects.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
+        await().untilAsserted(() -> {
+            Map<String, ProjectDto> projects0 = getProjects(normalClient);
+            assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
+        });
 
         aRes = adminClient.prepare()
                           .post("/api/v1/metadata/hyangtack/members")
@@ -283,9 +286,11 @@ class ProjectServiceV1ListProjectTest {
                                   TestAuthMessageUtil.USERNAME2, "OWNER"))
                           .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
-        projects = getProjects(normalClient);
-        assertThat(projects.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
-        assertThat(projects.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
+        await().untilAsserted(() -> {
+            Map<String, ProjectDto> projects0 = getProjects(normalClient);
+            assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
+        });
     }
 
     @Test
@@ -318,18 +323,22 @@ class ProjectServiceV1ListProjectTest {
                             .contentJson(new IdentifierWithRole(appId, "MEMBER"))
                             .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
-        projects = getProjects(tokenClient);
-        assertThat(projects.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
-        assertThat(projects.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
+        await().untilAsserted(() -> {
+            Map<String, ProjectDto> projects0 = getProjects(tokenClient);
+            assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.GUEST);
+        });
 
         aRes = normalClient.prepare()
                            .post("/api/v1/metadata/hyangtack/tokens")
                            .contentJson(new IdentifierWithRole(appId, "OWNER"))
                            .execute();
         assertThat(aRes.status()).isEqualTo(HttpStatus.OK);
-        projects = getProjects(tokenClient);
-        assertThat(projects.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
-        assertThat(projects.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
+        await().untilAsserted(() -> {
+            Map<String, ProjectDto> projects0 = getProjects(tokenClient);
+            assertThat(projects0.get("trustin").userRole()).isEqualTo(ProjectRole.MEMBER);
+            assertThat(projects0.get("hyangtack").userRole()).isEqualTo(ProjectRole.OWNER);
+        });
     }
 
     private Map<String, ProjectDto> getProjects(BlockingWebClient client) {


### PR DESCRIPTION
Motivation:

We may not get the new ProjectRole via projects API as it is updated. Because it is updated asynchronously.
```
ProjectServiceV1ListProjectTest > userRoleWithLoginUser() FAILED
    org.opentest4j.AssertionFailedError:
    expected: OWNER
     but was: GUEST
        at app//com.linecorp.centraldogma.server.internal.api.ProjectServiceV1ListProjectTest.userRoleWithLoginUser(ProjectServiceV1ListProjectTest.java:288)
```

Modifications:

- Wrap the test assertions with `await().untilAsserted()`

Result:

Stable CI results