### PR TITLE
Provide an easy way to import a directory into Central Dogma programmatically

### DIFF
--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -20,11 +20,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.net.UnknownHostException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Comparator;
+import java.util.Random;
 import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
@@ -49,12 +52,13 @@ class ArmeriaCentralDogmaTest {
         }
     };
 
-    private static void cleanProjectAndRepo(CentralDogma centralDogma, String project, String repository) throws IOException {
-        centralDogma.removeRepository(project, repository).join();
-        centralDogma.purgeRepository(project, repository).join();
+    private static void cleanProjectAndRepo(CentralDogma centralDogma, String project, String repository)
+            throws IOException {
+        centralDogma.removeRepository(project, repository).exceptionally(ex -> null);
+        centralDogma.purgeRepository(project, repository).exceptionally(ex -> null);
 
-        centralDogma.removeProject(project).join();
-        centralDogma.purgeProject(project).join();
+        centralDogma.removeProject(project).exceptionally(ex -> null);
+        centralDogma.purgeProject(project).exceptionally(ex -> null);
     }
 
     private static void cleanDirectory(Path dir) throws IOException {
@@ -106,13 +110,13 @@ class ArmeriaCentralDogmaTest {
 
     @Test
     void importDir_createsProjectRepo_andImportsFile() throws IOException {
-
-        final String project = "foo5";
+        final Random random = new Random();
+        final String project = "foo" + random.nextInt(1000);
         final String repository = "bar";
         final String fileName = "alice.txt";
-        final String content = "hello";
+        final String content = "world";
         final CentralDogma centralDogma = new ArmeriaCentralDogmaBuilder()
-                .host("localhost", 36462)
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
                 .build();
 
         final Path testRoot = Paths.get(project, repository);
@@ -123,19 +127,61 @@ class ArmeriaCentralDogmaTest {
         Files.write(file, content.getBytes(UTF_8));
 
         try {
-            final ImportResult importResult = centralDogma.importDir(Paths.get(project, repository, fileName)).join();
+            final ImportResult importResult = centralDogma.importDir(Paths.get(project, repository, fileName))
+                                                          .join();
             assertThat(importResult).isNotNull();
             assertThat(importResult.revision().major()).isPositive();
             assertThat(importResult.isEmpty()).isFalse();
 
             final Change<?> diff = centralDogma.forRepo(project, repository)
                                                .diff(Query.ofText('/' + fileName))
-                                               .get(Revision.HEAD, Revision.HEAD)
+                                               .get(Revision.INIT, Revision.HEAD)
                                                .join();
             assertThat(diff.path()).isEqualTo('/' + fileName);
+            assertThat(diff.contentAsText()).isEqualTo("world" + '\n');
         } finally {
             cleanProjectAndRepo(centralDogma, project, repository);
             cleanDirectory(testRoot);
+        }
+    }
+
+    @Test
+    void importResourceDir_createsProjectRepo_andImportsFile() throws IOException {
+        final Random random = new Random();
+        final String project = "foo" + random.nextInt(1000);
+        final String repository = "bar";
+        final String fileName = "hello.txt";
+        final String content = "world";
+
+        final CentralDogma centralDogma = new ArmeriaCentralDogmaBuilder()
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
+                .build();
+
+        final Path tempRoot = Files.createTempDirectory("cp-");
+        final Path fooBar = tempRoot.resolve(project).resolve(repository);
+        cleanDirectory(tempRoot);
+        Files.createDirectories(fooBar);
+        Files.write(fooBar.resolve(fileName), content.getBytes(UTF_8));
+
+        try (URLClassLoader cl = new URLClassLoader(new URL[] { tempRoot.toUri().toURL() },
+                                                    Thread.currentThread().getContextClassLoader())) {
+
+            final ImportResult result = centralDogma.importResourceDir(project + "/" + repository, cl)
+                                                    .join();
+
+            assertThat(result).isNotNull();
+            assertThat(result.revision().major()).isPositive();
+            assertThat(result.isEmpty()).isFalse();
+
+            final Change<?> diff = centralDogma.forRepo(project, repository)
+                                               .diff(Query.ofText('/' + fileName))
+                                               .get(Revision.INIT, Revision.HEAD)
+                                               .join();
+            assertThat(diff.path()).isEqualTo('/' + fileName);
+            assertThat(diff.content()).isEqualTo(content + '\n');
+        } finally {
+            cleanProjectAndRepo(centralDogma, project, repository);
+            cleanDirectory(tempRoot);
         }
     }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -235,12 +235,29 @@ public abstract class AbstractCentralDogma implements CentralDogma {
 
     @Override
     public CompletableFuture<ImportResult> importResourceDir(String dir) {
-        return null;
+        final Path path = Paths.get(dir);
+        if (path.getNameCount() < 2) {
+            return exceptionallyCompletedFuture(
+                    new IllegalArgumentException("Path must be <project>/<repo>[/…]: " + dir));
+        }
+        final String project = path.getName(0).toString();
+        final String repo = path.getName(1).toString();
+
+        return forRepo(project, repo).importResourceDir(dir);
     }
 
     @Override
     public CompletableFuture<ImportResult> importResourceDir(String dir, ClassLoader classLoader) {
-        return null;
+
+        final Path path = Paths.get(dir);
+        if (path.getNameCount() < 2) {
+            return exceptionallyCompletedFuture(
+                    new IllegalArgumentException("Path must be <project>/<repo>[/…]: " + dir));
+        }
+        final String project = path.getName(0).toString();
+        final String repo = path.getName(1).toString();
+
+        return forRepo(project, repo).importResourceDir(dir, classLoader);
     }
 
     /**

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -17,11 +17,14 @@
 package com.linecorp.centraldogma.client;
 
 import static com.linecorp.centraldogma.internal.PathPatternUtil.toPathPattern;
+import static com.spotify.futures.CompletableFutures.exceptionallyCompletedFuture;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
+import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -219,20 +222,15 @@ public abstract class AbstractCentralDogma implements CentralDogma {
 
     @Override
     public CompletableFuture<ImportResult> importDir(Path dir) {
-        requireNonNull(dir, "dir");
         if (dir.getNameCount() < 2) {
-            return CompletableFutures.exceptionallyCompletedFuture(new IllegalArgumentException(
+            return exceptionallyCompletedFuture(new IllegalArgumentException(
                     "Path must be <project>/<repo>[/…]: " + dir));
         }
         final String project = dir.getName(0).toString();
         final String repo = dir.getName(1).toString();
         final Path norm = dir.toAbsolutePath().normalize();
-        final CentralDogmaRepository centralDogmaRepository = forRepo(project, repo);
-        final CentralDogma centralDogma = centralDogmaRepository.centralDogma();
 
-        return centralDogma.createProject(project)
-                           .thenCompose(unused -> centralDogma.createRepository(project, repo))
-                           .thenCompose(a -> centralDogmaRepository.importDir(norm));
+        return forRepo(project, repo).importDir(norm);
     }
 
     @Override

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -420,7 +420,34 @@ public interface CentralDogma extends AutoCloseable {
     CompletableFuture<List<Change<?>>> getDiff(String projectName, String repositoryName,
                                                Revision from, Revision to, PathPattern pathPattern);
 
+    /**
+     * Imports files from the given absolute {@link Path} into a repository.
+     * <p>
+     * The {@code dir} must follow the format: {@code /<project>/<repository>[/path/to/files]}.
+     * If a single file is specified, only that file is imported. If a directory is specified,
+     * all eligible files under it will be imported.
+     */
     CompletableFuture<ImportResult> importDir(Path dir);
+
+    /**
+     * Imports resource files from the given directory located in the default classloader.
+     * <p>
+     * The path must follow the format: {@code <project>/<repository>[/resourcePath]}.
+     * The specified directory is resolved from the current classpath.
+     */
+    CompletableFuture<ImportResult> importResourceDir(String dir);
+
+    /**
+     * Imports resource files from the given directory using the specified {@link ClassLoader}.
+     * <p>
+     * This is useful for testing or loading from custom classpaths such as in embedded environments.
+     * The path must follow the format: {@code <project>/<repository>[/resourcePath]}.
+     *
+     * @param dir the resource directory path (project/repository/optionalSubPath)
+     * @param classLoader the class loader used to locate the resource directory
+     */
+    CompletableFuture<ImportResult> importResourceDir(String dir, ClassLoader classLoader);
+    
     /**
      * Retrieves the diffs of the files matched by the given path pattern between two {@link Revision}s.
      *

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.client;
 import static com.linecorp.centraldogma.internal.PathPatternUtil.toPathPattern;
 import static java.util.Objects.requireNonNull;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -419,6 +420,7 @@ public interface CentralDogma extends AutoCloseable {
     CompletableFuture<List<Change<?>>> getDiff(String projectName, String repositoryName,
                                                Revision from, Revision to, PathPattern pathPattern);
 
+    CompletableFuture<ImportResult> importDir(Path dir);
     /**
      * Retrieves the diffs of the files matched by the given path pattern between two {@link Revision}s.
      *

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
@@ -81,12 +81,10 @@ public final class CentralDogmaRepository {
             String lower = file.getFileName().toString().toLowerCase();
 
             if (lower.endsWith(".json")) {
-                return Change.ofJsonUpsert(repoPath,
-                                           Jackson.readTree(bytes));
+                return Change.ofJsonUpsert(repoPath, Jackson.readTree(bytes));
             }
 
-            return Change.ofTextUpsert(repoPath,
-                                       new String(bytes, StandardCharsets.UTF_8));
+            return Change.ofTextUpsert(repoPath, new String(bytes, StandardCharsets.UTF_8));
 
         } catch (Exception e) {
             throw new IllegalStateException("Failed to create Change for " + file, e);

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java
@@ -86,12 +86,6 @@ public final class CentralDogmaRepository {
                                            Jackson.readTree(bytes));
             }
 
-            if (lower.endsWith(".yml") || lower.endsWith(".yaml") ||
-                (Files.probeContentType(file) != null &&
-                 Files.probeContentType(file).startsWith("text/"))) {
-                return Change.ofTextUpsert(repoPath,
-                                           new String(bytes, StandardCharsets.UTF_8));
-            }
             return Change.ofTextUpsert(repoPath,
                                        new String(bytes, StandardCharsets.UTF_8));
 

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/ImportResult.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/ImportResult.java
@@ -13,19 +13,41 @@ public final class ImportResult {
     }
 
     public static ImportResult empty() {
-        //todo: should refactor this logic
-        return new ImportResult(Revision.INIT, 0);
+        return new ImportResult(Revision.INIT, 0, true);
     }
 
+    private final boolean isEmpty;
     private final Revision revision;
     private final long when;
 
-    private ImportResult(Revision revision, long when) {
+    private ImportResult(Revision revision, long when, boolean isEmpty) {
         this.revision = requireNonNull(revision, "revision");
-        this.when = when / 1000L * 1000L; // Drop the milliseconds
+        this.when = when / 1000L * 1000L;
+        this.isEmpty = isEmpty;
     }
 
-    public Revision revision() {return revision;}
+    private ImportResult(Revision revision, long when) {
+        this(revision, when, false);
+    }
 
-    public long whenMillis() {return when;}
+    public boolean isEmpty() {
+        return isEmpty;
+    }
+
+    public Revision revision() {
+        return revision;
+    }
+
+    public long whenMillis() {
+        return when;
+    }
+
+    @Override
+    public String toString() {
+        return "ImportResult{" +
+               "isEmpty=" + isEmpty +
+               ", revision=" + revision +
+               ", when=" + when +
+               '}';
+    }
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/ImportResult.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/ImportResult.java
@@ -1,0 +1,31 @@
+package com.linecorp.centraldogma.client;
+
+import static java.util.Objects.requireNonNull;
+
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Revision;
+
+public final class ImportResult {
+
+    public static ImportResult fromPushResult(PushResult pr) {
+        requireNonNull(pr, "pushResult");
+        return new ImportResult(pr.revision(), pr.when());
+    }
+
+    public static ImportResult empty() {
+        //todo: should refactor this logic
+        return new ImportResult(Revision.INIT, 0);
+    }
+
+    private final Revision revision;
+    private final long when;
+
+    private ImportResult(Revision revision, long when) {
+        this.revision = requireNonNull(revision, "revision");
+        this.when = when / 1000L * 1000L; // Drop the milliseconds
+    }
+
+    public Revision revision() {return revision;}
+
+    public long whenMillis() {return when;}
+}

--- a/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaImporterTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaImporterTest.java
@@ -1,0 +1,166 @@
+package com.linecorp.centraldogma.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.ChangeType;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Revision;
+
+class CentralDogmaImporterTest {
+
+    CentralDogma dogma = mock(CentralDogma.class);
+
+    private static void cleanUp(Path tempDir) throws IOException {
+        Files.walk(tempDir).sorted(Comparator.reverseOrder()).forEach(p -> {
+            try {Files.deleteIfExists(p);} catch (Exception ignored) {}
+        });
+    }
+
+    @Test
+    void importDir_createsProjectRepo_andPushes() throws Exception {
+        //given
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        CentralDogmaRepository repo = new CentralDogmaRepository(
+                dogma, "foo", "bar", scheduler, null);
+
+        final Path tempDir = Files.createTempDirectory("test-root");
+        final Path fooBar = tempDir.resolve("foo/bar");
+        Files.createDirectories(fooBar);
+        Path file = fooBar.resolve("hello.txt");
+        Files.write(file, "hello".getBytes(StandardCharsets.UTF_8));
+
+        //when
+        CompletableFuture<Void> ok = CompletableFuture.completedFuture(null);
+        when(dogma.createProject("foo")).thenReturn(ok);
+        when(dogma.createRepository(anyString(), anyString())).thenReturn(
+                CompletableFuture.completedFuture(null));
+
+        when(dogma.push(anyString(), anyString(),
+                        any(), anyString(), anyString(), any(), anyCollection()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new PushResult(Revision.HEAD, System.currentTimeMillis())));
+
+        repo.importDir(fooBar)        // project/repo path
+            .join();                               // ← 내부에서 repo.importDir(dir) 호출
+
+        //then
+        verify(dogma).createProject("foo");
+        verify(dogma).createRepository("foo", "bar");
+
+        //verify file successfully imported
+        ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(Collection.class);
+
+        verify(dogma).push(
+                eq("foo"), eq("bar"),
+                any(), anyString(), anyString(), any(), changeCaptor.capture());
+
+        Collection<Change<?>> changes = changeCaptor.getValue();
+        assertThat(changes).hasSize(1);
+
+        Change<?> ch = changes.iterator().next();
+        assertThat(ch.path()).isEqualTo("/hello.txt");
+        assertThat(ch.type()).isEqualTo(ChangeType.UPSERT_TEXT);
+        assertThat(ch.content()).isEqualTo("hello");
+
+        // cleanUp
+        scheduler.shutdownNow();
+        cleanUp(fooBar);
+    }
+
+    @Test
+    void importDir_shouldIgnoresPlaceholders() throws Exception {
+        // given
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        final CentralDogmaRepository repo = new CentralDogmaRepository(
+                dogma, "foo", "bar", scheduler, null);
+
+        final Path tempDir = Files.createTempDirectory("test-ignore");
+        final Path fooBar = tempDir.resolve("foo/bar");
+        final Path boundaryFile = fooBar.resolve("hello.txt");
+
+        // setUp Test Directory
+        Files.createDirectories(fooBar);
+        Files.write(fooBar.resolve(".gitkeep"), "".getBytes(StandardCharsets.UTF_8));
+        Files.write(fooBar.resolve(".gitignore"), "".getBytes(StandardCharsets.UTF_8));
+        Files.write(boundaryFile, "hello".getBytes(StandardCharsets.UTF_8));
+
+        final CompletableFuture<Void> ok = CompletableFuture.completedFuture(null);
+        when(dogma.createProject("foo")).thenReturn(CompletableFuture.completedFuture(null));
+        when(dogma.createRepository(any(), any())).thenReturn(CompletableFuture.completedFuture(null));
+        when(dogma.push(any(), any(), any(), any(), any(), any(), anyCollection()))
+                .thenReturn(CompletableFuture.completedFuture(
+                        new PushResult(Revision.HEAD, System.currentTimeMillis())));
+
+        // when
+        final ImportResult importResult = repo.importDir(fooBar).join();
+
+        // then
+        //ImportDir() should ignore placeholders such as .gitkeep and .gitignore
+        final ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(Collection.class);
+
+        verify(dogma).createProject("foo");
+        verify(dogma).createRepository("foo", "bar");
+        verify(dogma).push(
+                eq("foo"), eq("bar"),
+                any(), anyString(), anyString(), any(), changeCaptor.capture());
+
+        final Collection<Change<?>> changes = changeCaptor.getValue();
+        final List<String> importedPaths = changes.stream()
+                                                  .map(Change::path)
+                                                  .collect(Collectors.toList());
+
+        assertThat(importedPaths).containsExactly("/hello.txt");
+        assertThat(importedPaths).doesNotContain("/.gitkeep", "/.gitignore");
+
+        // cleanup
+        scheduler.shutdownNow();
+        cleanUp(tempDir);
+    }
+
+    @Test
+    void importDir_onlyCreateRepositoryWhenFilesNotExists() throws IOException {
+        // given
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        final CentralDogmaRepository repo = new CentralDogmaRepository(
+                dogma, "foo", "bar", scheduler, null);
+
+        // directory setUp
+        final Path tempDir = Files.createTempDirectory("test-ignore");
+        final Path fooBar = tempDir.resolve("foo/bar");
+        Files.createDirectories(fooBar);
+
+        // mock setUp
+        when(dogma.createProject("foo")).thenReturn(CompletableFuture.completedFuture(null));
+        when(dogma.createRepository(eq("foo"), eq("bar"))).thenReturn(CompletableFuture.completedFuture(null));
+
+        // when
+        final ImportResult result = repo.importDir(fooBar).join();
+
+        // then
+        verify(dogma).createProject("foo");
+        verify(dogma).createRepository("foo", "bar");
+        verify(dogma, never()).push(any(), any(), any(), any(), any(), any(), anyCollection());
+
+        // cleanup
+        scheduler.shutdownNow();
+        cleanUp(tempDir);
+    }
+}

--- a/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaImporterTest.java
+++ b/client/java/src/test/java/com/linecorp/centraldogma/client/CentralDogmaImporterTest.java
@@ -1,10 +1,28 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
 package com.linecorp.centraldogma.client;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -51,18 +69,18 @@ class CentralDogmaImporterTest {
     @Test
     void importDir_createsProjectRepo_andPushes() throws Exception {
         //given
-        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
-        CentralDogmaRepository repo = new CentralDogmaRepository(
+        final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        final CentralDogmaRepository repo = new CentralDogmaRepository(
                 dogma, "foo", "bar", scheduler, null);
 
         final Path tempDir = Files.createTempDirectory("test-root");
         final Path fooBar = tempDir.resolve("foo/bar");
         Files.createDirectories(fooBar);
-        Path file = fooBar.resolve("hello.txt");
+        final Path file = fooBar.resolve("hello.txt");
         Files.write(file, "hello".getBytes(StandardCharsets.UTF_8));
 
         //when
-        CompletableFuture<Void> ok = CompletableFuture.completedFuture(null);
+        final CompletableFuture<Void> ok = CompletableFuture.completedFuture(null);
         when(dogma.createProject("foo")).thenReturn(ok);
         when(dogma.createRepository(anyString(), anyString())).thenReturn(
                 CompletableFuture.completedFuture(null));
@@ -72,31 +90,31 @@ class CentralDogmaImporterTest {
                 .thenReturn(CompletableFuture.completedFuture(
                         new PushResult(Revision.HEAD, System.currentTimeMillis())));
 
-        repo.importDir(fooBar)        // project/repo path
-            .join();                               // ← 내부에서 repo.importDir(dir) 호출
+        try {
+            repo.importDir(fooBar).join();
 
-        //then
-        verify(dogma).createProject("foo");
-        verify(dogma).createRepository("foo", "bar");
+            //then
+            verify(dogma).createProject("foo");
+            verify(dogma).createRepository("foo", "bar");
 
-        //verify file successfully imported
-        ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(Collection.class);
+            //verify file successfully imported
+            ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(Collection.class);
 
-        verify(dogma).push(
-                eq("foo"), eq("bar"),
-                any(), anyString(), anyString(), any(), changeCaptor.capture());
+            verify(dogma).push(
+                    eq("foo"), eq("bar"),
+                    any(), anyString(), anyString(), any(), changeCaptor.capture());
 
-        Collection<Change<?>> changes = changeCaptor.getValue();
-        assertThat(changes).hasSize(1);
+            Collection<Change<?>> changes = changeCaptor.getValue();
+            assertThat(changes).hasSize(1);
 
-        Change<?> ch = changes.iterator().next();
-        assertThat(ch.path()).isEqualTo("/hello.txt");
-        assertThat(ch.type()).isEqualTo(ChangeType.UPSERT_TEXT);
-        assertThat(ch.content()).isEqualTo("hello");
-
-        // cleanUp
-        scheduler.shutdownNow();
-        removeCreatedDir(fooBar);
+            Change<?> ch = changes.iterator().next();
+            assertThat(ch.path()).isEqualTo("/hello.txt");
+            assertThat(ch.type()).isEqualTo(ChangeType.UPSERT_TEXT);
+            assertThat(ch.content()).isEqualTo("hello");
+        } finally {
+            scheduler.shutdownNow();
+            removeCreatedDir(fooBar);
+        }
     }
 
     @Test
@@ -123,30 +141,32 @@ class CentralDogmaImporterTest {
                 .thenReturn(CompletableFuture.completedFuture(
                         new PushResult(Revision.HEAD, System.currentTimeMillis())));
 
-        // when
-        final ImportResult importResult = repo.importDir(fooBar).join();
+        try {
+            // when
+            final ImportResult importResult = repo.importDir(fooBar).join();
 
-        // then
-        //ImportDir() should ignore placeholders such as .gitkeep and .gitignore
-        final ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(Collection.class);
+            // then
+            //ImportDir() should ignore placeholders such as .gitkeep and .gitignore
+            final ArgumentCaptor<Collection<Change<?>>> changeCaptor = ArgumentCaptor.forClass(
+                    Collection.class);
 
-        verify(dogma).createProject("foo");
-        verify(dogma).createRepository("foo", "bar");
-        verify(dogma).push(
-                eq("foo"), eq("bar"),
-                any(), anyString(), anyString(), any(), changeCaptor.capture());
+            verify(dogma).createProject("foo");
+            verify(dogma).createRepository("foo", "bar");
+            verify(dogma).push(
+                    eq("foo"), eq("bar"),
+                    any(), anyString(), anyString(), any(), changeCaptor.capture());
 
-        final Collection<Change<?>> changes = changeCaptor.getValue();
-        final List<String> importedPaths = changes.stream()
-                                                  .map(Change::path)
-                                                  .collect(Collectors.toList());
+            final Collection<Change<?>> changes = changeCaptor.getValue();
+            final List<String> importedPaths = changes.stream()
+                                                      .map(Change::path)
+                                                      .collect(Collectors.toList());
 
-        assertThat(importedPaths).containsExactly("/hello.txt");
-        assertThat(importedPaths).doesNotContain("/.gitkeep", "/.gitignore");
-
-        // cleanup
-        scheduler.shutdownNow();
-        removeCreatedDir(tempDir);
+            assertThat(importedPaths).containsExactly("/hello.txt");
+            assertThat(importedPaths).doesNotContain("/.gitkeep", "/.gitignore");
+        } finally {
+            scheduler.shutdownNow();
+            removeCreatedDir(tempDir);
+        }
     }
 
     @Test
@@ -164,8 +184,6 @@ class CentralDogmaImporterTest {
         // mock setUp
         when(dogma.createProject("foo")).thenReturn(CompletableFuture.completedFuture(null));
         when(dogma.createRepository(eq("foo"), eq("bar"))).thenReturn(CompletableFuture.completedFuture(null));
-
-        // when
         try {
             final ImportResult result = repo.importDir(fooBar).join();
 


### PR DESCRIPTION
### Motivation

- Related Issus : #963 
- Previously, the user had to call each client API to import files ( createProject(), createRepository(), commit(), push())
- With this feature, users can import files or create projects more easily 

### Modification

**Interface Addition**  
  - Added `importDir(Path)`, `importResourceDir(String)`, and `importResourceDir(String, ClassLoader)` methods to the `CentralDogma` interface. 

- **Delegation in AbstractCentralDogma**  
  - Parses the given `Path` or `String` to determine the target `<project>/<repository>` and delegates the actual import logic to the corresponding `CentralDogmaRepository`.
  https://github.com/hyunw9/centraldogma/blob/48a97cdb816cfe6499293b677c580750b8ca762d/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java#L225-L233

- **Core Implementation in CentralDogmaRepository**  
  - Implements actual [file resolution](https://github.com/hyunw9/centraldogma/blob/48a97cdb816cfe6499293b677c580750b8ca762d/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java#L94-L108), and [change computation](https://github.com/hyunw9/centraldogma/blob/48a97cdb816cfe6499293b677c580750b8ca762d/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java#L78C5-L92C6).
  - Automatically creates the project/repository if they do not exist, using `createProject()` and `createRepository()` with proper exception handling (e.g., `ProjectExistsException`).

- **Business Logic (change building)**  
  - Local file changes are converted via [`toChange()`](https://github.com/hyunw9/centraldogma/blob/48a97cdb816cfe6499293b677c580750b8ca762d/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java#L78-L92), with placeholder files ignored.
  - For `importResourceDir()`, resource paths are resolved using `ClassLoader.getResource()` with appropriate fallbacks.
  - [Exclude predefined placeholder](https://github.com/hyunw9/centraldogma/blob/48a97cdb816cfe6499293b677c580750b8ca762d/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogmaRepository.java#L98) files (e.g. .keep) during import

- **Testing**
  - Added unit tests for `CentralDogmaRepository` to verify import logic with mock `CentralDogma`.
  - Added integration tests (`ArmeriaCentralDogmaTest`) to confirm actual repository creation, content import, and correct diff results.

- **Design Note**
  - Considered using `join()` vs `thenCompose()` when handling project/repo creation.
 
<details>
<summary>detail</summary>
<div markdown="1">

There were cases where the `commit()` operation was attempted before the project or repository had been fully created, resulting in `ProjectNotFoundException` or `RepositoryNotFoundException`.

Initially, we handled this by chaining `createProject()` and `createRepository()` with `thenCompose()` and fallback logic to tolerate already-existing resources.  
Here is the original implementation:

```java
private CompletableFuture<Void> ensureProjectAndRepoExist() {
    final Function<Throwable, Throwable> unwrap = (t) -> {
        if (t instanceof CompletionException) {
            return t.getCause();
        }
        return t;
    };

    return centralDogma.createProject(projectName()).handle((r, ex) -> {
        if (ex != null && !(unwrap.apply(ex) instanceof ProjectExistsException)) {
            throw new CompletionException(unwrap.apply(ex));
        }
        return null;
    }).thenCompose(unused ->
        centralDogma.createRepository(projectName(), repositoryName())
                    .handle((r, ex) -> {
                        if (ex != null && !(unwrap.apply(ex) instanceof RepositoryExistsException)) {
                            throw new CompletionException(unwrap.apply(ex));
                        }
                        return null;
                    })
    ).thenApply(unused -> null);
}
```
While this ensures safe creation of the project and repository, it introduces multiple handle() blocks and deep exception wrapping, which may degrade readability and traceability.
</div>
</details>

### Result 

Without manually creating projects or repositories, users can now import files from both local file systems and classpath resources into Central Dogma with a single method call.
