### PR TITLE
Fix Deadlock Issue in Control Plane service

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -17,7 +17,6 @@
 package com.linecorp.centraldogma.xds.internal;
 
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.MoreObjects;
 
@@ -43,11 +42,7 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
                 pluginInitContext.projectManager().get(XDS_CENTRAL_DOGMA_PROJECT),
                 pluginInitContext.meterRegistry());
         this.controlPlaneService = controlPlaneService;
-        try {
-            controlPlaneService.start(pluginInitContext).get(60, TimeUnit.SECONDS);
-        } catch (Throwable t) {
-            throw new RuntimeException("Failed to init control plane plugin in 60 seconds.", t);
-        }
+        controlPlaneService.start(pluginInitContext);
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingPlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingPlugin.java
@@ -20,7 +20,6 @@ import static io.fabric8.kubernetes.client.Config.KUBERNETES_DISABLE_AUTO_CONFIG
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
@@ -57,11 +56,7 @@ public final class XdsKubernetesEndpointFetchingPlugin implements Plugin {
         fetchingService = new XdsKubernetesEndpointFetchingService(
                 context.projectManager().get(XDS_CENTRAL_DOGMA_PROJECT), context.commandExecutor(),
                 context.meterRegistry());
-        try {
-            fetchingService.start().get(60, TimeUnit.SECONDS);
-        } catch (Throwable t) {
-            throw new RuntimeException("Failed to start kubernetes endpoint fetching plugin in 60 seconds.", t);
-        }
+        fetchingService.start();
         return UnmodifiableFuture.completedFuture(null);
     }
 

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
 
@@ -81,8 +80,8 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
                         new DefaultThreadFactory("k8s-plugin-executor", true)), "k8sPluginExecutor");
     }
 
-    Future<?> start() {
-        return executorService.submit(this::init);
+    void start() {
+        init();
     }
 
     void stop() {

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CreatingInternalGroupPlugin.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CreatingInternalGroupPlugin.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.internal;
+
+import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
+
+import java.util.concurrent.CompletionStage;
+
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.plugin.AllReplicasPlugin;
+import com.linecorp.centraldogma.server.plugin.PluginContext;
+import com.linecorp.centraldogma.server.plugin.PluginInitContext;
+
+/**
+ * A plugin that creates an internal group before the control plane plugin starts.
+ * This is for checking the deadlock in the plugin initialization.
+ * See <a href="https://github.com/line/centraldogma/pull/1024#issuecomment-2306377086">this comment</a>.
+ */
+public final class CreatingInternalGroupPlugin extends AllReplicasPlugin {
+
+    @Override
+    public void init(PluginInitContext pluginInitContext) {
+        pluginInitContext.commandExecutor()
+                         .execute(Command.forcePush(Command.createRepository(
+                                 Author.SYSTEM, XDS_CENTRAL_DOGMA_PROJECT, "my-group")))
+                         .join();
+    }
+
+    @Override
+    public CompletionStage<Void> start(PluginContext context) {
+        return UnmodifiableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> stop(PluginContext context) {
+        return UnmodifiableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Class<?> configType() {
+        return getClass();
+    }
+}

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CreatingInternalGroupPlugin.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CreatingInternalGroupPlugin.java
@@ -35,6 +35,7 @@ public final class CreatingInternalGroupPlugin extends AllReplicasPlugin {
 
     @Override
     public void init(PluginInitContext pluginInitContext) {
+        pluginInitContext.internalProjectInitializer().initialize(XDS_CENTRAL_DOGMA_PROJECT);
         pluginInitContext.commandExecutor()
                          .execute(Command.forcePush(Command.createRepository(
                                  Author.SYSTEM, XDS_CENTRAL_DOGMA_PROJECT, "my-group")))

--- a/xds/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
+++ b/xds/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
@@ -1,0 +1,1 @@
+com.linecorp.centraldogma.xds.internal.CreatingInternalGroupPlugin


### PR DESCRIPTION
Modification:
A mistake in #1022 caused a deadlock in the control plane executor. The issue arose because the thread was waiting on a future to complete, but it needed to execute and complete that future itself, leading to a deadlock. https://github.com/line/centraldogma/pull/1022/files#diff-f99a1af4ac33cff7d57aea503c56b19cbadb765e6b1a48067de36c1998b367acR117 https://github.com/line/centraldogma/pull/1022/files#diff-f99a1af4ac33cff7d57aea503c56b19cbadb765e6b1a48067de36c1998b367acR115

Modifications:
- Changed to wait on the startup thread instead of the control plane executor.

Result:
- The deadlock issue during the control plane service startup has been resovled.