### PR TITLE
Provide a way to register an LbEndpoint to the existing ClusterLoadAssignment

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
@@ -16,21 +16,40 @@
 package com.linecorp.centraldogma.xds.endpoint.v1;
 
 import static com.linecorp.centraldogma.server.internal.admin.auth.AuthUtil.currentAuthor;
+import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
 import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.CLUSTERS_DIRECTORY;
 import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.ENDPOINTS_DIRECTORY;
+import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN_STRING;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.removePrefix;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.Empty;
 
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.ContentTransformer;
 import com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceGrpc.XdsEndpointServiceImplBase;
 import com.linecorp.centraldogma.xds.internal.XdsResourceManager;
 
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Builder;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -122,5 +141,227 @@ public final class XdsEndpointService extends XdsEndpointServiceImplBase {
 
     private static String fileName(String endpointId) {
         return ENDPOINTS_DIRECTORY + endpointId + ".json";
+    }
+
+    @Override
+    public void registerLocalityLbEndpoint(RegisterLocalityLbEndpointRequest request,
+                                           StreamObserver<LocalityLbEndpoint> responseObserver) {
+        final LocalityLbEndpoint localityLbEndpoint = request.getLocalityLbEndpoint();
+        final String endpointName = request.getEndpointName();
+        handleRegisterOrDeregister(
+                endpointName,
+                localityLbEndpoint,
+                localityLbEndpoint,
+                responseObserver,
+                "Register locality LB endpoint to " + endpointName + ". endpoint: " + localityLbEndpoint,
+                true,
+                cause -> {
+                    if (cause instanceof EntryNotFoundException) {
+                        responseObserver.onError(
+                                Status.NOT_FOUND.withDescription(
+                                              "Endpoint does not exist: " + endpointName)
+                                                .asRuntimeException());
+                    } else {
+                        responseObserver.onError(
+                                Status.INTERNAL.withCause(cause).asRuntimeException());
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deregisterLocalityLbEndpoint(DeregisterLocalityLbEndpointRequest request,
+                                             StreamObserver<Empty> responseObserver) {
+        final String endpointName = request.getEndpointName();
+        final LocalityLbEndpoint localityLbEndpoint = request.getLocalityLbEndpoint();
+        handleRegisterOrDeregister(
+                endpointName,
+                localityLbEndpoint,
+                Empty.getDefaultInstance(),
+                responseObserver,
+                "Deregister locality LB endpoint from " + endpointName + ". endpoint: " + localityLbEndpoint,
+                false,
+                cause -> {
+                    if (cause instanceof LocalityLbEndpointNotFoundException) {
+                        responseObserver.onError(
+                                Status.NOT_FOUND.withDescription(
+                                              "Locality LB endpoint does not exist: " +
+                                              localityLbEndpoint)
+                                                .asRuntimeException());
+                    } else if (cause instanceof EntryNotFoundException) {
+                        responseObserver.onError(
+                                Status.NOT_FOUND.withDescription(
+                                              "Endpoint does not exist: " + endpointName)
+                                                .asRuntimeException());
+                    } else {
+                        responseObserver.onError(
+                                Status.INTERNAL.withCause(cause).asRuntimeException());
+                    }
+                }
+        );
+    }
+
+    private <T> void handleRegisterOrDeregister(String endpointName,
+                                                LocalityLbEndpoint localityLbEndpoint,
+                                                T successResponse,
+                                                StreamObserver<T> responseObserver,
+                                                String commitMessage,
+                                                boolean register,
+                                                Consumer<Throwable> errorConsumer) {
+        final Matcher matcher = checkEndpointName(endpointName);
+        final String group = matcher.group(1);
+        xdsResourceManager.checkGroup(group);
+
+        final String endpointId = matcher.group(2);
+        final String fileName = fileName(endpointId);
+        final Author author = currentAuthor();
+
+        final ContentTransformer<JsonNode> transformer = new ContentTransformer<>(
+                fileName, EntryType.JSON, new RegisterOrDeregisterTransformer(localityLbEndpoint, register));
+
+        xdsResourceManager.updateOrDelete(
+                responseObserver, group, endpointName, fileName, () -> xdsResourceManager
+                        .commandExecutor()
+                        .execute(Command.transform(
+                                null, author, XDS_CENTRAL_DOGMA_PROJECT, group, Revision.HEAD,
+                                commitMessage, "", Markup.PLAINTEXT, transformer))
+                        .handle((result, cause) -> {
+                            if (cause != null) {
+                                final Throwable peeled = Exceptions.peel(cause);
+                                errorConsumer.accept(peeled);
+                                return null;
+                            }
+                            responseObserver.onNext(successResponse);
+                            responseObserver.onCompleted();
+                            return null;
+                        }));
+    }
+
+    private static class RegisterOrDeregisterTransformer implements BiFunction<Revision, JsonNode, JsonNode> {
+
+        final LocalityLbEndpoint localityLbEndpoint;
+        private final boolean register;
+
+        RegisterOrDeregisterTransformer(LocalityLbEndpoint localityLbEndpoint, boolean register) {
+            this.localityLbEndpoint = localityLbEndpoint;
+            this.register = register;
+        }
+
+        @Override
+        public JsonNode apply(Revision revision, JsonNode oldJsonNode) {
+            if (oldJsonNode.isNull()) {
+                throw new EntryNotFoundException();
+            }
+            final ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder =
+                    toClusterLoadAssignmentBuilder(oldJsonNode);
+            final int localityIndex =
+                    findLocalityAndPriorityIndex(clusterLoadAssignmentBuilder, localityLbEndpoint);
+            if (localityIndex < 0) {
+                if (register) {
+                    clusterLoadAssignmentBuilder.addEndpoints(
+                            LocalityLbEndpoints.newBuilder()
+                                               .setLocality(localityLbEndpoint.getLocality())
+                                               .setPriority(localityLbEndpoint.getPriority())
+                                               .addLbEndpoints(localityLbEndpoint.getLbEndpoint())
+                                               .build());
+                    return toJsonNode(clusterLoadAssignmentBuilder);
+                }
+                throw LocalityLbEndpointNotFoundException.INSTANCE;
+            }
+            final LocalityLbEndpoints targetLocalityLbEndpoints =
+                    clusterLoadAssignmentBuilder.getEndpoints(localityIndex);
+            // Remove from the endpoints. It will be added again.
+            clusterLoadAssignmentBuilder.removeEndpoints(localityIndex);
+
+            final int lbEndpointIndex =
+                    findLbEndpointIndex(targetLocalityLbEndpoints, localityLbEndpoint);
+            final LocalityLbEndpoints.Builder targetLocalityLbEndpointsBuilder =
+                    targetLocalityLbEndpoints.toBuilder();
+            if (register) {
+                if (lbEndpointIndex >= 0) {
+                    // When the endpoint whose address is the same as the registering endpoint exists,
+                    // remove it and add the registering endpoint because the other fields may be different.
+                    targetLocalityLbEndpointsBuilder.removeLbEndpoints(lbEndpointIndex);
+                }
+                targetLocalityLbEndpointsBuilder.addLbEndpoints(localityLbEndpoint.getLbEndpoint());
+                clusterLoadAssignmentBuilder.addEndpoints(targetLocalityLbEndpointsBuilder.build());
+            } else {
+                if (lbEndpointIndex < 0) {
+                    throw LocalityLbEndpointNotFoundException.INSTANCE;
+                }
+                targetLocalityLbEndpointsBuilder.removeLbEndpoints(lbEndpointIndex);
+                if (targetLocalityLbEndpointsBuilder.getLbEndpointsCount() > 0) {
+                    clusterLoadAssignmentBuilder.addEndpoints(targetLocalityLbEndpointsBuilder.build());
+                }
+            }
+            return toJsonNode(clusterLoadAssignmentBuilder);
+        }
+
+        private static int findLbEndpointIndex(LocalityLbEndpoints targetLocalityLbEndpoints,
+                                               LocalityLbEndpoint localityLbEndpoint) {
+            int sameLbEndpointIndex = -1;
+            final List<LbEndpoint> lbEndpointsList = targetLocalityLbEndpoints.getLbEndpointsList();
+            for (int i = 0; i < lbEndpointsList.size(); i++) {
+                final LbEndpoint lbEndpoint = lbEndpointsList.get(i);
+                if (lbEndpoint.getEndpoint().getAddress().equals(
+                        localityLbEndpoint.getLbEndpoint().getEndpoint().getAddress())) {
+                    sameLbEndpointIndex = i;
+                    break;
+                }
+            }
+            return sameLbEndpointIndex;
+        }
+
+        /**
+         * Find the index of the {@link LocalityLbEndpoints} that has the same locality and priority as the
+         * specified {@link LocalityLbEndpoint}.
+         * If the locality and priority are not found, return -1.
+         */
+        private static int findLocalityAndPriorityIndex(Builder clusterLoadAssignmentBuilder,
+                                                        LocalityLbEndpoint localityLbEndpoint) {
+            int sameLocalityIndex = -1;
+
+            final List<LocalityLbEndpoints> localityLbEndpointsList =
+                    clusterLoadAssignmentBuilder.getEndpointsList();
+            for (int i = 0; i < localityLbEndpointsList.size(); i++) {
+                final LocalityLbEndpoints localityLbEndpoints = localityLbEndpointsList.get(i);
+                if (localityLbEndpoints.getLocality().equals(localityLbEndpoint.getLocality()) &&
+                    localityLbEndpoints.getPriority() == localityLbEndpoint.getPriority()) {
+                    sameLocalityIndex = i;
+                    break;
+                }
+            }
+            return sameLocalityIndex;
+        }
+
+        private static ClusterLoadAssignment.Builder toClusterLoadAssignmentBuilder(JsonNode oldJsonNode) {
+            final Builder clusterLoadAssignmentBuilder =
+                    ClusterLoadAssignment.newBuilder();
+            try {
+                JSON_MESSAGE_MARSHALLER.mergeValue(Jackson.writeValueAsString(oldJsonNode),
+                                                   clusterLoadAssignmentBuilder);
+            } catch (Throwable t) {
+                // Should never reach here.
+                throw new Error();
+            }
+            return clusterLoadAssignmentBuilder;
+        }
+
+        private static JsonNode toJsonNode(ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder) {
+            try {
+                return Jackson.readTree(JSON_MESSAGE_MARSHALLER.writeValueAsString(
+                        clusterLoadAssignmentBuilder.build()));
+            } catch (IOException e) {
+                // Should never reach here
+                throw new Error(e);
+            }
+        }
+    }
+
+    private static final class LocalityLbEndpointNotFoundException extends EntryNotFoundException {
+
+        private static final long serialVersionUID = -4661118144903218907L;
+
+        static final LocalityLbEndpointNotFoundException INSTANCE = new LocalityLbEndpointNotFoundException();
     }
 }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
@@ -46,6 +46,7 @@ import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.xds.endpoint.v1.DeregisterLocalityLbEndpointRequest;
 import com.linecorp.centraldogma.xds.endpoint.v1.RegisterLocalityLbEndpointRequest;
 import com.linecorp.centraldogma.xds.group.v1.CreateGroupRequest;
 import com.linecorp.centraldogma.xds.k8s.v1.CreateKubernetesEndpointAggregatorRequest;
@@ -75,6 +76,7 @@ public final class XdsResourceManager {
                .register(Cluster.getDefaultInstance())
                .register(ClusterLoadAssignment.getDefaultInstance())
                .register(RegisterLocalityLbEndpointRequest.getDefaultInstance())
+               .register(DeregisterLocalityLbEndpointRequest.getDefaultInstance())
                .register(RouteConfiguration.getDefaultInstance())
                .register(CreateKubernetesEndpointAggregatorRequest.getDefaultInstance())
                .register(UpdateKubernetesEndpointAggregatorRequest.getDefaultInstance())

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceManager.java
@@ -46,6 +46,7 @@ import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.xds.endpoint.v1.RegisterLocalityLbEndpointRequest;
 import com.linecorp.centraldogma.xds.group.v1.CreateGroupRequest;
 import com.linecorp.centraldogma.xds.k8s.v1.CreateKubernetesEndpointAggregatorRequest;
 import com.linecorp.centraldogma.xds.k8s.v1.DeleteKubernetesEndpointAggregatorRequest;
@@ -73,6 +74,7 @@ public final class XdsResourceManager {
                .register(Listener.getDefaultInstance())
                .register(Cluster.getDefaultInstance())
                .register(ClusterLoadAssignment.getDefaultInstance())
+               .register(RegisterLocalityLbEndpointRequest.getDefaultInstance())
                .register(RouteConfiguration.getDefaultInstance())
                .register(CreateKubernetesEndpointAggregatorRequest.getDefaultInstance())
                .register(UpdateKubernetesEndpointAggregatorRequest.getDefaultInstance())
@@ -130,6 +132,10 @@ public final class XdsResourceManager {
 
     public Project xdsProject() {
         return xdsProject;
+    }
+
+    public CommandExecutor commandExecutor() {
+        return commandExecutor;
     }
 
     public void checkGroup(String group) {

--- a/xds/src/main/proto/centraldogma/xds/endpoint/v1/xds_endpoint.proto
+++ b/xds/src/main/proto/centraldogma/xds/endpoint/v1/xds_endpoint.proto
@@ -19,12 +19,16 @@ option java_multiple_files = true;
 option java_outer_classname = "XdsEndpointProto";
 option java_package = "com.linecorp.centraldogma.xds.endpoint.v1";
 
+import "envoy/config/core/v3/base.proto";
 import "envoy/config/endpoint/v3/endpoint.proto";
+import "envoy/config/endpoint/v3/endpoint_components.proto";
 
 import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/empty.proto";
+
+import "validate/validate.proto";
 
 // An XdsEndpointService provides methods to manage endpoints.
 service XdsEndpointService {
@@ -53,15 +57,19 @@ service XdsEndpointService {
     };
   }
 
-  // TODO(minwoox): Implement the following methods.
-  //rpc addLocalityLbEndpoint(addLocalityLbEndpointRequest) returns
-  //    (envoy.config.endpoint.v3.ClusterLoadAssignment) {
-  //  ..
-  //}
-  //rpc removeLocalityLbEndpoint(addLocalityLbEndpointRequest) returns
-  //    (envoy.config.endpoint.v3.ClusterLoadAssignment) {
-  //  ..
-  //}
+  rpc RegisterLocalityLbEndpoint(RegisterLocalityLbEndpointRequest) returns (LocalityLbEndpoint) {
+    option (google.api.http) = {
+      patch: "/api/v1/xds/{endpoint_name=groups/*/endpoints/**}:registerLocalityLbEndpoint"
+      body: "locality_lb_endpoint"
+    };
+  }
+
+  rpc DeregisterLocalityLbEndpoint(DeregisterLocalityLbEndpointRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {
+      delete: "/api/v1/xds/{endpoint_name=groups/*/endpoints/**}:deregisterLocalityLbEndpoint"
+      body: "locality_lb_endpoint"
+    };
+  }
 }
 
 message CreateEndpointRequest {
@@ -99,4 +107,24 @@ message DeleteEndpointRequest {
   // If set to true, and the endpoint is not found, the request will succeed
   // but no action will be taken on the server
   // bool allow_missing = 2;
+}
+
+message RegisterLocalityLbEndpointRequest {
+  // Format: groups/{group}/endpoints/{endpoint}
+  string endpoint_name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  LocalityLbEndpoint locality_lb_endpoint = 2 [(google.api.field_behavior) = REQUIRED];
+}
+
+message LocalityLbEndpoint {
+  envoy.config.core.v3.Locality locality = 1;
+  uint32 priority = 2 [(validate.rules).uint32 = {lte: 128}];
+  envoy.config.endpoint.v3.LbEndpoint lb_endpoint = 3 [(google.api.field_behavior) = REQUIRED];
+}
+
+message DeregisterLocalityLbEndpointRequest {
+  // Format: groups/{group}/endpoints/{endpoint}
+  string endpoint_name = 1 [(google.api.field_behavior) = REQUIRED];
+
+  LocalityLbEndpoint locality_lb_endpoint = 2 [(google.api.field_behavior) = REQUIRED];
 }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointServiceTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointServiceTest.java
@@ -90,7 +90,7 @@ public class XdsEndpointServiceTest {
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), actualEndpoint, clusterName);
     }
 
-    private static void assertOk(AggregatedHttpResponse response) {
+    static void assertOk(AggregatedHttpResponse response) {
         assertThat(response.status()).isSameAs(HttpStatus.OK);
         assertThat(response.headers().get("grpc-status")).isEqualTo("0");
     }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LINE Corporation
+ * Copyright 2025 LINE Corporation
  *
  * LINE Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
@@ -131,7 +131,6 @@ public class XdsRegisterEndpointTest {
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
-
         // Deregister the endpoint.
         response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
         assertOk(response);

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2024 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.endpoint.v1;
+
+import static com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceTest.assertOk;
+import static com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceTest.checkEndpointsViaDiscoveryRequest;
+import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createEndpoint;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.endpoint;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.protobuf.UInt32Value;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+
+public class XdsRegisterEndpointTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    @BeforeAll
+    static void setup() {
+        final AggregatedHttpResponse response = createGroup("foo", dogma.httpClient());
+        assertThat(response.status()).isSameAs(HttpStatus.OK);
+    }
+
+    @Test
+    void registerOrDeregister() throws Exception {
+        final String clusterName = "groups/foo/clusters/foo-endpoint/1";
+        final String endpointName = "groups/foo/endpoints/foo-endpoint/1";
+        final Locality locality1 = Locality.newBuilder().setRegion("region1").setZone("zone1").build();
+        ClusterLoadAssignment endpoint = loadAssignment(clusterName, locality1,
+                                                        endpoint("127.0.0.1", 8080));
+        AggregatedHttpResponse response = createEndpoint("groups/foo", "foo-endpoint/1",
+                                                         endpoint, dogma.httpClient());
+        assertOk(response);
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        // Register another endpoint to the same locality endpoint.
+        final LocalityLbEndpoint localityLbEndpoint1 =
+                LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                  .setLbEndpoint(endpoint("127.0.0.1", 8081))
+                                  .build();
+        response = registerOrDeregister(endpointName, localityLbEndpoint1, true);
+        assertOk(response);
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(0)
+                           .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                            .setLocality(locality1)
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8080))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081)))
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        // Register another endpoint with different priority.
+        final LocalityLbEndpoint localityLbEndpoint2 =
+                LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                  .setPriority(1)
+                                  .setLbEndpoint(endpoint("127.0.0.1", 8082))
+                                  .build();
+        response = registerOrDeregister(endpointName, localityLbEndpoint2, true);
+        assertOk(response);
+        endpoint = endpoint.toBuilder()
+                           .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                            .setLocality(locality1)
+                                                            .setPriority(1)
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8082)))
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        // Register another endpoint with different locality.
+        final Locality locality2 = Locality.newBuilder().setRegion("region2").setZone("zone2").build();
+        LbEndpoint endpoint8083 = endpoint("127.0.0.1", 8083);
+        final LocalityLbEndpoint localityLbEndpoint3 =
+                LocalityLbEndpoint.newBuilder().setLocality(locality2)
+                                  .setLbEndpoint(endpoint8083)
+                                  .build();
+        response = registerOrDeregister(endpointName, localityLbEndpoint3, true);
+        assertOk(response);
+        endpoint = endpoint.toBuilder()
+                           .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                            .setLocality(locality2)
+                                                            .addLbEndpoints(endpoint8083))
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        // Register the same endpoint with different property. This will replace the existing one.
+        endpoint8083 = endpoint8083.toBuilder().setLoadBalancingWeight(UInt32Value.of(200)).build();
+        final LocalityLbEndpoint localityLbEndpoint4 =
+                LocalityLbEndpoint.newBuilder().setLocality(locality2)
+                                  .setLbEndpoint(endpoint8083)
+                                  .build();
+        response = registerOrDeregister(endpointName, localityLbEndpoint4, true);
+        assertOk(response);
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(2)
+                           .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                            .setLocality(locality2)
+                                                            .addLbEndpoints(endpoint8083))
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+
+        // Deregister the endpoint.
+        response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
+        assertOk(response);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(2)
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        // Try to deregister a non-existent endpoint.
+        response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
+        assertThat(response.status()).isSameAs(HttpStatus.NOT_FOUND);
+        assertThat(response.contentUtf8()).contains("Locality LB endpoint does not exist");
+
+        response = registerOrDeregister(endpointName, localityLbEndpoint2, false);
+        assertOk(response);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(1)
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        response = registerOrDeregister(endpointName,
+                                        LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                                      .setLbEndpoint(endpoint("127.0.0.1", 8080))
+                                                      .build(),
+                                        false);
+        assertOk(response);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(0)
+                           .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                            .setLocality(locality1)
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081)))
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+
+        response = registerOrDeregister(endpointName,
+                                        LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                                          .setLbEndpoint(endpoint("127.0.0.1", 8081))
+                                                          .build(),
+                                        false);
+        assertOk(response);
+        assertThat(response.contentUtf8()).isEqualTo("{}");
+        endpoint = endpoint.toBuilder()
+                           .removeEndpoints(0)
+                           .build();
+        checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
+    }
+
+    private static AggregatedHttpResponse registerOrDeregister(
+            String endpointName, LocalityLbEndpoint localityLbEndpoint, boolean register) throws IOException {
+        final RequestHeaders headers =
+                RequestHeaders.builder(register ? HttpMethod.PATCH : HttpMethod.DELETE,
+                                       "/api/v1/xds/" + endpointName +
+                                       (register ? ":registerLocalityLbEndpoint"
+                                                 : ":deregisterLocalityLbEndpoint"))
+                              .set(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous")
+                              .contentType(MediaType.JSON_UTF_8).build();
+        return dogma.httpClient().execute(headers,
+                                          JSON_MESSAGE_MARSHALLER.writeValueAsString(localityLbEndpoint))
+                    .aggregate().join();
+    }
+
+    private static ClusterLoadAssignment loadAssignment(String clusterName, Locality locality,
+                                                        LbEndpoint endpoint) {
+        return ClusterLoadAssignment.newBuilder()
+                                    .setClusterName(clusterName)
+                                    .addEndpoints(LocalityLbEndpoints.newBuilder()
+                                                                     .setLocality(locality)
+                                                                     .addLbEndpoints(endpoint))
+                                    .build();
+    }
+
+    @Test
+    void invalidRegister() throws IOException {
+        final String endpointName = "groups/foo/endpoints/non-existent/1";
+        final Locality locality1 = Locality.newBuilder().setRegion("region1").setZone("zone1").build();
+        final LocalityLbEndpoint localityLbEndpoint =
+                LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                  .setLbEndpoint(endpoint("127.0.0.1", 8081))
+                                  .build();
+        AggregatedHttpResponse response = registerOrDeregister(endpointName, localityLbEndpoint, true);
+        // endpoint name is not found.
+        assertThat(response.status()).isSameAs(HttpStatus.NOT_FOUND);
+
+        // same as above but deregister
+        response = registerOrDeregister(endpointName, localityLbEndpoint, false);
+        // endpoint name is not found.
+        assertThat(response.status()).isSameAs(HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
Motivation:
Currently, there is no API to dynamically add a `LocalityLbEndpoint` to an existing `ClusterLoadAssignment`. This makes it difficult to update the `ClusterLoadAssignment` configuration efficiently.

Modifications:
- Added an API that allows (de)registering a `LocalityLbEndpoint` to an existing `ClusterLoadAssignment`.
  - Used the `Locality`, `Priority`, and `Address` as the key for an endpoint.
    - Might consider using the `endpoint_name` later if it's implemented in the upstream.

Result:
- Enables dynamic updates to `ClusterLoadAssignment` without needing to recreate the entire structure.

To-do:
- Add debouncing logic so the API can handle multiple concurrent updates.