### PR TITLE
Fix a bug where invalid file name is used for deleting a repository credential

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/CredentialServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/CredentialServiceV1.java
@@ -40,7 +40,6 @@ import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.common.RepositoryRole;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.CredentialUtil;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
@@ -286,7 +285,7 @@ public class CredentialServiceV1 extends AbstractService {
                                                         Repository repository,
                                                         @Param String id, Author author, User user) {
         final MetaRepository metaRepository = metaRepo(projectName, user);
-        final String credentialFile = CredentialUtil.repoCredentialFile(repository.name(), id);
-        return deleteCredential(projectName, author, metaRepository, credentialFile);
+        return deleteCredential(projectName, author, metaRepository,
+                                credentialName(projectName, repository.name(), id));
     }
 }

--- a/webapp/src/dogma/features/auth/RepositoryRole.tsx
+++ b/webapp/src/dogma/features/auth/RepositoryRole.tsx
@@ -1,13 +1,27 @@
 import { UserDto } from './UserDto';
 import { ProjectMetadataDto } from '../project/ProjectMetadataDto';
 import { ProjectRole } from './ProjectRole';
+import { useGetMetadataByProjectNameQuery } from '../api/apiSlice';
+import { useAppSelector } from '../../hooks';
+import { ReactNode } from 'react';
 
 export type RepositoryRole = 'READ' | 'WRITE' | 'ADMIN';
+
+type WithRepositoryRoleProps = {
+  projectName: string;
+  repoName: string;
+  roles: RepositoryRole[];
+  children: () => ReactNode;
+};
 
 export function findUserRepositoryRole(repoName: string, user: UserDto, metadata: ProjectMetadataDto) {
   if (user && user.systemAdmin) {
     return 'ADMIN';
   }
+  if (typeof metadata === 'undefined' || metadata === null || Object.keys(metadata).length == 0) {
+    return null;
+  }
+
   const projectRole = metadata.members[user.email]?.role as ProjectRole;
   if (projectRole === 'OWNER') {
     return 'ADMIN';
@@ -30,3 +44,22 @@ export function findUserRepositoryRole(repoName: string, user: UserDto, metadata
   }
   return null;
 }
+
+export const WithRepositoryRole = ({ projectName, repoName, roles, children }: WithRepositoryRoleProps) => {
+  const { data: metadata = {} as ProjectMetadataDto } = useGetMetadataByProjectNameQuery(projectName, {
+    refetchOnFocus: true,
+  });
+
+  const { user, isInAnonymousMode } = useAppSelector((state) => state.auth);
+  if (isInAnonymousMode) {
+    return <>{children()}</>;
+  }
+
+  const role = findUserRepositoryRole(repoName, user, metadata);
+
+  if (roles.find((r) => r === role)) {
+    return <>{children()}</>;
+  } else {
+    return null;
+  }
+};

--- a/webapp/src/dogma/features/repo/settings/mirrors/MirrorList.tsx
+++ b/webapp/src/dogma/features/repo/settings/mirrors/MirrorList.tsx
@@ -134,7 +134,7 @@ const MirrorList = <Data extends object>({ projectName, repoName }: MirrorListPr
               projectName={projectName}
               repoName={info.row.original.localRepo}
               id={info.getValue()}
-              deleteMirror={(projectName, id) => deleteMirror({ projectName, id }).unwrap()}
+              deleteMirror={(projectName, repoName, id) => deleteMirror({ projectName, repoName, id }).unwrap()}
               isLoading={isLoading}
             />
           </HStack>

--- a/webapp/src/dogma/features/settings/SettingView.tsx
+++ b/webapp/src/dogma/features/settings/SettingView.tsx
@@ -61,7 +61,6 @@ const SettingView = ({ currentTab, children }: SettingsViewProps) => {
       <Tabs variant="enclosed-colored" size="lg" index={tabIndex}>
         <TabList>
           {TABS.map((tab) => {
-            console.log('tab', tab);
             if (tab.admin && !user?.systemAdmin) {
               return null;
             }

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
@@ -16,9 +16,9 @@ import { Deferred } from 'dogma/common/components/Deferred';
 import { FcOpenedFolder } from 'react-icons/fc';
 import { GoRepo } from 'react-icons/go';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
-import { WithProjectRole } from 'dogma/features/auth/ProjectRole';
 import { FaHistory } from 'react-icons/fa';
 import { makeTraversalFileLinks, toFilePath } from 'dogma/util/path-util';
+import { WithRepositoryRole } from 'dogma/features/auth/RepositoryRole';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -143,7 +143,7 @@ cat ${project}/${repo}${path}`;
                 History
               </Button>
               {projectName === 'dogma' ? null : (
-                <WithProjectRole projectName={projectName} roles={['OWNER']}>
+                <WithRepositoryRole projectName={projectName} repoName={repoName} roles={['ADMIN']}>
                   {() => (
                     <MetadataButton
                       href={`/app/projects/${projectName}/repos/${repoName}/settings`}
@@ -151,7 +151,7 @@ cat ${project}/${repo}${path}`;
                       text={'Repository Settings'}
                     />
                   )}
-                </WithProjectRole>
+                </WithRepositoryRole>
               )}
               <Button
                 as={Link}


### PR DESCRIPTION
Motivation:
This addresses two issues:
- `.json` is added twice when deleting a repository credential.
- A repository admin cannot access the repository settings page.

Modifications:
- Fix those issues.

Result:
- The repository credential is correctly deleted.
- A repository admin can access the repository settings page.