### PR TITLE
Reload webpages when refreshed

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -872,19 +872,11 @@ public class CentralDogma implements AutoCloseable {
                 sb.service(LOGOUT_PATH, authProvider.webLogoutService());
             }
 
-            // Folder names contain path patterns such as `[projectName]` which FileService can't infer from
-            // the request path. Return `index.html` as a fallback so that Next.js client router handles the
-            // path patterns.
-            final HttpService fallbackFileService = HttpFile.of(CentralDogma.class.getClassLoader(),
-                                                                "com/linecorp/centraldogma/webapp/index.html")
-                                                            .asService();
-            sb.serviceUnder("/app", FileService.builder(CentralDogma.class.getClassLoader(),
-                                                        "com/linecorp/centraldogma/webapp/app")
-                                               .cacheControl(ServerCacheControl.REVALIDATED)
-                                               .autoDecompress(true)
-                                               .serveCompressedFiles(true)
-                                               .build().orElse(fallbackFileService));
-
+            // If the index.html is just returned, Next.js will handle the all remaining process such as
+            // fetching resources and routes to the target pages.
+            sb.serviceUnder("/app", HttpFile.of(CentralDogma.class.getClassLoader(),
+                                                "com/linecorp/centraldogma/webapp/index.html")
+                                            .asService());
             // Serve all web resources except for '/app'.
             sb.route()
               .pathPrefix("/")


### PR DESCRIPTION
Motivation:

After #1013 is merged, I found out that a web page failed to reload when a refresh button is clicked or directly access to `/app/projects`

It is caused by a bug of Armeria `FileService` which returns an empty file instead of a non-existent file when 1) the target path is a directory and 2) the path does not end with `/`.

The `FileService` has `.html` as a fallback extension. If `/app/projects` is requested, I expect `/app/projects.html` to be returned because `/app/projects` is directory. However, it only works with `FileSystemHttpVfs` but not `ClassPathHttpVfs`.
```
/app/projects/[projectName].html
/app/projects.html
```

The problem wasn't caught by unit tests because `FileSystemHttpVfs` was always used instead. During the tests, the class loader directly loads the test resources from the file system.

Modifications:

- Always return `/webapp/index.html` for `/app/**` paths.
  - Next.js will load the correct page on the client side.

Result:

Fixed a regression where the webapp failed to render deep links.