### PR TITLE
Expose a port number of `remoteUrl` in the mirror UI

### DIFF
--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
@@ -292,6 +292,40 @@ class MirroringAndCredentialServiceV1Test {
             final MirrorDto savedMirror = response1.content();
             assertThat(savedMirror).isEqualTo(newMirror);
         }
+
+        // Make sure that the mirror with a port number in the remote URL can be created and read.
+        final MirrorDto mirrorWithPort = new MirrorDto("mirror-with-port-3",
+                                               true,
+                                               FOO_PROJ,
+                                               "5 * * * * ?",
+                                               "REMOTE_TO_LOCAL",
+                                               BAR_REPO,
+                                               "/updated/local-path/",
+                                               "git+https",
+                                               "git.com:922/line/centraldogma-test.git",
+                                               "/updated/remote-path/",
+                                               "updated-mirror-branch",
+                                               ".updated-env",
+                                               "public-key-credential",
+                                               null);
+
+        final ResponseEntity<PushResultDto> response0 =
+                userClient.prepare()
+                          .post("/api/v1/projects/{proj}/mirrors")
+                          .pathParam("proj", FOO_PROJ)
+                          .contentJson(mirrorWithPort)
+                          .asJson(PushResultDto.class)
+                          .execute();
+        assertThat(response0.status()).isEqualTo(HttpStatus.CREATED);
+        final ResponseEntity<MirrorDto> response1 =
+                userClient.prepare()
+                          .get("/api/v1/projects/{proj}/mirrors/{id}")
+                          .pathParam("proj", FOO_PROJ)
+                          .pathParam("id", mirrorWithPort.id())
+                          .asJson(MirrorDto.class)
+                          .execute();
+        final MirrorDto savedMirror = response1.content();
+        assertThat(savedMirror).isEqualTo(mirrorWithPort);
     }
 
     private void updateMirror() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
@@ -223,7 +223,7 @@ public class MirroringServiceV1 extends AbstractService {
                              mirror.localRepo().name(),
                              mirror.localPath(),
                              remoteRepoUri.getScheme(),
-                             remoteRepoUri.getHost() + remoteRepoUri.getPath(),
+                             remoteRepoUri.getAuthority() + remoteRepoUri.getPath(),
                              mirror.remotePath(),
                              mirror.remoteBranch(),
                              mirror.gitignore(),


### PR DESCRIPTION
Motivation:

I found that the port number of a remote URI was missing and wasn't shown in the mirror UI.

Modifications:

- Use `URI.getAuthority()` to include the port number of a remote URI.

Result:

The custom port number of a remote URI is correctly displayed in the mirror UI.