### PR TITLE
Introduce LoggerService

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -140,6 +140,7 @@ import com.linecorp.centraldogma.server.internal.api.ContentServiceV1;
 import com.linecorp.centraldogma.server.internal.api.CredentialServiceV1;
 import com.linecorp.centraldogma.server.internal.api.GitHttpService;
 import com.linecorp.centraldogma.server.internal.api.HttpApiExceptionHandler;
+import com.linecorp.centraldogma.server.internal.api.LoggerService;
 import com.linecorp.centraldogma.server.internal.api.MetadataApiService;
 import com.linecorp.centraldogma.server.internal.api.MirroringServiceV1;
 import com.linecorp.centraldogma.server.internal.api.ProjectServiceV1;
@@ -912,7 +913,8 @@ public class CentralDogma implements AutoCloseable {
                 .annotatedService(new ServerStatusService(executor, statusManager))
                 .annotatedService(new ProjectServiceV1(projectApiManager, executor))
                 .annotatedService(new RepositoryServiceV1(executor, mds, encryptionStorageManager))
-                .annotatedService(new CredentialServiceV1(projectApiManager, executor));
+                .annotatedService(new CredentialServiceV1(projectApiManager, executor))
+                .annotatedService(new LoggerService());
 
         if (GIT_MIRROR_ENABLED) {
             mirrorRunner = new MirrorRunner(projectApiManager, executor, cfg, meterRegistry,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/LoggerService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/LoggerService.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+
+import com.linecorp.armeria.common.HttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.server.annotation.ConsumesJson;
+import com.linecorp.armeria.server.annotation.Get;
+import com.linecorp.armeria.server.annotation.Param;
+import com.linecorp.armeria.server.annotation.ProducesJson;
+import com.linecorp.armeria.server.annotation.Put;
+import com.linecorp.centraldogma.server.internal.api.auth.RequiresSystemAdministrator;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+
+@RequiresSystemAdministrator
+@ProducesJson
+public class LoggerService {
+
+    private static final List<String> LEVELS = ImmutableList.of(
+            "ALL", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF");
+
+    private final LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    @Nullable
+    private volatile List<LoggerInfo> loggerInfos;
+
+    /**
+     * Creates a new instance.
+     */
+    public LoggerService() {
+        loggerContext.addListener(new LoggerContextListener() {
+            @Override
+            public boolean isResetResistant() {
+                return true;
+            }
+
+            @Override
+            public void onStart(LoggerContext context) {}
+
+            @Override
+            public void onReset(LoggerContext context) {}
+
+            @Override
+            public void onStop(LoggerContext context) {}
+
+            @Override
+            public void onLevelChange(Logger logger, Level level) {
+                loggerInfos = null; // Invalidate the cached loggerInfos
+            }
+        });
+    }
+
+    @Put("/loggers/{logger}")
+    @ConsumesJson
+    public HttpResponse setLogLevel(@Param("logger") String loggerName, JsonNode jsonNode) {
+        final Logger logger = loggerContext.exists(loggerName);
+        if (logger == null) {
+            return HttpResponse.of(HttpStatus.NOT_FOUND, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Logger not found: " + loggerName);
+        }
+        final JsonNode levelNode = jsonNode.get("level");
+        if (levelNode == null) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Missing 'level' field in request body.");
+        }
+
+        if (levelNode.isNull()) {
+            logger.setLevel(null);
+            return HttpResponse.ofJson(LoggerInfo.of(logger));
+        }
+
+        if (!levelNode.isTextual()) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "'level' field must be a string. Found: " + levelNode.getNodeType());
+        }
+
+        final String level = levelNode.asText();
+        final String upperCase = level.toUpperCase();
+        if (!LEVELS.contains(upperCase)) {
+            return HttpResponse.of(HttpStatus.BAD_REQUEST, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Invalid log level: " + level + ". Valid levels are: " + LEVELS);
+        }
+        logger.setLevel(Level.toLevel(upperCase));
+        return HttpResponse.ofJson(LoggerInfo.of(logger));
+    }
+
+    @Get("/loggers/{logger}")
+    public HttpResponse getLogLevel(@Param("logger") String loggerName) {
+        final Logger logger = loggerContext.exists(loggerName);
+        if (logger == null) {
+            return HttpResponse.of(HttpStatus.NOT_FOUND, MediaType.PLAIN_TEXT_UTF_8,
+                                   "Logger not found: " + loggerName);
+        }
+        return HttpResponse.ofJson(LoggerInfo.of(logger));
+    }
+
+    @Get("/loggers")
+    @ProducesJson
+    public HttpResponse getLogLevels() {
+        List<LoggerInfo> loggerInfos = this.loggerInfos;
+        if (loggerInfos != null) {
+            return HttpResponse.ofJson(loggerInfos);
+        }
+
+        final Builder<LoggerInfo> builder = ImmutableList.builder();
+        for (Logger logger : loggerContext.getLoggerList()) {
+            builder.add(LoggerInfo.of(logger));
+        }
+        loggerInfos = builder.build();
+        this.loggerInfos = loggerInfos;
+        return HttpResponse.ofJson(loggerInfos);
+    }
+
+    private static final class LoggerInfo {
+
+        static LoggerInfo of(Logger logger) {
+            return new LoggerInfo(
+                    logger.getName(),
+                    logger.getLevel() != null ? logger.getLevel().toString() : null,
+                    logger.getEffectiveLevel().toString());
+        }
+
+        private final String name;
+        @Nullable
+        private final String level;
+        private final String effectiveLevel;
+
+        LoggerInfo(String name, @Nullable String level, String effectiveLevel) {
+            this.name = name;
+            this.level = level;
+            this.effectiveLevel = effectiveLevel;
+        }
+
+        @JsonProperty("name")
+        String name() {
+            return name;
+        }
+
+        @Nullable
+        @JsonProperty("level")
+        String level() {
+            return level;
+        }
+
+        @JsonProperty("effectiveLevel")
+        String effectiveLevel() {
+            return effectiveLevel;
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/LoggerServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/LoggerServiceTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class LoggerServiceTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    @Test
+    void logLevel() {
+        assertThat(dogma.blockingHttpClient().get("/api/v1/loggers/invalid.package").status())
+                .isSameAs(HttpStatus.NOT_FOUND);
+        assertThatJson(dogma.blockingHttpClient().get("/api/v1/loggers/com.linecorp").contentUtf8())
+                .isEqualTo("{\"name\":\"com.linecorp\",\"level\":\"DEBUG\",\"effectiveLevel\":\"DEBUG\"}");
+
+        assertThatJson(dogma.blockingHttpClient().get(
+                "/api/v1/loggers/com.linecorp.armeria.logging.traffic.server.http2").contentUtf8())
+                .isEqualTo("{\"name\":\"com.linecorp.armeria.logging.traffic.server.http2\"," +
+                           " \"level\":null," +
+                           " \"effectiveLevel\":\"DEBUG\"}");
+
+        // Send a request to trigger logger initialization such as HttpResponseUtil logger.
+        setHttp2TrafficLogLevel("{\"level\":\"TRACE\"}");
+        // Revert the log level to null.
+        setHttp2TrafficLogLevel("{\"level\":null}");
+
+        final String previousAllLoggers = allLoggers();
+
+        setHttp2TrafficLogLevel("{\"level\":\"TRACE\"}");
+        assertThatJson(dogma.blockingHttpClient().get(
+                "/api/v1/loggers/com.linecorp.armeria.logging.traffic.server.http2").contentUtf8())
+                .isEqualTo("{\"name\":\"com.linecorp.armeria.logging.traffic.server.http2\"," +
+                           " \"level\":\"TRACE\"," +
+                           " \"effectiveLevel\":\"TRACE\"}");
+
+        // Verify that the log level change is reflected in all loggers.
+        assertThatJson(allLoggers()).isNotEqualTo(previousAllLoggers);
+        setHttp2TrafficLogLevel("{\"level\":null}");
+        assertThatJson(dogma.blockingHttpClient().get(
+                "/api/v1/loggers/com.linecorp.armeria.logging.traffic.server.http2").contentUtf8())
+                .isEqualTo("{\"name\":\"com.linecorp.armeria.logging.traffic.server.http2\"," +
+                           " \"level\":null," +
+                           " \"effectiveLevel\":\"DEBUG\"}");
+
+        // Verify that the log level change is reverted in all loggers.
+        assertThatJson(allLoggers()).isEqualTo(previousAllLoggers);
+    }
+
+    private static void setHttp2TrafficLogLevel(String body) {
+        final RequestHeaders headers =
+                RequestHeaders.builder(HttpMethod.PUT,
+                                       "/api/v1/loggers/com.linecorp.armeria.logging.traffic.server.http2")
+                              .contentType(MediaType.JSON_UTF_8).build();
+        assertThat(dogma.blockingHttpClient().execute(headers, body).status()).isSameAs(HttpStatus.OK);
+    }
+
+    String allLoggers() {
+        final String allLoggers = dogma.blockingHttpClient().get("/api/v1/loggers").contentUtf8();
+        assertThat(allLoggers)
+                .contains("{\"name\":\"ROOT\",\"level\":\"WARN\",\"effectiveLevel\":\"WARN\"}",
+                          "{\"name\":\"com\",\"level\":null,\"effectiveLevel\":\"WARN\"}",
+                          "{\"name\":\"com.linecorp\",\"level\":\"DEBUG\",\"effectiveLevel\":\"DEBUG\"}");
+        return allLoggers;
+    }
+}

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -41,6 +41,7 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.AbstractArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.client.armeria.legacy.LegacyCentralDogmaBuilder;
+import com.linecorp.centraldogma.internal.CsrfToken;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
 import com.linecorp.centraldogma.server.MirroringService;
@@ -141,10 +142,8 @@ public class CentralDogmaRuleDelegate {
             final LegacyCentralDogmaBuilder legacyClientBuilder = new LegacyCentralDogmaBuilder();
 
             final String accessToken = accessToken();
-            if (accessToken != null) {
-                clientBuilder.accessToken(accessToken);
-                legacyClientBuilder.accessToken(accessToken);
-            }
+            clientBuilder.accessToken(accessToken);
+            legacyClientBuilder.accessToken(accessToken);
 
             configureClientCommon(clientBuilder);
             configureClientCommon(legacyClientBuilder);
@@ -308,9 +307,8 @@ public class CentralDogmaRuleDelegate {
     /**
      * Override this method to inject an access token to the clients.
      */
-    @Nullable
     protected String accessToken() {
-        return null;
+        return CsrfToken.ANONYMOUS;
     }
 
     /**


### PR DESCRIPTION
Motivation:  
To enable runtime logger level management via HTTP endpoints, a dedicated `LoggerService` is needed.  

Modifications:  
- Implemented `LoggerService` with HTTP API endpoints to get and update logger levels.
- Modified `CentralDogmaRuleDelegate` to return `CsrfToken.ANONYMOUS` instead of `null` as a default token.

Result:  
- Users can now inspect and update logger levels at runtime via HTTP.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a logging management API, allowing system administrators to view and update logger levels via new HTTP endpoints.
- **Tests**
  - Added tests to verify logging API behavior, including querying and updating logger levels.
- **Chores**
  - Improved internal handling of access tokens for testing, standardizing on an anonymous token instead of null.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->