### PR TITLE
Fix flaky test in ZoneAwareMirrorTest

### DIFF
--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestZoneAwareMirrorListener.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,7 +37,7 @@ public class TestZoneAwareMirrorListener implements MirrorListener {
 
     private static final Logger logger = LoggerFactory.getLogger(TestZoneAwareMirrorListener.class);
 
-    static final Map<String, AtomicInteger> startCount = new ConcurrentHashMap<>();
+    static final Map<String, Integer> startCount = new ConcurrentHashMap<>();
     static final Map<String, List<MirrorResult>> completions = new ConcurrentHashMap<>();
     static final Map<String, List<Throwable>> errors = new ConcurrentHashMap<>();
 
@@ -64,14 +63,7 @@ public class TestZoneAwareMirrorListener implements MirrorListener {
     @Override
     public void onStart(MirrorTask mirror) {
         logger.debug("onStart: {}", mirror);
-        startCount.compute(key(mirror), (k, v) -> {
-            if (v == null) {
-                return new AtomicInteger(1);
-            } else {
-                v.incrementAndGet();
-                return v;
-            }
-        });
+        startCount.merge(key(mirror), 1, Integer::sum);
     }
 
     @Override

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -31,7 +31,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
@@ -121,9 +120,7 @@ class ZoneAwareMirrorTest {
 
         await().untilAsserted(() -> {
             // Wait for three mirror tasks to run to ensure that all tasks are running in the same zone.
-            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(zone);
-            assertThat(atomicInteger).isNotNull();
-            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(3);
+            assertThat(TestZoneAwareMirrorListener.startCount.get(zone)).isGreaterThanOrEqualTo(3);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(zone);
@@ -144,9 +141,7 @@ class ZoneAwareMirrorTest {
         final String defaultZone = ZONES.get(0);
         await().untilAsserted(() -> {
             // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
-            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(defaultZone);
-            assertThat(atomicInteger).isNotNull();
-            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(3);
+            assertThat(TestZoneAwareMirrorListener.startCount.get(defaultZone)).isGreaterThanOrEqualTo(3);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(defaultZone);
@@ -195,9 +190,7 @@ class ZoneAwareMirrorTest {
 
         await().untilAsserted(() -> {
             // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
-            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(unknownZone);
-            assertThat(atomicInteger).isNotNull();
-            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(1);
+            assertThat(TestZoneAwareMirrorListener.startCount.get(unknownZone)).isGreaterThanOrEqualTo(1);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(unknownZone);

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -31,6 +31,7 @@ import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.annotation.Nullable;
 
@@ -54,7 +55,6 @@ import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.MirrorException;
-import com.linecorp.centraldogma.internal.CredentialUtil;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
@@ -121,7 +121,9 @@ class ZoneAwareMirrorTest {
 
         await().untilAsserted(() -> {
             // Wait for three mirror tasks to run to ensure that all tasks are running in the same zone.
-            assertThat(TestZoneAwareMirrorListener.startCount.get(zone)).isGreaterThanOrEqualTo(3);
+            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(zone);
+            assertThat(atomicInteger).isNotNull();
+            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(3);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(zone);
@@ -142,7 +144,9 @@ class ZoneAwareMirrorTest {
         final String defaultZone = ZONES.get(0);
         await().untilAsserted(() -> {
             // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
-            assertThat(TestZoneAwareMirrorListener.startCount.get(defaultZone)).isGreaterThanOrEqualTo(3);
+            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(defaultZone);
+            assertThat(atomicInteger).isNotNull();
+            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(3);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(defaultZone);
@@ -181,7 +185,7 @@ class ZoneAwareMirrorTest {
                                  URI.create("git+ssh://github.com/line/centraldogma-authtest.git/#main"),
                                  null,
                                  null,
-                                 CredentialUtil.credentialName("foo", "bar-unknown-zone", "credential-id"),
+                                 credentialName("foo", "bar-unknown-zone", "credential-id"),
                                  unknownZone);
         final Change<JsonNode> change = Change.ofJsonUpsert(
                 "/repos/bar-unknown-zone/mirrors/" + mirrorId + ".json",
@@ -191,7 +195,9 @@ class ZoneAwareMirrorTest {
 
         await().untilAsserted(() -> {
             // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.
-            assertThat(TestZoneAwareMirrorListener.startCount.get(unknownZone)).isGreaterThanOrEqualTo(1);
+            final AtomicInteger atomicInteger = TestZoneAwareMirrorListener.startCount.get(unknownZone);
+            assertThat(atomicInteger).isNotNull();
+            assertThat(atomicInteger.get()).isGreaterThanOrEqualTo(1);
         });
         await().untilAsserted(() -> {
             final List<MirrorResult> results = TestZoneAwareMirrorListener.completions.get(unknownZone);


### PR DESCRIPTION
MirrorListener.onX methods can be called by multiple threads: https://github.com/line/centraldogma/blob/e1eaf06745dbecfe009ec1a2fdb405de595acad2/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java#L167-L168 Thus, we should use thread-safe data structure in the methods.

Close #1132 