### PR TITLE
Remove GUEST write permission

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -448,11 +448,6 @@ public class MetadataService {
                 "Update the project roles of the '" + repoName + "' in the project '" + projectName + '\'';
         final RepositoryMetadataTransformer transformer = new RepositoryMetadataTransformer(
                 repoName, (headRevision, repositoryMetadata) -> {
-            if (repositoryMetadata.roles().projectRoles().equals(projectRoles)) {
-                throw new RedundantChangeException(
-                        headRevision,
-                        "the project roles of '" + projectName + '/' + repoName + "' isn't changed.");
-            }
             final Roles newRoles = new Roles(projectRoles, repositoryMetadata.roles().users(),
                                              repositoryMetadata.roles().tokens());
             return new RepositoryMetadata(repositoryMetadata.name(),

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectRoles.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectRoles.java
@@ -53,6 +53,11 @@ public final class ProjectRoles {
     public ProjectRoles(@JsonProperty("member") @Nullable RepositoryRole member,
                         @JsonProperty("guest") @Nullable RepositoryRole guest) {
         this.member = member;
+        if (guest != null && guest != RepositoryRole.READ) {
+            // TODO(ikhoon): Add a migration task to fix the invalid role in metadata.json.
+            // Guests can only have READ permission.
+            guest = RepositoryRole.READ;
+        }
         this.guest = guest;
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -178,7 +178,8 @@ class MetadataServiceTest {
 
         repositoryMetadata = getRepo1(mds);
         assertThat(repositoryMetadata.roles().projectRoles().member()).isSameAs(RepositoryRole.WRITE);
-        assertThat(repositoryMetadata.roles().projectRoles().guest()).isEqualTo(RepositoryRole.WRITE);
+        // WRITE permission is not allowed for GUEST so it is automatically lowered to READ.
+        assertThat(repositoryMetadata.roles().projectRoles().guest()).isEqualTo(RepositoryRole.READ);
 
         final Revision revision =
                 mds.updateRepositoryProjectRoles(author, project1, repo1, DEFAULT_PROJECT_ROLES).join();

--- a/webapp/src/dogma/features/repo/RepositoriesMetadataDto.ts
+++ b/webapp/src/dogma/features/repo/RepositoriesMetadataDto.ts
@@ -20,7 +20,7 @@ export interface RolesDto {
 
 export interface ProjectRolesDto {
   member: RepositoryRole | null;
-  guest: 'READ' | 'WRITE' | null;
+  guest: 'READ' | null;
 }
 
 export interface UserOrTokenRepositoryRoleDto {

--- a/webapp/src/dogma/features/repo/roles/ProjectRolesForm.tsx
+++ b/webapp/src/dogma/features/repo/roles/ProjectRolesForm.tsx
@@ -2,10 +2,10 @@ import { Box, Flex, FormControl, FormLabel, HStack, Radio, RadioGroup, Spacer, V
 import { RepositoryRole } from 'dogma/features/auth/RepositoryRole';
 import { ConfirmUpdateRepositoryProjectRoles } from 'dogma/features/repo/roles/ConfirmUpdateRepositoryProjectRoles';
 import { ProjectRolesDto } from 'dogma/features/repo/RepositoriesMetadataDto';
-import { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 
 const getRole = (role: RepositoryRole | null) => {
-  return role == null ? 'NONE' : role;
+  return role || 'NONE';
 };
 
 export const ProjectRolesForm = ({
@@ -17,48 +17,66 @@ export const ProjectRolesForm = ({
   repoName: string;
   projectRoles: ProjectRolesDto;
 }) => {
-  const [member, setMember] = useState(getRole(projectRoles.member));
-  const [guest, setGuest] = useState(getRole(projectRoles.guest));
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { isDirty },
+  } = useForm<ProjectRolesDto>({
+    defaultValues: projectRoles,
+  });
   return (
     <Box>
-      <VStack spacing={10} mt={6}>
-        <FormControl as="fieldset">
-          <Box borderWidth="1px" borderRadius="lg" overflow="hidden" p={4}>
-            <FormLabel as="legend">Member</FormLabel>
-            <RadioGroup colorScheme="teal" value={member} onChange={setMember}>
-              <HStack spacing={20}>
-                <Radio value="ADMIN">Admin</Radio>
-                <Radio value="WRITE">Write</Radio>
-                <Radio value="READ">Read</Radio>
-                <Radio value="NONE">Forbidden</Radio>
-              </HStack>
-            </RadioGroup>
-          </Box>
-        </FormControl>
-        <FormControl as="fieldset">
-          <Box borderWidth="1px" borderRadius="lg" overflow="hidden" p={4}>
-            <FormLabel as="legend">Guest</FormLabel>
-            <RadioGroup colorScheme="teal" value={guest} onChange={setGuest}>
-              <HStack spacing={20}>
-                <Radio value="WRITE">Write</Radio>
-                <Radio value="READ">Read</Radio>
-                <Radio value="NONE">Forbidden</Radio>
-              </HStack>
-            </RadioGroup>
-          </Box>
-        </FormControl>
-      </VStack>
-      <Flex gap={4} mt={10}>
-        <Spacer />
-        <ConfirmUpdateRepositoryProjectRoles
-          projectName={projectName}
-          repoName={repoName}
-          data={{
-            member: member === 'NONE' ? null : (member as RepositoryRole),
-            guest: guest === 'NONE' ? null : (guest as 'READ' | 'WRITE'),
-          }}
-        />
-      </Flex>
+      <form>
+        <VStack spacing={10} mt={6}>
+          <FormControl as="fieldset">
+            <Box borderWidth="1px" borderRadius="lg" overflow="hidden" p={4}>
+              <FormLabel as="legend">Member</FormLabel>
+              <Controller
+                control={control}
+                name="member"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup colorScheme="teal" value={getRole(value)} onChange={onChange}>
+                    <HStack spacing={20}>
+                      <Radio value="ADMIN">Admin</Radio>
+                      <Radio value="WRITE">Write</Radio>
+                      <Radio value="READ">Read</Radio>
+                      <Radio value="NONE">Forbidden</Radio>
+                    </HStack>
+                  </RadioGroup>
+                )}
+              />
+            </Box>
+          </FormControl>
+          <FormControl as="fieldset">
+            <Box borderWidth="1px" borderRadius="lg" overflow="hidden" p={4}>
+              <FormLabel as="legend">Guest</FormLabel>
+              <Controller
+                control={control}
+                name="guest"
+                render={({ field: { onChange, value } }) => (
+                  <RadioGroup colorScheme="teal" value={getRole(value)} onChange={onChange}>
+                    <HStack spacing={20}>
+                      <Radio value="READ">Read</Radio>
+                      <Radio value="NONE">Forbidden</Radio>
+                    </HStack>
+                  </RadioGroup>
+                )}
+              />
+            </Box>
+          </FormControl>
+        </VStack>
+        <Flex gap={4} mt={10}>
+          <Spacer />
+          <ConfirmUpdateRepositoryProjectRoles
+            projectName={projectName}
+            repoName={repoName}
+            handleSubmit={handleSubmit}
+            isDirty={isDirty}
+            reset={reset}
+          />
+        </Flex>
+      </form>
     </Box>
   );
 };


### PR DESCRIPTION
Motivation:

A public repository in GitHub grants READ permission to normal users but does not give WRITE permission to them. Similarly, it does not make sense to grant a `WRITE` permission to `GUEST` role in Central Dogma.

Related: https://github.com/line/centraldogma/issues/1048

Modifications:

- Disallow setting the GUEST WRITE permission in the repo role UI.
- The old WRITE permission of GUEST is automatically converted to READ permission.
  - I will write a migration to clean the GUEST WRITE permission data stored in `metadata.json` later. Because two role formats are fixed in `metadata.json` and I don't think the new format is stabilized. The new format could be changed when a new permission feature is added.
- Breaking) GUEST users no longer write a change to a repository. A MEMBER WRITE role is explicitly necessary.

Result:

The GUEST WRITE permission is removed from the repository roles.