### PR TITLE
Avoid Using Future.join() During Control Plane Plugin Startup

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
@@ -79,6 +79,7 @@ public abstract class XdsResourceWatchingService {
      * Must be executed by {@link #executor()}.
      */
     protected void init() {
+        logger.info("Initializing {}...", getClass().getSimpleName());
         final Builder<CompletableFuture<Void>> futures = ImmutableList.builder();
         for (Repository repository : xdsProject.repos().list().values()) {
             final String groupName = repository.name();
@@ -117,6 +118,7 @@ public abstract class XdsResourceWatchingService {
         CompletableFuture.allOf(futures.build().toArray(new CompletableFuture[0])).join();
         // Watch dogma repository to add newly created xDS projects.
         watchDogmaRepository();
+        logger.info("{} initialized.", getClass().getSimpleName());
     }
 
     private void watchDogmaRepository() {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
@@ -94,9 +94,8 @@ public abstract class XdsResourceWatchingService {
             futures.add(findFuture.handleAsync((entries, cause) -> {
                 // Executed by the repository worker thread.
                 if (cause != null) {
-                    logger.warn("Unexpected exception while finding {} at revision: {}",
-                                groupName, normalizedRevision, cause);
-                    return null;
+                    throw new RuntimeException("Unexpected exception while finding " + groupName +
+                                               " at revision: " + normalizedRevision, cause);
                 }
                 for (Entry<?> entry : entries.values()) {
                     if (entry.type() != EntryType.JSON || !entry.hasContent()) {


### PR DESCRIPTION
Motivation:
The use of `repository.find(...).join()` during the control plane plugin startup introduces unnecessary delays.

Modifications:
- Removed the use of `future.join()` during the control plane plugin startup to avoid blocking the control plane executor.

Result:
- Reduced startup time.