### PR TITLE
Fix regex for validating mirror remoteUrl

### DIFF
--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
@@ -300,7 +300,7 @@ const MirrorForm = ({ projectName, defaultValue, onSubmit, isWaitingResponse }: 
                 type="text"
                 defaultValue={defaultValue.remoteUrl}
                 placeholder="my.git.com/org/myrepo.git"
-                {...register('remoteUrl', { required: true, pattern: /^[\w.-]+(:[0-9]+)?\/[\w.-\/]+.git$/ })}
+                {...register('remoteUrl', { required: true, pattern: /^[\w.-]+(:[0-9]+)?\/[\w.\-\/]+.git$/ })}
               />
               <FieldErrorMessage
                 error={errors.remoteUrl}

--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorForm.tsx
@@ -300,7 +300,7 @@ const MirrorForm = ({ projectName, defaultValue, onSubmit, isWaitingResponse }: 
                 type="text"
                 defaultValue={defaultValue.remoteUrl}
                 placeholder="my.git.com/org/myrepo.git"
-                {...register('remoteUrl', { required: true, pattern: /^[\w.-]+(:[0-9]+)?\/[\w.\-\/]+.git$/ })}
+                {...register('remoteUrl', { required: true, pattern: /^[\w.\-]+(:[0-9]+)?\/[\w.\-\/]+.git$/ })}
               />
               <FieldErrorMessage
                 error={errors.remoteUrl}


### PR DESCRIPTION
Motivation:
The regex for validating mirror remoteUrl is wrong. `[.-\/]` is interpreted as `.` to `/`. However, it should be `[.\-\/]` which allows `.`, `-` and `/` characters.

Modifications:
- Fixed regex for validating mirror remoteUrl

Result:
- You can now correctly setup a mirror url when it contains `-` in its name.