### PR TITLE
Implement `LogMeta#toString` to easily debug zookeeper log removal warnings

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         java: [21]
         include:
           - java: 8

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -83,6 +83,7 @@ import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.escape.Escaper;
@@ -1202,6 +1203,16 @@ public final class ZooKeeperCommandExecutor
 
         public void appendBlock(long blockId) {
             blocks.add(blockId);
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("replicaId", replicaId)
+                              .add("timestamp", timestamp)
+                              .add("size", size)
+                              .add("blocks", blocks)
+                              .toString();
         }
     }
 


### PR DESCRIPTION
**Motivation**

With the improvement introduced by https://github.com/line/centraldogma/pull/1040, we have been observing logs where CentralDogma attempts to delete logs that don't exist.

In order to 1) verify which nodes are being prematurely deleted and 2) to observe trends as to why this may occur, I propose that `LogMeta#toString` be implemented.