### PR TITLE
Access JAR file only once to find Envoy extension classes

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -121,6 +121,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                .addService(new XdsKubernetesService(xdsResourceManager))
                                .jsonMarshallerFactory(
                                        serviceDescriptor -> {
+                                           // Use JSON_MESSAGE_MARSHALLER not to parse Envoy extensions twice.
                                            final MessageMarshaller.Builder builder =
                                                    JSON_MESSAGE_MARSHALLER.toBuilder();
                                            for (MethodDescriptor<?, ?> method : ImmutableList.copyOf(
@@ -136,12 +137,10 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                                    builder.register(resPrototype);
                                                }
                                            }
-
                                            return new DefaultJsonMarshaller(builder.build());
                                        })
                                .enableHttpJsonTranscoding(true).build();
-            pluginInitContext.serverBuilder().service(xdsApplicationService,
-                                                      pluginInitContext.authService());
+            pluginInitContext.serverBuilder().service(xdsApplicationService, pluginInitContext.authService());
             return null;
         });
     }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -17,20 +17,21 @@ package com.linecorp.centraldogma.xds.internal;
 
 import static com.linecorp.centraldogma.server.internal.ExecutorServiceUtil.terminate;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
-import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.envoyExtension;
 
 import java.io.IOException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
+import org.curioswitch.common.protobuf.json.MessageMarshaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.GeneratedMessageV3;
+import com.google.protobuf.Message;
 
-import com.linecorp.armeria.common.grpc.GrpcJsonMarshaller;
+import com.linecorp.armeria.common.annotation.Nullable;
+import com.linecorp.armeria.internal.common.grpc.DefaultJsonMarshaller;
 import com.linecorp.armeria.server.grpc.GrpcService;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.plugin.PluginInitContext;
@@ -53,6 +54,9 @@ import io.envoyproxy.envoy.config.route.v3.RouteConfiguration;
 import io.envoyproxy.envoy.service.discovery.v3.DeltaDiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryRequest;
 import io.envoyproxy.envoy.service.discovery.v3.DiscoveryResponse;
+import io.grpc.MethodDescriptor;
+import io.grpc.MethodDescriptor.Marshaller;
+import io.grpc.MethodDescriptor.PrototypeMarshaller;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
 import io.netty.util.concurrent.DefaultThreadFactory;
@@ -105,9 +109,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                                        .addService(server.getAggregatedDiscoveryServiceImpl())
                                                        .build();
             pluginInitContext.serverBuilder().route().build(grpcService);
-            final XdsResourceManager xdsResourceManager = new XdsResourceManager(xdsProject(),
-                                                                                 commandExecutor);
-            final ImmutableList<Class<? extends GeneratedMessageV3>> extensionClasses = envoyExtension();
+            final XdsResourceManager xdsResourceManager = new XdsResourceManager(xdsProject(), commandExecutor);
             final GrpcService xdsApplicationService =
                     GrpcService.builder()
                                .addService(new XdsGroupService(pluginInitContext.projectManager(),
@@ -118,16 +120,41 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                .addService(new XdsEndpointService(xdsResourceManager))
                                .addService(new XdsKubernetesService(xdsResourceManager))
                                .jsonMarshallerFactory(
-                                       serviceDescriptor -> GrpcJsonMarshaller
-                                               .builder()
-                                               .jsonMarshallerCustomizer(
-                                                       builder -> extensionClasses.forEach(builder::register))
-                                               .build(serviceDescriptor))
+                                       serviceDescriptor -> {
+                                           final MessageMarshaller.Builder builder =
+                                                   JSON_MESSAGE_MARSHALLER.toBuilder();
+                                           for (MethodDescriptor<?, ?> method : ImmutableList.copyOf(
+                                                   serviceDescriptor.getMethods())) {
+                                               final Message reqPrototype =
+                                                       marshallerPrototype(method.getRequestMarshaller());
+                                               final Message resPrototype =
+                                                       marshallerPrototype(method.getResponseMarshaller());
+                                               if (reqPrototype != null) {
+                                                   builder.register(reqPrototype);
+                                               }
+                                               if (resPrototype != null) {
+                                                   builder.register(resPrototype);
+                                               }
+                                           }
+
+                                           return new DefaultJsonMarshaller(builder.build());
+                                       })
                                .enableHttpJsonTranscoding(true).build();
             pluginInitContext.serverBuilder().service(xdsApplicationService,
                                                       pluginInitContext.authService());
             return null;
         });
+    }
+
+    @Nullable
+    private static Message marshallerPrototype(Marshaller<?> marshaller) {
+        if (marshaller instanceof MethodDescriptor.PrototypeMarshaller) {
+            final Object prototype = ((PrototypeMarshaller<?>) marshaller).getMessagePrototype();
+            if (prototype instanceof Message) {
+                return (Message) prototype;
+            }
+        }
+        return null;
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
@@ -78,8 +78,7 @@ public final class XdsResourceManager {
         JSON_MESSAGE_MARSHALLER = builder.build();
     }
 
-    private static void envoyExtension(
-            MessageMarshaller.Builder builder) {
+    private static void envoyExtension(MessageMarshaller.Builder builder) {
         final Reflections reflections = new Reflections(
                 "io.envoyproxy.envoy.extensions", HttpConnectionManager.class.getClassLoader(),
                 new SubTypesScanner(true));


### PR DESCRIPTION
In #1008, I used reflection to find Envoy extension classes in the Jar file.
However, I've noticed that accessing the JAR file for the second time takes significantly longer, though I haven't been able to determine the cause.