### PR TITLE
Disable json generation for CentralDogma.thrift

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ configure(projectsWithFlags('java')) {
     // Common properties and functions.
     ext {
         thriftVersion = '0.9'
+        disableThriftJson()
     }
 
     dependencies {


### PR DESCRIPTION
Because

- The linux thrift binary creates a json file that causes issues in conjunction with [ThriftDocServiceExtractor](https://github.com/line/armeria/blob/a9e3e4c97372d7f802cfd958d08a44bab48030e5/thrift/thrift0.13/src/main/java/com/linecorp/armeria/internal/server/thrift/ThriftDocStringExtractor.java#L68)
  - The generated json file can be seen from published artifacts; the `namespace` key does not exist
- Nobody is really using it, and we already specify in the javadocs that thrift 0.9 does not really support json generation
  - https://github.com/line/gradle-scripts/blob/main/README.md#building-java-projects-with-java-flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build configuration to disable Thrift JSON handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->