### PR TITLE
Ignore known exceptions from logging

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/HttpApiExceptionHandler.java
@@ -127,14 +127,17 @@ public final class HttpApiExceptionHandler implements ServerErrorHandler {
         final BiFunction<ServiceRequestContext, Throwable, HttpResponse> func =
                 exceptionHandlers.get(peeledCause.getClass());
         if (func != null) {
+            ctx.setShouldReportUnloggedExceptions(false);
             return func.apply(ctx, peeledCause);
         }
 
         if (peeledCause instanceof IllegalArgumentException) {
+            ctx.setShouldReportUnloggedExceptions(false);
             return newResponse(ctx, HttpStatus.BAD_REQUEST, peeledCause);
         }
 
         if (peeledCause instanceof RequestAlreadyTimedOutException) {
+            ctx.setShouldReportUnloggedExceptions(false);
             return newResponse(ctx, HttpStatus.SERVICE_UNAVAILABLE, peeledCause);
         }
 


### PR DESCRIPTION
Motivation:

Central Dogma does not use Armeria's `LoggingClient`, so known exceptions handled by `HttpApiExceptionHandler` are logged in `DefaultUnloggedExceptionsReporter`.

Moditications:

- Set `ctx.setShouldReportUnloggedExceptions(false)` to ignore known exceptions they don't need to be logged.

Result:

You no longer see warnings about ignorable exceptions.