### PR TITLE
Improve the server shutdown process

### DIFF
--- a/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
+++ b/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
@@ -16,6 +16,9 @@
 
 package com.linecorp.centraldogma.it.zoneleader;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -36,9 +39,6 @@ import com.linecorp.centraldogma.server.plugin.Plugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 class ZoneLeaderPluginTest {
 

--- a/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
+++ b/it/zone-leader-plugin/src/test/java/com/linecorp/centraldogma/it/zoneleader/ZoneLeaderPluginTest.java
@@ -16,9 +16,6 @@
 
 package com.linecorp.centraldogma.it.zoneleader;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -26,6 +23,8 @@ import java.util.concurrent.CompletionStage;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
 
@@ -38,7 +37,12 @@ import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
 class ZoneLeaderPluginTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ZoneLeaderPluginTest.class);
 
     private static final List<ZoneLeaderTestPlugin> plugins = new ArrayList<>();
     private static final int NUM_REPLICAS = 9;
@@ -135,6 +139,7 @@ class ZoneLeaderPluginTest {
 
         @Override
         public CompletionStage<Void> stop(PluginContext context) {
+            logger.debug("Stopping test plugin on server {}", serverId);
             started = false;
             return UnmodifiableFuture.completedFuture(null);
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -94,6 +94,7 @@ import com.linecorp.centraldogma.server.storage.repository.FindOptions;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.netty.util.AttributeKey;
 
 /**
  * Annotated service object for managing and watching contents.
@@ -102,6 +103,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 @RequiresRepositoryRole(RepositoryRole.READ)
 @RequestConverter(CommitMessageRequestConverter.class)
 public class ContentServiceV1 extends AbstractService {
+
+    static final AttributeKey<Boolean> IS_WATCH_REQUEST =
+            AttributeKey.valueOf(ContentServiceV1.class, "IS_WATCH_REQUEST");
 
     private static final String MIRROR_LOCAL_REPO = "localRepo";
 
@@ -269,6 +273,7 @@ public class ContentServiceV1 extends AbstractService {
 
         // watch repository or a file
         if (watchRequest != null) {
+            ctx.setAttr(IS_WATCH_REQUEST, true);
             final Revision lastKnownRevision = watchRequest.lastKnownRevision();
             final long timeOutMillis = watchRequest.timeoutMillis();
             final boolean errorOnEntryNotFound = watchRequest.notifyEntryNotFound();


### PR DESCRIPTION
Motivation:

When a Central Dogma server stops, it first closes  `GitRepository` and other resources internally. The shutdown process does not respect `GracefulShutdownTimeout` but immediately closes them. As a result, inflight requests fail with `ShuttingDownException` even though they were received before the shutdown process started.

To gracefully shut down the server, I propose closing the Armeria server first. During the Armeria shutdown process, it will wait for requests to be finished during the GracefulShutdownTimeout.

Motifications:

- Close the server first and then shut down other resources.
- Configure Armeria `GracefulShutdown` to fail long-running requests with `ShuttingdownException`
- Fix `HttpApiExceptionHandler` to return 304 Not Modified for watch requests after the graceful shutdown timeout.

Result:

The Central Dogma server gracefully terminates requests while respecting `GracefulShutdownTimeout`.
