### PR TITLE
Provide a way to pin a mirror to a zone

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/MirrorDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/MirrorDto.java
@@ -48,6 +48,8 @@ public final class MirrorDto {
     @Nullable
     private final String gitignore;
     private final String credentialId;
+    @Nullable
+    private final String zone;
 
     @JsonCreator
     public MirrorDto(@JsonProperty("id") String id,
@@ -62,7 +64,8 @@ public final class MirrorDto {
                      @JsonProperty("remotePath") String remotePath,
                      @JsonProperty("remoteBranch") String remoteBranch,
                      @JsonProperty("gitignore") @Nullable String gitignore,
-                     @JsonProperty("credentialId") String credentialId) {
+                     @JsonProperty("credentialId") String credentialId,
+                     @JsonProperty("zone") @Nullable String zone) {
         this.id = requireNonNull(id, "id");
         this.enabled = firstNonNull(enabled, true);
         this.projectName = requireNonNull(projectName, "projectName");
@@ -76,6 +79,7 @@ public final class MirrorDto {
         this.remoteBranch = requireNonNull(remoteBranch, "remoteBranch");
         this.gitignore = gitignore;
         this.credentialId = requireNonNull(credentialId, "credentialId");
+        this.zone = zone;
     }
 
     @JsonProperty("id")
@@ -145,6 +149,12 @@ public final class MirrorDto {
         return credentialId;
     }
 
+    @Nullable
+    @JsonProperty("zone")
+    public String zone() {
+        return zone;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -166,13 +176,14 @@ public final class MirrorDto {
                remotePath.equals(mirrorDto.remotePath) &&
                remoteBranch.equals(mirrorDto.remoteBranch) &&
                Objects.equals(gitignore, mirrorDto.gitignore) &&
-               credentialId.equals(mirrorDto.credentialId);
+               credentialId.equals(mirrorDto.credentialId) &&
+               Objects.equals(zone, mirrorDto.zone);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(id, projectName, schedule, direction, localRepo, localPath, remoteScheme,
-                            remoteUrl, remotePath, remoteBranch, gitignore, credentialId, enabled);
+                            remoteUrl, remotePath, remoteBranch, gitignore, credentialId, enabled, zone);
     }
 
     @Override
@@ -191,6 +202,7 @@ public final class MirrorDto {
                           .add("remotePath", remotePath)
                           .add("gitignore", gitignore)
                           .add("credentialId", credentialId)
+                          .add("zone", zone)
                           .toString();
     }
 }

--- a/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
+++ b/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
@@ -89,7 +89,7 @@ class CustomMirrorListenerTest {
         final Mirror mirror = new AbstractMirror("my-mirror-1", true, EVERY_SECOND,
                                                  MirrorDirection.REMOTE_TO_LOCAL,
                                                  Credential.FALLBACK, r, "/",
-                                                 URI.create("unused://uri"), "/", "", null) {
+                                                 URI.create("unused://uri"), "/", "", null, null) {
             @Override
             protected MirrorResult mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes,
                                                        Instant triggeredTime) {
@@ -114,7 +114,7 @@ class CustomMirrorListenerTest {
         when(mr.mirrors()).thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mirror)));
 
         final MirrorSchedulingService service = new MirrorSchedulingService(
-                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1);
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null);
         final CommandExecutor executor = mock(CommandExecutor.class);
         service.start(executor);
 

--- a/it/mirror/build.gradle
+++ b/it/mirror/build.gradle
@@ -7,4 +7,6 @@ dependencies {
     testImplementation libs.jsch
     testImplementation libs.mina.sshd.core
     testImplementation libs.mina.sshd.git
+    testImplementation libs.zookeeper
+    testImplementation libs.dropwizard.metrics.core
 }

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
@@ -88,7 +88,8 @@ class GitMirrorIntegrationTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.pluginConfigs(new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES,
+                                                                   false));
         }
     };
 
