### PR TITLE
Pass the mirror creator and updater to `MirrorListener`

### DIFF
--- a/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/TestMirrorListener.java
+++ b/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/TestMirrorListener.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
@@ -40,10 +41,10 @@ public final class TestMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onCreate(Mirror mirror, MirrorAccessController accessController) {}
+    public void onCreate(Mirror mirror, User creator, MirrorAccessController accessController) {}
 
     @Override
-    public void onUpdate(Mirror mirror, MirrorAccessController accessController) {}
+    public void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController) {}
 
     @Override
     public void onDisallowed(Mirror mirror) {}

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestMirrorRunnerListener.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestMirrorRunnerListener.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
@@ -48,12 +49,12 @@ public class TestMirrorRunnerListener implements MirrorListener {
     }
 
     @Override
-    public void onCreate(Mirror mirror, MirrorAccessController accessController) {
+    public void onCreate(Mirror mirror, User creator, MirrorAccessController accessController) {
         creationCount.merge(mirror.remoteRepoUri().toString(), 1, Integer::sum);
     }
 
     @Override
-    public void onUpdate(Mirror mirror, MirrorAccessController accessController) {
+    public void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController) {
         updateCount.merge(mirror.remoteRepoUri().toString(), 1, Integer::sum);
     }
 

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
@@ -51,10 +52,10 @@ public class TestZoneAwareMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onCreate(Mirror mirror, MirrorAccessController accessController) {}
+    public void onCreate(Mirror mirror, User creator, MirrorAccessController accessController) {}
 
     @Override
-    public void onUpdate(Mirror mirror, MirrorAccessController accessController) {}
+    public void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController) {}
 
     @Override
     public void onDisallowed(Mirror mirror) {}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CompositeMirrorListener.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
@@ -38,10 +39,10 @@ final class CompositeMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onCreate(Mirror mirror, MirrorAccessController accessController) {
+    public void onCreate(Mirror mirror, User creator, MirrorAccessController accessController) {
         for (MirrorListener delegate : delegates) {
             try {
-                delegate.onCreate(mirror, accessController);
+                delegate.onCreate(mirror, creator, accessController);
             } catch (Exception e) {
                 logger.warn("Failed to notify a listener of the mirror create event: {}", delegate, e);
             }
@@ -49,10 +50,10 @@ final class CompositeMirrorListener implements MirrorListener {
     }
 
     @Override
-    public void onUpdate(Mirror mirror, MirrorAccessController accessController) {
+    public void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController) {
         for (MirrorListener delegate : delegates) {
             try {
-                delegate.onUpdate(mirror, accessController);
+                delegate.onUpdate(mirror, updater, accessController);
             } catch (Exception e) {
                 logger.warn("Failed to notify a listener of the mirror update event: {}", delegate, e);
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirrorListener.java
@@ -19,6 +19,7 @@ package com.linecorp.centraldogma.server.internal.mirror;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.mirror.MirrorListener;
@@ -32,12 +33,12 @@ enum DefaultMirrorListener implements MirrorListener {
     private static final Logger logger = LoggerFactory.getLogger(DefaultMirrorListener.class);
 
     @Override
-    public void onCreate(Mirror mirror, MirrorAccessController accessController) {
+    public void onCreate(Mirror mirror, User creator, MirrorAccessController accessController) {
         logger.debug("A new mirroring from {} is created. mirror: {}", mirror.remoteRepoUri(), mirror);
     }
 
     @Override
-    public void onUpdate(Mirror mirror, MirrorAccessController accessController) {
+    public void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController) {
         logger.debug("The mirroring ID {} is updated. mirror: {}", mirror.id(), mirror);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorListener.java
@@ -20,6 +20,8 @@ import java.util.ServiceLoader;
 
 import javax.annotation.Nullable;
 
+import com.linecorp.centraldogma.server.metadata.User;
+
 /**
  * A listener which is notified when a {@link Mirror} operation is started, completed or failed.
  *
@@ -37,12 +39,12 @@ public interface MirrorListener {
     /**
      * Invoked when a new {@link Mirror} is created.
      */
-    void onCreate(Mirror mirror, MirrorAccessController accessController);
+    void onCreate(Mirror mirror, User creator, MirrorAccessController accessController);
 
     /**
      * Invoked when the {@link Mirror} is updated.
      */
-    void onUpdate(Mirror mirror, MirrorAccessController accessController);
+    void onUpdate(Mirror mirror, User updater, MirrorAccessController accessController);
 
     /**
      * Invoked when the {@link Mirror} operation is disallowed.


### PR DESCRIPTION
Motivation:

The user information may be useful if the implementation of `MirrorListener` is integrated with external systems.

Modifications:

- Add `User` to `onCreate()` and `onUpdate()`

Result:

The mirror creator and updater are accessible in `MirrorListener`.