### PR TITLE
Migrate Legacy Metadata Format to new Role-Based Format

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationPlugin.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal;
+
+import java.time.Instant;
+import java.util.concurrent.CompletionStage;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.CentralDogmaConfig;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.command.CommitResult;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.plugin.Plugin;
+import com.linecorp.centraldogma.server.plugin.PluginContext;
+import com.linecorp.centraldogma.server.plugin.PluginTarget;
+import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+
+public final class MetadataRolesMigrationPlugin implements Plugin {
+
+    private static final Logger logger = LoggerFactory.getLogger(MetadataRolesMigrationPlugin.class);
+
+    @VisibleForTesting
+    static final String METADATA_ROLES_MIGRATION_JOB_LOG =
+            "/metadata-roles-job.json";
+
+    @Override
+    public PluginTarget target(CentralDogmaConfig config) {
+        return PluginTarget.LEADER_ONLY;
+    }
+
+    @Override
+    public CompletionStage<Void> start(PluginContext context) {
+        if (hasMigrationLog(context)) {
+            logger.debug("Metadata roles have already been migrated. Skipping auto migration...");
+            return UnmodifiableFuture.completedFuture(null);
+        }
+        logger.info("Starting metadata roles migration ...");
+
+        final MetadataService metadataService = new MetadataService(context.projectManager(),
+                                                                    context.commandExecutor());
+        final Stopwatch stopwatch = Stopwatch.createStarted();
+        for (Project project : context.projectManager().list().values()) {
+            final String name = project.name();
+            try {
+                metadataService.migrateMetadata(name).join();
+            } catch (Exception ex) {
+                // No need to rollback because the migration is not committed. Just log the error.
+                logger.warn("Failed to migrate metadata roles of {}", name, ex);
+                return UnmodifiableFuture.completedFuture(null);
+            }
+        }
+        logMigrationJob(context.commandExecutor());
+        logger.info("Metadata roles migration has been completed. (took: {} ms.)",
+                    stopwatch.elapsed().toMillis());
+        return UnmodifiableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletionStage<Void> stop(PluginContext context) {
+        return UnmodifiableFuture.completedFuture(null);
+    }
+
+    @Override
+    public Class<?> configType() {
+        // Return the plugin class itself because it does not have a configuration.
+        return getClass();
+    }
+
+    private static boolean hasMigrationLog(PluginContext context) {
+        final Project internalProj =
+                context.projectManager().get(InternalProjectInitializer.INTERNAL_PROJECT_DOGMA);
+        final Repository repository = internalProj.repos().get(Project.REPO_DOGMA);
+        final Entry<JsonNode> entry = repository.getOrNull(Revision.HEAD, Query.ofJson(
+                METADATA_ROLES_MIGRATION_JOB_LOG)).join();
+        return entry != null;
+    }
+
+    private static void logMigrationJob(CommandExecutor commandExecutor) {
+        final ImmutableMap<String, Object> data = ImmutableMap.of("timestamp", Instant.now());
+        final Change<JsonNode> change;
+        try {
+            change = Change.ofJsonUpsert(METADATA_ROLES_MIGRATION_JOB_LOG,
+                                         Jackson.writeValueAsString(data));
+        } catch (JsonProcessingException e) {
+            // Should never reach here.
+            throw new Error(e);
+        }
+        final Command<CommitResult> command =
+                Command.push(Author.SYSTEM, InternalProjectInitializer.INTERNAL_PROJECT_DOGMA,
+                             Project.REPO_DOGMA, Revision.HEAD,
+                             "Migration of metadata roles has been done", "",
+                             Markup.PLAINTEXT, change);
+        commandExecutor.execute(command).join();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationPlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationPlugin.java
@@ -78,7 +78,6 @@ public final class MetadataRolesMigrationPlugin implements Plugin {
             } catch (Exception ex) {
                 // No need to rollback because the migration is not committed. Just log the error.
                 logger.warn("Failed to migrate metadata roles of {}", name, ex);
-                return UnmodifiableFuture.completedFuture(null);
             }
         }
         logMigrationJob(context.commandExecutor());

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1215,4 +1215,20 @@ public class MetadataService {
                   .filter(e -> !e.getKey().equals(id))
                   .collect(toImmutableMap(Entry::getKey, Entry::getValue));
     }
+
+    /**
+     * Migrates the metadata of the specified {@code projectName} with the new format.
+     */
+    public CompletableFuture<Revision> migrateMetadata(String projectName) {
+        requireNonNull(projectName, "projectName");
+
+        final String commitSummary = "Rebuild metadata with the new format";
+
+        final ProjectMetadataTransformer transformer =
+                new ProjectMetadataTransformer((headRevision, projectMetadata) -> {
+                    // The projectMetadata is serialized into the new format.
+                    return projectMetadata;
+                });
+        return metadataRepo.push(projectName, Project.REPO_DOGMA, Author.SYSTEM, commitSummary, transformer);
+    }
 }

--- a/server/src/main/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
+++ b/server/src/main/resources/META-INF/services/com.linecorp.centraldogma.server.plugin.Plugin
@@ -1,2 +1,3 @@
 com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin
 com.linecorp.centraldogma.server.internal.storage.PurgeSchedulingServicePlugin
+com.linecorp.centraldogma.server.internal.MetadataRolesMigrationPlugin

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/MetadataRolesMigrationTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal;
+
+import static com.linecorp.centraldogma.internal.jsonpatch.JsonPatchOperation.asJsonArray;
+import static com.linecorp.centraldogma.server.metadata.MetadataService.METADATA_JSON;
+import static com.linecorp.centraldogma.server.storage.project.Project.REPO_DOGMA;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Query;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.jsonpatch.AddOperation;
+import com.linecorp.centraldogma.internal.jsonpatch.TestAbsenceOperation;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.project.ProjectManager;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
+
+class MetadataRolesMigrationTest {
+
+    private static final String TEST_PROJ = "fooProj";
+    private static final String TEST_REPO = "barRepo";
+
+    @RegisterExtension
+    static ProjectManagerExtension projectManagerExtension = new ProjectManagerExtension() {
+
+        @Override
+        protected void afterExecutorStarted() {
+            final ProjectManager projectManager = projectManagerExtension.projectManager();
+            final Project project = projectManager.create(TEST_PROJ, Author.SYSTEM);
+            final RepositoryManager repoManager = project.repos();
+            repoManager.create(TEST_REPO, Author.SYSTEM);
+
+            final JsonPointer path = JsonPointer.compile("/repos/" + TEST_REPO);
+            final String legacyFormat = '{' +
+                                        "  \"name\": \"" + TEST_REPO + "\"," +
+                                        "  \"perRolePermissions\": {" +
+                                        "    \"owner\": [" +
+                                        "      \"READ\"," +
+                                        "      \"WRITE\"" +
+                                        "    ]," +
+                                        "    \"member\": []," +
+                                        "    \"guest\": []" +
+                                        "  }," +
+                                        "  \"perUserPermissions\": {}," +
+                                        "  \"perTokenPermissions\": {" +
+                                        "    \"token1\": [" +
+                                        "      \"READ\"" +
+                                        "    ]" +
+                                        "  }," +
+                                        "  \"creation\": {" +
+                                        "    \"user\": \"aaa@linecorp.com\"," +
+                                        "    \"timestamp\": \"2024-11-23T12:28:05.472983Z\"" +
+                                        "  }" +
+                                        '}';
+            try {
+                final Change<JsonNode> change =
+                        Change.ofJsonPatch(METADATA_JSON,
+                                           asJsonArray(new TestAbsenceOperation(path),
+                                                       new AddOperation(path,
+                                                                        Jackson.readTree(legacyFormat))));
+                projectManagerExtension.executor().execute(
+                        Command.push(Author.SYSTEM, TEST_PROJ, REPO_DOGMA, Revision.HEAD,
+                                     "Add", "", Markup.PLAINTEXT, change)).join();
+            } catch (JsonParseException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    };
+
+    @Test
+    void migrate() throws Exception {
+        final ProjectManager projectManager = projectManagerExtension.projectManager();
+        final Project project = projectManager.get(TEST_PROJ);
+        final Repository dogmaRepository = project.repos().get(REPO_DOGMA);
+        final MetadataService metadataService = new MetadataService(projectManager,
+                                                                    projectManagerExtension.executor());
+        metadataService.migrateMetadata(TEST_PROJ).join();
+        final Entry<JsonNode> entry = dogmaRepository.get(Revision.HEAD, Query.ofJson(METADATA_JSON)).join();
+        assertThatJson(entry.content().get("repos").get(TEST_REPO))
+                .isEqualTo('{' +
+                           "  \"name\": \"barRepo\"," +
+                           "  \"creation\": {" +
+                           "    \"user\": \"aaa@linecorp.com\"," +
+                           "    \"timestamp\": \"2024-11-23T12:28:05.472983Z\"" +
+                           "  }," +
+                           "  \"roles\": {" +
+                           "    \"projects\": {" +
+                           "      \"member\": null," +
+                           "      \"guest\": null" +
+                           "    }," +
+                           "    \"users\": { }," +
+                           "    \"tokens\": {" +
+                           "      \"token1\": \"READ\"" +
+                           "    }" +
+                           "  }" +
+                           '}');
+    }
+}


### PR DESCRIPTION
Motivation:
In #1060, role-based authentication was introduced, changing the structure of metadata to support roles (READ, WRITE, ADMIN).

Modifications:
- Implemented a migration plugin to convert legacy metadata into the new role-based format.

Result:
- The legacy metadata format is migrated to new role-based format.