### PR TITLE
Fix a bug where `Created by me` filter fails to render

### DIFF
--- a/webapp/src/dogma/features/project/Projects.tsx
+++ b/webapp/src/dogma/features/project/Projects.tsx
@@ -56,7 +56,7 @@ function filterProjects(projects: ProjectDto[], projectFilterType: ProjectFilter
     case 'MEMBER':
       return projects.filter((p) => p.userRole === 'MEMBER' || p.userRole === 'OWNER');
     case 'CREATOR':
-      return projects.filter((p) => p.creator.email === user.email);
+      return projects.filter((p) => p.creator?.email === user.email);
   }
 }
 


### PR DESCRIPTION
Motivation:

If a project is removed, `ProjectDto.creator` is null. `TypeError: Cannot read properties of undefined (reading 'email')` will be raised for the removed project.

Modifications:

- Use null-safe operator (?) to access `projectDto.creator.email`

Result:

`Created by me` filter correctly excludes removed projects.