### PR TITLE
Fix code completion for centraldogma.initialization-timeout-millis

### DIFF
--- a/client/java-spring-boot3-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
+++ b/client/java-spring-boot3-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaClientAutoConfiguration.java
@@ -131,7 +131,7 @@ public class CentralDogmaClientAutoConfiguration {
         }
 
         final CentralDogma centralDogma = builder.build();
-        Long initializationTimeoutMillis = settings.initializationTimeoutMillis();
+        Long initializationTimeoutMillis = settings.getInitializationTimeoutMillis();
         if (initializationTimeoutMillis == null) {
             initializationTimeoutMillis = DEFAULT_INITIALIZATION_TIMEOUT_MILLIS;
         }

--- a/client/java-spring-boot3-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
+++ b/client/java-spring-boot3-autoconfigure/src/main/java/com/linecorp/centraldogma/client/spring/CentralDogmaSettings.java
@@ -240,7 +240,7 @@ public class CentralDogmaSettings {
      * @return {@code null} if not specified.
      */
     @Nullable
-    public Long initializationTimeoutMillis() {
+    public Long getInitializationTimeoutMillis() {
         return initializationTimeoutMillis;
     }
 


### PR DESCRIPTION
Motivation:
Address this issue. #1039

Modifications:
- Add "get" prefix to the getter name of initializationTimeoutMillis.

Result:
![Screen Shot 2024-10-02 at 21 06 20](https://github.com/user-attachments/assets/68cee9c8-27e6-47d9-afd5-b51b13961214)

![Screen Shot 2024-10-02 at 21 05 46](https://github.com/user-attachments/assets/90565c30-3754-45a0-9bec-407aa34d122f)