### PR TITLE
Prepare Token Updates for #1054 Compatibility

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -67,7 +67,7 @@ class SerializationTest {
         final Member member = new Member(userLogin, ProjectRole.MEMBER, newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.ofDefault());
-        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null, null);
+        final Token token = new Token("testApp", "testSecret", false, false, newCreationTag(), null, null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),
@@ -141,7 +141,7 @@ class SerializationTest {
                                          newCreationTag());
         final RepositoryMetadata repositoryMetadata = new RepositoryMetadata("sample", newCreationTag(),
                                                                              PerRolePermissions.ofDefault());
-        final Token token = new Token("testApp", "testSecret", false, newCreationTag(), null, null);
+        final Token token = new Token("testApp", "testSecret", false, false, newCreationTag(), null, null);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
                                     ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/TokenTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/TokenTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.metadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.linecorp.centraldogma.internal.Jackson;
+
+class TokenTest {
+
+    private static final String APP_ID = "foo-id";
+    private static final String APP_SECRET = "appToken-foo";
+
+    @Test
+    void deserializeToken() throws Exception {
+        final String legacyTokenJson = tokenJson(true);
+        final Token legacyToken = Jackson.readValue(legacyTokenJson, Token.class);
+        assertThat(legacyToken.appId()).isEqualTo(APP_ID);
+        assertThat(legacyToken.isAdmin()).isTrue();
+
+        final String tokenJson = tokenJson(false);
+        final Token token = Jackson.readValue(tokenJson, Token.class);
+        assertThat(token.appId()).isEqualTo(APP_ID);
+        assertThat(token.isAdmin()).isTrue();
+    }
+
+    private static String tokenJson(boolean legacy) {
+        return "{\"appId\": \"" + APP_ID + "\"," +
+               "  \"secret\": \"" + APP_SECRET + "\"," +
+               (legacy ? "  \"admin\": true," : " \"systemAdmin\": true,") +
+               "  \"creation\": {" +
+               "    \"user\": \"foo@foo.com\"," +
+               "    \"timestamp\": \"2018-04-10T09:58:20.032Z\"" +
+               "}}";
+    }
+}


### PR DESCRIPTION
Motivation
To ensure smooth compatibility with #1054, the `Token` structure needs an update to support changes in `admin` property.

Modifications:
- Enhanced the Token deserializer to accept both `admin` and `systemAdmin` properties, ensuring backward compatibility.
- Updated `MetadataService.updateTokenLevel()` to avoid direct access to the `admin` property.

Result:
- The `Token` structure now supports the upcoming changes, allowing seamless updates with #1054.