### PR TITLE
Update dependencies

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -3,18 +3,18 @@
 #     If its classes are exposed in Javadoc, update offline links as well.
 #
 [versions]
-armeria = "1.31.3"
-assertj = "3.26.3"
-awaitility = "4.2.2"
-bouncycastle = "1.79"
+armeria = "1.32.0"
+assertj = "3.27.3"
+awaitility = "4.3.0"
+bouncycastle = "1.80"
 # Don"t upgrade Caffeine to 3.x that requires Java 11.
 caffeine = "2.9.3"
 checkstyle = "10.3.3"
-controlplane = "1.0.46"
+controlplane = "1.0.48"
 # Ensure that we use the same ZooKeeper version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
 #      (Switch to the right tag to find out the right version.)
-curator = "5.7.0"
+curator = "5.7.1"
 # Do not upgrade cron-utils until there's another CVE or Armeria's SLF4J and Logback are upgraded.
 cron-utils = "9.2.0"
 diffutils = "1.3.0"
@@ -24,13 +24,13 @@ dropwizard-metrics = "4.2.28"
 eddsa = "0.3.0"
 findbugs = "3.0.2"
 futures-completable = "0.3.6"
-grpc-java = "1.68.1"
-guava = "33.3.1-jre"
+grpc-java = "1.70.0"
+guava = "33.4.0-jre"
 guava-failureaccess = "1.0.1"
 hamcrest-library = "2.2"
 hibernate-validator6 = "6.2.5.Final"
 hibernate-validator8 = "8.0.1.Final"
-jackson = "2.18.1"
+jackson = "2.18.2"
 javassist = "3.30.2-GA"
 javax-annotation = "1.3.2"
 javax-inject = "1"
@@ -38,10 +38,11 @@ javax-validation = "2.0.1.Final"
 jcommander = "1.82"
 jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-agent = "2.0.10"
+# JGit 7.x.x requires Java 17
 jgit = "5.13.3.202401111512-r"
 jgit6 = "6.10.0.202406032230-r"
 junit4 = "4.13.2"
-junit5 = "5.11.3"
+junit5 = "5.12.0"
 # Don't upgrade junit-pioneer to 2.x.x that requires Java 11
 junit-pioneer = "1.9.1"
 jsch = "0.1.55"
@@ -49,16 +50,17 @@ jsch = "0.1.55"
 json-path = "2.2.0"
 # 3.0.0 requires java 17
 json-unit = "2.38.0"
-jsoup = "1.18.1" # JSoup is only used for Gradle script.
+jsoup = "1.19.1" # JSoup is only used for Gradle script.
 jmh-core = "1.37"
-jmh-gradle-plugin = "0.7.2"
+jmh-gradle-plugin = "0.7.3"
 jxr = "0.2.1"
+# Don't uprade kubernetes-client to 7.x.x that requires Java 11
 kubernetes-client = "6.13.4"
 logback12 = { strictly = "1.2.13" }
 logback15 = { strictly = "1.5.7" }
 logback = "1.2.13"
-micrometer = "1.13.6"
-mina-sshd = "2.14.0"
+micrometer = "1.14.4"
+mina-sshd = "2.15.0"
 # Don't uprade mockito to 5.x.x that requires Java 11
 mockito = "4.11.0"
 nexus-publish-plugin = "2.0.0"
@@ -73,20 +75,20 @@ shadow-gradle-plugin = "7.1.2"
 # Don't update `shiro` version
 shiro = "1.3.2"
 slf4j1 = { strictly = "1.7.36" }
-slf4j2 = { strictly = "2.0.16" }
+slf4j2 = { strictly = "2.0.17" }
 # Ensure that we use the same Snappy version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
 snappy = "1.1.10.5"
 sphinx = "2.10.1"
 spring-boot2 = "2.7.18"
-spring-boot3 = "3.3.5"
+spring-boot3 = "3.4.3"
 spring-test-junit5 = "1.5.0"
-testcontainers = "1.20.3"
+testcontainers = "1.20.6"
 thrift09 = { strictly = "0.9.3-1" }
 # Ensure that we use the same ZooKeeper version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
 #      (Switch to the right tag to find out the right version.)
-zookeeper = "3.9.1"
+zookeeper = "3.9.2"
 
 [boms]
 armeria = { module = "com.linecorp.armeria:armeria-bom", version.ref = "armeria" }


### PR DESCRIPTION
- Armeria 1.31.3 -> 1.32.0
- Bouncy Castle 1.79 ->
- ControlPlane 1.0.46 -> 1.0.48
- Curator 5.7.0 -> 5.7.1
- gRPC Java 1.68.1 -> 1.70.0
- Guava 33.3.1-jre -> 33.4.0-jre
- Jackson 2.18.1 -> 2.18.2
- Micrometer 1.13.6 -> 1.14.4
- Mina SSHD 2.14.0 -> 2.15.0
- SLF4J2 2.0.16 -> 2.0.17
- Spring Boot 3.3.5 -> 3.4.3
- ZooKeeper 3.9.1 -> 3.9.2
- Build and Test
  - AssertJ 3.26.3 -> 3.27.3
  - Awaitility 4.2.2 -> 4.3.0
  - jmh-gradle-plugin 0.7.2 -> 0.7.3
  - JSoup 1.18.1 -> 1.18.3
  - JUnit5 5.11.3 -> 5.12.0
  - Test Containers 1.20.3 -> 1.20.5