### PR TITLE
Support Aggregating Multiple Kubernetes Clusters into a Single xDS Cluster

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
@@ -47,9 +47,9 @@ import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.xds.group.v1.CreateGroupRequest;
-import com.linecorp.centraldogma.xds.k8s.v1.CreateServiceEndpointWatcherRequest;
-import com.linecorp.centraldogma.xds.k8s.v1.DeleteServiceEndpointWatcherRequest;
-import com.linecorp.centraldogma.xds.k8s.v1.UpdateServiceEndpointWatcherRequest;
+import com.linecorp.centraldogma.xds.k8s.v1.CreateKubernetesEndpointAggregatorRequest;
+import com.linecorp.centraldogma.xds.k8s.v1.DeleteKubernetesEndpointAggregatorRequest;
+import com.linecorp.centraldogma.xds.k8s.v1.UpdateKubernetesEndpointAggregatorRequest;
 
 import io.envoyproxy.envoy.config.cluster.v3.Cluster;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
@@ -74,9 +74,9 @@ public final class XdsResourceManager {
                .register(Cluster.getDefaultInstance())
                .register(ClusterLoadAssignment.getDefaultInstance())
                .register(RouteConfiguration.getDefaultInstance())
-               .register(CreateServiceEndpointWatcherRequest.getDefaultInstance())
-               .register(UpdateServiceEndpointWatcherRequest.getDefaultInstance())
-               .register(DeleteServiceEndpointWatcherRequest.getDefaultInstance());
+               .register(CreateKubernetesEndpointAggregatorRequest.getDefaultInstance())
+               .register(UpdateKubernetesEndpointAggregatorRequest.getDefaultInstance())
+               .register(DeleteKubernetesEndpointAggregatorRequest.getDefaultInstance());
         envoyExtension(builder);
         JSON_MESSAGE_MARSHALLER = builder.build();
     }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
@@ -19,6 +19,7 @@ import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENT
 import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.K8S_ENDPOINTS_DIRECTORY;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
 import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.AGGREGATORS_REPLCACE_PATTERN;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.K8S_ENDPOINT_AGGREGATORS_DIRECTORY;
 import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.K8S_ENDPOINT_AGGREGATORS_NAME_PATTERN;
 import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.createKubernetesEndpointGroup;
 
@@ -111,7 +112,7 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
 
     @Override
     protected String pathPattern() {
-        return XdsKubernetesService.K8S_ENDPOINT_AGGREGATORS_DIRECTORY + "**";
+        return K8S_ENDPOINT_AGGREGATORS_DIRECTORY + "**";
     }
 
     @Override
@@ -257,7 +258,7 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
                     return;
                 }
                 pushK8sEndpoints();
