### PR TITLE
Provide a way to listen to the events of mirroring

### DIFF
--- a/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
+++ b/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it.mirror.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import java.net.URI;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.parser.CronParser;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.credential.Credential;
+import com.linecorp.centraldogma.server.internal.mirror.AbstractMirror;
+import com.linecorp.centraldogma.server.internal.mirror.MirrorSchedulingService;
+import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorDirection;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirrorStatus;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+class CustomMirrorListenerTest {
+
+    private static final Cron EVERY_SECOND = new CronParser(
+            CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ)).parse("* * * * * ?");
+
+    @TempDir
+    static File temporaryFolder;
+
+    @BeforeEach
+    void setUp() {
+        TestMirrorListener.reset();
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestMirrorListener.reset();
+    }
+
+    @Test
+    void shouldNotifyMirrorEvents() {
+        final AtomicInteger taskCounter = new AtomicInteger();
+        final ProjectManager pm = mock(ProjectManager.class);
+        final Project p = mock(Project.class);
+        final MetaRepository mr = mock(MetaRepository.class);
+        final Repository r = mock(Repository.class);
+        when(pm.list()).thenReturn(ImmutableMap.of("foo", p));
+        when(p.name()).thenReturn("foo");
+        when(p.metaRepo()).thenReturn(mr);
+        when(r.parent()).thenReturn(p);
+        when(r.name()).thenReturn("bar");
+
+        final Mirror mirror = new AbstractMirror("my-mirror-1", true, EVERY_SECOND,
+                                                 MirrorDirection.REMOTE_TO_LOCAL,
+                                                 Credential.FALLBACK, r, "/",
+                                                 URI.create("unused://uri"), "/", "", null) {
+            @Override
+            protected MirrorResult mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes,
+                                                       Instant triggeredTime) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            protected MirrorResult mirrorRemoteToLocal(File workDir, CommandExecutor executor,
+                                                       int maxNumFiles, long maxNumBytes, Instant triggeredTime)
+                    throws Exception {
+                final int counter = taskCounter.incrementAndGet();
+                if (counter == 1) {
+                    return newMirrorResult(MirrorStatus.SUCCESS, "1", Instant.now());
+                } else if (counter == 2) {
+                    return newMirrorResult(MirrorStatus.UP_TO_DATE, "2", Instant.now());
+                } else {
+                    throw new IllegalStateException("failed");
+                }
+            }
+        };
+
+        when(mr.mirrors()).thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mirror)));
+
+        final MirrorSchedulingService service = new MirrorSchedulingService(
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1);
+        final CommandExecutor executor = mock(CommandExecutor.class);
+        service.start(executor);
+
+        try {
+            await().until(() -> taskCounter.get() >= 3);
+        } finally {
+            service.stop();
+        }
+        final Integer startCount = TestMirrorListener.startCount.get(mirror);
+        assertThat(startCount).isGreaterThanOrEqualTo(3);
+
+        final List<MirrorResult> completions = TestMirrorListener.completions.get(mirror);
+        assertThat(completions).hasSize(2);
+        assertThat(completions.get(0).mirrorStatus()).isEqualTo(MirrorStatus.SUCCESS);
+        assertThat(completions.get(1).mirrorStatus()).isEqualTo(MirrorStatus.UP_TO_DATE);
+
+        final List<Throwable> errors = TestMirrorListener.errors.get(mirror);
+        assertThat(errors).hasSizeGreaterThanOrEqualTo(1);
+        assertThat(errors.get(0).getCause())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("failed");
+    }
+}

--- a/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/TestMirrorListener.java
+++ b/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/TestMirrorListener.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it.mirror.listener;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorListener;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+
+public final class TestMirrorListener implements MirrorListener {
+
+    static final Map<Mirror, Integer> startCount = new ConcurrentHashMap<>();
+    static final Map<Mirror, List<MirrorResult>> completions = new ConcurrentHashMap<>();
+    static final Map<Mirror, List<Throwable>> errors = new ConcurrentHashMap<>();
+
+    static void reset() {
+        startCount.clear();
+        completions.clear();
+        errors.clear();
+    }
+
+    @Override
+    public void onStart(Mirror mirror) {
+        startCount.merge(mirror, 1, Integer::sum);
+    }
+
+    @Override
+    public void onComplete(Mirror mirror, MirrorResult result) {
+        final ArrayList<MirrorResult> results = new ArrayList<>();
+        results.add(result);
+        completions.merge(mirror, results, (oldValue, newValue) -> {
+            oldValue.addAll(newValue);
+            return oldValue;
+        });
+    }
+
+    @Override
+    public void onError(Mirror mirror, Throwable cause) {
+        //noinspection ArraysAsListWithZeroOrOneArgument
+        errors.merge(mirror, Arrays.asList(cause), (oldValue, newValue) -> {
+            oldValue.addAll(newValue);
+            return oldValue;
+        });
+    }
+}

