### PR TITLE
Disable sphinx for aarch_64

### DIFF
--- a/site/build.gradle
+++ b/site/build.gradle
@@ -15,10 +15,14 @@ if (project.hasProperty("noSite")) {
 
 apply plugin: "kr.motd.sphinx"
 
+def osdetector = project.rootProject.osdetector
+def skipSphinx = osdetector.os == 'osx' && osdetector.arch == 'aarch_64'
+
 sphinx {
     group = 'Documentation'
     description = 'Generates the Sphinx web site.'
     sourceDirectory "${project.projectDir}/src/sphinx"
+    skip = skipSphinx
 }
 
 task javadoc(type: Javadoc,


### PR DESCRIPTION
Until we actually upload the binary since:

1) A simple `assemble` task fails for osx users
2) Now the CI is failing as well