### PR TITLE
Paginate the commit history page with query params

### DIFF
--- a/webapp/src/dogma/common/components/Breadcrumbs.tsx
+++ b/webapp/src/dogma/common/components/Breadcrumbs.tsx
@@ -39,8 +39,10 @@ export const Breadcrumbs = ({
         if (omitIndexList.includes(i)) {
           return null;
         }
-        let query0 = '';
-        if (!omitQueryList.includes(i)) {
+        let query0;
+        if (omitQueryList.includes(i) || omitQueryList.includes(i - asPathNestedRoutes.length)) {
+          query0 = '';
+        } else {
           query0 = query ? `?${query}` : '';
         }
 

--- a/webapp/src/dogma/common/components/Breadcrumbs.tsx
+++ b/webapp/src/dogma/common/components/Breadcrumbs.tsx
@@ -5,18 +5,22 @@ import NextLink from 'next/link';
 interface BreadcrumbsProps {
   path: string;
   omitIndexList?: number[];
+  omitQueryList?: number[];
   unlinkedList?: number[];
   replaces?: { [key: number]: string };
   suffixes?: { [key: number]: string };
+  query?: string;
 }
 
 export const Breadcrumbs = ({
   path,
   omitIndexList = [],
+  omitQueryList = [],
   unlinkedList = [],
   replaces = {},
   // /project/projectName/repos/repoName -> /project/projectName/repos/repoName/tree/head
   suffixes = {},
+  query = '',
 }: BreadcrumbsProps) => {
   const asPathNestedRoutes = path
     // If the path belongs to a file, the top level should be a directory
@@ -30,10 +34,14 @@ export const Breadcrumbs = ({
   return (
     <Breadcrumb spacing="8px" separator={<FcNext />} mb={8} fontWeight="medium" fontSize="2xl">
       {asPathNestedRoutes.map((page, i) => {
-        prefixes.push(page);
         const item = replaces[i] || page;
+        prefixes.push(item);
         if (omitIndexList.includes(i)) {
           return null;
+        }
+        let query0 = '';
+        if (!omitQueryList.includes(i)) {
+          query0 = query ? `?${query}` : '';
         }
 
         return (
@@ -41,7 +49,7 @@ export const Breadcrumbs = ({
             {!unlinkedList.includes(i) && i < asPathNestedRoutes.length - 1 ? (
               <BreadcrumbLink
                 as={NextLink}
-                href={`/${prefixes.join('/')}${suffixes[i] || ''}`}
+                href={`/${prefixes.join('/')}${suffixes[i] || ''}${query0}`}
                 paddingBottom={1}
               >
                 {decodeURI(item)}

--- a/webapp/src/dogma/common/components/CompareButton.tsx
+++ b/webapp/src/dogma/common/components/CompareButton.tsx
@@ -51,7 +51,7 @@ const CompareButton = ({ projectName, repoName, headRevision }: CompareButtonPro
           Compare
         </Button>
       </PopoverTrigger>
-      <PopoverContent width={'220px'}>
+      <PopoverContent width={'240px'}>
         <PopoverArrow />
         <PopoverBody>
           <form onSubmit={handleSubmit(onSubmit)}>
@@ -59,7 +59,7 @@ const CompareButton = ({ projectName, repoName, headRevision }: CompareButtonPro
               <FormControl isRequired>
                 <Input
                   type="number"
-                  placeholder={`Revision 1..${headRevision - 1}`}
+                  placeholder={`Rev 1..${headRevision - 1}`}
                   autoFocus
                   {...register('baseRevision', { required: true, min: 1, max: headRevision - 1 })}
                 />

--- a/webapp/src/dogma/common/components/Deferred.tsx
+++ b/webapp/src/dogma/common/components/Deferred.tsx
@@ -21,6 +21,7 @@ import { Loading } from './Loading';
 
 interface LoadingProps {
   isLoading: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   error: any;
   children: () => ReactNode;
 }

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -37,6 +37,7 @@ export type FileEditorProps = {
   originalContent: string;
   path: string;
   name: string;
+  revision: string | number;
 };
 
 // Map file extension to language identifier
@@ -58,7 +59,15 @@ export const extensionToLanguageMap: { [key: string]: string } = {
   toml: 'toml',
 };
 
-const FileEditor = ({ projectName, repoName, extension, originalContent, path, name }: FileEditorProps) => {
+const FileEditor = ({
+  projectName,
+  repoName,
+  extension,
+  originalContent,
+  path,
+  name,
+  revision,
+}: FileEditorProps) => {
   const dispatch = useAppDispatch();
   const language = extensionToLanguageMap[extension] || extension;
   let jsonContent = '';
@@ -108,7 +117,7 @@ const FileEditor = ({ projectName, repoName, extension, originalContent, path, n
         <Button
           size={'sm'}
           as={Link}
-          href={`/app/projects/${projectName}/repos/${repoName}/commits/${path}`}
+          href={`/app/projects/${projectName}/repos/${repoName}/commits/${path}${revision !== 'head' ? `?from=${revision}` : ''}`}
           leftIcon={<FaHistory />}
           variant="outline"
           colorScheme="gray"

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -28,7 +28,7 @@ import { newNotification } from 'dogma/features/notification/notificationSlice';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import Router from 'next/router';
 import Link from 'next/link';
-import { FaCodeCommit } from 'react-icons/fa6';
+import { FaHistory } from 'react-icons/fa';
 
 export type FileEditorProps = {
   projectName: string;
@@ -37,7 +37,6 @@ export type FileEditorProps = {
   originalContent: string;
   path: string;
   name: string;
-  commitRevision: number;
 };
 
 // Map file extension to language identifier
@@ -59,15 +58,7 @@ export const extensionToLanguageMap: { [key: string]: string } = {
   toml: 'toml',
 };
 
-const FileEditor = ({
-  projectName,
-  repoName,
-  extension,
-  originalContent,
-  path,
-  name,
-  commitRevision,
-}: FileEditorProps) => {
+const FileEditor = ({ projectName, repoName, extension, originalContent, path, name }: FileEditorProps) => {
   const dispatch = useAppDispatch();
   const language = extensionToLanguageMap[extension] || extension;
   let jsonContent = '';
@@ -117,12 +108,12 @@ const FileEditor = ({
         <Button
           size={'sm'}
           as={Link}
-          href={`/app/projects/${projectName}/repos/${repoName}/commit/${commitRevision}/${path}`}
-          leftIcon={<FaCodeCommit />}
+          href={`/app/projects/${projectName}/repos/${repoName}/commits/${path}`}
+          leftIcon={<FaHistory />}
           variant="outline"
           colorScheme="gray"
         >
-          Commit
+          History
         </Button>
         <Button
           onClick={switchMode}

--- a/webapp/src/dogma/common/components/table/DataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DataTable.tsx
@@ -11,6 +11,7 @@ export const DataTable = <Data extends object>({ table }: { table: ReactTable<Da
           <Tr key={headerGroup.id}>
             {headerGroup.headers.map((header) => {
               // see https://tanstack.com/table/v8/docs/api/core/column-def#meta to type this correctly
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
               const meta: any = header.column.columnDef.meta;
               return (
                 <Th
@@ -41,6 +42,7 @@ export const DataTable = <Data extends object>({ table }: { table: ReactTable<Da
             <Tr key={row.id} data-testid="table-row">
               {row.getVisibleCells().map((cell) => {
                 // see https://tanstack.com/table/v8/docs/api/core/column-def#meta to type this correctly
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const meta: any = cell.column.columnDef.meta;
                 return (
                   <Td key={cell.id} isNumeric={meta?.isNumeric}>

--- a/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
+++ b/webapp/src/dogma/common/components/table/DynamicDataTable.tsx
@@ -13,14 +13,16 @@ import {
 import { DataTable } from 'dogma/common/components/table/DataTable';
 import { Filter } from 'dogma/common/components/table/Filter';
 import { PaginationBar } from 'dogma/common/components/table/PaginationBar';
-import { Dispatch, SetStateAction, useState } from 'react';
+import React, { ReactElement, useState } from 'react';
 
 export type DynamicDataTableProps<Data extends object> = {
   data: Data[];
   columns: ColumnDef<Data>[];
   pagination?: { pageIndex: number; pageSize: number };
-  setPagination?: Dispatch<SetStateAction<PaginationState>>;
+  setPagination?: (updater: (old: PaginationState) => PaginationState) => void;
   pageCount?: number;
+  disableGotoButton?: boolean;
+  onEmptyData?: ReactElement;
 };
 
 export const DynamicDataTable = <Data extends object>({
@@ -29,6 +31,8 @@ export const DynamicDataTable = <Data extends object>({
   pagination,
   setPagination,
   pageCount,
+  disableGotoButton,
+  onEmptyData,
 }: DynamicDataTableProps<Data>) => {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -53,13 +57,19 @@ export const DynamicDataTable = <Data extends object>({
 
   return (
     <>
-      <Text mb="8px">Filter by {table.getHeaderGroups()[0].headers[0].id} </Text>
-      <Filter
-        table={table}
-        column={table.getHeaderGroups()[0].headers[0].column /* Filter by the 1st column */}
-      />
-      <DataTable table={table} />
-      {pagination && <PaginationBar table={table} />}
+      {table.getRowModel().rows.length == 0 && onEmptyData ? (
+        onEmptyData
+      ) : (
+        <>
+          <Text mb="8px">Filter by {table.getHeaderGroups()[0].headers[0].id} </Text>
+          <Filter
+            table={table}
+            column={table.getHeaderGroups()[0].headers[0].column /* Filter by the 1st column */}
+          />
+          <DataTable table={table} />
+        </>
+      )}
+      {pagination && <PaginationBar table={table} disableGotoButton={disableGotoButton} />}
     </>
   );
 };

--- a/webapp/src/dogma/common/components/table/PaginationBar.tsx
+++ b/webapp/src/dogma/common/components/table/PaginationBar.tsx
@@ -1,4 +1,4 @@
-import { Flex, Input, Text, Select, Spacer, IconButton, Box, HStack, Stack } from '@chakra-ui/react';
+import { Flex, IconButton, Input, Select, Spacer, Text } from '@chakra-ui/react';
 import { Table as ReactTable } from '@tanstack/react-table';
 import { MdNavigateBefore, MdNavigateNext, MdSkipNext, MdSkipPrevious } from 'react-icons/md';
 

--- a/webapp/src/dogma/common/components/table/PaginationBar.tsx
+++ b/webapp/src/dogma/common/components/table/PaginationBar.tsx
@@ -1,10 +1,16 @@
-import { Flex, Input, Text, Select, Spacer, IconButton } from '@chakra-ui/react';
+import { Flex, Input, Text, Select, Spacer, IconButton, Box, HStack, Stack } from '@chakra-ui/react';
 import { Table as ReactTable } from '@tanstack/react-table';
 import { MdNavigateBefore, MdNavigateNext, MdSkipNext, MdSkipPrevious } from 'react-icons/md';
 
-export const PaginationBar = <Data extends object>({ table }: { table: ReactTable<Data> }) => {
+type PaginationBarProps<Data extends object> = {
+  table: ReactTable<Data>;
+  disableGotoButton?: boolean;
+};
+
+export const PaginationBar = <Data extends object>({ table, disableGotoButton }: PaginationBarProps<Data>) => {
   return (
     <Flex gap={2} mt={2} alignItems="center">
+      {disableGotoButton && <Spacer />}
       <IconButton
         aria-label="First page"
         icon={<MdSkipPrevious />}
@@ -34,29 +40,33 @@ export const PaginationBar = <Data extends object>({ table }: { table: ReactTabl
         {table.getState().pagination.pageIndex + 1} of {table.getPageCount()}
       </Text>
       <Spacer />
-      <Text>Go to page:</Text>
-      <Input
-        type="number"
-        defaultValue={table.getState().pagination.pageIndex + 1}
-        onChange={(e) => {
-          const page = e.target.value ? Number(e.target.value) - 1 : 0;
-          table.setPageIndex(page);
-        }}
-        width={20}
-      />
-      <Select
-        value={table.getState().pagination.pageSize}
-        onChange={(e) => {
-          table.setPageSize(Number(e.target.value));
-        }}
-        width="auto"
-      >
-        {[10, 20, 30, 40, 50].map((pageSize) => (
-          <option key={pageSize} value={pageSize}>
-            Show {pageSize}
-          </option>
-        ))}
-      </Select>
+      {!disableGotoButton && (
+        <>
+          <Text>Go to page:</Text>
+          <Input
+            type="number"
+            defaultValue={table.getState().pagination.pageIndex + 1}
+            onChange={(e) => {
+              const page = e.target.value ? Number(e.target.value) - 1 : 0;
+              table.setPageIndex(page);
+            }}
+            width={20}
+          />
+          <Select
+            value={table.getState().pagination.pageSize}
+            onChange={(e) => {
+              table.setPageSize(Number(e.target.value));
+            }}
+            width="auto"
+          >
+            {[10, 20, 30, 40, 50, 100, 200, 400].map((pageSize) => (
+              <option key={pageSize} value={pageSize}>
+                Show {pageSize}
+              </option>
+            ))}
+          </Select>
+        </>
+      )}
     </Flex>
   );
 };

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -328,6 +328,7 @@ export const apiSlice = createApi({
       query: ({ projectName, id }) => `/api/v1/projects/${projectName}/mirrors/${id}`,
       providesTags: ['Metadata'],
     }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     addNewMirror: builder.mutation<any, MirrorDto>({
       query: (mirror) => ({
         url: `/api/v1/projects/${mirror.projectName}/mirrors`,
@@ -336,6 +337,7 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['Metadata'],
     }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     updateMirror: builder.mutation<any, { projectName: string; id: string; mirror: MirrorDto }>({
       query: ({ projectName, id, mirror }) => ({
         url: `/api/v1/projects/${projectName}/mirrors/${id}`,
@@ -352,6 +354,7 @@ export const apiSlice = createApi({
       query: ({ projectName, id }) => `/api/v1/projects/${projectName}/credentials/${id}`,
       providesTags: ['Metadata'],
     }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     addNewCredential: builder.mutation<any, { projectName: string; credential: CredentialDto }>({
       query: ({ projectName, credential }) => ({
         url: `/api/v1/projects/${projectName}/credentials`,
@@ -360,6 +363,7 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['Metadata'],
     }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     updateCredential: builder.mutation<any, { projectName: string; id: string; credential: CredentialDto }>({
       query: ({ projectName, id, credential }) => ({
         url: `/api/v1/projects/${projectName}/credentials/${id}`,

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -66,7 +66,7 @@ export type GetFileContent = {
   projectName: string;
   repoName: string;
   filePath: string;
-  revision: string;
+  revision: string | number;
 };
 
 export type TitleDto = {

--- a/webapp/src/dogma/features/file/FileDto.ts
+++ b/webapp/src/dogma/features/file/FileDto.ts
@@ -5,5 +5,6 @@ export interface FileDto {
   revision: number;
   type: FileType;
   url: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   content?: string | any;
 }

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -86,7 +86,7 @@ const HistoryList = ({
         header: 'Timestamp',
       }),
     ],
-    [columnHelper, projectName, repoName, filePath],
+    [columnHelper, projectName, repoName, filePath, isDirectory],
   );
 
   return (

--- a/webapp/src/dogma/features/services/ErrorMessageParser.ts
+++ b/webapp/src/dogma/features/services/ErrorMessageParser.ts
@@ -1,5 +1,5 @@
 class ErrorMessageParser {
-  // eslint-disable-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static parse(object: any): string {
     if (object.response && object.response.data.message) {
       return object.response.data.message;

--- a/webapp/src/dogma/util/path-util.ts
+++ b/webapp/src/dogma/util/path-util.ts
@@ -30,11 +30,16 @@ export type UrlAndSegment = {
   url: string;
 };
 
-export function makeTraversalFileLinks(projectName: string, repoName: string, path: string): UrlAndSegment[] {
+export function makeTraversalFileLinks(
+  projectName: string,
+  repoName: string,
+  infix: string,
+  path: string,
+): UrlAndSegment[] {
   const links: UrlAndSegment[] = [];
   const segments = path.split('/');
   for (let i = 1; i < segments.length; i++) {
-    const url = `/app/projects/${projectName}/repos/${repoName}/tree/head/${segments.slice(1, i + 1).join('/')}`;
+    const url = `/app/projects/${projectName}/repos/${repoName}/${infix}/${segments.slice(1, i + 1).join('/')}`;
     links.push({ segment: segments[i], url });
   }
   return links;

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/commit/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/commit/[revision]/[[...path]]/index.tsx
@@ -83,7 +83,7 @@ const CommitViewPage = () => {
     data: oldData,
     isLoading: isOldLoading,
     error: oldError,
-  }: any = useGetFilesQuery(
+  } = useGetFilesQuery(
     {
       projectName,
       repoName,
@@ -114,7 +114,8 @@ const CommitViewPage = () => {
     return <FourOhFour title={`Revision ${revision} does not exist..`} />;
   }
   // 404 Not Found is returned if the file does not exist in the old revision.
-  const oldError0 = oldError && oldError.status != 404 ? oldError : null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const oldError0 = oldError && (oldError as any).status != 404 ? oldError : null;
 
   return (
     <Deferred

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/commits/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/commits/[[...path]]/index.tsx
@@ -51,9 +51,7 @@ const HistoryListPage = () => {
   const pageCount = headPageCount + fromPageCount;
   const pageIndex = headPageCount;
   const pagination = { pageIndex, pageSize };
-  const setPagination: (updater: (old: PaginationState) => PaginationState) => void = (
-    updater: (old: PaginationState) => PaginationState,
-  ) => {
+  function setPagination(updater: (old: PaginationState) => PaginationState): void {
     if (headRevision <= 0) {
       return;
     }
@@ -78,7 +76,7 @@ const HistoryListPage = () => {
       });
       return;
     }
-  };
+  }
 
   const historyFrom = Math.min(fromRevision, headRevision);
   const historyTo = Math.max(baseRevision, 1);
@@ -91,8 +89,8 @@ const HistoryListPage = () => {
       projectName,
       repoName,
       filePath: targetPath,
-      revision: Math.min(fromRevision, headRevision),
-      to: Math.max(baseRevision, 1),
+      revision: historyFrom,
+      to: historyTo,
       maxCommits: historyFrom - historyTo + 1,
     },
     {

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/compare/[revision]/base/[baseRevision]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/compare/[revision]/base/[baseRevision]/index.tsx
@@ -65,7 +65,7 @@ const ChangesViewPage = () => {
     data: oldData,
     isLoading: isOldLoading,
     error: oldError,
-  }: any = useGetFilesQuery({
+  } = useGetFilesQuery({
     projectName,
     repoName,
     revision: baseRevision,

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -1,6 +1,6 @@
 import { InfoIcon } from '@chakra-ui/icons';
 import { Box, Flex, Heading, HStack, Tag, Tooltip } from '@chakra-ui/react';
-import { useGetFileContentQuery, useGetHistoryQuery } from 'dogma/features/api/apiSlice';
+import { useGetFileContentQuery } from 'dogma/features/api/apiSlice';
 import { useRouter } from 'next/router';
 import FileEditor from 'dogma/common/components/editor/FileEditor';
 import { Breadcrumbs } from 'dogma/common/components/Breadcrumbs';
@@ -27,20 +27,8 @@ const FileContentPage = () => {
       refetchOnMountOrArgChange: true,
     },
   );
-  const {
-    data: historyData,
-    isLoading: isHistoryLoading,
-    error: historyError,
-  } = useGetHistoryQuery({
-    projectName,
-    repoName,
-    revision,
-    to: 1,
-    filePath,
-    maxCommits: 1,
-  });
   return (
-    <Deferred isLoading={isLoading || isHistoryLoading} error={error || historyError}>
+    <Deferred isLoading={isLoading} error={error}>
       {() => {
         return (
           <Box p="2">
@@ -72,7 +60,6 @@ const FileContentPage = () => {
               originalContent={data.content}
               path={data.path}
               name={fileName}
-              commitRevision={historyData[0].revision}
             />
           </Box>
         );

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/files/[revision]/[[...path]]/index.tsx
@@ -41,7 +41,7 @@ const FileContentPage = () => {
             <Flex minWidth="max-content" alignItems="center" gap="2" mb={6}>
               <Heading size="lg">
                 <HStack color="teal">
-                  <Box>
+                  <Box marginBottom={-1}>
                     <FileIcon fileName={fileName} />
                   </Box>
                   <Box>{fileName}</Box>
@@ -60,6 +60,7 @@ const FileContentPage = () => {
               originalContent={data.content}
               path={data.path}
               name={fileName}
+              revision={revision}
             />
           </Box>
         );

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
@@ -140,7 +140,7 @@ cat ${project}/${repo}${path}`;
               <Button
                 size={'sm'}
                 as={ChakraLink}
-                href={`/app/projects/${projectName}/repos/${repoName}/commits${filePath}?type=tree`}
+                href={`/app/projects/${projectName}/repos/${repoName}/commits${filePath}?type=tree${revision !== 'head' ? `&from=${revision}` : ''}`}
                 leftIcon={<FaHistory />}
                 variant="outline"
                 colorScheme="gray"

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
@@ -18,14 +18,14 @@ import { GoRepo } from 'react-icons/go';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { WithProjectRole } from 'dogma/features/auth/ProjectRole';
 import { FaHistory } from 'react-icons/fa';
-import { makeTraversalFileLinks } from 'dogma/util/path-util';
+import { makeTraversalFileLinks, toFilePath } from 'dogma/util/path-util';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
   const repoName = router.query.repoName ? (router.query.repoName as string) : '';
   const projectName = router.query.projectName ? (router.query.projectName as string) : '';
   const revision = router.query.revision ? (router.query.revision as string) : 'head';
-  const filePath = router.query.path ? `/${Array.from(router.query.path).join('/')}` : '';
+  const filePath = router.query.path ? toFilePath(router.query.path) : '';
   const directoryPath = router.asPath;
   const dispatch = useAppDispatch();
 
@@ -108,14 +108,16 @@ cat ${project}/${repo}${path}`;
                     <Box color={'teal'} marginRight={2}>
                       <FcOpenedFolder />
                     </Box>
-                    {makeTraversalFileLinks(projectName, repoName, filePath).map(({ segment, url }) => {
-                      return (
-                        <Box key={url}>
-                          {'/'}
-                          <ChakraLink href={url}>{segment}</ChakraLink>
-                        </Box>
-                      );
-                    })}
+                    {makeTraversalFileLinks(projectName, repoName, 'tree/head', filePath).map(
+                      ({ segment, url }) => {
+                        return (
+                          <Box key={url}>
+                            {'/'}
+                            <ChakraLink href={url}>{segment}</ChakraLink>
+                          </Box>
+                        );
+                      },
+                    )}
                   </HStack>
                 ) : (
                   <HStack>
@@ -138,7 +140,7 @@ cat ${project}/${repo}${path}`;
               <Button
                 size={'sm'}
                 as={ChakraLink}
-                href={`/app/projects/${projectName}/repos/${repoName}/commits${filePath}`}
+                href={`/app/projects/${projectName}/repos/${repoName}/commits${filePath}?type=tree`}
                 leftIcon={<FaHistory />}
                 variant="outline"
                 colorScheme="gray"


### PR DESCRIPTION
Motivation:

It could paginate the commit history page but a page index or a page size is not exposed in query parameters. Because these values were managed only as internal states of Javascript, sharing specific history as a URL was impossible.

Modifications:

- Update `Breadcrumbs` to specify query parameters
- Increase the width of `CompareButton`
- Add an option to render a custom component when data is empty in `DynamicDataTable`
- Add an option to hide a go-to button in `PaginationBar`.
- Expose a browse button when if the path is a directory in `HistoryList`
- Refactored `HistoryListPage` to use query parameters to specify revision ranges.
- Use a form tag to submit the revision range with an enter key in `ChangesViewPage`
- Link to a history page instead of a commit page in a `FileEditor`
  - Commits for a specific file must be retrieved sequentially from the `HEAD` revision, the Central Dogma server has a limit of 1000 if `maxCommits` is not specified. This means a commit for a specific file is not indexed and may not be found in the recent 1000 commits.
  - As we can't scan the entire history, it would be better to show the history and guide the user to find a commit rather than failing to find a commit for the file.

Result:

You can now share a specific range of commit history as a URL.