@@ -405,7 +406,7 @@ class GitMirrorIntegrationTest {
         // Add files whose total size exceeds the allowed maximum.
         long remainder = MAX_NUM_BYTES + 1;
         final int defaultFileSize = (int) (MAX_NUM_BYTES / MAX_NUM_FILES * 2);
-        for (int i = 0;; i++) {
+        for (int i = 0; ; i++) {
             final int fileSize;
             if (remainder > defaultFileSize) {
                 remainder -= defaultFileSize;

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
@@ -406,7 +406,7 @@ class GitMirrorIntegrationTest {
         // Add files whose total size exceeds the allowed maximum.
         long remainder = MAX_NUM_BYTES + 1;
         final int defaultFileSize = (int) (MAX_NUM_BYTES / MAX_NUM_FILES * 2);
-        for (int i = 0; ; i++) {
+        for (int i = 0;; i++) {
             final int fileSize;
             if (remainder > defaultFileSize) {
                 remainder -= defaultFileSize;

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
@@ -81,7 +81,8 @@ class LocalToRemoteGitMirrorTest {
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
         @Override
         protected void configure(CentralDogmaBuilder builder) {
-            builder.pluginConfigs(new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES));
+            builder.pluginConfigs(
+                    new MirroringServicePluginConfig(true, 1, MAX_NUM_FILES, MAX_NUM_BYTES, false));
         }
     };
 
@@ -371,7 +372,7 @@ class LocalToRemoteGitMirrorTest {
                   .push().join();
         } catch (CompletionException e) {
             if (e.getCause() instanceof RedundantChangeException) {
-               // The same content can be pushed several times.
+                // The same content can be pushed several times.
             } else {
                 throw e;
             }

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
@@ -49,10 +49,10 @@ import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class MirrorRunnerTest {
 
-    private static final String FOO_PROJ = "foo";
-    private static final String BAR_REPO = "bar";
-    private static final String PRIVATE_KEY_FILE = "ecdsa_256.openssh";
-    private static final String TEST_MIRROR_ID = "test-mirror";
+    static final String FOO_PROJ = "foo";
+    static final String BAR_REPO = "bar";
+    static final String PRIVATE_KEY_FILE = "ecdsa_256.openssh";
+    static final String TEST_MIRROR_ID = "test-mirror";
 
     @RegisterExtension
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
@@ -159,10 +159,11 @@ class MirrorRunnerTest {
                              "/",
                              "main",
                              null,
-                             PRIVATE_KEY_FILE);
+                             PRIVATE_KEY_FILE,
+                             null);
     }
 
-    private static PublicKeyCredential getCredential() throws Exception {
+    static PublicKeyCredential getCredential() throws Exception {
         final String publicKeyFile = "ecdsa_256.openssh.pub";
 
         final byte[] privateKeyBytes =

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it.mirror.git;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.server.mirror.MirrorListener;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirrorTask;
+
+public class TestZoneAwareMirrorListener implements MirrorListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(TestZoneAwareMirrorListener.class);
+
+    static final Map<String, Integer> startCount = new ConcurrentHashMap<>();
+    static final Map<String, List<MirrorResult>> completions = new ConcurrentHashMap<>();
+    static final Map<String, List<Throwable>> errors = new ConcurrentHashMap<>();
+
+    static void reset() {
+        startCount.clear();
+        completions.clear();
+        errors.clear();
+    }
+
+    private static String key(MirrorTask task) {
+        return firstNonNull(task.currentZone(), "default");
+    }
+
+    @Override
+    public void onStart(MirrorTask mirror) {
+        logger.debug("onStart: {}", mirror);
+        startCount.merge(key(mirror), 1, Integer::sum);
+    }
+
+    @Override
+    public void onComplete(MirrorTask mirror, MirrorResult result) {
+        logger.debug("onComplete: {} -> {}", mirror, result);
+        final List<MirrorResult> results = new ArrayList<>();
+        results.add(result);
+        completions.merge(key(mirror), results, (oldValue, newValue) -> {
+            oldValue.addAll(newValue);
+            return oldValue;
+        });
+    }
+
+    @Override
+    public void onError(MirrorTask mirror, Throwable cause) {
+        logger.debug("onError: {}", mirror, cause);
+        final List<Throwable> exceptions = new ArrayList<>();
+        exceptions.add(cause);
+        errors.merge(key(mirror), exceptions, (oldValue, newValue) -> {
+            oldValue.addAll(newValue);
+            return oldValue;
+        });
+    }
+}

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -63,8 +61,6 @@ import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 class ZoneAwareMirrorTest {
 
     private static final List<String> ZONES = ImmutableList.of("zone1", "zone2", "zone3");
-    private static final Logger logger = LoggerFactory.getLogger(ZoneAwareMirrorTest.class);
-
 
     @RegisterExtension
     CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
@@ -125,7 +121,6 @@ class ZoneAwareMirrorTest {
                 assertThat(result.repoName()).isEqualTo(BAR_REPO + '-' + zone);
             });
         });
-        logger.info("### listener.errors: {}", TestZoneAwareMirrorListener.errors);
         assertThat(TestZoneAwareMirrorListener.errors.get(zone)).isNullOrEmpty();
     }
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -28,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowableOfType;
 import static org.awaitility.Awaitility.await;
 
+import java.net.URI;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.BlockingWebClient;
@@ -47,12 +49,18 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.MirrorException;
+import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorDto;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.internal.credential.PublicKeyCredential;
+import com.linecorp.centraldogma.server.internal.storage.repository.MirrorConfig;
+import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
@@ -153,6 +161,47 @@ class ZoneAwareMirrorTest {
         assertThat(invalidResponseException.response().status()).isEqualTo(HttpStatus.BAD_REQUEST);
         assertThat(invalidResponseException.response().contentUtf8())
                 .contains("The zone 'unknown-zone' is not in the zone configuration");
+    }
+
+    @Test
+    void shouldWarnUnknownZoneForScheduledJob() throws Exception {
+        final CentralDogma client = cluster.servers().get(0).client();
+        final CentralDogmaRepository repo = client.forRepo(FOO_PROJ, "meta");
+        final String mirrorId = TEST_MIRROR_ID + "-unknown-zone";
+        final String unknownZone = "unknown-zone";
+        final MirrorConfig mirrorConfig =
+                new MirrorConfig(mirrorId,
+                                 true,
+                                 "0/1 * * * * ?",
+                                 MirrorDirection.REMOTE_TO_LOCAL,
+                                 "bar-unknown-zone",
+                                 "/",
+                                 URI.create(
+                                         "git+ssh://github.com/line/centraldogma-authtest.git/#main"),
+                                 null,
+                                 "foo",
+                                 unknownZone);
+        final Change<JsonNode> change =
+                Change.ofJsonUpsert("/mirrors/" + mirrorId + ".json", Jackson.writeValueAsString(mirrorConfig));
+        repo.commit("Add a mirror having an invalid zone", change)
+            .push().join();
+
+        await().untilAsserted(() -> {
+            // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
+            assertThat(TestZoneAwareMirrorListener.startCount.get(unknownZone)).isGreaterThanOrEqualTo(1);
+        });
+        await().untilAsserted(() -> {
+            final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(unknownZone);
+            assertThat(results).isNullOrEmpty();
+            final List<Throwable> causes = TestZoneAwareMirrorListener.errors.get(unknownZone);
+
+            // Make sure that the mirror was executed in the specified zone.
+            assertThat(causes).allSatisfy(cause -> {
+                assertThat(cause).isInstanceOf(MirrorException.class)
+                                 .hasMessage("The mirror is pinned to an unknown zone: unknown-zone " +
+                                             "(valid zones: " + ZONES + ')');
+            });
+        });
     }
 
     private static void createMirror(String zone) throws Exception {

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -61,6 +63,8 @@ import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 class ZoneAwareMirrorTest {
 
     private static final List<String> ZONES = ImmutableList.of("zone1", "zone2", "zone3");
+    private static final Logger logger = LoggerFactory.getLogger(ZoneAwareMirrorTest.class);
+
 
     @RegisterExtension
     CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
@@ -121,7 +125,8 @@ class ZoneAwareMirrorTest {
                 assertThat(result.repoName()).isEqualTo(BAR_REPO + '-' + zone);
             });
         });
-        assertThat(TestZoneAwareMirrorListener.errors.get(zone)).isEmpty();
+        logger.info("### listener.errors: {}", TestZoneAwareMirrorListener.errors);
+        assertThat(TestZoneAwareMirrorListener.errors.get(zone)).isNullOrEmpty();
     }
 
     @Test

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.it.mirror.git;
+
+import static com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.BAR_REPO;
+import static com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.FOO_PROJ;
+import static com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.PRIVATE_KEY_FILE;
+import static com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.TEST_MIRROR_ID;
+import static com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.getCredential;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.internal.api.v1.MirrorDto;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.ZoneConfig;
+import com.linecorp.centraldogma.server.internal.credential.PublicKeyCredential;
+import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+
+class ZoneAwareMirrorTest {
+
+    private static final List<String> ZONES = ImmutableList.of("zone1", "zone2", "zone3");
+
+    @RegisterExtension
+    CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
+        @Override
+        protected void configureEach(int serverId, CentralDogmaBuilder builder) {
+            builder.authProviderFactory(new TestAuthProviderFactory());
+            builder.administrators(USERNAME);
+            builder.zone(new ZoneConfig(ZONES.get(serverId - 1), ZONES));
+            builder.pluginConfigs(new MirroringServicePluginConfig(true, null, null, null, true));
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    private static int serverPort;
+    private static String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        final CentralDogmaRuleDelegate server1 = cluster.servers().get(0);
+        serverPort = server1.serverAddress().getPort();
+        accessToken = getAccessToken(
+                WebClient.of("http://127.0.0.1:" + serverPort),
+                USERNAME, PASSWORD);
+
+        final CentralDogma client =
+                new ArmeriaCentralDogmaBuilder()
+                        .host("127.0.0.1", serverPort)
+                        .accessToken(accessToken)
+                        .build();
+        client.createProject(FOO_PROJ).join();
+        for (String zone : ZONES) {
+            client.createRepository(FOO_PROJ, BAR_REPO + '-' + zone).join();
+        }
+        client.createRepository(FOO_PROJ, "bar-default").join();
+        client.createRepository(FOO_PROJ, "bar-unknown-zone").join();
+        TestZoneAwareMirrorListener.reset();
+    }
+
+    @FieldSource("ZONES")
+    @ParameterizedTest
+    void shouldRunMirrorTaskOnPinnedZone(String zone) throws Exception {
+        createMirror(zone);
+
+        await().untilAsserted(() -> {
+            // Wait for three mirror tasks to run to ensure that all tasks are running in the same zone.
+            assertThat(TestZoneAwareMirrorListener.startCount.get(zone)).isGreaterThanOrEqualTo(3);
+        });
+        await().untilAsserted(() -> {
+            final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(zone);
+            assertThat(results).hasSizeGreaterThan(3);
+            // Make sure that the mirror was executed in the specified zone.
+            assertThat(results).allSatisfy(result -> {
+                assertThat(result.zone()).isEqualTo(zone);
+                assertThat(result.repoName()).isEqualTo(BAR_REPO + '-' + zone);
+            });
+        });
+        assertThat(TestZoneAwareMirrorListener.errors.get(zone)).isEmpty();
+    }
+
+    @Test
+    void shouldRunUnpinnedMirrorTaskOnDefaultZone() throws Exception {
+        createMirror(null);
+        // The default zone is the first zone in the list.
+        final String defaultZone = ZONES.get(0);
+        await().untilAsserted(() -> {
+            // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
+            assertThat(TestZoneAwareMirrorListener.startCount.get(defaultZone)).isGreaterThanOrEqualTo(3);
+        });
+        await().untilAsserted(() -> {
+            final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(defaultZone);
+            assertThat(results).hasSizeGreaterThan(3);
+            // Make sure that the mirror was executed in the specified zone.
+            assertThat(results).allSatisfy(mirrorResult -> {
+                assertThat(mirrorResult.zone()).isNull();
+                assertThat(mirrorResult.repoName()).isEqualTo("bar-default");
+            });
+        });
+    }
+
+    @Test
+    void shouldNotRunMirrorTaskForUnknownZone() throws Exception {
+        final String unknownZone = "unknown-zone";
+        createMirror(unknownZone);
+
+        // Wait for 3 seconds to ensure that the mirror task is not executed.
+        Thread.sleep(3000);
+
+        await().untilAsserted(() -> {
+            assertThat(TestZoneAwareMirrorListener.startCount).isEmpty();
+        });
+        await().untilAsserted(() -> {
+            assertThat(TestZoneAwareMirrorListener.completions).isEmpty();
+            assertThat(TestZoneAwareMirrorListener.errors).isEmpty();
+        });
+    }
+
+    private static List<String> testZone() {
+        final ArrayList<String> zones = new ArrayList<>(ZONES);
+        // Add a null zone to test the default zone.
+        zones.add(null);
+        return zones;
+    }
+
+    private static void createMirror(String zone) throws Exception {
+        final BlockingWebClient client = WebClient.builder("http://127.0.0.1:" + serverPort)
+                                                  .auth(AuthToken.ofOAuth2(accessToken))
+                                                  .build()
+                                                  .blocking();
+
+        final PublicKeyCredential credential = getCredential();
+        ResponseEntity<PushResultDto> response =
+                client.prepare()
+                      .post("/api/v1/projects/{proj}/credentials")
+                      .pathParam("proj", FOO_PROJ)
+                      .contentJson(credential)
+                      .asJson(PushResultDto.class)
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
+
+        final MirrorDto newMirror = newMirror(zone);
+        response = client.prepare()
+                         .post("/api/v1/projects/{proj}/mirrors")
+                         .pathParam("proj", FOO_PROJ)
+                         .contentJson(newMirror)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    private static MirrorDto newMirror(@Nullable String zone) {
+        return new MirrorDto(TEST_MIRROR_ID + '-' + (zone == null ? "default" : zone),
+                             true,
+                             FOO_PROJ,
+                             "0/1 * * * * ?",
+                             "REMOTE_TO_LOCAL",
+                             BAR_REPO + '-' + (zone == null ? "default" : zone),
+                             "/",
+                             "git+ssh",
+                             "github.com/line/centraldogma-authtest.git",
+                             "/",
+                             "main",
+                             null,
+                             PRIVATE_KEY_FILE,
+                             zone);
+    }
+}

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -27,7 +27,6 @@ import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUti
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.annotation.Nullable;

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -161,13 +161,6 @@ class ZoneAwareMirrorTest {
         });
     }
 
-    private static List<String> testZone() {
-        final ArrayList<String> zones = new ArrayList<>(ZONES);
-        // Add a null zone to test the default zone.
-        zones.add(null);
-        return zones;
-    }
-
     private static void createMirror(String zone) throws Exception {
         final BlockingWebClient client = WebClient.builder("http://127.0.0.1:" + serverPort)
                                                   .auth(AuthToken.ofOAuth2(accessToken))

--- a/it/mirror/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
+++ b/it/mirror/src/test/resources/META-INF/services/com.linecorp.centraldogma.server.mirror.MirrorListener
@@ -1,1 +1,2 @@
 com.linecorp.centraldogma.it.mirror.git.TestMirrorRunnerListener
+com.linecorp.centraldogma.it.mirror.git.TestZoneAwareMirrorListener

--- a/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
+++ b/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
@@ -27,8 +27,12 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.google.common.collect.ImmutableList;
+
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.plugin.Plugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
@@ -38,17 +42,18 @@ class ZoneLeaderPluginTest {
 
     private static final List<ZoneLeaderTestPlugin> plugins = new ArrayList<>();
     private static final int NUM_REPLICAS = 9;
+    private static final List<String> zones = ImmutableList.of("zone1", "zone2", "zone3");
 
     @RegisterExtension
     static CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(NUM_REPLICAS) {
         @Override
         protected void configureEach(int serverId, CentralDogmaBuilder builder) {
             if (serverId <= 3) {
-                builder.zone("zone1");
+                builder.zone(new ZoneConfig("zone1", zones));
             } else if (serverId <= 6) {
-                builder.zone("zone2");
+                builder.zone(new ZoneConfig("zone2", zones));
             } else {
-                builder.zone("zone3");
+                builder.zone(new ZoneConfig("zone3", zones));
             }
             final ZoneLeaderTestPlugin plugin = new ZoneLeaderTestPlugin(serverId);
             plugins.add(plugin);
@@ -114,7 +119,7 @@ class ZoneLeaderPluginTest {
         }
 
         @Override
-        public PluginTarget target() {
+        public PluginTarget target(CentralDogmaConfig config) {
             return PluginTarget.ZONE_LEADER_ONLY;
         }
 

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
@@ -125,9 +125,9 @@ abstract class AbstractGitMirror extends AbstractMirror {
     AbstractGitMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                       Credential credential, Repository localRepo, String localPath,
                       URI remoteRepoUri, String remotePath, String remoteBranch,
-                      @Nullable String gitignore) {
+                      @Nullable String gitignore, @Nullable String zone) {
         super(id, enabled, schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath,
-              remoteBranch, gitignore);
+              remoteBranch, gitignore, zone);
 
         if (gitignore != null) {
             ignoreNode = new IgnoreNode();

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultGitMirror.java
@@ -47,9 +47,9 @@ final class DefaultGitMirror extends AbstractGitMirror {
     DefaultGitMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                      Credential credential, Repository localRepo, String localPath,
                      URI remoteRepoUri, String remotePath, String remoteBranch,
-                     @Nullable String gitignore) {
+                     @Nullable String gitignore, @Nullable String zone) {
         super(id, enabled, schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath,
-              remoteBranch, gitignore);
+              remoteBranch, gitignore, zone);
     }
 
     @Override

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
@@ -49,7 +49,7 @@ public final class GitMirrorProvider implements MirrorProvider {
                                         context.direction(), context.credential(),
                                         context.localRepo(), context.localPath(),
                                         repositoryUri.uri(), repositoryUri.path(), repositoryUri.branch(),
-                                        context.gitignore());
+                                        context.gitignore(), context.zone());
             }
             case SCHEME_GIT_HTTP:
             case SCHEME_GIT_HTTPS:
@@ -60,7 +60,7 @@ public final class GitMirrorProvider implements MirrorProvider {
                                             context.direction(), context.credential(),
                                             context.localRepo(), context.localPath(),
                                             repositoryUri.uri(), repositoryUri.path(), repositoryUri.branch(),
-                                            context.gitignore());
+                                            context.gitignore(), context.zone());
             }
         }
 

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
@@ -85,10 +85,9 @@ final class SshGitMirror extends AbstractGitMirror {
     SshGitMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                  Credential credential, Repository localRepo, String localPath,
                  URI remoteRepoUri, String remotePath, String remoteBranch,
-                 @Nullable String gitignore) {
+                 @Nullable String gitignore, @Nullable String zone) {
         super(id, enabled, schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath,
-              remoteBranch,
-              gitignore);
+              remoteBranch, gitignore, zone);
     }
 
     @Override

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
@@ -182,7 +182,7 @@ class DefaultMetaRepositoryWithMirrorTest {
             }
             for (MirrorDto mirror : mirrors) {
                 final Command<CommitResult> command =
-                        metaRepo.createPushCommand(mirror, Author.SYSTEM, false).join();
+                        metaRepo.createPushCommand(mirror, Author.SYSTEM, null, false).join();
                 pmExtension.executor().execute(command).join();
             }
         }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
