### PR TITLE
Allow overriding SAML ACS endpoint for proxy support

### DIFF
--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
@@ -19,6 +19,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.linecorp.centraldogma.server.CentralDogmaConfig.convertValue;
 import static java.util.Objects.requireNonNull;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -57,6 +58,16 @@ import com.linecorp.centraldogma.internal.Jackson;
  *             },
  *             "signatureAlgorithm": "...the signature algorithm for signing and encryption (optional)..."
  *         },
+ *         // Specify when your server uses different uri from the recipient of the assertion that
+ *         // the IdP sends. // For example, if your server is behind a proxy, you need to specify
+ *         // the uri of the proxy.
+ *         "acs": [{
+ *             "uri": "https://dogma-example.linecorp.com/saml/acs/post",
+ *             "binding": "HTTP_POST"
+ *         }, {
+ *             "uri": "https://dogma-example.linecorp.com/saml/acs/redirect",
+ *             "binding": "HTTP_REDIRECT"
+ *         }]
  *         "idp": {
  *             "entityId": "...the identity provider ID...",
  *             "uri": "https://idp-example.linecorp.com/saml/sso",
@@ -108,6 +119,12 @@ final class SamlAuthProperties {
     private final KeyStore keyStore;
 
     /**
+     * {@link SamlEndpoint}s of the assertion consumer service.
+     */
+    @Nullable
+    private final Acs acs;
+
+    /**
      * An identity provider configuration. A single identity provider is supported.
      */
     private final Idp idp;
@@ -119,42 +136,50 @@ final class SamlAuthProperties {
             @JsonProperty("signingKey") @Nullable String signingKey,
             @JsonProperty("encryptionKey") @Nullable String encryptionKey,
             @JsonProperty("keyStore") KeyStore keyStore,
+            @JsonProperty("acs") @Nullable Acs acs,
             @JsonProperty("idp") Idp idp) {
         this.entityId = requireNonNull(entityId, "entityId");
         this.hostname = requireNonNull(hostname, "hostname");
         this.signingKey = firstNonNull(signingKey, DEFAULT_SIGNING_KEY);
         this.encryptionKey = firstNonNull(encryptionKey, DEFAULT_ENCRYPTION_KEY);
         this.keyStore = requireNonNull(keyStore, "keyStore");
+        this.acs = acs;
         this.idp = requireNonNull(idp, "idp");
     }
 
     @JsonProperty
-    public String entityId() {
+    String entityId() {
         return entityId;
     }
 
     @JsonProperty
-    public String hostname() {
+    String hostname() {
         return hostname;
     }
 
     @JsonProperty
-    public String signingKey() {
+    String signingKey() {
         return signingKey;
     }
 
     @JsonProperty
-    public String encryptionKey() {
+    String encryptionKey() {
         return encryptionKey;
     }
 
     @JsonProperty
-    public KeyStore keyStore() {
+    KeyStore keyStore() {
         return keyStore;
     }
 
+    @Nullable
     @JsonProperty
-    public Idp idp() {
+    Acs acs() {
+        return acs;
+    }
+
+    @JsonProperty
+    Idp idp() {
         return idp;
     }
 
@@ -218,23 +243,23 @@ final class SamlAuthProperties {
         }
 
         @JsonProperty
-        public String type() {
+        String type() {
             return type;
         }
 
         @JsonProperty
-        public String path() {
+        String path() {
             return path;
         }
 
         @Nullable
         @JsonProperty
-        public String password() {
+        String password() {
             return convertValue(password, "keyStore.password");
         }
 
         @JsonProperty
-        public Map<String, String> keyPasswords() {
+        Map<String, String> keyPasswords() {
             return sanitizePasswords(keyPasswords);
         }
 
@@ -249,8 +274,23 @@ final class SamlAuthProperties {
         }
 
         @JsonProperty
-        public String signatureAlgorithm() {
+        String signatureAlgorithm() {
             return signatureAlgorithm;
+        }
+    }
+
+    static class Acs {
+
+        private final List<SamlEndpoint> endpoints;
+
+        @JsonCreator
+        Acs(@JsonProperty("uri") List<SamlEndpoint> endpoints) {
+            this.endpoints = requireNonNull(endpoints, "endpoints");
+        }
+
+        @JsonProperty
+        List<SamlEndpoint> endpoints() {
+            return endpoints;
         }
     }
 
@@ -320,43 +360,43 @@ final class SamlAuthProperties {
         }
 
         @JsonProperty
-        public String entityId() {
+        String entityId() {
             return entityId;
         }
 
         @JsonProperty
-        public String uri() {
+        String uri() {
             return uri;
         }
 
         @JsonProperty
-        public String binding() {
+        String binding() {
             return binding.name();
         }
 
         @JsonProperty
-        public String signingKey() {
+        String signingKey() {
             return signingKey;
         }
 
         @JsonProperty
-        public String encryptionKey() {
+        String encryptionKey() {
             return encryptionKey;
         }
 
         @Nullable
         @JsonProperty
-        public String subjectLoginNameIdFormat() {
+        String subjectLoginNameIdFormat() {
             return subjectLoginNameIdFormat;
         }
 
         @Nullable
         @JsonProperty
-        public String attributeLoginName() {
+        String attributeLoginName() {
             return attributeLoginName;
         }
 
-        public SamlEndpoint endpoint() {
+        SamlEndpoint endpoint() {
             switch (binding) {
                 case HTTP_POST:
                     return SamlEndpoint.ofHttpPost(uri);

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
@@ -61,13 +61,15 @@ import com.linecorp.centraldogma.internal.Jackson;
  *         // Specify when your server uses different uri from the recipient of the assertion that
  *         // the IdP sends. // For example, if your server is behind a proxy, you need to specify
  *         // the uri of the proxy.
- *         "acs": [{
- *             "uri": "https://dogma-example.linecorp.com/saml/acs/post",
- *             "binding": "HTTP_POST"
- *         }, {
- *             "uri": "https://dogma-example.linecorp.com/saml/acs/redirect",
- *             "binding": "HTTP_REDIRECT"
- *         }]
+ *         "acs": {
+ *             "endpoints": [{
+ *                 "uri": "https://dogma-example.linecorp.com/saml/acs/post",
+ *                 "binding": "HTTP_POST"
+ *             }, {
+ *                 "uri": "https://dogma-example.linecorp.com/saml/acs/redirect",
+ *                 "binding": "HTTP_REDIRECT"
+ *             }]
+ *         },
  *         "idp": {
  *             "entityId": "...the identity provider ID...",
  *             "uri": "https://idp-example.linecorp.com/saml/sso",
@@ -284,7 +286,7 @@ final class SamlAuthProperties {
         private final List<SamlEndpoint> endpoints;
 
         @JsonCreator
-        Acs(@JsonProperty("uri") List<SamlEndpoint> endpoints) {
+        Acs(@JsonProperty("endpoints") List<SamlEndpoint> endpoints) {
             this.endpoints = requireNonNull(endpoints, "endpoints");
         }
 

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProperties.java
@@ -59,7 +59,7 @@ import com.linecorp.centraldogma.internal.Jackson;
  *             "signatureAlgorithm": "...the signature algorithm for signing and encryption (optional)..."
  *         },
  *         // Specify when your server uses different uri from the recipient of the assertion that
- *         // the IdP sends. // For example, if your server is behind a proxy, you need to specify
+ *         // the IdP sends. For example, if your server is behind a proxy, you need to specify
  *         // the uri of the proxy.
  *         "acs": {
  *             "endpoints": [{

--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProviderFactory.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthProviderFactory.java
@@ -33,6 +33,7 @@ import com.linecorp.centraldogma.server.auth.AuthConfig;
 import com.linecorp.centraldogma.server.auth.AuthProvider;
 import com.linecorp.centraldogma.server.auth.AuthProviderFactory;
 import com.linecorp.centraldogma.server.auth.AuthProviderParameters;
+import com.linecorp.centraldogma.server.auth.saml.SamlAuthProperties.Acs;
 import com.linecorp.centraldogma.server.auth.saml.SamlAuthProperties.Idp;
 import com.linecorp.centraldogma.server.auth.saml.SamlAuthProperties.KeyStore;
 
@@ -66,6 +67,11 @@ public final class SamlAuthProviderFactory implements AuthProviderFactory {
                    .ssoEndpoint(idp.endpoint())
                    .signingKey(idp.signingKey())
                    .encryptionKey(idp.encryptionKey());
+            final Acs acs = properties.acs();
+            if (acs != null && !acs.endpoints().isEmpty()) {
+                acs.endpoints().forEach(builder::acs);
+            }
+
             return new SamlAuthProvider(builder.build());
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create " +

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/AuthenticationDeserializationTest.java
@@ -57,6 +57,8 @@ class AuthenticationDeserializationTest {
         assertThat(properties.keyStore().keyPasswords()).containsOnly(Maps.immutableEntry("dogma", "bar1"));
     }
 
+    // This is used by SPI.
+    @SuppressWarnings("unused")
     public static class KeyConfigValueConverter implements ConfigValueConverter {
 
         @Override

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
@@ -51,6 +51,13 @@ class SamlAuthTest {
                     "        \"encryption\": \"centraldogma\"" +
                     "    }" +
                     "}," +
+                    "\"acs\": [{" +
+                    "    \"uri\": \"https://dogma-example.linecorp.com/saml/acs/post\"," +
+                    "    \"binding\": \"HTTP_POST\"" +
+                    "},{" +
+                    "    \"uri\": \"https://dogma-example.linecorp.com/saml/acs/redirect\"," +
+                    "    \"binding\": \"HTTP_REDIRECT\"" +
+                    "}]," +
                     "\"idp\": {" +
                     "    \"entityId\": \"test-idp\"," +
                     "    \"uri\": \"https://idp-example.linecorp.com/saml/sso\"" +

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthTest.java
@@ -51,13 +51,15 @@ class SamlAuthTest {
                     "        \"encryption\": \"centraldogma\"" +
                     "    }" +
                     "}," +
-                    "\"acs\": [{" +
-                    "    \"uri\": \"https://dogma-example.linecorp.com/saml/acs/post\"," +
-                    "    \"binding\": \"HTTP_POST\"" +
-                    "},{" +
-                    "    \"uri\": \"https://dogma-example.linecorp.com/saml/acs/redirect\"," +
-                    "    \"binding\": \"HTTP_REDIRECT\"" +
-                    "}]," +
+                    "\"acs\": {" +
+                    "    \"endpoints\": [{" +
+                    "        \"uri\": \"https://foo.linecorp.com/saml/acs/post\"," +
+                    "        \"binding\": \"HTTP_POST\"" +
+                    "    },{" +
+                    "        \"uri\": \"/saml/acs/redirect\"," +
+                    "        \"binding\": \"HTTP_REDIRECT\"" +
+                    "    }]" +
+                    "}," +
                     "\"idp\": {" +
                     "    \"entityId\": \"test-idp\"," +
                     "    \"uri\": \"https://idp-example.linecorp.com/saml/sso\"" +
@@ -108,9 +110,11 @@ class SamlAuthTest {
                 .contains("entityID=\"test-sp\"")
                 .contains("<md:AssertionConsumerService " +
                           "Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" " +
-                          "Location=\"http://dogma-example.linecorp.com:" + port + "/saml/acs/post")
+                          // full URI is specified in the acs.
+                          "Location=\"https://foo.linecorp.com/saml/acs/post")
                 .contains("<md:AssertionConsumerService " +
                           "Binding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect\" " +
+                          // Only the path is specified in the acs. Scheme, host and port are auto-filled.
                           "Location=\"http://dogma-example.linecorp.com:" + port + "/saml/acs/redirect");
     }
 }

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -110,6 +110,18 @@ the authentication to.
             },
             "signatureAlgorithm": "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
           },
+          "acs": {
+            "endpoints": [
+              {
+                "uri": "https://dogma-example.linecorp.com/saml/acs/post",
+                "binding": "HTTP_POST"
+              },
+              {
+                "uri": "https://dogma-example.linecorp.com/saml/acs/redirect",
+                "binding": "HTTP_REDIRECT"
+              }
+            ]
+          },
           "idp": {
             "entityId": "some-idp",
             "uri": "https://idp.some-service.com/saml/single_sign_on_service",
@@ -168,6 +180,23 @@ The following describes the meaning of SAML-specific properties.
 
     - a name of the signature algorithm for signing and encryption.
       If unspecified, ``http://www.w3.org/2000/09/xmldsig#rsa-sha1`` is used by default.
+
+- ``acs``
+
+  - the assertion consumer service configuration. If unspecified, the default value is used which is
+    ``{scheme}://{hostname}:{port}/saml/acs/post`` and ``{scheme}://{hostname}:{port}/saml/acs/redirect``.
+  - ``endpoints`` (array of object)
+
+    - an array of assertion consumer service endpoints. Each endpoint has the following properties:
+
+    - ``uri`` (string)
+
+      - a uri where a SAML response is supposed to be sent to.
+
+    - ``binding`` (string)
+
+      - a binding protocol of the ``uri``. It can be one of ``HTTP_POST`` or ``HTTP_REDIRECT``.
+        If unspecified, ``HTTP_POST`` is used by default.
 
 - ``idp``
 


### PR DESCRIPTION
Motivation:
Currently, SAML endpoints are automatically generated using the default hostname and active port.
This behavior can cause assertion failures when Central Dogma is deployed behind a proxy,
as the active port may differ from the externally visible one.

Modifications:
- Added `SamlAuthProperties.acs` property to allow users to manually specify the ACS endpoint that matches the proxy's exposed URL.

Result:
- SAML authentication now works correctly when Central Dogma is behind a proxy by allowing the ACS endpoint to be explicitly configured.