### PR TITLE
Fix missing migration marker file in dogma repository

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -22,7 +22,6 @@ import static com.linecorp.centraldogma.server.storage.project.InternalProjectIn
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -192,14 +191,11 @@ public class DefaultProject implements Project {
                     dogmaRepository.commit(
                             Revision.HEAD, creationTimeMillis, Author.SYSTEM,
                             "Add " + META_TO_DOGMA_MIGRATED + " file to dogma repository", "", Markup.PLAINTEXT,
-                            Change.ofJsonUpsert(META_TO_DOGMA_MIGRATED,
-                                                Jackson.writeValueAsString(
-                                                        ImmutableMap.of("timestamp", Instant.now())))).join();
+                            Change.ofJsonUpsert(META_TO_DOGMA_MIGRATED, "{}"))
+                                   .join();
                 }
             } catch (RepositoryExistsException ignored) {
                 // Just in case there's a race.
-            } catch (JsonProcessingException e) {
-                // Should never happen because map is used.
             }
         }
         if (!useDogmaRepoAsMetaRepo && !repos.exists(REPO_META)) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProjectTest.java
@@ -81,5 +81,8 @@ class DefaultProjectTest {
         // Meta repository is not created when a project is created.
         assertThat(foo.repos().list().keySet()).containsExactlyInAnyOrder("dogma");
         assertThat(foo.metaRepo().name()).isEqualTo("dogma");
+
+        // No exception is raised while reopening the project.
+        extension.recreateProjectManager();
     }
 }


### PR DESCRIPTION
Motivation:
While implementing #1123, I forgot to add the `/meta-to-dogma-migrated.json` file to the `dogma` repository. This file is necessary to indicate that the migration from `meta` to `dogma` has been completed.

Modifications:
- Added the `/meta-to-dogma-migrated.json` file to the `dogma` repository when a project is created.

Result:
- The `dogma` repository now contains the correct marker file.