@@ -171,9 +171,10 @@ class DefaultMetaRepositoryWithMirrorTest {
         } else {
             final List<MirrorDto> mirrors = ImmutableList.of(
                     new MirrorDto("foo", true, project.name(), DEFAULT_SCHEDULE, "LOCAL_TO_REMOTE", "foo",
-                                  "/mirrors/foo", "git+ssh", "foo.com/foo.git", "", "", null, "alice"),
+                                  "/mirrors/foo", "git+ssh", "foo.com/foo.git", "", "", null, "alice", null),
                     new MirrorDto("bar", true, project.name(), "0 */10 * * * ?", "REMOTE_TO_LOCAL", "bar",
-                                  "", "git+ssh", "bar.com/bar.git", "/some-path", "develop", null, "bob"));
+                                  "", "git+ssh", "bar.com/bar.git", "/some-path", "develop", null, "bob",
+                                  null));
             for (Credential credential : CREDENTIALS) {
                 final Command<CommitResult> command =
                         metaRepo.createPushCommand(credential, Author.SYSTEM, false).join();

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingServiceTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingServiceTest.java
@@ -75,7 +75,7 @@ class MirrorSchedulingServiceTest {
         final Mirror mirror = new AbstractMirror("my-mirror-1", true, EVERY_SECOND,
                                                  MirrorDirection.REMOTE_TO_LOCAL,
                                                  Credential.FALLBACK, r, "/",
-                                                 URI.create("unused://uri"), "/", "", null) {
+                                                 URI.create("unused://uri"), "/", "", null, null) {
             @Override
             protected MirrorResult mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes,
                                                        Instant triggeredTime) {
@@ -96,7 +96,7 @@ class MirrorSchedulingServiceTest {
         when(mr.mirrors()).thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mirror)));
 
         final MirrorSchedulingService service = new MirrorSchedulingService(
-                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1);
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null);
         final CommandExecutor executor = mock(CommandExecutor.class);
         service.start(executor);
 

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
@@ -132,7 +132,8 @@ class MirroringAndCredentialServiceV1Test {
                               "/remote-path/1",
                               "mirror-branch",
                               ".my-env0\n.my-env1",
-                              "public-key-credential");
+                              "public-key-credential",
+                              null);
         final AggregatedHttpResponse response =
                 userClient.prepare()
                           .post("/api/v1/projects/{proj}/mirrors")
@@ -306,7 +307,8 @@ class MirroringAndCredentialServiceV1Test {
                                                "/updated/remote-path/",
                                                "updated-mirror-branch",
                                                ".updated-env",
-                                               "access-token-credential");
+                                               "access-token-credential",
+                                               null);
         final ResponseEntity<PushResultDto> updateResponse =
                 userClient.prepare()
                           .put("/api/v1/projects/{proj}/mirrors/{id}")
@@ -376,6 +378,7 @@ class MirroringAndCredentialServiceV1Test {
                              "/remote-path/" + id + '/',
                              "mirror-branch",
                              ".my-env0\n.my-env1",
-                             "public-key-credential");
+                             "public-key-credential",
+                             null);
     }
 }

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTaskTest.java
@@ -51,9 +51,9 @@ class MirroringTaskTest {
         Mirror mirror = newMirror("git://a.com/b.git", DefaultGitMirror.class, "foo", "bar");
         mirror = spy(mirror);
         doReturn(new MirrorResult(mirror.id(), "foo", "bar", MirrorStatus.SUCCESS, "", Instant.now(),
-                                  Instant.now()))
+                                  Instant.now(), null))
                 .when(mirror).mirror(any(), any(), anyInt(), anyLong(), any());
-        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), true);
+        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), null, true);
         new InstrumentedMirroringJob(mirrorTask, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .contains(entry("mirroring.result#count{direction=LOCAL_TO_REMOTE,localPath=/," +
@@ -67,7 +67,7 @@ class MirroringTaskTest {
         mirror = spy(mirror);
         final RuntimeException e = new RuntimeException();
         doThrow(e).when(mirror).mirror(any(), any(), anyInt(), anyLong(), any());
-        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), true);
+        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), null, true);
         final InstrumentedMirroringJob task = new InstrumentedMirroringJob(mirrorTask, meterRegistry);
         assertThatThrownBy(() -> task.run(null, null, 0, 0L))
                 .isSameAs(e);
@@ -86,7 +86,7 @@ class MirroringTaskTest {
             Thread.sleep(1000);
             return null;
         }).when(mirror).mirror(any(), any(), anyInt(), anyLong(), any());
