### PR TITLE
Enable `respect_dns_ttl` by default for xDS cluster

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/cluster/v1/XdsClusterService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/cluster/v1/XdsClusterService.java
@@ -64,10 +64,20 @@ public final class XdsClusterService extends XdsClusterServiceImplBase {
         }
 
         final String clusterName = parent + CLUSTERS_DIRECTORY + clusterId;
-        // Ignore the specified name in the cluster and set the name
-        // with the format of "groups/{group}/clusters/{cluster}".
-        // https://github.com/aip-dev/google.aip.dev/blob/master/aip/general/0133.md#user-specified-ids
-        final Cluster cluster = request.getCluster().toBuilder().setName(clusterName).build();
+        final Cluster cluster
+                = request.getCluster()
+                         .toBuilder()
+                         // Ignore the specified name in the cluster and set the name with the format of
+                         // "groups/{group}/clusters/{cluster}".
+                         // https://github.com/aip-dev/google.aip.dev/blob/master/aip/general/0133.md#user-specified-ids
+                         .setName(clusterName)
+                         // Respect the DNS TTL would be more efficient in terms of DNS resolution.
+                         // https://github.com/envoyproxy/envoy/issues/6876
+                         // `respect_dns_ttl` is a `bool` field so it is not possible to check whether a value
+                         // has not been set for the field. Until we create our own proto file, the value only
+                         // can be set to false via the update API.
+                         .setRespectDnsTtl(true)
+                         .build();
         xdsResourceManager.push(responseObserver, group, clusterName, CLUSTERS_DIRECTORY + clusterId + ".json",
                                 "Create cluster: " + clusterName, cluster, currentAuthor(), true);
     }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/cluster/v1/XdsClusterServiceTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/cluster/v1/XdsClusterServiceTest.java
@@ -81,7 +81,10 @@ class XdsClusterServiceTest {
         JSON_MESSAGE_MARSHALLER.mergeValue(response.contentUtf8(), clusterBuilder);
         final Cluster actualCluster = clusterBuilder.build();
         final String clusterName = "groups/foo/clusters/foo-cluster/1";
-        assertThat(actualCluster).isEqualTo(cluster.toBuilder().setName(clusterName).build());
+        assertThat(actualCluster).isEqualTo(cluster.toBuilder()
+                                                   .setName(clusterName)
+                                                   .setRespectDnsTtl(true)
+                                                   .build());
         checkResourceViaDiscoveryRequest(actualCluster, clusterName, true);
 
         // Create the same cluster again.
@@ -149,11 +152,18 @@ class XdsClusterServiceTest {
         JSON_MESSAGE_MARSHALLER.mergeValue(response.contentUtf8(), clusterBuilder);
         final Cluster actualCluster = clusterBuilder.build();
         final String clusterName = "groups/foo/clusters/foo-cluster/2";
-        assertThat(actualCluster).isEqualTo(cluster.toBuilder().setName(clusterName).build());
+        assertThat(actualCluster).isEqualTo(cluster.toBuilder()
+                                                   .setName(clusterName)
+                                                   .setRespectDnsTtl(true)
+                                                   .build());
         checkResourceViaDiscoveryRequest(actualCluster, clusterName, true);
 
-        final Cluster updatingCluster = cluster.toBuilder().setConnectTimeout(
-                Duration.newBuilder().setSeconds(2).build()).setName(clusterName).build();
+        final Cluster updatingCluster = cluster.toBuilder()
+                                               .setConnectTimeout(
+                                                       Duration.newBuilder().setSeconds(2).build())
+                                               .setName(clusterName)
+                                               .setRespectDnsTtl(false)
+                                               .build();
         response = updateCluster("groups/foo", "foo-cluster/2", updatingCluster, dogma.httpClient());
         assertOk(response);
         final Cluster.Builder clusterBuilder2 = Cluster.newBuilder();
@@ -177,7 +187,10 @@ class XdsClusterServiceTest {
         response = createCluster("groups/foo", "foo-cluster/3/4", cluster, dogma.httpClient());
         assertOk(response);
 
-        final Cluster actualCluster = cluster.toBuilder().setName(clusterName).build();
+        final Cluster actualCluster = cluster.toBuilder()
+                                             .setName(clusterName)
+                                             .setRespectDnsTtl(true)
+                                             .build();
         checkResourceViaDiscoveryRequest(actualCluster, clusterName, true);
 
         // Add permission test.
@@ -204,7 +217,10 @@ class XdsClusterServiceTest {
                                                                     .setClusterId("foo-cluster/5/6")
                                                                     .setCluster(cluster).build());
         final String clusterName = "groups/foo/clusters/foo-cluster/5/6";
-        assertThat(response).isEqualTo(cluster.toBuilder().setName(clusterName).build());
+        assertThat(response).isEqualTo(cluster.toBuilder()
+                                              .setName(clusterName)
+                                              .setRespectDnsTtl(true)
+                                              .build());
 
         final Cluster updatingCluster = cluster.toBuilder().setConnectTimeout(
                 Duration.newBuilder().setSeconds(2).build()).setName(clusterName).build();

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/XdsTestUtil.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/XdsTestUtil.java
@@ -202,6 +202,7 @@ public final class XdsTestUtil {
                                                       .setEdsConfig(configSource)
                                                       .setServiceName(clusterName))
                       .setType(Cluster.DiscoveryType.EDS)
+                      .setRespectDnsTtl(true)
                       .build();
     }
 


### PR DESCRIPTION
Motivation:

Envoy refreshes DNS every 5 seconds regardless of DNS TTL. The frequent refresh consumes additional CPU and memory resources and may put a heavy load on DNS servers.

`respect_dns_ttl` is an option to let Envoy use the TTL of DNS respones. https://github.com/envoyproxy/envoy/issues/6876
Respecting DNS TTL seems more sensible behavior for Armeria xDS modules.

Modifications:

- Set `respect_dns_ttl` to true when creating an xDS cluster.
  - Due to the limation of protobuf, `respect_dns_ttl` in a request is ignored but the value still can be modified via xDS update API.

Result:

`respect_dns_ttl` is now enabled by default for xDS cluster.