--- a/it/mirror-listener/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
+++ b/it/mirror-listener/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
@@ -1,0 +1,1 @@
+com.linecorp.centraldogma.it.mirror.listener.TestMirrorListener

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
@@ -22,6 +22,7 @@ import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUti
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -90,6 +91,7 @@ class MirrorRunnerTest {
                                .auth(AuthToken.ofOAuth2(adminToken))
                                .build()
                                .blocking();
+        TestMirrorRunnerListener.reset();
     }
 
     @Test
@@ -134,6 +136,14 @@ class MirrorRunnerTest {
                         .contains("Repository 'foo/bar' already at");
             }
         }
+
+        final String listenerKey = FOO_PROJ + '/' + TEST_MIRROR_ID + '/' + USERNAME;
+        assertThat(TestMirrorRunnerListener.startCount.get(listenerKey)).isEqualTo(3);
+        final List<MirrorResult> results = TestMirrorRunnerListener.completions.get(listenerKey);
+        final MirrorResult firstResult = results.get(0);
+        assertThat(firstResult.mirrorStatus()).isEqualTo(MirrorStatus.SUCCESS);
+        assertThat(results.get(1).mirrorStatus()).isEqualTo(MirrorStatus.UP_TO_DATE);
+        assertThat(results.get(2).mirrorStatus()).isEqualTo(MirrorStatus.UP_TO_DATE);
     }
 
     private static MirrorDto newMirror() {

--- a/it/mirror/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
+++ b/it/mirror/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
@@ -1,0 +1,1 @@
+com.linecorp.centraldogma.it.mirror.git.TestMirrorRunnerListener

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
@@ -42,6 +42,7 @@ import com.linecorp.centraldogma.server.internal.api.auth.RequiresReadPermission
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresWritePermission;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorRunner;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager;
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -142,9 +143,9 @@ public class MirroringServiceV1 extends AbstractService {
     // Mirroring may be a long-running task, so we need to increase the timeout.
     @RequestTimeout(value = 5, unit = TimeUnit.MINUTES)
     @Post("/projects/{projectName}/mirrors/{mirrorId}/run")
-    public CompletableFuture<MirrorResult> runMirror(@Param String projectName, @Param String mirrorId)
-            throws Exception {
-        return mirrorRunner.run(projectName, mirrorId);
+    public CompletableFuture<MirrorResult> runMirror(@Param String projectName, @Param String mirrorId,
+                                                     User user) throws Exception {
+        return mirrorRunner.run(projectName, mirrorId, user);
     }
 
     private static MirrorDto convertToMirrorDto(String projectName, Mirror mirror) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -176,8 +176,7 @@ public abstract class AbstractMirror implements Mirror {
 
     @Override
     public final MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles,
-                                     long maxNumBytes) {
-        final Instant triggeredTime = Instant.now();
+                                     long maxNumBytes, Instant triggeredTime) {
         try {
             switch (direction()) {
                 case LOCAL_TO_REMOTE:
@@ -213,7 +212,7 @@ public abstract class AbstractMirror implements Mirror {
     protected final MirrorResult newMirrorResult(MirrorStatus mirrorStatus, @Nullable String description,
                                                  Instant triggeredTime) {
         return new MirrorResult(id, localRepo.parent().name(), localRepo.name(), mirrorStatus, description,
-                                triggeredTime);
+                                triggeredTime, Instant.now());
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
@@ -21,9 +21,9 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirrorTask;
 
 final class CompositeMirrorListener implements MirrorListener {
 
@@ -36,10 +36,10 @@ final class CompositeMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onStart(Mirror mirror) {
+    public void onStart(MirrorTask mirrorTask) {
         for (MirrorListener delegate : delegates) {
             try {
-                delegate.onStart(mirror);
+                delegate.onStart(mirrorTask);
             } catch (Exception e) {
                 logger.warn("Failed to notify a listener of the mirror start event: {}", delegate, e);
             }
@@ -47,10 +47,10 @@ final class CompositeMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onComplete(Mirror mirror, MirrorResult result) {
+    public void onComplete(MirrorTask mirrorTask, MirrorResult result) {
         for (MirrorListener delegate : delegates) {
             try {
-                delegate.onComplete(mirror, result);
+                delegate.onComplete(mirrorTask, result);
             } catch (Exception e) {
                 logger.warn("Failed to notify a listener of the mirror complete event: {}", delegate, e);
             }
@@ -58,10 +58,10 @@ final class CompositeMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onError(Mirror mirror, Throwable cause) {
+    public void onError(MirrorTask mirrorTask, Throwable cause) {
         for (MirrorListener delegate : delegates) {
             try {
-                delegate.onError(mirror, cause);
+                delegate.onError(mirrorTask, cause);
             } catch (Exception e) {
                 logger.warn("Failed to notify a listener of the mirror error event: {}", delegate, e);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorListener;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+
+final class CompositeMirrorListener implements MirrorListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(CompositeMirrorListener.class);
+
+    private final List<MirrorListener> delegates;
+
+    CompositeMirrorListener(List<MirrorListener> delegates) {
+        this.delegates = delegates;
+    }
+
+    @Override
+    public void onStart(Mirror mirror) {
+        for (MirrorListener delegate : delegates) {
+            try {
+                delegate.onStart(mirror);
+            } catch (Exception e) {
+                logger.warn("Failed to notify a listener of the mirror start event: {}", delegate, e);
+            }
+        }
+    }
+
+    @Override
+    public void onComplete(Mirror mirror, MirrorResult result) {
+        for (MirrorListener delegate : delegates) {
+            try {
+                delegate.onComplete(mirror, result);
+            } catch (Exception e) {
+                logger.warn("Failed to notify a listener of the mirror complete event: {}", delegate, e);
+            }
+        }
+    }
+
+    @Override
+    public void onError(Mirror mirror, Throwable cause) {
+        for (MirrorListener delegate : delegates) {
+            try {
+                delegate.onError(mirror, cause);
+            } catch (Exception e) {
+                logger.warn("Failed to notify a listener of the mirror error event: {}", delegate, e);
+            }
+        }
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
@@ -19,9 +19,9 @@ package com.linecorp.centraldogma.server.internal.mirror;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirrorTask;
 
 enum DefaultMirrorListener implements MirrorListener {
 
@@ -30,17 +30,21 @@ enum DefaultMirrorListener implements MirrorListener {
     private static final Logger logger = LoggerFactory.getLogger(DefaultMirrorListener.class);
 
     @Override
-    public void onStart(Mirror mirror) {
-        logger.info("Mirroring: {}", mirror);
+    public void onStart(MirrorTask mirrorTask) {
+        if (mirrorTask.scheduled()) {
+            logger.info("Mirroring: {}", mirrorTask);
+        }
     }
 
     @Override
-    public void onComplete(Mirror mirror, MirrorResult result) {
+    public void onComplete(MirrorTask mirrorTask, MirrorResult result) {
         // Do nothing
     }
 
     @Override
-    public void onError(Mirror mirror, Throwable cause) {
-        logger.warn("Unexpected exception while mirroring: {}", mirror, cause);
+    public void onError(MirrorTask mirrorTask, Throwable cause) {
+        if (mirrorTask.scheduled()) {
+            logger.warn("Unexpected exception while mirroring: {}", mirrorTask, cause);
+        }
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.mirror;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorListener;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+
+enum DefaultMirrorListener implements MirrorListener {
+
+    INSTANCE;
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMirrorListener.class);
+
+    @Override
+    public void onStart(Mirror mirror) {
+        logger.info("Mirroring: {}", mirror);
+    }
+
+    @Override
+    public void onComplete(Mirror mirror, MirrorResult result) {
+        // Do nothing
+    }
+
+    @Override
+    public void onError(Mirror mirror, Throwable cause) {
+        logger.warn("Unexpected exception while mirroring: {}", mirror, cause);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTask.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.mirror.Mirror;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -56,11 +57,13 @@ final class MirroringTask {
                       .register(meterRegistry);
     }
 
-    void run(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes) {
+    MirrorResult run(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes) {
         try {
-            meterRegistry.timer("mirroring.task", tags)
-                         .record(() -> mirror.mirror(workDir, executor, maxNumFiles, maxNumBytes));
+            final MirrorResult mirrorResult =
+                    meterRegistry.timer("mirroring.task", tags)
+                                 .record(() -> mirror.mirror(workDir, executor, maxNumFiles, maxNumBytes));
             counter(true).increment();
+            return mirrorResult;
         } catch (Exception e) {
             counter(false).increment();
             throw e;

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/User.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/User.java
@@ -50,6 +50,7 @@ public class User implements Identifiable, Serializable {
 
     public static final User DEFAULT = new User("user@localhost.localdomain", LEVEL_USER);
     public static final User ADMIN = new User("admin@localhost.localdomain", LEVEL_ADMIN);
+    public static final User SYSTEM = new User("system@localhost.localdomain", LEVEL_ADMIN);
 
     private final String login;
     private final String name;

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.server.mirror;
 
 import java.io.File;
 import java.net.URI;
+import java.time.Instant;
 import java.time.ZonedDateTime;
 
 import javax.annotation.Nullable;
@@ -109,6 +110,8 @@ public interface Mirror {
      *                    would be raised if the number of files to be mirrored exceeds it.
      * @param maxNumBytes the maximum bytes allowed to the mirroring task. A {@link MirrorException} would be
      *                    raised if the total size of the files to be mirrored exceeds it.
+     * @param triggeredTime the time when the mirroring task is triggered.
      */
-    MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes);
+    MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes,
+                        Instant triggeredTime);
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.mirror;
+
+import java.util.ServiceLoader;
+
+import javax.annotation.Nullable;
+
+/**
+ * A listener which is notified when a {@link Mirror} operation is started, completed or failed.
+ *
+ * <p>Implement this interface and register it using {@link ServiceLoader} to override the default behavior:
+ * <ul>
+ *     <li>{@link #onStart(Mirror)}: Logs an info message for the start of {@link Mirror}.</li>
+ *     <li>{@link #onComplete(Mirror, MirrorResult)}: Does nothing.</li>
+ *     <li>{@link #onError(Mirror, Throwable)}: Logs a warning message for the error of {@link Mirror}.</li>
+ * </ul>
+ */
+@Nullable
+public interface MirrorListener {
+
+    /**
+     * Invoked when the {@link Mirror} operation is started.
+     */
+    void onStart(Mirror mirror);
+
+    /**
+     * Invoked when the {@link Mirror} operation is completed.
+     */
+    void onComplete(Mirror mirror, MirrorResult result);
+
+    /**
+     * Invoked when the {@link Mirror} operation is failed.
+     */
+    void onError(Mirror mirror, Throwable cause);
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
@@ -25,9 +25,10 @@ import javax.annotation.Nullable;
  *
  * <p>Implement this interface and register it using {@link ServiceLoader} to override the default behavior:
  * <ul>
- *     <li>{@link #onStart(Mirror)}: Logs an info message for the start of {@link Mirror}.</li>
- *     <li>{@link #onComplete(Mirror, MirrorResult)}: Does nothing.</li>
- *     <li>{@link #onError(Mirror, Throwable)}: Logs a warning message for the error of {@link Mirror}.</li>
+ *     <li>{@link #onStart(MirrorTask)}: Logs an info message for the start of a scheduled {@link Mirror}.</li>
+ *     <li>{@link #onComplete(MirrorTask, MirrorResult)}: Does nothing.</li>
+ *     <li>{@link #onError(MirrorTask, Throwable)}: Logs a warning message for the error of a scheduled
+ *         {@link Mirror}.</li>
  * </ul>
  */
 @Nullable
@@ -36,15 +37,15 @@ public interface MirrorListener {
     /**
      * Invoked when the {@link Mirror} operation is started.
      */
-    void onStart(Mirror mirror);
+    void onStart(MirrorTask mirror);
 
     /**
      * Invoked when the {@link Mirror} operation is completed.
      */
-    void onComplete(Mirror mirror, MirrorResult result);
+    void onComplete(MirrorTask mirror, MirrorResult result);
 
     /**
      * Invoked when the {@link Mirror} operation is failed.
      */
-    void onError(Mirror mirror, Throwable cause);
+    void onError(MirrorTask mirror, Throwable cause);
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorResult.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorResult.java
@@ -41,6 +41,7 @@ public final class MirrorResult {
     @Nullable
     private final String description;
     private final Instant triggeredTime;
+    private final Instant completedTime;
 
     /**
      * Creates a new instance.
@@ -51,13 +52,15 @@ public final class MirrorResult {
                         @JsonProperty("repoName") String repoName,
                         @JsonProperty("mirrorStatus") MirrorStatus mirrorStatus,
                         @JsonProperty("description") @Nullable String description,
-                        @JsonProperty("triggeredTime") Instant triggeredTime) {
+                        @JsonProperty("triggeredTime") Instant triggeredTime,
+                        @JsonProperty("completedTime") Instant completedTime) {
         this.mirrorId = requireNonNull(mirrorId, "mirrorId");
         this.projectName = requireNonNull(projectName, "projectName");
         this.repoName = requireNonNull(repoName, "repoName");
         this.mirrorStatus = requireNonNull(mirrorStatus, "mirrorStatus");
         this.description = description;
         this.triggeredTime = requireNonNull(triggeredTime, "triggeredTime");
+        this.completedTime = requireNonNull(completedTime, "completedTime");
     }
 
     /**
@@ -109,6 +112,14 @@ public final class MirrorResult {
         return triggeredTime;
     }
 
+    /**
+     * Returns the time when the mirroring operation was completed.
+     */
+    @JsonProperty("completedTime")
+    public Instant completedTime() {
+        return completedTime;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -123,12 +134,14 @@ public final class MirrorResult {
                repoName.equals(that.repoName) &&
                mirrorStatus == that.mirrorStatus &&
                Objects.equals(description, that.description) &&
-               triggeredTime.equals(triggeredTime);
+               triggeredTime.equals(that.triggeredTime) &&
+               completedTime.equals(that.completedTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(mirrorId, projectName, repoName, mirrorStatus, description, triggeredTime);
+        return Objects.hash(mirrorId, projectName, repoName, mirrorStatus, description,
+                            triggeredTime, completedTime);
     }
 
     @Override
@@ -141,6 +154,7 @@ public final class MirrorResult {
                           .add("mirrorStatus", mirrorStatus)
                           .add("description", description)
                           .add("triggeredTime", triggeredTime)
+                          .add("completedTime", completedTime)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorTask.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.mirror;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import com.google.common.base.MoreObjects;
+
+import com.linecorp.centraldogma.server.metadata.User;
+import com.linecorp.centraldogma.server.storage.project.Project;
+
+/**
+ * A task to mirror a repository.
+ */
+public final class MirrorTask {
+
+    private final Mirror mirror;
+    private final User triggeredBy;
+    private final Instant triggeredTime;
+    private final boolean scheduled;
+
+    /**
+     * Creates a new instance.
+     */
+    public MirrorTask(Mirror mirror, User triggeredBy, Instant triggeredTime, boolean scheduled) {
+        this.mirror = mirror;
+        this.triggeredTime = triggeredTime;
+        this.triggeredBy = triggeredBy;
+        this.scheduled = scheduled;
+    }
+
+    /**
+     * Returns the {@link Mirror} to be executed.
+     */
+    public Mirror mirror() {
+        return mirror;
+    }
+
+    /**
+     * Returns the {@link Project} where the {@link Mirror} belongs to.
+     */
+    public Project project() {
+        return mirror.localRepo().parent();
+    }
+
+    /**
+     * Returns the user who triggered the {@link Mirror}.
+     */
+    public User triggeredBy() {
+        return triggeredBy;
+    }
+
+    /**
+     * Returns the time when the {@link Mirror} was triggered.
+     */
+    public Instant triggeredTime() {
+        return triggeredTime;
+    }
+
+    /**
+     * Returns whether the {@link Mirror} is triggered by a scheduler.
+     */
+    public boolean scheduled() {
+        return scheduled;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MirrorTask)) {
+            return false;
+        }
+        final MirrorTask that = (MirrorTask) o;
+        return mirror.equals(that.mirror) &&
+               triggeredTime.equals(that.triggeredTime) &&
+               triggeredBy.equals(that.triggeredBy) &&
+               scheduled == that.scheduled;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mirror, triggeredTime, triggeredBy, scheduled);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("mirror", mirror)
+                          .add("triggeredTime", triggeredTime)
+                          .add("triggeredBy", triggeredBy)
+                          .add("scheduled", scheduled)
+                          .toString();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,7 @@ project(':it:it-mirror').projectDir = file('it/mirror')
 includeWithFlags ':it:it-server',     'java', 'relocate'
 // Set correct directory names
 project(':it:it-server').projectDir = file('it/server')
+includeWithFlags ':it:mirror-listener', 'java', 'relocate'
 includeWithFlags ':it:zone-leader-plugin',    'java', 'relocate'
 includeWithFlags ':it:xds-member-permission', 'java', 'relocate'
 includeWithFlags ':testing-internal',         'java', 'relocate'


### PR DESCRIPTION
Motivation:

Mirroring failure is only recorded as a warning, but there is a need to handle it in a different way. For example, it can be recorded in metrics or end-users can be notified immediately.

`MirrorListener` is provided as an extension point to utilize various events occurring in the mirror.

Modifications:

- Introduce `MirrorListener` whose implementations can be loaded dynamically via Java SPI.
- `onStart()`, `onComplete()` and `onError()` events are added.
- The default behavior is preserved in `DefaultMirrorListener` which is only used when no custom `MirrorListener` is configured.

Result:

You can now use `MirrorListener` to listen to `Mirror` events.