### PR TITLE
Refactor `MetadataService` to Use `ContentTransformer`

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/RedundantChangeException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RedundantChangeException.java
@@ -59,9 +59,8 @@ public class RedundantChangeException extends CentralDogmaException {
     /**
      * Returns the head revision of the repository when this exception was raised.
      */
+    @Nullable
     public Revision headRevision() {
-        // This is only called from the server-side which always sets the head revision.
-        assert headRevision != null;
         return headRevision;
     }
 }

--- a/common/src/main/java/com/linecorp/centraldogma/common/RedundantChangeException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/RedundantChangeException.java
@@ -16,37 +16,33 @@
 
 package com.linecorp.centraldogma.common;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.annotation.Nullable;
+
 /**
  * A {@link CentralDogmaException} that is raised when attempted to push a commit without effective changes.
  */
 public class RedundantChangeException extends CentralDogmaException {
 
     private static final long serialVersionUID = 8739464985038079688L;
-
-    /**
-     * Creates a new instance.
-     */
-    public RedundantChangeException() {}
+    @Nullable
+    private final Revision headRevision;
 
     /**
      * Creates a new instance.
      */
     public RedundantChangeException(String message) {
         super(message);
+        headRevision = null;
     }
 
     /**
      * Creates a new instance.
      */
-    public RedundantChangeException(Throwable cause) {
-        super(cause);
-    }
-
-    /**
-     * Creates a new instance.
-     */
-    public RedundantChangeException(String message, Throwable cause) {
-        super(message, cause);
+    public RedundantChangeException(Revision headRevision, String message) {
+        super(message);
+        this.headRevision = requireNonNull(headRevision, "headRevision");
     }
 
     /**
@@ -57,13 +53,15 @@ public class RedundantChangeException extends CentralDogmaException {
      */
     public RedundantChangeException(String message, boolean writableStackTrace) {
         super(message, writableStackTrace);
+        headRevision = null;
     }
 
     /**
-     * Creates a new instance.
+     * Returns the head revision of the repository when this exception was raised.
      */
-    protected RedundantChangeException(String message, Throwable cause, boolean enableSuppression,
-                                       boolean writableStackTrace) {
-        super(message, cause, enableSuppression, writableStackTrace);
+    public Revision headRevision() {
+        // This is only called from the server-side which always sets the head revision.
+        assert headRevision != null;
+        return headRevision;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/AbstractChangesApplier.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/AbstractChangesApplier.java
@@ -38,6 +38,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.internal.admin.service.TokenNotFoundException;
 import com.linecorp.centraldogma.server.storage.StorageException;
 
 abstract class AbstractChangesApplier {
@@ -59,7 +60,7 @@ abstract class AbstractChangesApplier {
             }
 
             return doApply(dirCache, reader, inserter);
-        } catch (CentralDogmaException | IllegalArgumentException e) {
+        } catch (CentralDogmaException | TokenNotFoundException | IllegalArgumentException e) {
             throw e;
         } catch (Exception e) {
             throw new StorageException("failed to apply changes on revision: " +

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitExecutor.java
@@ -156,10 +156,12 @@ final class CommitExecutor {
             }
 
             if (!allowEmptyCommit && isEmpty) {
+                // prevRevision is not null when allowEmptyCommit is false.
+                assert prevRevision != null;
                 throw new RedundantChangeException(
+                        prevRevision,
                         "changes did not change anything in " + gitRepository.parent().name() + '/' +
-                        gitRepository.name() + " at revision " +
-                        (prevRevision != null ? prevRevision.major() : 0) + ": " + changes);
+                        gitRepository.name() + " at revision " + prevRevision.major() + ": " + changes);
             }
 
             // flush the current index to repository and get the result tree object id.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TransformingChangesApplier.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TransformingChangesApplier.java
@@ -30,10 +30,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.google.common.base.MoreObjects;
 
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.ChangeConflictException;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.command.ContentTransformer;
+import com.linecorp.centraldogma.server.internal.admin.service.TokenNotFoundException;
 
 final class TransformingChangesApplier extends AbstractChangesApplier {
 
@@ -61,6 +63,8 @@ final class TransformingChangesApplier extends AbstractChangesApplier {
                 applyPathEdit(dirCache, new InsertJson(changePath, inserter, newJsonNode));
                 return 1;
             }
+        } catch (CentralDogmaException | TokenNotFoundException | IllegalArgumentException e) {
+            throw e;
         } catch (Exception e) {
             throw new ChangeConflictException("failed to transform the content: " + oldJsonNode +
                                               " transformer: " + transformer, e);

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -50,6 +50,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
@@ -548,8 +549,8 @@ public class MetadataService {
             final Map<String, TokenRegistration> newTokens;
             if (tokens.get(appId) == null) {
                 if (!quiet) {
-                    throw new IllegalArgumentException(
-                            "the token " + appId + " doesn't exist at '" + projectName + '/');
+                    throw new EntryNotFoundException(
+                            "failed to find the token " + appId + " in project " + projectName);
                 }
                 newTokens = tokens;
             } else {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
@@ -163,7 +163,7 @@ public class ProjectMetadata implements Identifiable {
         if (member != null) {
             return member;
         }
-        throw new EntryNotFoundException(memberId);
+        throw new EntryNotFoundException("failed to find member " + memberId + " in project " + name());
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
@@ -120,7 +120,9 @@ final class RepositorySupport<T> {
                        .exceptionally(cause -> {
                            final Throwable peeled = Exceptions.peel(cause);
                            if (peeled instanceof RedundantChangeException) {
-                               return ((RedundantChangeException) peeled).headRevision();
+                               final Revision revision = ((RedundantChangeException) peeled).headRevision();
+                               assert revision != null;
+                               return revision;
                            }
                            return Exceptions.throwUnsafely(peeled);
                        });

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
@@ -16,13 +16,10 @@
 
 package com.linecorp.centraldogma.server.metadata;
 
-import static com.linecorp.armeria.common.util.Functions.voidFunction;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +27,6 @@ import com.google.common.collect.ImmutableList;
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
-import com.linecorp.centraldogma.common.ChangeConflictException;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.RedundantChangeException;
@@ -39,6 +35,7 @@ import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.command.CommitResult;
+import com.linecorp.centraldogma.server.command.ContentTransformer;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
@@ -108,53 +105,25 @@ final class RepositorySupport<T> {
                        .thenApply(CommitResult::revision);
     }
 
-    CompletableFuture<Revision> push(String projectName, String repoName, Author author, String commitSummary,
-                                     Supplier<CompletionStage<HolderWithRevision<Change<?>>>> changeSupplier) {
+    CompletableFuture<Revision> push(String projectName, String repoName,
+                                     Author author, String commitSummary,
+                                     ContentTransformer<JsonNode> transformer) {
         requireNonNull(projectName, "projectName");
         requireNonNull(repoName, "repoName");
         requireNonNull(author, "author");
         requireNonNull(commitSummary, "commitSummary");
-        requireNonNull(changeSupplier, "changeSupplier");
+        requireNonNull(transformer, "transformer");
 
-        final CompletableFuture<Revision> future = new CompletableFuture<>();
-        push(projectName, repoName, author, commitSummary, changeSupplier, future);
-        return future;
-    }
-
-    private void push(String projectName, String repoName, Author author, String commitSummary,
-                      Supplier<CompletionStage<HolderWithRevision<Change<?>>>> changeSupplier,
-                      CompletableFuture<Revision> future) {
-        changeSupplier.get().thenAccept(changeWithRevision -> {
-            final Revision revision = changeWithRevision.revision();
-            final Change<?> change = changeWithRevision.object();
-
-            push(projectName, repoName, author, commitSummary, change, revision)
-                    .thenAccept(future::complete)
-                    .exceptionally(voidFunction(cause -> {
-                        cause = Exceptions.peel(cause);
-                        if (cause instanceof ChangeConflictException) {
-                            final Revision latestRevision;
-                            try {
-                                latestRevision = projectManager().get(projectName).repos().get(repoName)
-                                                                 .normalizeNow(Revision.HEAD);
-                            } catch (Throwable cause1) {
-                                future.completeExceptionally(cause1);
-                                return;
-                            }
-
-                            if (revision.equals(latestRevision)) {
-                                future.completeExceptionally(cause);
-                                return;
-                            }
-                            // Try again.
-                            push(projectName, repoName, author, commitSummary, changeSupplier, future);
-                        } else if (cause instanceof RedundantChangeException) {
-                            future.complete(revision);
-                        } else {
-                            future.completeExceptionally(cause);
-                        }
-                    }));
-        }).exceptionally(voidFunction(future::completeExceptionally));
+        return executor.execute(Command.transform(null, author, projectName, repoName, Revision.HEAD,
+                                                  commitSummary, "", Markup.PLAINTEXT, transformer))
+                       .thenApply(CommitResult::revision)
+                       .exceptionally(cause -> {
+                           final Throwable peeled = Exceptions.peel(cause);
+                           if (peeled instanceof RedundantChangeException) {
+                               return ((RedundantChangeException) peeled).headRevision();
+                           }
+                           return Exceptions.throwUnsafely(peeled);
+                       });
     }
 
     Revision normalize(Repository repository) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -35,12 +35,14 @@ import com.spotify.futures.CompletableFutures;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.ProjectExistsException;
 import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.server.QuotaConfig;
 import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.internal.admin.service.TokenNotFoundException;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
 class MetadataServiceTest {
@@ -314,6 +316,10 @@ class MetadataServiceTest {
 
         assertThat(mds.findPermissions(project1, repo1, user2).join())
                 .containsExactly(Permission.READ);
+
+        // Remove 'user1' again.
+        assertThatThrownBy(() -> mds.removeMember(author, project1, user1).join())
+                .hasCauseInstanceOf(EntryNotFoundException.class);
     }
 
     @Test
@@ -340,6 +346,10 @@ class MetadataServiceTest {
 
         assertThat(mds.findPermissions(project1, repo1, app2).join())
                 .containsExactly(Permission.READ);
+
+        // Remove 'app1' again.
+        assertThatThrownBy(() -> mds.removeToken(author, project1, app1).join())
+                .hasCauseInstanceOf(EntryNotFoundException.class);
     }
 
     @Test
@@ -369,6 +379,10 @@ class MetadataServiceTest {
 
         assertThat(mds.findPermissions(project1, repo1, app2).join())
                 .containsExactly(Permission.READ);
+
+        // Remove 'app1' again.
+        assertThatThrownBy(() -> mds.destroyToken(author, app1).join())
+                .hasCauseInstanceOf(TokenNotFoundException.class);
     }
 
     @Test
@@ -387,8 +401,14 @@ class MetadataServiceTest {
         assertThat(token.deactivation()).isNotNull();
         assertThat(token.deactivation().user()).isEqualTo(owner.id());
 
+        assertThatThrownBy(() -> mds.deactivateToken(author, app1).join())
+                .hasCauseInstanceOf(IllegalArgumentException.class);
+
         mds.activateToken(author, app1).join();
         assertThat(mds.getTokens().join().get(app1).isActive()).isTrue();
+
+        assertThatThrownBy(() -> mds.activateToken(author, app1).join())
+                .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
@@ -422,10 +442,14 @@ class MetadataServiceTest {
         mds.updateTokenLevel(author, app1, true).join();
         token = mds.getTokens().join().get(app1);
         assertThat(token.isAdmin()).isTrue();
+        assertThatThrownBy(() -> mds.updateTokenLevel(author, app1, true).join())
+                .hasCauseInstanceOf(IllegalArgumentException.class);
 
         mds.updateTokenLevel(author, app1, false).join();
         token = mds.getTokens().join().get(app1);
         assertThat(token.isAdmin()).isFalse();
+        assertThatThrownBy(() -> mds.updateTokenLevel(author, app1, false).join())
+                .hasCauseInstanceOf(IllegalArgumentException.class);
     }
 
     private static RepositoryMetadata getRepo1(MetadataService mds) {


### PR DESCRIPTION
Motivation:
Previously, the Central Dogma server in `MetadataService` would repeatedly attempt to commit when
- `ChangeConflictException` is raised.
- The revision for fetching the content differs from the repository head revision.
With the introduction of `ContentTransformer` in #1064, the server can now handle transformations in a single attempt, avoiding unnecessary retries.

Modifications:
- Updated `MetadataService` to utilize `ContentTransformer` for commit operations.

Result:
- Improved efficiency in `MetadataService` by eliminating repeated commit attempts.

To-do:
- Encapsulate `tokenRepo` and `metadataRepo` in `MetadataService` into its class respectively.