-            }, 1, TimeUnit.SECONDS);
+            }, 3, TimeUnit.SECONDS);
         }
 
         private void pushK8sEndpoints() {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
@@ -59,7 +59,6 @@ import com.linecorp.centraldogma.xds.internal.XdsResourceWatchingService;
 import io.envoyproxy.envoy.config.core.v3.Address;
 import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
-import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Builder;
 import io.envoyproxy.envoy.config.endpoint.v3.Endpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
@@ -250,7 +249,7 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
             if (closing || scheduledFuture != null) {
                 return;
             }
-            // Commit after 1 second so that it pushes with all the fetched endpoints in the duration
+            // Commit after 3 seconds so that it pushes with all the fetched endpoints in the duration
             // instead of pushing one by one.
             scheduledFuture = executorService.schedule(() -> {
                 scheduledFuture = null;
@@ -303,7 +302,7 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
         }
 
         private static void addLocalityLbEndpoints(
-                Builder clusterLoadAssignmentBuilder,
+                ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder,
                 CompletableFuture<KubernetesEndpointGroup> future,
                 KubernetesLocalityLbEndpoints kubernetesLocalityLbEndpoints) {
             if (!future.isDone()) {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesService.java
@@ -21,6 +21,7 @@ import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN_STRING;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.removePrefix;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -61,11 +62,14 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
 
     private static final Logger logger = LoggerFactory.getLogger(XdsKubernetesService.class);
 
-    static final String K8S_WATCHERS_DIRECTORY = "/k8s/watchers/";
-    public static final Pattern WATCHERS_REPLCACE_PATTERN = Pattern.compile("(?<=/k8s)/watchers/");
+    static final String K8S_ENDPOINT_AGGREGATORS_DIRECTORY = "/k8s/endpointAggregators/";
+    public static final Pattern AGGREGATORS_REPLCACE_PATTERN =
+            Pattern.compile("(?<=/k8s)/endpointAggregators/");
 
-    public static final Pattern WATCHER_NAME_PATTERN = Pattern.compile(
-            "^groups/([^/]+)" + K8S_WATCHERS_DIRECTORY + '(' + RESOURCE_ID_PATTERN_STRING + ")$");
+    public static final Pattern K8S_ENDPOINT_AGGREGATORS_NAME_PATTERN = Pattern.compile(
+            "^groups/([^/]+)" + K8S_ENDPOINT_AGGREGATORS_DIRECTORY + '(' + RESOURCE_ID_PATTERN_STRING + ")$");
+
+    public static final CompletableFuture<?>[] EMPTY_FUTURES = new CompletableFuture[0];
 
     private final XdsResourceManager xdsResourceManager;
 
@@ -78,81 +82,103 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
 
     @Blocking
     @Override
-    public void createServiceEndpointWatcher(CreateServiceEndpointWatcherRequest request,
-                                             StreamObserver<ServiceEndpointWatcher> responseObserver) {
+    public void createKubernetesEndpointAggregator(
+            CreateKubernetesEndpointAggregatorRequest request,
+            StreamObserver<KubernetesEndpointAggregator> responseObserver) {
         final String parent = request.getParent();
         final String group = removePrefix("groups/", parent);
         xdsResourceManager.checkGroup(group);
-        final String watcherId = request.getWatcherId();
-        if (!RESOURCE_ID_PATTERN.matcher(watcherId).matches()) {
-            throw Status.INVALID_ARGUMENT.withDescription("Invalid watcher_id: " + watcherId +
+        final String aggregatorId = request.getAggregatorId();
+        if (!RESOURCE_ID_PATTERN.matcher(aggregatorId).matches()) {
+            throw Status.INVALID_ARGUMENT.withDescription("Invalid aggregator_id: " + aggregatorId +
                                                           " (expected: " + RESOURCE_ID_PATTERN + ')')
                                          .asRuntimeException();
         }
 
-        final String watcherName = parent + K8S_WATCHERS_DIRECTORY + watcherId;
-        final String clusterName = parent + "/k8s/clusters/" + watcherId;
-        final ServiceEndpointWatcher watcher = request.getWatcher().toBuilder()
-                                                      .setName(watcherName)
-                                                      .setClusterName(clusterName)
-                                                      .build();
+        final String kubernetesEndpointName = parent + K8S_ENDPOINT_AGGREGATORS_DIRECTORY + aggregatorId;
+        final String clusterName = parent + "/k8s/clusters/" + aggregatorId;
+        final KubernetesEndpointAggregator aggregator = request.getKubernetesEndpointAggregator().toBuilder()
+                                                               .setName(kubernetesEndpointName)
+                                                               .setClusterName(clusterName)
+                                                               .build();
         final Author author = currentAuthor();
-        validateWatcherAndPush(responseObserver, watcher, () -> xdsResourceManager.push(
-                responseObserver, group, watcherName, K8S_WATCHERS_DIRECTORY + watcherId + ".json",
-                "Create watcher: " + watcherName, watcher, author, true));
+        validateKubernetesEndpointAndPush(responseObserver, aggregator, () -> xdsResourceManager.push(
+                responseObserver, group, kubernetesEndpointName,
+                K8S_ENDPOINT_AGGREGATORS_DIRECTORY + aggregatorId + ".json",
+                "Create kubernetes endpoint: " + kubernetesEndpointName, aggregator, author, true));
     }
 
-    private void validateWatcherAndPush(
-            StreamObserver<ServiceEndpointWatcher> responseObserver,
-            ServiceEndpointWatcher watcher, Runnable onSuccess) {
+    private void validateKubernetesEndpointAndPush(
+            StreamObserver<KubernetesEndpointAggregator> responseObserver,
+            KubernetesEndpointAggregator aggregator, Runnable onSuccess) {
         // Create a KubernetesEndpointGroup to check if the watcher is valid.
         // We use KubernetesEndpointGroup for simplicity, but we will implement a custom implementation
         // for better debugging and error handling in the future.
         final ContextAwareBlockingTaskExecutor taskExecutor =
                 ServiceRequestContext.current().blockingTaskExecutor();
-        final CompletableFuture<KubernetesEndpointGroup> future =
-                createKubernetesEndpointGroup(watcher, xdsResourceManager.xdsProject().metaRepo(),
-                                              taskExecutor);
-        future.handle((kubernetesEndpointGroup, cause) -> {
-            if (cause != null) {
-                cause = Exceptions.peel(cause);
-                if (cause instanceof IllegalArgumentException || cause instanceof EntryNotFoundException) {
-                    responseObserver.onError(Status.INVALID_ARGUMENT.withCause(cause).asRuntimeException());
-                } else {
-                    responseObserver.onError(Status.INTERNAL.withCause(cause).asRuntimeException());
-                }
-                return null;
-            }
-            final AtomicBoolean completed = new AtomicBoolean();
-            final CompletableFuture<List<Endpoint>> whenReady = kubernetesEndpointGroup.whenReady();
 
-            // Use a schedule to time out the watcher creation until we implement a custom implementation.
-            final ScheduledFuture<?> scheduledFuture = taskExecutor.schedule(() -> {
-                if (!completed.compareAndSet(false, true)) {
-                    return;
-                }
-                kubernetesEndpointGroup.closeAsync();
-                responseObserver.onError(
-                        Status.INTERNAL.withDescription(
-                                "Failed to retrieve k8s endpoints within 5 seconds. watcherName: " +
-                                watcher.getName()).asRuntimeException());
-            }, 5, TimeUnit.SECONDS);
+        final ArrayList<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (KubernetesLocalityLbEndpoints kubernetesLocalityLbEndpoints
+                : aggregator.getLocalityLbEndpointsList()) {
+            final CompletableFuture<Void> future = new CompletableFuture<>();
+            futures.add(future);
 
-            whenReady.handle((endpoints, cause1) -> {
-                if (!completed.compareAndSet(false, true)) {
+            final ServiceEndpointWatcher watcher = kubernetesLocalityLbEndpoints.getWatcher();
+            final CompletableFuture<KubernetesEndpointGroup> endpointGroupFuture =
+                    createKubernetesEndpointGroup(watcher, xdsResourceManager.xdsProject().metaRepo(),
+                                                  taskExecutor);
+            endpointGroupFuture.handle((kubernetesEndpointGroup, cause) -> {
+                if (cause != null) {
+                    cause = Exceptions.peel(cause);
+                    if (cause instanceof IllegalArgumentException || cause instanceof EntryNotFoundException) {
+                        future.completeExceptionally(
+                                Status.INVALID_ARGUMENT.withCause(cause).asRuntimeException());
+                    } else {
+                        future.completeExceptionally(Status.INTERNAL.withCause(cause).asRuntimeException());
+                    }
                     return null;
                 }
-                scheduledFuture.cancel(false);
-                kubernetesEndpointGroup.closeAsync();
-                if (cause1 != null) {
-                    // Specific types.
-                    responseObserver.onError(Status.INTERNAL.withCause(cause1).asRuntimeException());
+                final AtomicBoolean completed = new AtomicBoolean();
+                final CompletableFuture<List<Endpoint>> whenReady = kubernetesEndpointGroup.whenReady();
+                // Use a schedule to time out the watcher creation until we implement a custom implementation.
+                final ScheduledFuture<?> scheduledFuture = taskExecutor.schedule(() -> {
+                    if (!completed.compareAndSet(false, true)) {
+                        return;
+                    }
+                    kubernetesEndpointGroup.closeAsync();
+                    future.completeExceptionally(
+                            Status.INTERNAL.withDescription(
+                                    "Failed to retrieve k8s endpoints within 5 seconds. watcher: " +
+                                    watcher).asRuntimeException());
+                }, 5, TimeUnit.SECONDS);
+
+                whenReady.handle((endpoints, cause1) -> {
+                    if (!completed.compareAndSet(false, true)) {
+                        return null;
+                    }
+                    scheduledFuture.cancel(false);
+                    kubernetesEndpointGroup.closeAsync();
+                    if (cause1 != null) {
+                        // Specific types.
+                        responseObserver.onError(Status.INTERNAL.withCause(cause1).asRuntimeException());
+                        return null;
+                    }
+                    logger.debug("Successfully retrieved k8s endpoints: {}, watcher: {}", endpoints, watcher);
+                    future.complete(null);
                     return null;
-                }
-                logger.debug("Successfully retrieved k8s endpoints: {}", endpoints);
-                onSuccess.run();
+                });
                 return null;
             });
+        }
+
+        final CompletableFuture<Void> allOfFuture =
+                CompletableFuture.allOf(futures.toArray(EMPTY_FUTURES));
+        allOfFuture.handle((unused, cause) -> {
+            if (cause != null) {
+                responseObserver.onError(cause);
+            } else {
+                onSuccess.run();
+            }
             return null;
         });
     }
@@ -164,14 +190,14 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
      */
     public static CompletableFuture<KubernetesEndpointGroup> createKubernetesEndpointGroup(
             ServiceEndpointWatcher watcher, MetaRepository metaRepository, Executor executor) {
-        final KubernetesConfig kubernetesConfig = watcher.getKubernetesConfig();
+        final Kubeconfig kubeconfig = watcher.getKubeconfig();
         final String serviceName = watcher.getServiceName();
 
-        return toConfig(kubernetesConfig, metaRepository).thenApplyAsync(config -> {
+        return toConfig(kubeconfig, metaRepository).thenApplyAsync(config -> {
             final KubernetesEndpointGroupBuilder kubernetesEndpointGroupBuilder =
                     KubernetesEndpointGroup.builder(config).serviceName(serviceName);
-            if (!isNullOrEmpty(kubernetesConfig.getNamespace())) {
-                kubernetesEndpointGroupBuilder.namespace(kubernetesConfig.getNamespace());
+            if (!isNullOrEmpty(kubeconfig.getNamespace())) {
+                kubernetesEndpointGroupBuilder.namespace(kubeconfig.getNamespace());
             }
             if (!isNullOrEmpty(watcher.getPortName())) {
                 kubernetesEndpointGroupBuilder.portName(watcher.getPortName());
@@ -182,13 +208,12 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
         }, executor);
     }
 
-    private static CompletableFuture<Config> toConfig(KubernetesConfig kubernetesConfig,
-                                                      MetaRepository metaRepository) {
+    private static CompletableFuture<Config> toConfig(Kubeconfig kubeconfig, MetaRepository metaRepository) {
         final ConfigBuilder configBuilder = new ConfigBuilder()
-                .withMasterUrl(kubernetesConfig.getControlPlaneUrl())
-                .withTrustCerts(kubernetesConfig.getTrustCerts());
+                .withMasterUrl(kubeconfig.getControlPlaneUrl())
+                .withTrustCerts(kubeconfig.getTrustCerts());
 
-        final String credentialId = kubernetesConfig.getCredentialId();
+        final String credentialId = kubeconfig.getCredentialId();
         if (isNullOrEmpty(credentialId)) {
             return CompletableFuture.completedFuture(configBuilder.build());
         }
@@ -207,38 +232,42 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
 
     @Blocking
     @Override
-    public void updateServiceEndpointWatcher(UpdateServiceEndpointWatcherRequest request,
-                                             StreamObserver<ServiceEndpointWatcher> responseObserver) {
-        final ServiceEndpointWatcher watcher = request.getWatcher();
-        final String watcherName = watcher.getName();
-        final String group = checkWatcherName(watcherName).group(1);
+    public void updateKubernetesEndpointAggregator(
+            UpdateKubernetesEndpointAggregatorRequest request,
+            StreamObserver<KubernetesEndpointAggregator> responseObserver) {
+        final KubernetesEndpointAggregator aggregator = request.getKubernetesEndpointAggregator();
+        final String aggregatorName = aggregator.getName();
+        final String group = checkAggregatorName(aggregatorName).group(1);
         xdsResourceManager.checkGroup(group);
 
         // Update the cluster name just in case it's mistakenly set by the user.
-        final ServiceEndpointWatcher watcher0 = watcher.toBuilder().setClusterName(
-                WATCHERS_REPLCACE_PATTERN.matcher(watcherName).replaceFirst("/clusters/")).build();
+        final KubernetesEndpointAggregator aggregator0 = aggregator.toBuilder().setClusterName(
+                AGGREGATORS_REPLCACE_PATTERN.matcher(aggregatorName).replaceFirst("/clusters/")).build();
         final Author author = currentAuthor();
-        validateWatcherAndPush(responseObserver, watcher0, () -> xdsResourceManager.update(
-                responseObserver, group, watcherName, "Update watcher: " + watcherName, watcher0, author));
+        validateKubernetesEndpointAndPush(responseObserver, aggregator0, () -> xdsResourceManager.update(
+                responseObserver, group, aggregatorName,
+                "Update kubernetes endpoint aggregator: " + aggregatorName, aggregator0, author));
     }
 
-    private static Matcher checkWatcherName(String watcherName) {
-        final Matcher matcher = WATCHER_NAME_PATTERN.matcher(watcherName);
+    private static Matcher checkAggregatorName(String aggregatorName) {
+        final Matcher matcher = K8S_ENDPOINT_AGGREGATORS_NAME_PATTERN.matcher(aggregatorName);
         if (!matcher.matches()) {
-            throw Status.INVALID_ARGUMENT.withDescription("Invalid watcher name: " + watcherName +
-                                                          " (expected: " + WATCHER_NAME_PATTERN + ')')
+            throw Status.INVALID_ARGUMENT.withDescription(
+                                "Invalid kubernetes endpoint aggregator name: " + aggregatorName +
+                                " (expected: " + K8S_ENDPOINT_AGGREGATORS_NAME_PATTERN + ')')
                                          .asRuntimeException();
         }
         return matcher;
     }
 
     @Override
-    public void deleteServiceEndpointWatcher(DeleteServiceEndpointWatcherRequest request,
-                                             StreamObserver<Empty> responseObserver) {
-        final String watcherName = request.getName();
-        final String group = checkWatcherName(watcherName).group(1);
+    public void deleteKubernetesEndpointAggregator(DeleteKubernetesEndpointAggregatorRequest request,
+                                                   StreamObserver<Empty> responseObserver) {
+        final String aggregatorName = request.getName();
+        final String group = checkAggregatorName(aggregatorName).group(1);
         xdsResourceManager.checkGroup(group);
-        xdsResourceManager.delete(responseObserver, group, watcherName, "Delete watcher: " + watcherName,
+        xdsResourceManager.delete(responseObserver, group, aggregatorName,
+                                  "Delete kubernetes endpoint aggregator: " + aggregatorName,
                                   currentAuthor());
     }
 }

--- a/xds/src/main/proto/centraldogma/xds/k8s/v1/xds_kubernetes.proto
+++ b/xds/src/main/proto/centraldogma/xds/k8s/v1/xds_kubernetes.proto
@@ -19,46 +19,82 @@ option java_multiple_files = true;
 option java_outer_classname = "XdsKubernetesProto";
 option java_package = "com.linecorp.centraldogma.xds.k8s.v1";
 
+import "envoy/config/core/v3/base.proto";
+import "envoy/config/endpoint/v3/endpoint.proto";
+
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 
 service XdsKubernetesService {
 
-  rpc CreateServiceEndpointWatcher(CreateServiceEndpointWatcherRequest) returns (ServiceEndpointWatcher) {
+  rpc CreateKubernetesEndpointAggregator(CreateKubernetesEndpointAggregatorRequest)
+      returns (KubernetesEndpointAggregator) {
     option (google.api.http) = {
-      post: "/api/v1/xds/{parent=groups/*}/k8s/watchers"
-      body: "watcher"
+      post: "/api/v1/xds/{parent=groups/*}/k8s/endpointAggregators"
+      body: "kubernetes_endpoint_aggregator"
     };
-    option (google.api.method_signature) = "project,watcher";
+    option (google.api.method_signature) = "project,kubernetes_endpoint_aggregator";
   }
 
-  rpc UpdateServiceEndpointWatcher(UpdateServiceEndpointWatcherRequest) returns (ServiceEndpointWatcher) {
+  rpc UpdateKubernetesEndpointAggregator(UpdateKubernetesEndpointAggregatorRequest)
+      returns (KubernetesEndpointAggregator) {
     option (google.api.http) = {
-      patch: "/api/v1/xds/{watcher.name=groups/*/k8s/watchers/**}"
-      body: "watcher"
+      patch: "/api/v1/xds/{kubernetes_endpoint.name=groups/*/k8s/endpointAggregators/**}"
+      body: "kubernetes_endpoint_aggregator"
     };
   }
 
-  rpc DeleteServiceEndpointWatcher(DeleteServiceEndpointWatcherRequest) returns (google.protobuf.Empty) {
+  rpc DeleteKubernetesEndpointAggregator(DeleteKubernetesEndpointAggregatorRequest)
+      returns (google.protobuf.Empty) {
     option (google.api.http) = {
-      delete: "/api/v1/xds/{name=groups/*/k8s/watchers/**}"
+      delete: "/api/v1/xds/{name=groups/*/k8s/endpointAggregators/**}"
     };
   }
 }
 
-message CreateServiceEndpointWatcherRequest {
-  // The parent resource where this watcher will be created.
+message CreateKubernetesEndpointAggregatorRequest {
+  // The parent resource where this kubernetes endpoint will be created.
   // Format: groups/{group}
   string parent = 1 [(google.api.field_behavior) = REQUIRED];
   // Valid pattern is "^[a-z]([a-z0-9-/]*[a-z0-9])?$"
-  string watcher_id = 2 [(google.api.field_behavior) = REQUIRED];
-  ServiceEndpointWatcher watcher = 3 [(google.api.field_behavior) = REQUIRED];
+  string aggregator_id = 2 [(google.api.field_behavior) = REQUIRED];
+  KubernetesEndpointAggregator kubernetes_endpoint_aggregator = 3 [(google.api.field_behavior) = REQUIRED];
 }
 
-message UpdateServiceEndpointWatcherRequest {
+message KubernetesEndpointAggregator {
+  // Format: groups/{group}/k8s/endpointAggregators/{endpoint}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  string cluster_name = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  envoy.config.endpoint.v3.ClusterLoadAssignment.Policy policy = 3 [(google.api.field_behavior) = OPTIONAL];
+  repeated KubernetesLocalityLbEndpoints locality_lb_endpoints = 4 [(google.api.field_behavior) = REQUIRED];
+}
+
+message KubernetesLocalityLbEndpoints {
   ServiceEndpointWatcher watcher = 1 [(google.api.field_behavior) = REQUIRED];
+  envoy.config.core.v3.Locality locality = 2 [(google.api.field_behavior) = OPTIONAL];
+  int32 priority = 3 [(google.api.field_behavior) = OPTIONAL];
+  google.protobuf.UInt32Value load_balancing_weight = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+message ServiceEndpointWatcher {
+  string service_name = 1 [(google.api.field_behavior) = REQUIRED];
+  string port_name = 2 [(google.api.field_behavior) = OPTIONAL];
+  Kubeconfig kubeconfig = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+message Kubeconfig {
+  string control_plane_url = 1 [(google.api.field_behavior) = REQUIRED];
+  string namespace = 2 [(google.api.field_behavior) = OPTIONAL];
+  string credential_id = 3 [(google.api.field_behavior) = OPTIONAL];
+  bool trust_certs = 4 [(google.api.field_behavior) = OPTIONAL];
+}
+
+message UpdateKubernetesEndpointAggregatorRequest {
+  // The kubernetes_endpoint_aggregator's `name` field is used to identify the endpoint to update.
+  KubernetesEndpointAggregator kubernetes_endpoint_aggregator = 1 [(google.api.field_behavior) = REQUIRED];
 
   // TODO(minwoox): Implement these fields
   // google.protobuf.FieldMask update_mask = 2;
@@ -66,23 +102,6 @@ message UpdateServiceEndpointWatcherRequest {
   // bool allow_missing = 3;
 }
 
-message DeleteServiceEndpointWatcherRequest {
+message DeleteKubernetesEndpointAggregatorRequest {
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-}
-
-message KubernetesConfig {
-  string control_plane_url = 1 [(google.api.field_behavior) = REQUIRED];
-  string namespace = 2 [(google.api.field_behavior) = OPTIONAL];
-  string credential_id = 3 [(google.api.field_behavior) = OPTIONAL];
-  bool trust_certs = 4 [(google.api.field_behavior) = OPTIONAL];
-}
-
-message ServiceEndpointWatcher {
-  // The resource name of the watcher.
-  // Format: groups/{group}/k8s/watchers/{watcher}_id
-  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-  string cluster_name = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-  string service_name = 3 [(google.api.field_behavior) = REQUIRED];
-  string port_name = 4 [(google.api.field_behavior) = OPTIONAL];
-  KubernetesConfig kubernetes_config = 5 [(google.api.field_behavior) = REQUIRED];
 }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointServiceTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointServiceTest.java
@@ -97,7 +97,7 @@ public class XdsEndpointServiceTest {
 
     public static void checkEndpointsViaDiscoveryRequest(
             URI uri, @Nullable ClusterLoadAssignment actualEndpoint, String resourceName) {
-        await().pollInterval(100, TimeUnit.MILLISECONDS).untilAsserted(
+        await().pollInterval(300, TimeUnit.MILLISECONDS).untilAsserted(
                 () -> checkEndpointsViaDiscoveryRequest0(uri, actualEndpoint, resourceName));
     }
 

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/AggregatingMultipleKubernetesTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/AggregatingMultipleKubernetesTest.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.k8s.v1;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
+import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.K8S_ENDPOINTS_DIRECTORY;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.K8S_ENDPOINT_AGGREGATORS_DIRECTORY;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.assertAggregator;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.assertOk;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.createAggregator;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.newDeployment;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.newNode;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.newPod;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.newService;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.updateAggregator;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.UInt32Value;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+@EnableKubernetesMockClient(crud = true)
+class AggregatingMultipleKubernetesTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    static KubernetesClient client;
+
+    @BeforeAll
+    static void setup() {
+        final AggregatedHttpResponse response = createGroup("foo", dogma.httpClient());
+        assertThat(response.status()).isSameAs(HttpStatus.OK);
+
+        // Prepare Kubernetes resources
+        final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"));
+        final Map<String, String> selector = ImmutableMap.of("app1", "nginx1");
+        final Deployment deployment = newDeployment("deployment1", selector);
+        final Service service = newService("service1", selector);
+        createResources(nodes, deployment, service);
+
+        final List<Node> nodes2 = ImmutableList.of(newNode("3.3.3.3"), newNode("4.4.4.4"));
+        final Map<String, String> selector2 = ImmutableMap.of("app2", "nginx2");
+        final Deployment deployment2 = newDeployment("deployment2", selector2);
+        final Service service2 = newService("service2", selector2);
+        createResources(nodes2, deployment2, service2);
+    }
+
+    private static void createResources(List<Node> nodes, Deployment deployment, Service service) {
+        final List<Pod> pods = nodes.stream()
+                                    .map(node -> node.getMetadata().getName())
+                                    .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
+                                    .collect(toImmutableList());
+
+        // Create Kubernetes resources
+        for (Node node : nodes) {
+            client.nodes().resource(node).create();
+        }
+        client.pods().resource(pods.get(0)).create();
+        client.pods().resource(pods.get(1)).create();
+        client.apps().deployments().resource(deployment).create();
+        client.services().resource(service).create();
+    }
+
+    @Test
+    void aggregateMultipleKubernetes() throws IOException {
+        final String aggregatorId = "foo-k8s-cluster/1";
+        final String clusterName = "groups/foo/k8s/clusters/" + aggregatorId;
+        final KubernetesEndpointAggregator aggregator = aggregator(aggregatorId);
+        final AggregatedHttpResponse response = createAggregator(aggregator, aggregatorId, dogma.httpClient());
+        assertOk(response);
+        final String json = response.contentUtf8();
+        final KubernetesEndpointAggregator expectedAggregator =
+                aggregator.toBuilder().setClusterName(clusterName) // cluster name is set by the service.
+                          .build();
+        assertAggregator(json, expectedAggregator);
+
+        final Repository fooGroup = dogma.projectManager().get(XDS_CENTRAL_DOGMA_PROJECT).repos().get("foo");
+        final Entry<JsonNode> aggregatorEntry =
+                fooGroup.get(Revision.HEAD, Query.ofJson(
+                        K8S_ENDPOINT_AGGREGATORS_DIRECTORY + aggregatorId + ".json")).join();
+        assertAggregator(aggregatorEntry.contentAsText(), expectedAggregator);
+        System.err.println("aggregatorEntry.revision(): " + aggregatorEntry.revision());
+
+        await().until(() -> fooGroup.normalizeNow(Revision.HEAD).equals(aggregatorEntry.revision().forward(1)));
+
+        final Entry<JsonNode> endpointEntry = fooGroup.getOrNull(Revision.HEAD, Query.ofJson(
+                K8S_ENDPOINTS_DIRECTORY + aggregatorId + ".json")).join();
+        System.err.println("endpointEntry.revision(): " + endpointEntry.revision());
+        assertThatJson(endpointEntry.content()).isEqualTo(
+                '{' +
+                "  \"clusterName\": \"groups/foo/k8s/clusters/foo-k8s-cluster/1\"," +
+                "  \"endpoints\": [ {" +
+                "    \"locality\": {" +
+                "      \"zone\": \"zone1\"" +
+                "    }," +
+                "    \"lbEndpoints\": [ {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"1.1.1.1\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    }, {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"2.2.2.2\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    } ]" +
+                "  }, {" +
+                "    \"locality\": {" +
+                "      \"zone\": \"zone2\"" +
+                "    }," +
+                "    \"lbEndpoints\": [ {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"3.3.3.3\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    }, {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"4.4.4.4\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    } ]," +
+                "    \"loadBalancingWeight\": 10," +
+                "    \"priority\": 1" +
+                "  } ]" +
+                '}'
+        );
+        // Remove service2
+        final KubernetesEndpointAggregator aggregator1 =
+                aggregator.toBuilder().removeLocalityLbEndpoints(1).build();
+        final AggregatedHttpResponse response1 =
+                updateAggregator(aggregator1, aggregatorId, dogma.httpClient());
+        assertOk(response1);
+        await().until(() -> fooGroup.normalizeNow(Revision.HEAD).equals(
+                endpointEntry.revision().forward(2))); // 2 because of the aggregator update and endpoint update
+        final Entry<JsonNode> endpointEntry1 = fooGroup.getOrNull(Revision.HEAD, Query.ofJson(
+                K8S_ENDPOINTS_DIRECTORY + aggregatorId + ".json")).join();
+        System.err.println("endpointEntry.revision(): " + endpointEntry1.revision());
+        assertThatJson(endpointEntry1.content()).isEqualTo(
+                '{' +
+                "  \"clusterName\": \"groups/foo/k8s/clusters/foo-k8s-cluster/1\"," +
+                "  \"endpoints\": [ {" +
+                "    \"locality\": {" +
+                "      \"zone\": \"zone1\"" +
+                "    }," +
+                "    \"lbEndpoints\": [ {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"1.1.1.1\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    }, {" +
+                "      \"endpoint\": {" +
+                "        \"address\": {" +
+                "          \"socketAddress\": {" +
+                "            \"address\": \"2.2.2.2\"," +
+                "            \"portValue\": 30000" +
+                "          }" +
+                "        }" +
+                "      }" +
+                "    } ]" +
+                "  }]" +
+                '}'
+        );
+    }
+
+    private static KubernetesEndpointAggregator aggregator(String aggregatorId) {
+        final Kubeconfig kubeconfig = Kubeconfig.newBuilder()
+                                                .setControlPlaneUrl(client.getMasterUrl().toString())
+                                                .setNamespace(client.getNamespace())
+                                                .setTrustCerts(true)
+                                                .build();
+        final ServiceEndpointWatcher watcher = ServiceEndpointWatcher.newBuilder()
+                                                                     .setServiceName("service1")
+                                                                     .setKubeconfig(kubeconfig)
+                                                                     .build();
+        final ServiceEndpointWatcher watcher2 = ServiceEndpointWatcher.newBuilder()
+                                                                      .setServiceName("service2")
+                                                                      .setKubeconfig(kubeconfig)
+                                                                      .build();
+        return KubernetesEndpointAggregator
+                .newBuilder()
+                .setName("groups/foo/k8s/endpointAggregators/" + aggregatorId)
+                .addLocalityLbEndpoints(KubernetesLocalityLbEndpoints.newBuilder()
+                                                                     .setWatcher(watcher)
+                                                                     .setLocality(Locality.newBuilder()
+                                                                                          .setZone("zone1")
+                                                                                          .build())
+                                                                     .build())
+                .addLocalityLbEndpoints(KubernetesLocalityLbEndpoints.newBuilder()
+                                                                     .setWatcher(watcher2)
+                                                                     .setLocality(Locality.newBuilder()
+                                                                                          .setZone("zone2")
+                                                                                          .build())
+                                                                     .setLoadBalancingWeight(UInt32Value.of(10))
+                                                                     .setPriority(1)
+                                                                     .build())
+                .build();
+    }
+}

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/AggregatingMultipleKubernetesTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/AggregatingMultipleKubernetesTest.java
@@ -50,7 +50,6 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesServiceTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesServiceTest.java
@@ -218,6 +218,7 @@ class XdsKubernetesServiceTest {
         dispatcher.queue().forEach(req -> {
             // All requests contain the credential.
             assertThat(req.getHeaders().get(HttpHeaderNames.AUTHORIZATION.toString()))
+                    .describedAs("Request: %s does not contain the credential", req)
                     .isEqualTo("Bearer secret");
         });
     }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesServiceTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesServiceTest.java
@@ -21,7 +21,7 @@ import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENT
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
 import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
 import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.endpoint;
-import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.K8S_WATCHERS_DIRECTORY;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesService.K8S_ENDPOINT_AGGREGATORS_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
@@ -113,8 +113,9 @@ class XdsKubernetesServiceTest {
         final AggregatedHttpResponse response = createGroup("foo", dogma.httpClient());
         assertThat(response.status()).isSameAs(HttpStatus.OK);
         final List<Node> nodes = ImmutableList.of(newNode("1.1.1.1"), newNode("2.2.2.2"));
-        final Deployment deployment = newDeployment();
-        final Service service = newService();
+        final Map<String, String> selector = ImmutableMap.of("app", "nginx");
+        final Deployment deployment = newDeployment("nginx-deployment", selector);
+        final Service service = newService("nginx-service", selector);
         final List<Pod> pods = nodes.stream()
                                     .map(node -> node.getMetadata().getName())
                                     .map(nodeName -> newPod(deployment.getSpec().getTemplate(), nodeName))
@@ -170,33 +171,36 @@ class XdsKubernetesServiceTest {
 
     @Test
     void invalidProperty() throws IOException {
-        final String watcherId = "foo-cluster";
-        ServiceEndpointWatcher watcher = watcher(watcherId, "invalid-service-name", "my-credential");
-        AggregatedHttpResponse response = createWatcher(watcher, watcherId);
+        final String aggregatorId = "foo-cluster";
+        KubernetesEndpointAggregator aggregator =
+                aggregator(aggregatorId, "invalid-service-name", "my-credential");
+        AggregatedHttpResponse response = createAggregator(aggregator, aggregatorId);
         assertThat(response.status()).isSameAs(HttpStatus.INTERNAL_SERVER_ERROR);
         assertThat(response.contentUtf8()).contains("Failed to retrieve k8s endpoints");
 
-        watcher = watcher(watcherId, "nginx-service", "invalid-credential-id");
-        response = createWatcher(watcher, watcherId);
+        aggregator = aggregator(aggregatorId, "nginx-service", "invalid-credential-id");
+        response = createAggregator(aggregator, aggregatorId);
         assertThat(response.status()).isSameAs(HttpStatus.BAD_REQUEST);
         assertThat(response.contentUtf8()).contains("failed to find credential 'invalid-credential-id'");
     }
 
     @Test
-    void createWatcherRequest() throws IOException {
-        final String watcherId = "foo-k8s-cluster/1";
-        final String clusterName = "groups/foo/k8s/clusters/" + watcherId;
-        final ServiceEndpointWatcher watcher = watcher(watcherId);
-        final AggregatedHttpResponse response = createWatcher(watcher, watcherId);
+    void createEndpointAggregatorsRequest() throws IOException {
+        final String aggregatorId = "foo-k8s-cluster/1";
+        final String clusterName = "groups/foo/k8s/clusters/" + aggregatorId;
+        final KubernetesEndpointAggregator aggregator = aggregator(aggregatorId);
+        final AggregatedHttpResponse response = createAggregator(aggregator, aggregatorId);
         assertOk(response);
         final String json = response.contentUtf8();
-        final ServiceEndpointWatcher expectedWatcher =
-                watcher.toBuilder().setClusterName(clusterName).build(); // cluster name is set by the service.
-        assertWatcher(json, expectedWatcher);
+        final KubernetesEndpointAggregator expectedAggregator =
+                aggregator.toBuilder().setClusterName(clusterName) // cluster name is set by the service.
+                          .build();
+        assertAggregator(json, expectedAggregator);
         final Repository fooGroup = dogma.projectManager().get(XDS_CENTRAL_DOGMA_PROJECT).repos().get("foo");
         final Entry<JsonNode> entry =
-                fooGroup.get(Revision.HEAD, Query.ofJson(K8S_WATCHERS_DIRECTORY + watcherId + ".json")).join();
-        assertWatcher(entry.contentAsText(), expectedWatcher);
+                fooGroup.get(Revision.HEAD, Query.ofJson(
+                        K8S_ENDPOINT_AGGREGATORS_DIRECTORY + aggregatorId + ".json")).join();
+        assertAggregator(entry.contentAsText(), expectedAggregator);
         final ClusterLoadAssignment loadAssignment = clusterLoadAssignment(clusterName, 30000);
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), loadAssignment, clusterName);
 
@@ -205,7 +209,7 @@ class XdsKubernetesServiceTest {
         // so that endpoints are not updated one by one.
         final Entry<JsonNode> clusterEntry =
                 fooGroup.get(entry.revision().forward(1),
-                             Query.ofJson("/k8s/endpoints/" + watcherId + ".json"))
+                             Query.ofJson("/k8s/endpoints/" + aggregatorId + ".json"))
                         .join();
         final ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder = ClusterLoadAssignment.newBuilder();
         JSON_MESSAGE_MARSHALLER.mergeValue(clusterEntry.contentAsText(), clusterLoadAssignmentBuilder);
@@ -218,47 +222,59 @@ class XdsKubernetesServiceTest {
         });
     }
 
-    private static ServiceEndpointWatcher watcher(String watcherId) {
-        return watcher(watcherId, "nginx-service", "my-credential");
+    private static KubernetesEndpointAggregator aggregator(String aggregatorId) {
+        return aggregator(aggregatorId, "nginx-service", "my-credential");
     }
 
-    private static ServiceEndpointWatcher watcher(String watcherId, String serviceName, String credentialId) {
-        final KubernetesConfig kubernetesConfig =
-                KubernetesConfig.newBuilder()
-                                .setControlPlaneUrl(client.getMasterUrl().toString())
-                                .setNamespace(client.getNamespace())
-                                .setCredentialId(credentialId)
-                                .setTrustCerts(true)
-                                .build();
-        return ServiceEndpointWatcher.newBuilder()
-                                     .setName("groups/foo/k8s/watchers/" + watcherId)
-                                     .setServiceName(serviceName)
-                                     .setKubernetesConfig(kubernetesConfig)
-                                     .build();
+    private static KubernetesEndpointAggregator aggregator(
+            String aggregatorId, String serviceName, String credentialId) {
+        final Kubeconfig kubeconfig = Kubeconfig.newBuilder()
+                                                .setControlPlaneUrl(client.getMasterUrl().toString())
+                                                .setNamespace(client.getNamespace())
+                                                .setCredentialId(credentialId)
+                                                .setTrustCerts(true)
+                                                .build();
+        final ServiceEndpointWatcher watcher = ServiceEndpointWatcher.newBuilder()
+                                                                     .setServiceName(serviceName)
+                                                                     .setKubeconfig(kubeconfig)
+                                                                     .build();
+        return KubernetesEndpointAggregator
+                .newBuilder().setName("groups/foo/k8s/endpointAggregators/" + aggregatorId)
+                .addLocalityLbEndpoints(KubernetesLocalityLbEndpoints.newBuilder()
+                                                                     .setWatcher(watcher)
+                                                                     .build())
+                .build();
     }
 
-    private static AggregatedHttpResponse createWatcher(
-            ServiceEndpointWatcher watcher, String watcherId) throws IOException {
+    private static AggregatedHttpResponse createAggregator(
+            KubernetesEndpointAggregator aggregator, String aggregatorId) throws IOException {
+        return createAggregator(aggregator, aggregatorId, dogma.httpClient());
+    }
+
+    static AggregatedHttpResponse createAggregator(
+            KubernetesEndpointAggregator aggregator, String aggregatorId,
+            WebClient webClient) throws IOException {
         final RequestHeaders headers =
                 RequestHeaders.builder(HttpMethod.POST,
-                                       "/api/v1/xds/groups/foo/k8s/watchers?watcher_id=" + watcherId)
+                                       "/api/v1/xds/groups/foo/k8s/endpointAggregators?" +
+                                       "aggregator_id=" + aggregatorId)
                               .contentType(MediaType.JSON_UTF_8)
                               .set(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
                               .build();
 
-        return dogma.httpClient().blocking().execute(
-                headers, JSON_MESSAGE_MARSHALLER.writeValueAsString(watcher));
+        return webClient.blocking().execute(headers, JSON_MESSAGE_MARSHALLER.writeValueAsString(aggregator));
     }
 
-    private static void assertOk(AggregatedHttpResponse response) {
+    static void assertOk(AggregatedHttpResponse response) {
         assertThat(response.status()).isSameAs(HttpStatus.OK);
         assertThat(response.headers().get("grpc-status")).isEqualTo("0");
     }
 
-    private static void assertWatcher(String json, ServiceEndpointWatcher expected) throws IOException {
-        final ServiceEndpointWatcher.Builder responseWatcherBuilder = ServiceEndpointWatcher.newBuilder();
-        JSON_MESSAGE_MARSHALLER.mergeValue(json, responseWatcherBuilder);
-        assertThat(responseWatcherBuilder.build()).isEqualTo(expected);
+    static void assertAggregator(
+            String json, KubernetesEndpointAggregator expected) throws IOException {
+        final KubernetesEndpointAggregator.Builder responseBuilder = KubernetesEndpointAggregator.newBuilder();
+        JSON_MESSAGE_MARSHALLER.mergeValue(json, responseBuilder);
+        assertThat(responseBuilder.build()).isEqualTo(expected);
     }
 
     private static ClusterLoadAssignment clusterLoadAssignment(String clusterName, int port) {
@@ -273,55 +289,62 @@ class XdsKubernetesServiceTest {
     }
 
     @Test
-    void updateWatcher() throws IOException {
-        final String watcherId = "foo-k8s-cluster/2";
-        final ServiceEndpointWatcher watcher = watcher(watcherId);
-        AggregatedHttpResponse response = createWatcher(watcher, watcherId);
+    void updateAggregator() throws IOException {
+        final String aggregatorId = "foo-k8s-cluster/2";
+        final KubernetesEndpointAggregator aggregator = aggregator(aggregatorId);
+        AggregatedHttpResponse response = createAggregator(aggregator, aggregatorId);
         assertOk(response);
-        final String clusterName = "groups/foo/k8s/clusters/" + watcherId;
+        final String clusterName = "groups/foo/k8s/clusters/" + aggregatorId;
         final ClusterLoadAssignment loadAssignment = clusterLoadAssignment(clusterName, 30000);
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), loadAssignment, clusterName);
 
-        final ServiceEndpointWatcher updatingWatcher = watcher.toBuilder().setPortName("https").build();
-        response = updateWatcher(updatingWatcher, watcherId, dogma.httpClient());
+        final KubernetesLocalityLbEndpoints localityLbEndpoints = aggregator.getLocalityLbEndpoints(0);
+        final ServiceEndpointWatcher updatedWatcher =
+                localityLbEndpoints.getWatcher().toBuilder().setPortName("https").build();
+        final KubernetesLocalityLbEndpoints updatedLbEndpoints =
+                localityLbEndpoints.toBuilder().setWatcher(updatedWatcher).build();
+        final KubernetesEndpointAggregator updatingAggregator =
+                aggregator.toBuilder().setLocalityLbEndpoints(0, updatedLbEndpoints).build();
+        response = updateAggregator(updatingAggregator, aggregatorId, dogma.httpClient());
 
         assertOk(response);
-        assertWatcher(response.contentUtf8(),
-                      // cluster name is set by the service.
-                      updatingWatcher.toBuilder().setClusterName(clusterName).build());
+        assertAggregator(response.contentUtf8(),
+                         // cluster name is set by the service.
+                         updatingAggregator.toBuilder().setClusterName(clusterName).build());
         final ClusterLoadAssignment loadAssignment2 = clusterLoadAssignment(clusterName, 30001);
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), loadAssignment2, clusterName);
     }
 
-    public static AggregatedHttpResponse updateWatcher(
-            ServiceEndpointWatcher watcher, String watcherId, WebClient webClient) throws IOException {
+    static AggregatedHttpResponse updateAggregator(
+            KubernetesEndpointAggregator aggregator,
+            String aggregatorId, WebClient webClient) throws IOException {
         final RequestHeaders headers =
                 RequestHeaders.builder(HttpMethod.PATCH,
-                                       "/api/v1/xds/groups/foo/k8s/watchers/" + watcherId)
+                                       "/api/v1/xds/groups/foo/k8s/endpointAggregators/" + aggregatorId)
                               .set(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
                               .contentType(MediaType.JSON_UTF_8).build();
-        return webClient.execute(headers, JSON_MESSAGE_MARSHALLER.writeValueAsString(watcher))
+        return webClient.execute(headers, JSON_MESSAGE_MARSHALLER.writeValueAsString(aggregator))
                         .aggregate().join();
     }
 
     @Test
-    void deleteWatcher() throws IOException {
-        final String watcherId = "foo-k8s-cluster/3";
-        final ServiceEndpointWatcher watcher = watcher(watcherId);
-        AggregatedHttpResponse response = createWatcher(watcher, watcherId);
+    void deleteAggregator() throws IOException {
+        final String aggregatorId = "foo-k8s-cluster/3";
+        final KubernetesEndpointAggregator aggregator = aggregator(aggregatorId);
+        AggregatedHttpResponse response = createAggregator(aggregator, aggregatorId);
         assertOk(response);
-        final String clusterName = "groups/foo/k8s/clusters/" + watcherId;
+        final String clusterName = "groups/foo/k8s/clusters/" + aggregatorId;
         final ClusterLoadAssignment loadAssignment = clusterLoadAssignment(clusterName, 30000);
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), loadAssignment, clusterName);
-        response = deleteWatcher(watcher.getName());
+        response = deleteAggregator(aggregator.getName());
         assertOk(response);
         assertThat(response.contentUtf8()).isEqualTo("{}");
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), null, clusterName);
     }
 
-    private static AggregatedHttpResponse deleteWatcher(String watcherName) {
+    private static AggregatedHttpResponse deleteAggregator(String aggregatorName) {
         final RequestHeaders headers =
-                RequestHeaders.builder(HttpMethod.DELETE, "/api/v1/xds/" + watcherName)
+                RequestHeaders.builder(HttpMethod.DELETE, "/api/v1/xds/" + aggregatorName)
                               .set(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
                               .build();
         return dogma.httpClient().execute(headers).aggregate().join();
@@ -348,9 +371,9 @@ class XdsKubernetesServiceTest {
                 .build();
     }
 
-    static Service newService() {
+    static Service newService(String serviceName, Map<String, String> selector) {
         final ObjectMeta metadata = new ObjectMetaBuilder()
-                .withName("nginx-service")
+                .withName(serviceName)
                 .build();
         final ServicePort servicePort = new ServicePortBuilder()
                 .withPort(80)
@@ -363,7 +386,7 @@ class XdsKubernetesServiceTest {
                 .build();
         final ServiceSpec serviceSpec = new ServiceSpecBuilder()
                 .withPorts(servicePort, httpsServicePort)
-                .withSelector(ImmutableMap.of("app", "nginx"))
+                .withSelector(selector)
                 .withType("NodePort")
                 .build();
         return new ServiceBuilder()
@@ -372,17 +395,17 @@ class XdsKubernetesServiceTest {
                 .build();
     }
 
-    static Deployment newDeployment() {
+    static Deployment newDeployment(String deploymentName, Map<String, String> matchLabels) {
         final ObjectMeta metadata = new ObjectMetaBuilder()
-                .withName("nginx-deployment")
+                .withName(deploymentName)
                 .build();
         final LabelSelector selector = new LabelSelectorBuilder()
-                .withMatchLabels(ImmutableMap.of("app", "nginx"))
+                .withMatchLabels(matchLabels)
                 .build();
         final DeploymentSpec deploymentSpec = new DeploymentSpecBuilder()
                 .withReplicas(4)
                 .withSelector(selector)
-                .withTemplate(newPodTemplate())
+                .withTemplate(newPodTemplate(matchLabels))
                 .build();
         return new DeploymentBuilder()
                 .withMetadata(metadata)
@@ -390,9 +413,9 @@ class XdsKubernetesServiceTest {
                 .build();
     }
 
-    private static PodTemplateSpec newPodTemplate() {
+    private static PodTemplateSpec newPodTemplate(Map<String, String> matchLabels) {
         final ObjectMeta metadata = new ObjectMetaBuilder()
-                .withLabels(ImmutableMap.of("app", "nginx"))
+                .withLabels(matchLabels)
                 .build();
         final Container container = new ContainerBuilder()
                 .withName("nginx")


### PR DESCRIPTION
Motivation:
The current `XdsKubernetesService` does not allow combining multiple Kubernetes clusters into a single xDS cluster.

Modifications:
- Introduced `KubernetesEndpointAggregator` to support aggregation of multiple Kubernetes clusters into one xDS cluster.
  - The fields in `KubernetesEndpointAggregator` are similar to `ClusterLoadAssignment`, with the addition of `ServiceEndpointWatcher` to retrieve Kubernetes information from multiple clusters.

Result:
- xDS now supports the aggregation of multiple Kubernetes clusters.