### PR TITLE
Support basic access authentication

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -849,7 +849,10 @@ public class CentralDogma implements AutoCloseable {
     private Function<? super HttpService, AuthService> authService(
             MetadataService mds, @Nullable AuthProvider authProvider, @Nullable SessionManager sessionManager) {
         if (authProvider == null) {
-            return AuthService.newDecorator(new CsrfTokenAuthorizer());
+            return AuthService.builder()
+                              .add(new CsrfTokenAuthorizer())
+                              .onFailure(new CentralDogmaAuthFailureHandler())
+                              .newDecorator();
         }
         final AuthConfig authCfg = cfg.authConfig();
         assert authCfg != null : "authCfg";

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandler.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaAuthFailureHandler.java
@@ -20,9 +20,11 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpResponse;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.armeria.server.HttpService;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.auth.AuthFailureHandler;
@@ -35,6 +37,13 @@ final class CentralDogmaAuthFailureHandler implements AuthFailureHandler {
     private static final Logger logger = LoggerFactory.getLogger(CentralDogmaAuthFailureHandler.class);
 
     private static final AuthorizationException AUTHORIZATION_EXCEPTION = new AuthorizationException("", false);
+    private static final ResponseHeaders UNAUTHORIZED_HEADERS =
+            ResponseHeaders.builder(HttpStatus.UNAUTHORIZED)
+                           .add(HttpHeaderNames.WWW_AUTHENTICATE,
+                                "Bearer realm=\"Central Dogma\", charset=\"UTF-8\"")
+                           .add(HttpHeaderNames.WWW_AUTHENTICATE,
+                                "Basic realm=\"Central Dogma\", charset=\"UTF-8\"")
+                           .build();
 
     @Override
     public HttpResponse authFailed(HttpService delegate,
@@ -47,6 +56,6 @@ final class CentralDogmaAuthFailureHandler implements AuthFailureHandler {
             return HttpApiUtil.newResponse(ctx, HttpStatus.INTERNAL_SERVER_ERROR, cause);
         }
 
-        return HttpApiUtil.newResponse(ctx, HttpStatus.UNAUTHORIZED, AUTHORIZATION_EXCEPTION);
+        return HttpApiUtil.newResponse(ctx, UNAUTHORIZED_HEADERS, AUTHORIZATION_EXCEPTION);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/AbstractAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/AbstractAuthorizer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.admin.auth;
+
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpRequest;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.auth.BasicToken;
+import com.linecorp.armeria.common.auth.OAuth2Token;
+import com.linecorp.armeria.common.util.UnmodifiableFuture;
+import com.linecorp.armeria.server.ServiceRequestContext;
+import com.linecorp.armeria.server.auth.AuthTokenExtractors;
+import com.linecorp.armeria.server.auth.Authorizer;
+
+import io.netty.util.AttributeKey;
+
+public abstract class AbstractAuthorizer implements Authorizer<HttpRequest> {
+
+    private static final AttributeKey<String> TOKEN_KEY =
+            AttributeKey.valueOf(AbstractAuthorizer.class, "TOKEN_KEY");
+
+    private static final String BASIC_USERNAME = "dogma";
+
+    @Override
+    public CompletionStage<Boolean> authorize(ServiceRequestContext ctx, HttpRequest req) {
+        final String token = extractToken(ctx, req);
+        if (token == null) {
+            return UnmodifiableFuture.completedFuture(false);
+        }
+
+        return authorize(ctx, req, token);
+    }
+
+    protected abstract CompletionStage<Boolean> authorize(ServiceRequestContext ctx, HttpRequest req,
+                                                          String accessToken);
+
+    @Nullable
+    private static String extractToken(ServiceRequestContext ctx, HttpRequest req) {
+        String token = ctx.attr(TOKEN_KEY);
+        if (token != null) {
+            return token;
+        }
+
+        final RequestHeaders headers = req.headers();
+        final String authorization = headers.get(HttpHeaderNames.AUTHORIZATION);
+        if (authorization == null) {
+            return null;
+        }
+
+        // Check the scheme of the authorization header to avoid unnecessary warning logs.
+        if (authorization.startsWith("Bearer")) {
+            final OAuth2Token oAuth2Token = AuthTokenExtractors.oAuth2().apply(headers);
+            if (oAuth2Token != null) {
+                token = oAuth2Token.accessToken();
+            }
+        } else if (authorization.startsWith("Basic")) {
+            final BasicToken basicToken = AuthTokenExtractors.basic().apply(headers);
+            if (basicToken != null) {
+                // Allow only the 'dogma' username for basic authentication.
+                if (BASIC_USERNAME.equals(basicToken.username())) {
+                    token = basicToken.password();
+                }
+            }
+        }
+
+        if (token != null) {
+            ctx.setAttr(TOKEN_KEY, token);
+        }
+        return token;
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/auth/BasicAuthTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/auth/BasicAuthTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.internal.api.v1.ProjectDto;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.metadata.Token;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class BasicAuthTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.authProviderFactory(new TestAuthProviderFactory());
+            builder.systemAdministrators(TestAuthMessageUtil.USERNAME);
+        }
+    };
+
+    @Test
+    void shouldReturnWwwAuthenticateHeadersForUnauthorizedRequest() {
+        final BlockingWebClient client = WebClient.builder(dogma.httpClient().uri())
+                                                  .build()
+                                                  .blocking();
+        final AggregatedHttpResponse response = client.get("/api/v1/projects");
+        assertThat(response.status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.headers().getAll(HttpHeaderNames.WWW_AUTHENTICATE))
+                .containsExactly("Bearer realm=\"Central Dogma\", charset=\"UTF-8\"",
+                                 "Basic realm=\"Central Dogma\", charset=\"UTF-8\"");
+    }
+
+    @Test
+    void useSessionTokenToAccessResources() throws InterruptedException {
+        Thread.sleep(Long.MAX_VALUE);
+        final String accessToken = TestAuthMessageUtil.getAccessToken(dogma.httpClient(),
+                                                                      TestAuthMessageUtil.USERNAME,
+                                                                      TestAuthMessageUtil.PASSWORD);
+        final BlockingWebClient client = WebClient.builder(dogma.httpClient().uri())
+                                                  .auth(AuthToken.ofBasic("dogma", accessToken))
+                                                  .build()
+                                                  .blocking();
+        final ResponseEntity<List<ProjectDto>> response =
+                client.prepare()
+                      .get("/api/v1/projects")
+                      .asJson(new TypeReference<List<ProjectDto>>() {})
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content()).anyMatch(project -> project.name().equals("dogma"));
+    }
+
+    @Test
+    void useApplicationTokenToAccessResources() {
+        final String accessToken = TestAuthMessageUtil.getAccessToken(dogma.httpClient(),
+                                                                      TestAuthMessageUtil.USERNAME,
+                                                                      TestAuthMessageUtil.PASSWORD);
+
+        final BlockingWebClient adminClient = WebClient.builder(dogma.httpClient().uri())
+                                                       .auth(AuthToken.ofBasic("dogma", accessToken))
+                                                       .build()
+                                                       .blocking();
+
+        final QueryParams params = QueryParams.builder()
+                                              .add("appId", "test")
+                                              .add("isSystemAdmin", "true")
+                                              .build();
+        final Token token =
+                adminClient.prepare()
+                           .post("/api/v1/tokens")
+                           .content(MediaType.FORM_DATA, params.toQueryString())
+                           .asJson(Token.class, new ObjectMapper())
+                           .execute()
+                           .content();
+
+        final BlockingWebClient client = WebClient.builder(dogma.httpClient().uri())
+                                                  .auth(AuthToken.ofBasic("dogma", token.secret()))
+                                                  .build()
+                                                  .blocking();
+        final ResponseEntity<List<ProjectDto>> response =
+                client.prepare()
+                      .get("/api/v1/projects")
+                      .asJson(new TypeReference<List<ProjectDto>>() {})
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.content()).anyMatch(project -> project.name().equals("dogma"));
+    }
+}


### PR DESCRIPTION
Motivation:

Git over HTTP implementation in Central Dogma uses Bearer token-based authentication, which is not a standard Git HTTP authentication method.
https://git-scm.com/docs/http-protocol#_authentication
> Servers SHOULD support Basic authentication by relying upon the HTTP server placed in front of the Git server software.

Users should use `http.extraheader` to set the bearer token.
```
git clone -c http.extraheader="Authorization: Bearer <token>" https://dogma.com/foo/bar.git`
```
Supporting Basic authentication would make it eaiser to integate with systems like Git CLI and Spring Cloud Config Server that use usernames and passwords.

Modifications:

- Include `WWW-Authenticate` header field for 401 Unauthorized response to prompt the client to use Basic auth.
- Introduce `AbstractAuthorizer` to centralize the token parsing logic.
- When Basic authenitication is used:
  - `username` is fixed to `dogma`
  - `password` is set to the application token.
  -  The Authorization header will appear as: `Basic base64(dogma:appToken-...)`
- Fix GitHttpServiceTest to set username and password instead of Bearer tokens.

Result:

You can use basic authentication to access Central Dogma resources.