### PR TITLE
Fix flaky test in GitRepositoryListenerTest

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryListenerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryListenerTest.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git;
 
 import static java.util.concurrent.ForkJoinPool.commonPool;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -56,6 +57,7 @@ class GitRepositoryListenerTest {
                                  commonPool(), 0L, Author.SYSTEM);
         listener = new TestRepositoryListener();
         repo.addListener(listener);
+        await().until(() -> listener.updateCount.get() == 1);
     }
 
     @AfterAll


### PR DESCRIPTION
`listener.latestEntries` can be null if it's called before `TestRepositoryListener.onUpdate` is called. https://github.com/line/centraldogma/blob/767eff37a5cafe84fc4bdc78e9bc2c0d1a54f1a9/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryListenerTest.java#L71 https://github.com/line/centraldogma/blob/767eff37a5cafe84fc4bdc78e9bc2c0d1a54f1a9/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryListenerTest.java#L139-L140