### PR TITLE
Fix `:dist:copyLib` Task not to copy duplicate libraries

### DIFF
--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -79,7 +79,6 @@ task copyLib(group: 'Build',
         if (jgits.size() != 1 || !jgits.first().name.startsWith("org.eclipse.jgit-6")) {
             throw new IllegalStateException("Unexpected JGit JARs: $jgits.files")
         }
-
     }
 }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -23,20 +23,19 @@ apply plugin: 'com.bmuschko.docker-remote-api'
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.google.common.base.CaseFormat
 
-evaluationDependsOn(':server')
-evaluationDependsOn(':server-auth:saml')
-evaluationDependsOn(':server-auth:shiro')
-evaluationDependsOn(':server-mirror-git')
-evaluationDependsOn(':xds')
-
 ext {
     distDir = "${project.buildDir}/dist"
     relativeDistDir = distDir.substring("${rootProject.projectDir}/".length())
     cliDownloadDir = "${gradle.gradleUserHomeDir}/caches/centraldogma-go/cli"
 }
 
-
 dependencies {
+    implementation project(':server')
+    implementation project(':server-auth:saml')
+    implementation project(':server-auth:shiro')
+    implementation project(':server-mirror-git')
+    implementation project(':xds')
+
     // Logging
     runtimeOnly libs.logback12
     runtimeOnly libs.slf4j1.jcl.over.slf4j
@@ -64,26 +63,7 @@ task copyLib(group: 'Build',
              dependsOn: project(':server').tasks.jar,
              type: Copy) {
 
-    from project(':server').configurations.runtimeClasspath {
-        exclude group: 'org.eclipse.jgit'
-    }
-    from project(':server').tasks.jar
-    from project.configurations.runtimeClasspath
-    from project(':server-auth:saml').configurations.runtimeClasspath {
-        exclude group: 'org.eclipse.jgit'
-    }
-    from project(':server-auth:saml').tasks.jar
-    from project(':server-auth:shiro').configurations.runtimeClasspath {
-        exclude group: 'org.eclipse.jgit'
-    }
-    from project(':server-auth:shiro').tasks.jar
-    from project(':server-mirror-git').configurations.runtimeClasspath
-    from project(':server-mirror-git').tasks.jar
-    from project(':xds').configurations.runtimeClasspath {
-        exclude group: 'org.eclipse.jgit'
-    }
-    from project(':xds').tasks.jar
-
+    from configurations.runtimeClasspath
     File libDir = new File("${project.ext.distDir}/lib")
     into libDir
 
@@ -99,6 +79,7 @@ task copyLib(group: 'Build',
         if (jgits.size() != 1 || !jgits.first().name.startsWith("org.eclipse.jgit-6")) {
             throw new IllegalStateException("Unexpected JGit JARs: $jgits.files")
         }
+
     }
 }
 

--- a/server-auth/saml/build.gradle
+++ b/server-auth/saml/build.gradle
@@ -5,4 +5,6 @@ dependencies {
     }
 
     implementation libs.bouncycastle.bcprov
+    // Declare explicitly to resolve the version conflict.
+    implementation libs.logback12
 }

--- a/server-auth/shiro/build.gradle
+++ b/server-auth/shiro/build.gradle
@@ -9,5 +9,4 @@ dependencies {
 
     // Shiro
     implementation libs.shiro.core
-
 }

--- a/server-auth/shiro/build.gradle
+++ b/server-auth/shiro/build.gradle
@@ -4,6 +4,10 @@ dependencies {
     // Caffeine
     implementation libs.caffeine
 
+    // Declare explicitly to resolve the version conflict.
+    implementation libs.logback12
+
     // Shiro
     implementation libs.shiro.core
+
 }

--- a/server-mirror-git/build.gradle
+++ b/server-mirror-git/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation libs.bouncycastle.bcprov
     implementation libs.eddsa
     implementation libs.jgit6
+    // Declare explicitly to resolve the version conflict.
+    implementation libs.logback12
     implementation libs.mina.sshd.core
     implementation libs.mina.sshd.git
 

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -8,6 +8,8 @@ dependencies {
     implementation libs.controlplane.api
     implementation libs.controlplane.cache
     implementation libs.controlplane.server
+    // Declare explicitly to resolve the version conflict.
+    implementation libs.logback12
     implementation libs.reflections
 
     testImplementation libs.armeria.junit5


### PR DESCRIPTION
Motivation:
The `:dist:copyLib` task currently copies dependencies into the lib directory from multiple modules. Since each module resolves dependencies independently, it can result in duplicate libraries with differing versions.

Modifications:
- Updated the task to use the dependencies section for centralized dependency resolution.
  - @ikhoon suggested this. 😉 

Result:
- The libraries in the lib directory are now deduplicated.