### PR TITLE
Cache revision tree bytes for history call

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -75,7 +75,7 @@ public final class CentralDogmaBuilder {
     static final int DEFAULT_NUM_REPOSITORY_WORKERS = 16;
     static final long DEFAULT_MAX_REMOVED_REPOSITORY_AGE_MILLIS = 604_800_000;  // 7 days
 
-    static final String DEFAULT_REPOSITORY_CACHE_SPEC =
+    public static final String DEFAULT_REPOSITORY_CACHE_SPEC =
             "maximumWeight=134217728," + // Cache up to apx. 128-megachars.
             "expireAfterAccess=5m";      // Expire on 5 minutes of inactivity.
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
@@ -127,9 +127,6 @@ public class RepositoryCache {
                 logger.debug("Cache miss: {}", key);
             }
             return value;
-        } catch (Throwable t) {
-            System.err.println(t);
-            throw t;
         } finally {
             lock.unlock();
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryCache.java
@@ -19,6 +19,8 @@ package com.linecorp.centraldogma.server.internal.storage.repository;
 import static java.util.Objects.requireNonNull;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -94,6 +96,43 @@ public class RepositoryCache {
         requireNonNull(call, "call");
         requireNonNull(value, "value");
         cache.put(call, CompletableFuture.completedFuture(value));
+    }
+
+    public <T> T load(CacheableCall<T> key, Supplier<T> supplier, boolean logIfMiss) {
+        CompletableFuture<T> existingFuture = getIfPresent(key);
+        if (existingFuture != null) {
+            final T existingValue = existingFuture.getNow(null);
+            if (existingValue != null) {
+                // Cached already.
+                return existingValue;
+            }
+        }
+
+        // Not cached yet.
+        final Lock lock = key.coarseGrainedLock();
+        lock.lock();
+        try {
+            existingFuture = getIfPresent(key);
+            if (existingFuture != null) {
+                final T existingValue = existingFuture.getNow(null);
+                if (existingValue != null) {
+                    // Other thread already put the entries to the cache before we acquire the lock.
+                    return existingValue;
+                }
+            }
+
+            final T value = supplier.get();
+            put(key, value);
+            if (logIfMiss) {
+                logger.debug("Cache miss: {}", key);
+            }
+            return value;
+        } catch (Throwable t) {
+            System.err.println(t);
+            throw t;
+        } finally {
+            lock.unlock();
+        }
     }
 
     public CacheStats stats() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CacheableObjectLoaderCall.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CacheableObjectLoaderCall.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static org.eclipse.jgit.lib.Constants.OBJ_TREE;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+
+import com.google.common.base.MoreObjects.ToStringHelper;
+import com.google.common.primitives.Ints;
+
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.centraldogma.server.internal.storage.repository.CacheableCall;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+
+final class CacheableObjectLoaderCall extends CacheableCall<ObjectLoader> {
+
+    private final CachingTreeObjectReader objectReader;
+    private final AnyObjectId objectId;
+    private final int hashCode;
+
+    CacheableObjectLoaderCall(Repository repo, CachingTreeObjectReader objectReader, AnyObjectId objectId) {
+        super(repo);
+        this.objectReader = objectReader;
+        this.objectId = objectId;
+        hashCode = objectId.hashCode() * 31 + System.identityHashCode(repo);
+    }
+
+    @Override
+    protected int weigh(ObjectLoader value) {
+        return Ints.saturatedCast(value.getSize());
+    }
+
+    /**
+     * Never invoked because {@link GitRepository} produces the value of this call.
+     */
+    @Override
+    public CompletableFuture<ObjectLoader> execute() {
+        try {
+            return UnmodifiableFuture.completedFuture(objectReader.delegate().open(objectId, OBJ_TREE));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final CacheableObjectLoaderCall that = (CacheableObjectLoaderCall) o;
+        return objectId.equals(that.objectId);
+    }
+
+    @Override
+    protected void toString(ToStringHelper helper) {
+        helper.add("objectId", objectId);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CacheableObjectLoaderCall.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CacheableObjectLoaderCall.java
@@ -15,9 +15,6 @@
  */
 package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
-import static org.eclipse.jgit.lib.Constants.OBJ_TREE;
-
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.jgit.lib.AnyObjectId;
@@ -26,19 +23,16 @@ import org.eclipse.jgit.lib.ObjectLoader;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.primitives.Ints;
 
-import com.linecorp.armeria.common.util.UnmodifiableFuture;
 import com.linecorp.centraldogma.server.internal.storage.repository.CacheableCall;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 final class CacheableObjectLoaderCall extends CacheableCall<ObjectLoader> {
 
-    private final CachingTreeObjectReader objectReader;
     private final AnyObjectId objectId;
     private final int hashCode;
 
-    CacheableObjectLoaderCall(Repository repo, CachingTreeObjectReader objectReader, AnyObjectId objectId) {
+    CacheableObjectLoaderCall(Repository repo, AnyObjectId objectId) {
         super(repo);
-        this.objectReader = objectReader;
         this.objectId = objectId;
         hashCode = objectId.hashCode() * 31 + System.identityHashCode(repo);
     }
@@ -53,11 +47,7 @@ final class CacheableObjectLoaderCall extends CacheableCall<ObjectLoader> {
      */
     @Override
     public CompletableFuture<ObjectLoader> execute() {
-        try {
-            return UnmodifiableFuture.completedFuture(objectReader.delegate().open(objectId, OBJ_TREE));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        throw new IllegalStateException();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CachingTreeObjectReader.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CachingTreeObjectReader.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.storage.repository.git;
+
+import static org.eclipse.jgit.lib.Constants.OBJ_TREE;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.Lock;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.jgit.lib.AnyObjectId;
+import org.eclipse.jgit.lib.ObjectLoader;
+import org.eclipse.jgit.lib.ObjectReader;
+import org.eclipse.jgit.lib.ObjectReader.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+
+final class CachingTreeObjectReader extends Filter {
+
+    private static final Logger logger = LoggerFactory.getLogger(CachingTreeObjectReader.class);
+
+    private final Repository repository;
+
+    private final ObjectReader delegate;
+
+    @Nullable
+    private final RepositoryCache cache;
+
+    CachingTreeObjectReader(Repository repository, ObjectReader delegate, @Nullable RepositoryCache cache) {
+        this.repository = repository;
+        this.delegate = delegate;
+        this.cache = cache;
+    }
+
+    @Override
+    protected ObjectReader delegate() {
+        return delegate;
+    }
+
+    @Override
+    public ObjectLoader open(AnyObjectId objectId, int typeHint)
+            throws IOException {
+        if (OBJ_TREE != typeHint || cache == null) {
+            return super.open(objectId, typeHint);
+        }
+
+        // Need to convert to objectId from MutableObjectId
+        objectId = objectId.toObjectId();
+
+        final CacheableObjectLoaderCall key = new CacheableObjectLoaderCall(repository, this, objectId);
+        CompletableFuture<ObjectLoader> existingFuture = cache.getIfPresent(key);
+        if (existingFuture != null) {
+            final ObjectLoader existingDiffEntries = existingFuture.getNow(null);
+            if (existingDiffEntries != null) {
+                // Cached already.
+                return existingDiffEntries;
+            }
+        }
+
+        // Not cached yet. Acquire a lock so that we do not compare the same tree pairs simultaneously.
+        final ObjectLoader newDiffEntries;
+        final Lock lock = key.coarseGrainedLock();
+        lock.lock();
+        try {
+            existingFuture = cache.getIfPresent(key);
+            if (existingFuture != null) {
+                return existingFuture.join();
+            }
+
+            newDiffEntries = delegate.open(objectId, typeHint);
+            cache.put(key, newDiffEntries);
+            logger.debug("Cached tree: {}", objectId);
+        } finally {
+            lock.unlock();
+        }
+
+        return newDiffEntries;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CachingTreeObjectReader.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CachingTreeObjectReader.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git;
 import static org.eclipse.jgit.lib.Constants.OBJ_TREE;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import javax.annotation.Nullable;
 
@@ -26,15 +27,11 @@ import org.eclipse.jgit.lib.AnyObjectId;
 import org.eclipse.jgit.lib.ObjectLoader;
 import org.eclipse.jgit.lib.ObjectReader;
 import org.eclipse.jgit.lib.ObjectReader.Filter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 final class CachingTreeObjectReader extends Filter {
-
-    private static final Logger logger = LoggerFactory.getLogger(CachingTreeObjectReader.class);
 
     private final Repository repository;
 
@@ -70,7 +67,7 @@ final class CachingTreeObjectReader extends Filter {
             try {
                 return delegate.open(objectId0, typeHint);
             } catch (IOException e) {
-                throw new RuntimeException("failed to open an object: " + objectId0, e);
+                throw new UncheckedIOException("failed to open an object: " + objectId0, e);
             }
         }, false);
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManagerTest.java
@@ -35,7 +35,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
-import com.linecorp.centraldogma.server.internal.storage.repository.RepositoryCache;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
@@ -55,7 +54,6 @@ class GitRepositoryManagerTest {
         final GitRepositoryManager gitRepositoryManager = newRepositoryManager();
         final Repository repository = gitRepositoryManager.create(TEST_REPO, Author.SYSTEM);
         assertThat(repository).isInstanceOf(GitRepository.class);
-        assertThat(((GitRepository) repository).cache).isNotNull();
 
         // Must disallow creating a duplicate.
         assertThatThrownBy(() -> gitRepositoryManager.create(TEST_REPO, Author.SYSTEM))
@@ -76,7 +74,6 @@ class GitRepositoryManagerTest {
         gitRepositoryManager = newRepositoryManager();
         final Repository repository = gitRepositoryManager.get(TEST_REPO);
         assertThat(repository).isInstanceOf(GitRepository.class);
-        assertThat(((GitRepository) repository).cache).isNotNull();
 
         gitRepositoryManager.remove(TEST_REPO);
         gitRepositoryManager.purgeMarked();
@@ -163,6 +160,6 @@ class GitRepositoryManagerTest {
     private GitRepositoryManager newRepositoryManager() {
         return new GitRepositoryManager(mock(Project.class), tempDir.toFile(),
                                         ForkJoinPool.commonPool(), MoreExecutors.directExecutor(),
-                                        mock(RepositoryCache.class));
+                                        null);
     }
 }


### PR DESCRIPTION
Motivation:
The history call is resource-intensive, consuming significant CPU and memory when it cannot locate the requested content in a single call.
By caching revision trees, we can optimize resource usage.

Modifications:
- Introduced `CachingTreeObjectReader` to cache revision trees and reduce redundant computations.

Result:
- Improved CPU and memory efficiency for history calls.