-        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), true);
+        final MirrorTask mirrorTask = new MirrorTask(mirror, User.SYSTEM, Instant.now(), null, true);
         new InstrumentedMirroringJob(mirrorTask, meterRegistry).run(null, null, 0, 0L);
         assertThat(MoreMeters.measureAll(meterRegistry))
                 .hasEntrySatisfying(

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringTestUtils.java
@@ -59,7 +59,7 @@ final class MirroringTestUtils {
         final Mirror mirror =
                 new GitMirrorProvider().newMirror(
                         new MirrorContext("mirror-id", true, schedule, MirrorDirection.LOCAL_TO_REMOTE,
-                                          credential, repository, "/", URI.create(remoteUri), null));
+                                          credential, repository, "/", URI.create(remoteUri), null, null));
 
         assertThat(mirror).isInstanceOf(mirrorType);
         assertThat(mirror.direction()).isEqualTo(MirrorDirection.LOCAL_TO_REMOTE);
@@ -76,7 +76,7 @@ final class MirroringTestUtils {
         final Credential credential = mock(Credential.class);
         final Mirror mirror = new GitMirrorProvider().newMirror(
                 new MirrorContext("mirror-id", true, EVERY_MINUTE, MirrorDirection.LOCAL_TO_REMOTE,
-                                  credential, mock(Repository.class), "/", URI.create(remoteUri), null));
+                                  credential, mock(Repository.class), "/", URI.create(remoteUri), null, null));
         assertThat(mirror).isNull();
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -137,7 +137,7 @@ public final class CentralDogmaBuilder {
     @Nullable
     private ManagementConfig managementConfig;
     @Nullable
-    private String zone;
+    private ZoneConfig zoneConfig;
 
     /**
      * Creates a new builder with the specified data directory.
@@ -536,6 +536,13 @@ public final class CentralDogmaBuilder {
     }
 
     /**
+     * Returns the {@link PluginConfig}s that have been added.
+     */
+    public List<PluginConfig> pluginConfigs() {
+        return pluginConfigs;
+    }
+
+    /**
      * Adds the {@link Plugin}s.
      */
     public CentralDogmaBuilder plugins(Plugin... plugins) {
@@ -562,11 +569,11 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Specifies the zone of the server.
+     * Specifies the {@link ZoneConfig} of the server.
      */
-    public CentralDogmaBuilder zone(String zone) {
-        requireNonNull(zone, "zone");
-        this.zone = zone;
+    public CentralDogmaBuilder zone(ZoneConfig zoneConfig) {
+        requireNonNull(zoneConfig, "zoneConfig");
+        this.zoneConfig = zoneConfig;
         return this;
     }
 
@@ -601,8 +608,8 @@ public final class CentralDogmaBuilder {
                                       requestTimeoutMillis, idleTimeoutMillis, maxFrameLength,
                                       numRepositoryWorkers, repositoryCacheSpec,
                                       maxRemovedRepositoryAgeMillis, gracefulShutdownTimeout,
-                                      webAppEnabled, webAppTitle,replicationConfig,
+                                      webAppEnabled, webAppTitle, replicationConfig,
                                       null, accessLogFormat, authCfg, quotaConfig,
-                                      corsConfig, pluginConfigs, managementConfig, zone);
+                                      corsConfig, pluginConfigs, managementConfig, zoneConfig);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaConfig.java
@@ -271,7 +271,7 @@ public final class CentralDogmaConfig {
     private final ManagementConfig managementConfig;
 
     @Nullable
-    private final String zone;
+    private final ZoneConfig zoneConfig;
 
     CentralDogmaConfig(
             @JsonProperty(value = "dataDir", required = true) File dataDir,
@@ -300,7 +300,7 @@ public final class CentralDogmaConfig {
             @JsonProperty("cors") @Nullable CorsConfig corsConfig,
             @JsonProperty("pluginConfigs") @Nullable List<PluginConfig> pluginConfigs,
             @JsonProperty("management") @Nullable ManagementConfig managementConfig,
-            @JsonProperty("zone") @Nullable String zone) {
+            @JsonProperty("zone") @Nullable ZoneConfig zoneConfig) {
 
         this.dataDir = requireNonNull(dataDir, "dataDir");
         this.ports = ImmutableList.copyOf(requireNonNull(ports, "ports"));
@@ -349,7 +349,7 @@ public final class CentralDogmaConfig {
         pluginConfigMap = this.pluginConfigs.stream().collect(
                 toImmutableMap(PluginConfig::getClass, Function.identity()));
         this.managementConfig = managementConfig;
-        this.zone = convertValue(zone, "zone");
+        this.zoneConfig = zoneConfig;
     }
 
     /**
@@ -589,13 +589,13 @@ public final class CentralDogmaConfig {
     }
 
     /**
-     * Returns the zone of the server.
+     * Returns the zone information of the server.
      * Note that the zone must be specified to use the {@link PluginTarget#ZONE_LEADER_ONLY} target.
      */
     @Nullable
     @JsonProperty("zone")
-    public String zone() {
-        return zone;
+    public ZoneConfig zone() {
+        return zoneConfig;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -108,8 +108,8 @@ final class PluginGroup {
                          .collect(toImmutableMap(Entry::getKey, e -> {
                              final PluginTarget target = e.getKey();
                              final List<Plugin> targetPlugins = e.getValue();
-                             final String poolName = "plugins-for-" + target.name().toLowerCase().replace("_",
-                                                                                                          "-");
+                             final String poolName =
+                                     "plugins-for-" + target.name().toLowerCase().replace("_", "-");
                              return new PluginGroup(targetPlugins,
                                                     Executors.newSingleThreadExecutor(
                                                             new DefaultThreadFactory(poolName, true)));

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -118,7 +118,7 @@ final class PluginGroup {
         pluginGroups.forEach((target, group) -> {
             logger.debug("Loaded plugins for target {}: {}", target,
                          group.plugins().stream().map(plugin -> plugin.getClass().getName())
-                              .collect(Collectors.toList()));
+                              .collect(toImmutableList()));
         });
         return pluginGroups;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZoneConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZoneConfig.java
@@ -17,6 +17,7 @@
 
 package com.linecorp.centraldogma.server;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static java.util.Objects.requireNonNull;
 
@@ -45,9 +46,8 @@ public final class ZoneConfig {
         requireNonNull(allZones, "allZones");
         this.currentZone = convertValue(currentZone, "zone.currentZone");
         this.allZones = allZones;
-        if (!allZones.contains(currentZone)) {
-            throw new IllegalArgumentException("The current zone must be one of the all zones.");
-        }
+        checkArgument(allZones.contains(currentZone), "The current zone: %s, (expected: one of %s)",
+                      currentZone, allZones);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/ZoneConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/ZoneConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package com.linecorp.centraldogma.server;
+
+import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+/**
+ * A configuration class for the zone.
+ */
+public final class ZoneConfig {
+
+    private final String currentZone;
+    private final List<String> allZones;
+
+    /**
+     * Creates a new instance.
+     */
+    @JsonCreator
+    public ZoneConfig(@JsonProperty("currentZone") String currentZone,
+                      @JsonProperty("allZones") List<String> allZones) {
+        requireNonNull(currentZone, "currentZone");
+        requireNonNull(allZones, "allZones");
+        this.currentZone = convertValue(currentZone, "zone.currentZone");
+        this.allZones = allZones;
+        if (!allZones.contains(currentZone)) {
+            throw new IllegalArgumentException("The current zone must be one of the all zones.");
+        }
+    }
+
+    /**
+     * Returns the current zone.
+     */
+    @JsonProperty("currentZone")
+    public String currentZone() {
+        return currentZone;
+    }
+
+    /**
+     * Returns all zones.
+     */
+    @JsonProperty("allZones")
+    public List<String> allZones() {
+        return allZones;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ZoneConfig)) {
+            return false;
+        }
+        final ZoneConfig that = (ZoneConfig) o;
+        return currentZone.equals(that.currentZone) &&
+               allZones.equals(that.allZones);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(currentZone, allZones);
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("currentZone", currentZone)
+                          .add("allZones", allZones)
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
@@ -18,14 +18,17 @@ package com.linecorp.centraldogma.server.internal.api;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin.mirrorConfig;
 import static com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository.mirrorFile;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import com.cronutils.model.Cron;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.server.annotation.ConsumesJson;
 import com.linecorp.armeria.server.annotation.Delete;
@@ -42,6 +45,8 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.api.v1.MirrorDto;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.command.CommitResult;
@@ -52,6 +57,7 @@ import com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManag
 import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
 
@@ -67,12 +73,26 @@ public class MirroringServiceV1 extends AbstractService {
 
     private final ProjectApiManager projectApiManager;
     private final MirrorRunner mirrorRunner;
+    private final Map<String, Object> mirrorZoneConfig;
 
     public MirroringServiceV1(ProjectApiManager projectApiManager, CommandExecutor executor,
-                              MirrorRunner mirrorRunner) {
+                              MirrorRunner mirrorRunner, CentralDogmaConfig config) {
         super(executor);
         this.projectApiManager = projectApiManager;
         this.mirrorRunner = mirrorRunner;
+        mirrorZoneConfig = mirrorZoneConfig(config);
+    }
+
+    private static Map<String, Object> mirrorZoneConfig(CentralDogmaConfig config) {
+        final MirroringServicePluginConfig mirrorConfig = mirrorConfig(config);
+        final ImmutableMap.Builder<String, Object> builder = ImmutableMap.builderWithExpectedSize(2);
+        final boolean zonePinned = mirrorConfig != null && mirrorConfig.zonePinned();
+        builder.put("zonePinned", zonePinned);
+        final ZoneConfig zone = config.zone();
+        if (zone != null) {
+            builder.put("zone", zone);
+        }
+        return builder.build();
     }
 
     /**
@@ -175,6 +195,17 @@ public class MirroringServiceV1 extends AbstractService {
         return mirrorRunner.run(projectName, mirrorId, user);
     }
 
+    /**
+     * GET /mirror/config
+     *
+     * <p>Returns the configuration of the mirroring service.
+     */
+    @Get("/mirror/config")
+    public Map<String, Object> config() {
+        // TODO(ikhoon): Add more configurations if necessary.
+        return mirrorZoneConfig;
+    }
+
     private static MirrorDto convertToMirrorDto(String projectName, Mirror mirror) {
         final URI remoteRepoUri = mirror.remoteRepoUri();
         final Cron schedule = mirror.schedule();
@@ -190,7 +221,7 @@ public class MirroringServiceV1 extends AbstractService {
                              mirror.remotePath(),
                              mirror.remoteBranch(),
                              mirror.gitignore(),
-                             mirror.credential().id());
+                             mirror.credential().id(), mirror.zone());
     }
 
     private MetaRepository metaRepo(String projectName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -64,6 +64,8 @@ public abstract class AbstractMirror implements Mirror {
     @Nullable
     private final String gitignore;
     @Nullable
+    private final String zone;
+    @Nullable
     private final Cron schedule;
     @Nullable
     private final ExecutionTime executionTime;
@@ -72,7 +74,7 @@ public abstract class AbstractMirror implements Mirror {
     protected AbstractMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                              Credential credential, Repository localRepo, String localPath,
                              URI remoteRepoUri, String remotePath, String remoteBranch,
-                             @Nullable String gitignore) {
+                             @Nullable String gitignore, @Nullable String zone) {
         this.id = requireNonNull(id, "id");
         this.enabled = enabled;
         this.direction = requireNonNull(direction, "direction");
@@ -83,6 +85,7 @@ public abstract class AbstractMirror implements Mirror {
         this.remotePath = normalizePath(requireNonNull(remotePath, "remotePath"));
         this.remoteBranch = requireNonNull(remoteBranch, "remoteBranch");
         this.gitignore = gitignore;
+        this.zone = zone;
 
         if (schedule != null) {
             this.schedule = requireNonNull(schedule, "schedule");
@@ -174,6 +177,12 @@ public abstract class AbstractMirror implements Mirror {
         return enabled;
     }
 
+    @Nullable
+    @Override
+    public String zone() {
+        return zone;
+    }
+
     @Override
     public final MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles,
                                      long maxNumBytes, Instant triggeredTime) {
@@ -212,7 +221,7 @@ public abstract class AbstractMirror implements Mirror {
     protected final MirrorResult newMirrorResult(MirrorStatus mirrorStatus, @Nullable String description,
                                                  Instant triggeredTime) {
         return new MirrorResult(id, localRepo.parent().name(), localRepo.name(), mirrorStatus, description,
-                                triggeredTime, Instant.now());
+                                triggeredTime, Instant.now(), zone);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -40,10 +40,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
     public CentralDogmaMirror(String id, boolean enabled, Cron schedule, MirrorDirection direction,
                               Credential credential, Repository localRepo, String localPath,
                               URI remoteRepoUri, String remoteProject, String remoteRepo, String remotePath,
-                              @Nullable String gitignore) {
+                              @Nullable String gitignore, @Nullable String zone) {
         // Central Dogma has no notion of 'branch', so we just pass an empty string as a placeholder.
         super(id, enabled, schedule, direction, credential, localRepo, localPath, remoteRepoUri, remotePath,
-              "", gitignore);
+              "", gitignore, zone);
 
         this.remoteProject = requireNonNull(remoteProject, "remoteProject");
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
@@ -80,10 +80,7 @@ public final class DefaultMirroringServicePlugin implements Plugin {
                 maxNumBytesPerMirror = mirroringServicePluginConfig.maxNumBytesPerMirror();
                 if (mirroringServicePluginConfig.zonePinned()) {
                     zoneConfig = cfg.zone();
-                    if (zoneConfig == null) {
-                        throw new IllegalStateException(
-                                "zonePinned is enabled but no zone configuration found");
-                    }
+                    assert zoneConfig != null : "zonePinned is enabled but no zone configuration found";
                 } else {
                     zoneConfig = null;
                 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorRunner.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorRunner.java
@@ -109,7 +109,7 @@ public final class MirrorRunner implements SafeCloseable {
                             throw new MirrorException("The mirror is not in the current zone: " + currentZone);
                         }
                         final MirrorTask mirrorTask = new MirrorTask(mirror, user, Instant.now(),
-                                                                     currentZone, true);
+                                                                     currentZone, false);
                         final MirrorListener listener = MirrorSchedulingService.mirrorListener;
                         listener.onStart(mirrorTask);
                         try {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/PurgeSchedulingServicePlugin.java
@@ -36,7 +36,7 @@ public final class PurgeSchedulingServicePlugin implements Plugin {
     private volatile PurgeSchedulingService purgeSchedulingService;
 
     @Override
-    public PluginTarget target() {
+    public PluginTarget target(CentralDogmaConfig config) {
         return PluginTarget.LEADER_ONLY;
     }
 
@@ -87,7 +87,7 @@ public final class PurgeSchedulingServicePlugin implements Plugin {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .omitNullValues()
-                          .add("target", target())
+                          .add("target", PluginTarget.LEADER_ONLY)
                           .add("purgeSchedulingService", purgeSchedulingService)
                           .toString();
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/CentralDogmaMirrorProvider.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/CentralDogmaMirrorProvider.java
@@ -62,6 +62,6 @@ public final class CentralDogmaMirrorProvider implements MirrorProvider {
         return new CentralDogmaMirror(context.id(), context.enabled(), context.schedule(), context.direction(),
                                       context.credential(), context.localRepo(), context.localPath(),
                                       repositoryUri.uri(), remoteProject, remoteRepo, remotePath,
-                                      context.gitignore());
+                                      context.gitignore(), context.zone());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -25,6 +25,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronField;
 import com.cronutils.model.field.CronFieldName;
@@ -44,6 +46,7 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorDto;
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommitResult;
 import com.linecorp.centraldogma.server.credential.Credential;
@@ -237,8 +240,9 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
 
     @Override
     public CompletableFuture<Command<CommitResult>> createPushCommand(MirrorDto mirrorDto, Author author,
+                                                                      @Nullable ZoneConfig zoneConfig,
                                                                       boolean update) {
-        validateMirror(mirrorDto);
+        validateMirror(mirrorDto, zoneConfig);
         if (update) {
             final String summary = "Update the mirror '" + mirrorDto.id() + '\'';
             return mirror(mirrorDto.id()).thenApply(mirror -> {
@@ -290,7 +294,7 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
                             change);
     }
 
-    private static void validateMirror(MirrorDto mirror) {
+    private static void validateMirror(MirrorDto mirror, @Nullable ZoneConfig zoneConfig) {
         checkArgument(!Strings.isNullOrEmpty(mirror.id()), "Mirror ID is empty");
         final String scheduleString = mirror.schedule();
         if (scheduleString != null) {
@@ -298,6 +302,13 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
             final CronField secondField = schedule.retrieve(CronFieldName.SECOND);
             checkArgument(!secondField.getExpression().asString().contains("*"),
                           "The second field of the schedule must be specified. (seconds: *, expected: 0-59)");
+        }
+
+        final String zone = mirror.zone();
+        if (zone != null) {
+            checkArgument(zoneConfig != null, "Zone configuration is missing");
+            checkArgument(zoneConfig.allZones().contains(zone),
+                          "The zone '%s' is not in the zone configuration: %s", zone, zoneConfig);
         }
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -315,6 +315,7 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
                 mirrorDto.localPath(),
                 URI.create(remoteUri),
                 mirrorDto.gitignore(),
-                mirrorDto.credentialId());
+                mirrorDto.credentialId(),
+                mirrorDto.zone());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConfig.java
@@ -81,6 +81,8 @@ public final class MirrorConfig {
     private final String credentialId;
     @Nullable
     private final Cron schedule;
+    @Nullable
+    private final String zone;
 
     @JsonCreator
     public MirrorConfig(@JsonProperty("id") String id,
@@ -91,7 +93,8 @@ public final class MirrorConfig {
                         @JsonProperty("localPath") @Nullable String localPath,
                         @JsonProperty(value = "remoteUri", required = true) URI remoteUri,
                         @JsonProperty("gitignore") @Nullable Object gitignore,
-                        @JsonProperty("credentialId") String credentialId) {
+                        @JsonProperty("credentialId") String credentialId,
+                        @JsonProperty("zone") @Nullable String zone) {
         this.id = requireNonNull(id, "id");
         this.enabled = firstNonNull(enabled, true);
         if (schedule != null) {
@@ -122,6 +125,7 @@ public final class MirrorConfig {
             this.gitignore = null;
         }
         this.credentialId = requireNonNull(credentialId, "credentialId");
+        this.zone = zone;
     }
 
     @Nullable
@@ -132,7 +136,7 @@ public final class MirrorConfig {
 
         final MirrorContext mirrorContext = new MirrorContext(
                 id, enabled, schedule, direction, findCredential(credentials, credentialId),
-                parent.repos().get(localRepo), localPath, remoteUri, gitignore);
+                parent.repos().get(localRepo), localPath, remoteUri, gitignore, zone);
         for (MirrorProvider mirrorProvider : MIRROR_PROVIDERS) {
             final Mirror mirror = mirrorProvider.newMirror(mirrorContext);
             if (mirror != null) {
@@ -209,6 +213,12 @@ public final class MirrorConfig {
         }
     }
 
+    @Nullable
+    @JsonProperty("zone")
+    public String zone() {
+        return zone;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
@@ -220,6 +230,7 @@ public final class MirrorConfig {
                           .add("gitignore", gitignore)
                           .add("credentialId", credentialId)
                           .add("schedule", schedule)
+                          .add("zone", zone)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -101,6 +101,12 @@ public interface Mirror {
     boolean enabled();
 
     /**
+     * Returns the zone where this {@link Mirror} is pinned to.
+     */
+    @Nullable
+    String zone();
+
+    /**
      * Performs the mirroring task.
      *
      * @param workDir the local directory where keeps the mirrored files

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorContext.java
@@ -44,13 +44,15 @@ public final class MirrorContext {
     private final URI remoteUri;
     @Nullable
     private final String gitignore;
+    @Nullable
+    private final String zone;
 
     /**
      * Creates a new instance.
      */
     public MirrorContext(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                          Credential credential, Repository localRepo, String localPath, URI remoteUri,
-                         @Nullable String gitignore) {
+                         @Nullable String gitignore, @Nullable String zone) {
         this.id = requireNonNull(id, "id");
         this.enabled = enabled;
         this.schedule = schedule;
@@ -60,6 +62,7 @@ public final class MirrorContext {
         this.localPath = requireNonNull(localPath, "localPath");
         this.remoteUri = requireNonNull(remoteUri, "remoteUri");
         this.gitignore = gitignore;
+        this.zone = zone;
     }
 
     /**
@@ -128,6 +131,14 @@ public final class MirrorContext {
         return gitignore;
     }
 
+    /**
+     * Returns the zone where this mirror is pinned.
+     */
+    @Nullable
+    public String zone() {
+        return zone;
+    }
+
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this).omitNullValues()
@@ -140,6 +151,7 @@ public final class MirrorContext {
                           .add("localPath", localPath)
                           .add("remoteUri", remoteUri)
                           .add("gitignore", gitignore)
+                          .add("zone", zone)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorResult.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorResult.java
@@ -42,6 +42,8 @@ public final class MirrorResult {
     private final String description;
     private final Instant triggeredTime;
     private final Instant completedTime;
+    @Nullable
+    private final String zone;
 
     /**
      * Creates a new instance.
@@ -53,7 +55,8 @@ public final class MirrorResult {
                         @JsonProperty("mirrorStatus") MirrorStatus mirrorStatus,
                         @JsonProperty("description") @Nullable String description,
                         @JsonProperty("triggeredTime") Instant triggeredTime,
-                        @JsonProperty("completedTime") Instant completedTime) {
+                        @JsonProperty("completedTime") Instant completedTime,
+                        @JsonProperty("zone") @Nullable String zone) {
         this.mirrorId = requireNonNull(mirrorId, "mirrorId");
         this.projectName = requireNonNull(projectName, "projectName");
         this.repoName = requireNonNull(repoName, "repoName");
@@ -61,6 +64,7 @@ public final class MirrorResult {
         this.description = description;
         this.triggeredTime = requireNonNull(triggeredTime, "triggeredTime");
         this.completedTime = requireNonNull(completedTime, "completedTime");
+        this.zone = zone;
     }
 
     /**
@@ -120,6 +124,15 @@ public final class MirrorResult {
         return completedTime;
     }
 
+    /**
+     * Returns the zone where the mirroring operation was performed.
+     */
+    @Nullable
+    @JsonProperty("zone")
+    public String zone() {
+        return zone;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -135,13 +148,14 @@ public final class MirrorResult {
                mirrorStatus == that.mirrorStatus &&
                Objects.equals(description, that.description) &&
                triggeredTime.equals(that.triggeredTime) &&
-               completedTime.equals(that.completedTime);
+               completedTime.equals(that.completedTime) &&
+               Objects.equals(zone, that.zone);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(mirrorId, projectName, repoName, mirrorStatus, description,
-                            triggeredTime, completedTime);
+                            triggeredTime, completedTime, zone);
     }
 
     @Override
@@ -155,6 +169,7 @@ public final class MirrorResult {
                           .add("description", description)
                           .add("triggeredTime", triggeredTime)
                           .add("completedTime", completedTime)
+                          .add("zone", zone)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorTask.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorTask.java
@@ -19,8 +19,11 @@ package com.linecorp.centraldogma.server.mirror;
 import java.time.Instant;
 import java.util.Objects;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.storage.project.Project;
 
@@ -32,15 +35,19 @@ public final class MirrorTask {
     private final Mirror mirror;
     private final User triggeredBy;
     private final Instant triggeredTime;
+    @Nullable
+    private final String currentZone;
     private final boolean scheduled;
 
     /**
      * Creates a new instance.
      */
-    public MirrorTask(Mirror mirror, User triggeredBy, Instant triggeredTime, boolean scheduled) {
+    public MirrorTask(Mirror mirror, User triggeredBy, Instant triggeredTime, @Nullable String currentZone,
+                      boolean scheduled) {
         this.mirror = mirror;
         this.triggeredTime = triggeredTime;
         this.triggeredBy = triggeredBy;
+        this.currentZone = currentZone;
         this.scheduled = scheduled;
     }
 
@@ -70,6 +77,15 @@ public final class MirrorTask {
      */
     public Instant triggeredTime() {
         return triggeredTime;
+    }
+
+    /**
+     * Returns the current zone where the {@link Mirror} is running.
+     * This value is {@code null} if the {@link ZoneConfig} is not available.
+     */
+    @Nullable
+    public String currentZone() {
+        return currentZone;
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
@@ -32,7 +32,7 @@ import com.linecorp.centraldogma.server.plugin.AbstractPluginConfig;
 public final class MirroringServicePluginConfig extends AbstractPluginConfig {
 
     public static final MirroringServicePluginConfig INSTANCE =
-            new MirroringServicePluginConfig(true, null, null, null);
+            new MirroringServicePluginConfig(true, null, null, null, false);
 
     static final int DEFAULT_NUM_MIRRORING_THREADS = 16;
     static final int DEFAULT_MAX_NUM_FILES_PER_MIRROR = 8192;
@@ -41,12 +41,13 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     private final int numMirroringThreads;
     private final int maxNumFilesPerMirror;
     private final long maxNumBytesPerMirror;
+    private final boolean zonePinned;
 
     /**
      * Creates a new instance.
      */
     public MirroringServicePluginConfig(boolean enabled) {
-        this(enabled, null, null, null);
+        this(enabled, null, null, null, false);
     }
 
     /**
@@ -57,7 +58,8 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
             @JsonProperty("enabled") @Nullable Boolean enabled,
             @JsonProperty("numMirroringThreads") @Nullable Integer numMirroringThreads,
             @JsonProperty("maxNumFilesPerMirror") @Nullable Integer maxNumFilesPerMirror,
-            @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror) {
+            @JsonProperty("maxNumBytesPerMirror") @Nullable Long maxNumBytesPerMirror,
+            @JsonProperty("zonePinned") boolean zonePinned) {
         super(enabled);
         this.numMirroringThreads = firstNonNull(numMirroringThreads, DEFAULT_NUM_MIRRORING_THREADS);
         checkArgument(this.numMirroringThreads > 0,
@@ -68,12 +70,13 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
         this.maxNumBytesPerMirror = firstNonNull(maxNumBytesPerMirror, DEFAULT_MAX_NUM_BYTES_PER_MIRROR);
         checkArgument(this.maxNumBytesPerMirror > 0,
                       "maxNumBytesPerMirror: %s (expected: > 0)", this.maxNumBytesPerMirror);
+        this.zonePinned = zonePinned;
     }
 
     /**
      * Returns the number of mirroring threads.
      */
-    @JsonProperty
+    @JsonProperty("numMirroringThreads")
     public int numMirroringThreads() {
         return numMirroringThreads;
     }
@@ -81,7 +84,7 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     /**
      * Returns the maximum allowed number of files per mirror.
      */
-    @JsonProperty
+    @JsonProperty("maxNumFilesPerMirror")
     public int maxNumFilesPerMirror() {
         return maxNumFilesPerMirror;
     }
@@ -89,9 +92,17 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     /**
      * Returns the maximum allowed number of bytes per mirror.
      */
-    @JsonProperty
+    @JsonProperty("maxNumBytesPerMirror")
     public long maxNumBytesPerMirror() {
         return maxNumBytesPerMirror;
+    }
+
+    /**
+     * Returns whether a {@link Mirror} is pinned to a specific zone.
+     */
+    @JsonProperty("zonePinned")
+    public boolean zonePinned() {
+        return zonePinned;
     }
 
     @Override
@@ -100,6 +111,7 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
                           .add("numMirroringThreads", numMirroringThreads)
                           .add("maxNumFilesPerMirror", maxNumFilesPerMirror)
                           .add("maxNumBytesPerMirror", maxNumBytesPerMirror)
+                          .add("zonePinned", zonePinned)
                           .toString();
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirroringServicePluginConfig.java
@@ -76,7 +76,7 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     /**
      * Returns the number of mirroring threads.
      */
-    @JsonProperty("numMirroringThreads")
+    @JsonProperty
     public int numMirroringThreads() {
         return numMirroringThreads;
     }
@@ -84,7 +84,7 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     /**
      * Returns the maximum allowed number of files per mirror.
      */
-    @JsonProperty("maxNumFilesPerMirror")
+    @JsonProperty
     public int maxNumFilesPerMirror() {
         return maxNumFilesPerMirror;
     }
@@ -92,7 +92,7 @@ public final class MirroringServicePluginConfig extends AbstractPluginConfig {
     /**
      * Returns the maximum allowed number of bytes per mirror.
      */
-    @JsonProperty("maxNumBytesPerMirror")
+    @JsonProperty
     public long maxNumBytesPerMirror() {
         return maxNumBytesPerMirror;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/AllReplicasPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/AllReplicasPlugin.java
@@ -15,8 +15,11 @@
  */
 package com.linecorp.centraldogma.server.plugin;
 
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+
 /**
- * A Base class for {@link Plugin} whose {@link #target()} is {@link PluginTarget#ALL_REPLICAS}.
+ * A Base class for {@link Plugin} whose {@link #target(CentralDogmaConfig)} is
+ * {@link PluginTarget#ALL_REPLICAS}.
  */
 public abstract class AllReplicasPlugin implements Plugin {
 
@@ -26,7 +29,7 @@ public abstract class AllReplicasPlugin implements Plugin {
     public void init(PluginInitContext pluginInitContext) {}
 
     @Override
-    public final PluginTarget target() {
+    public final PluginTarget target(CentralDogmaConfig config) {
         return PluginTarget.ALL_REPLICAS;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/Plugin.java
@@ -27,7 +27,7 @@ public interface Plugin {
     /**
      * Returns the {@link PluginTarget} which specifies the replicas that this {@link Plugin} is applied to.
      */
-    PluginTarget target();
+    PluginTarget target(CentralDogmaConfig config);
 
     /**
      * Invoked when this {@link Plugin} is supposed to be started.

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/MetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/MetaRepository.java
@@ -19,8 +19,11 @@ package com.linecorp.centraldogma.server.storage.repository;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nullable;
+
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.internal.api.v1.MirrorDto;
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommitResult;
 import com.linecorp.centraldogma.server.credential.Credential;
@@ -63,6 +66,7 @@ public interface MetaRepository extends Repository {
      * Create a push {@link Command} for the {@link MirrorDto}.
      */
     CompletableFuture<Command<CommitResult>> createPushCommand(MirrorDto mirrorDto, Author author,
+                                                               @Nullable ZoneConfig zoneConfig,
                                                                boolean update);
 
     /**

--- a/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/PluginGroupTest.java
@@ -41,7 +41,7 @@ class PluginGroupTest {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         final PluginGroup group = PluginGroup.loadPlugins(PluginTarget.ALL_REPLICAS, cfg);
         assertThat(group).isNotNull();
-        confirmPluginStartStop(group.findFirstPlugin(NoopPluginForAllReplicas.class).orElse(null));
+        confirmPluginStartStop(group.findFirstPlugin(NoopPluginForAllReplicas.class));
     }
 
     @Test
@@ -49,7 +49,7 @@ class PluginGroupTest {
         final CentralDogmaConfig cfg = mock(CentralDogmaConfig.class);
         final PluginGroup group = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group).isNotNull();
-        confirmPluginStartStop(group.findFirstPlugin(NoopPluginForLeader.class).orElse(null));
+        confirmPluginStartStop(group.findFirstPlugin(NoopPluginForLeader.class));
     }
 
     @Test
@@ -58,19 +58,19 @@ class PluginGroupTest {
         when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of());
         final PluginGroup group1 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group1).isNotNull();
-        assertThat(group1.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
+        assertThat(group1.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotNull();
 
         when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of(
                 MirroringServicePluginConfig.class, new MirroringServicePluginConfig(true)));
         final PluginGroup group2 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group2).isNotNull();
-        assertThat(group2.findFirstPlugin(DefaultMirroringServicePlugin.class)).isPresent();
+        assertThat(group2.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotNull();
 
         when(cfg.pluginConfigMap()).thenReturn(ImmutableMap.of(
                 MirroringServicePluginConfig.class, new MirroringServicePluginConfig(false)));
         final PluginGroup group3 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group3).isNotNull();
-        assertThat(group3.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNotPresent();
+        assertThat(group3.findFirstPlugin(DefaultMirroringServicePlugin.class)).isNull();
     }
 
     /**
@@ -83,12 +83,12 @@ class PluginGroupTest {
         when(cfg.maxRemovedRepositoryAgeMillis()).thenReturn(1L);
         final PluginGroup group1 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group1).isNotNull();
-        assertThat(group1.findFirstPlugin(PurgeSchedulingServicePlugin.class)).isPresent();
+        assertThat(group1.findFirstPlugin(PurgeSchedulingServicePlugin.class)).isNotNull();
 
         when(cfg.maxRemovedRepositoryAgeMillis()).thenReturn(0L);
         final PluginGroup group2 = PluginGroup.loadPlugins(PluginTarget.LEADER_ONLY, cfg);
         assertThat(group2).isNotNull();
-        assertThat(group2.findFirstPlugin(PurgeSchedulingServicePlugin.class)).isNotPresent();
+        assertThat(group2.findFirstPlugin(PurgeSchedulingServicePlugin.class)).isNull();
     }
 
     private static void confirmPluginStartStop(@Nullable AbstractNoopPlugin plugin) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirrorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirrorTest.java
@@ -123,7 +123,7 @@ class CentralDogmaMirrorTest {
         final Mirror mirror =
                 new CentralDogmaMirrorProvider().newMirror(
                         new MirrorContext(mirrorId, true, schedule, MirrorDirection.LOCAL_TO_REMOTE,
-                                          credential, repository, "/", URI.create(remoteUri), null));
+                                          credential, repository, "/", URI.create(remoteUri), null, null));
 
         assertThat(mirror).isInstanceOf(mirrorType);
         assertThat(mirror.id()).isEqualTo(mirrorId);
@@ -141,7 +141,7 @@ class CentralDogmaMirrorTest {
         final Credential credential = mock(Credential.class);
         final Mirror mirror = new CentralDogmaMirrorProvider().newMirror(
                 new MirrorContext("mirror-id", true, EVERY_MINUTE, MirrorDirection.LOCAL_TO_REMOTE,
-                                  credential, mock(Repository.class), "/", URI.create(remoteUri), null));
+                                  credential, mock(Repository.class), "/", URI.create(remoteUri), null, null));
         assertThat(mirror).isNull();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForAllReplicas.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForAllReplicas.java
@@ -15,9 +15,11 @@
  */
 package com.linecorp.centraldogma.server.plugin;
 
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+
 public class NoopPluginForAllReplicas extends AbstractNoopPlugin {
     @Override
-    public PluginTarget target() {
+    public PluginTarget target(CentralDogmaConfig config) {
         return PluginTarget.ALL_REPLICAS;
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/plugin/NoopPluginForLeader.java
@@ -15,9 +15,11 @@
  */
 package com.linecorp.centraldogma.server.plugin;
 
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+
 public class NoopPluginForLeader extends AbstractNoopPlugin {
     @Override
-    public PluginTarget target() {
+    public PluginTarget target(CentralDogmaConfig config) {
         return PluginTarget.LEADER_ONLY;
     }
 

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -124,8 +124,8 @@ Setting up a mirroring task
 
    - If unspecified:
 
-     - a mirroring task is executed in the first zone of ``zone.zones`` configuration.
-     - if ``zone.zones`` is not configured, a mirroring task is executed in the leader replica.
+     - a mirroring task is executed in the first zone of ``zone.allZones`` configuration.
+     - if ``zone.allZones`` is not configured, a mirroring task is executed in the leader replica.
 
 Setting up a credential
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -57,7 +57,8 @@ Setting up a mirroring task
      "gitignore": [
          "/credential.txt",
          "private_dir"
-     ]
+     ],
+     "zone": "zone1"
    }
 
 - ``id`` (string)
@@ -116,6 +117,15 @@ Setting up a mirroring task
     The type of gitignore can either be a string containing the entire file (e.g. ``/filename.txt\ndirectory``) or an array 
     of strings where each line represents a single pattern. The file pattern expressed in gitignore is relative to the
     path of ``remoteUri``.
+
+- ``zone`` (string, optional)
+
+   - the zone where the mirroring task is executed.
+
+   - If unspecified:
+
+     - a mirroring task is executed in the first zone of ``zone.zones`` configuration.
+     - if ``zone.zones`` is not configured, a mirroring task is executed in the leader replica.
 
 Setting up a credential
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -278,7 +278,7 @@ Core properties
 
       - the list of zone names.
 
-      - The current zone name must be included in the list of zone names.
+      - the current zone name must be included in the list of zone names.
 
 .. _replication:
 

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -265,13 +265,20 @@ Core properties
 
 - ``zone`` (string)
 
-    - the zone name of the server. If not specified, ``PluginTarget.ZONE_LEADER_ONLY`` can't be used.
+    - the zone information of the server. If not specified, ``PluginTarget.ZONE_LEADER_ONLY`` can't be used.
 
-      - If the value starts with ``env:``, the environment variable is used as the zone name.
+    - ``currentZone`` (string)
+
+      - the current zone name. If the value starts with ``env:``, the environment variable is used as the zone name.
         For example, if the value is ``env:ZONE_NAME``, the environment variable named ``ZONE_NAME`` is used as the
         zone name.
 
       - You can also dynamically load a zone name by implementing :api:`com.linecorp.centraldogma.server.ConfigValueConverter`.
+    - ``zones`` (string array)
+
+      - the list of zone names.
+
+      - The current zone name must be included in the list of zone names.
 
 .. _replication:
 
@@ -528,6 +535,7 @@ with ``pluginConfigs`` property in ``dogma.json`` as follows.
           "numMirroringThreads": null,
           "maxNumFilesPerMirror": null,
           "maxNumBytesPerMirror": null,
+          "zonePinned": false
         }
       ]
     }
@@ -554,6 +562,11 @@ properties that can be configured:
   - the maximum allowed number of bytes in a mirror. If the total size of the files in a Git repository exceeds
     this, Central Dogma will reject to mirror the Git repository. If ``null``, the default value of
     '33554432 bytes' (32 MiB) is used.
+
+- ``zonePinned`` (boolean)
+
+   - whether the mirroring plugin is pinned to a specific zone. If ``true``, a mirroring task will be executed
+     only in the specified zone. If ``false``, the plugin will be executed in the leader replica.
 
 For more information about mirroring, refer to :ref:`mirroring`.
 

--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -274,7 +274,8 @@ Core properties
         zone name.
 
       - You can also dynamically load a zone name by implementing :api:`com.linecorp.centraldogma.server.ConfigValueConverter`.
-    - ``zones`` (string array)
+
+    - ``allZones`` (string array)
 
       - the list of zone names.
 

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -116,10 +116,17 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
                     builder.port(new InetSocketAddress(NetUtil.LOCALHOST4, dogmaPort), SessionProtocol.HTTP)
                            .administrators(TestAuthMessageUtil.USERNAME)
                            .authProviderFactory(factory)
-                           .pluginConfigs(new MirroringServicePluginConfig(false))
                            .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                            .replication(new ZooKeeperReplicationConfig(serverId, zooKeeperServers));
                     configureEach(serverId, builder);
+                    final boolean isMirrorConfigured =
+                            builder.pluginConfigs()
+                                   .stream()
+                                   .anyMatch(pluginCfg -> pluginCfg instanceof MirroringServicePluginConfig);
+                    if (!isMirrorConfigured) {
+                        // Disable the mirroring service when it is not explicitly configured.
+                        builder.pluginConfigs(new MirroringServicePluginConfig(false));
+                    }
                 }
 
                 @Override

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -16,6 +16,8 @@
 
 package com.linecorp.centraldogma.testing.internal;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.io.File;
 import java.io.IOError;
 import java.net.InetSocketAddress;
@@ -217,7 +219,9 @@ public class CentralDogmaRuleDelegate {
      * @throws IllegalStateException if Central Dogma did not start yet
      */
     public final MirroringService mirroringService() {
-        return dogma().mirroringService().get();
+        final MirroringService mirroringService = dogma().mirroringService();
+        checkState(mirroringService != null, "Mirroring service not available");
+        return mirroringService;
     }
 
     /**

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -75,6 +75,16 @@ export type TitleDto = {
   hostname: string;
 };
 
+export type ZoneDto = {
+  currentZone: string;
+  allZones: string[];
+};
+
+export type MirrorConfig = {
+  zonePinned: boolean;
+  zone: ZoneDto;
+};
+
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({
@@ -361,6 +371,12 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['Metadata'],
     }),
+    getMirrorConfig: builder.query<MirrorConfig, void>({
+      query: () => ({
+        url: `/api/v1/mirror/config`,
+        method: 'GET',
+      }),
+    }),
     getCredentials: builder.query<CredentialDto[], string>({
       query: (projectName) => `/api/v1/projects/${projectName}/credentials`,
       providesTags: ['Metadata'],
@@ -396,7 +412,6 @@ export const apiSlice = createApi({
     }),
     getTitle: builder.query<TitleDto, void>({
       query: () => ({
-        baseUrl: '',
         url: `/title`,
         method: 'GET',
       }),
@@ -446,6 +461,7 @@ export const {
   useUpdateMirrorMutation,
   useDeleteMirrorMutation,
   useRunMirrorMutation,
+  useGetMirrorConfigQuery,
   // Credential
   useGetCredentialsQuery,
   useGetCredentialQuery,

--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorDto.ts
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorDto.ts
@@ -12,4 +12,5 @@ export interface MirrorDto {
   gitignore?: string;
   credentialId: string;
   enabled: boolean;
+  zone?: string;
 }

--- a/webapp/src/dogma/features/project/settings/mirrors/MirrorView.tsx
+++ b/webapp/src/dogma/features/project/settings/mirrors/MirrorView.tsx
@@ -30,6 +30,7 @@ import { FiBox } from 'react-icons/fi';
 import cronstrue from 'cronstrue';
 import { RunMirror } from '../../../mirror/RunMirrorButton';
 import { FaPlay } from 'react-icons/fa';
+import { CiLocationOn } from 'react-icons/ci';
 
 const HeadRow = ({ children }: { children: ReactNode }) => (
   <Td width="250px" fontWeight="semibold">
@@ -135,6 +136,14 @@ const MirrorView = ({ projectName, mirror, credential }: MirrorViewProps) => {
                   )}
                 </Td>
               </Tr>
+              {mirror.zone && (
+                <Tr>
+                  <HeadRow>
+                    <AlignedIcon as={CiLocationOn} /> Zone
+                  </HeadRow>
+                  <Td>{mirror.zone}</Td>
+                </Tr>
+              )}
               <Tr>
                 <HeadRow>
                   <AlignedIcon as={IoBanSharp} /> gitignore

--- a/webapp/src/test/java/com/linecorp/centraldogma/webapp/ShiroCentralDogmaTestServer.java
+++ b/webapp/src/test/java/com/linecorp/centraldogma/webapp/ShiroCentralDogmaTestServer.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import org.apache.shiro.config.Ini;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -39,7 +40,9 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.AccessToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.ZoneConfig;
 import com.linecorp.centraldogma.server.auth.shiro.ShiroAuthProviderFactory;
+import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
 
 final class ShiroCentralDogmaTestServer {
 
@@ -64,6 +67,8 @@ final class ShiroCentralDogmaTestServer {
                     users.put(USERNAME2, PASSWORD2);
                     return iniConfig;
                 }))
+                .pluginConfigs(new MirroringServicePluginConfig(true, null, null, null, true))
+                .zone(new ZoneConfig("zoneA", ImmutableList.of("zoneA", "zoneB", "zoneC")))
                 .build();
         server.start().join();
         scaffold();

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -25,6 +25,7 @@ import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.centraldogma.server.plugin.AllReplicasPlugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginInitContext;
+import com.linecorp.centraldogma.server.plugin.PluginTarget;
 import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 
 public final class ControlPlanePlugin extends AllReplicasPlugin {
@@ -67,8 +68,8 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
-                          .add("configType", configType())
-                          .add("target", target())
+                          .add("configType", configType().getName())
+                          .add("target", PluginTarget.LEADER_ONLY)
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlanePlugin.java
@@ -69,7 +69,7 @@ public final class ControlPlanePlugin extends AllReplicasPlugin {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("configType", configType().getName())
-                          .add("target", PluginTarget.LEADER_ONLY)
+                          .add("target", PluginTarget.ALL_REPLICAS)
                           .toString();
     }
 }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingPlugin.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingPlugin.java
@@ -23,7 +23,10 @@ import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
 
+import com.google.common.base.MoreObjects;
+
 import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.plugin.Plugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
@@ -41,7 +44,7 @@ public final class XdsKubernetesEndpointFetchingPlugin implements Plugin {
     private XdsKubernetesEndpointFetchingService fetchingService;
 
     @Override
-    public PluginTarget target() {
+    public PluginTarget target(CentralDogmaConfig config) {
         return PluginTarget.LEADER_ONLY;
     }
 
@@ -73,5 +76,13 @@ public final class XdsKubernetesEndpointFetchingPlugin implements Plugin {
     @Override
     public Class<?> configType() {
         return getClass();
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("target", PluginTarget.LEADER_ONLY)
+                          .add("configType", configType().getName())
+                          .toString();
     }
 }


### PR DESCRIPTION
Motivation:

I propose running the mirror in a zone close to the git server or only in zones that are allowed access.

Modifications:

- Add `zone` as an optional property to mirror configurations.
- Add `GET /api/v1/mirror/config` API to provide zone-related configurations.
  - The API is used to select a pinned zone on the mirror form.
- Add `zonePinned` flag to `MirroringServicePluginConfig` to enable zone-pinned mirroring.
  - The option is disabled by default.
  - `DefaultMirroringServicePlugin.target()` returns `PluginTarget.ZONE_LEADER_ONLY` if `zonePinned == true`
  - Fixed `MirrorSchedulingService` to only run a pinned zone if `zonePinned == true`
- Add `ZoneConfig` to replace `zone: string` configuration.
  - `allZones` is newly added to specify the list of zone names.
- Breaking) Make `Plugin.target()` take `CentralDogmaConfig` as an argument.

Result:

You can now specify a zone where you want to perform mirroring.