### PR TITLE
Introduce Data Encryption Key (DEK) per Object

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/AesGcmSivCipher.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/AesGcmSivCipher.java
@@ -21,6 +21,7 @@ import java.security.Security;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.conscrypt.Conscrypt;
@@ -35,7 +36,7 @@ public final class AesGcmSivCipher {
 
     private static final String ALGORITHM = "AES/GCM-SIV/NoPadding";
     // https://datatracker.ietf.org/doc/html/rfc8452#section-4
-    private static final int KEY_SIZE_BYTES = 32;
+    public static final int KEY_SIZE_BYTES = 32;
     public static final int NONCE_SIZE_BYTES = 12;
     private static final int TAG_SIZE_BITS = 128;
 
@@ -56,8 +57,13 @@ public final class AesGcmSivCipher {
 
     public static byte[] generateAes256Key() {
         final byte[] keyBytes = new byte[KEY_SIZE_BYTES]; // 256bit
+        // Consider sharding the SecureRandom instance if this method is called frequently.
         SECURE_RANDOM.nextBytes(keyBytes);
         return keyBytes;
+    }
+
+    public static SecretKeySpec aesSecretKey(byte[] key) {
+        return new SecretKeySpec(key, "AES");
     }
 
     public static byte[] generateNonce() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorage.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorage.java
@@ -15,7 +15,9 @@
  */
 package com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb;
 
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.KEY_SIZE_BYTES;
 import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.NONCE_SIZE_BYTES;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.aesSecretKey;
 import static org.eclipse.jgit.lib.Constants.R_REFS;
 import static org.eclipse.jgit.lib.Constants.encode;
 import static org.eclipse.jgit.lib.ObjectReader.OBJ_ANY;
@@ -27,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.jgit.errors.IncorrectObjectTypeException;
 import org.eclipse.jgit.internal.storage.file.RefDirectory;
@@ -94,18 +97,27 @@ public final class EncryptionGitStorage {
         }
 
         final byte[] nonce = AesGcmSivCipher.generateNonce();
-        final byte[] nonceAndType = new byte[NONCE_SIZE_BYTES + 4];
+        // Generate a new DEK for the data so that we don't decrypt and encrypt the data again when the
+        // repository key is rotated.
+        final byte[] objectDek = AesGcmSivCipher.generateAes256Key();
+        final byte[] objeckWdek = encrypt(nonce, objectDek, 0, KEY_SIZE_BYTES);
 
-        System.arraycopy(nonce, 0, nonceAndType, 0, NONCE_SIZE_BYTES);
+        assert objeckWdek.length == KEY_SIZE_BYTES + 16; // 16 bytes for the tag
 
-        nonceAndType[NONCE_SIZE_BYTES] = (byte) (type >> 24);
-        nonceAndType[NONCE_SIZE_BYTES + 1] = (byte) (type >> 16);
-        nonceAndType[NONCE_SIZE_BYTES + 2] = (byte) (type >> 8);
-        nonceAndType[NONCE_SIZE_BYTES + 3] = (byte) type;
+        final byte[] nonceAndObjectWdek = new byte[NONCE_SIZE_BYTES + 4 + objeckWdek.length];
+
+        System.arraycopy(nonce, 0, nonceAndObjectWdek, 0, NONCE_SIZE_BYTES);
+        nonceAndObjectWdek[NONCE_SIZE_BYTES] = (byte) (type >> 24);
+        nonceAndObjectWdek[NONCE_SIZE_BYTES + 1] = (byte) (type >> 16);
+        nonceAndObjectWdek[NONCE_SIZE_BYTES + 2] = (byte) (type >> 8);
+        nonceAndObjectWdek[NONCE_SIZE_BYTES + 3] = (byte) type;
+        System.arraycopy(objeckWdek, 0, nonceAndObjectWdek, NONCE_SIZE_BYTES + 4, objeckWdek.length);
+
+        final SecretKeySpec keySpec = aesSecretKey(objectDek);
 
         final byte[] encryptedId = encryptObjectId(nonce, objectId);
-        final byte[] encryptedValue = encrypt(nonce, data, off, len);
-        encryptionStorageManager.putObject(metadataKey, nonceAndType, encryptedId, encryptedValue);
+        final byte[] encryptedValue = encrypt(keySpec, nonce, data, off, len);
+        encryptionStorageManager.putObject(metadataKey, nonceAndObjectWdek, encryptedId, encryptedValue);
         return objectId;
     }
 
@@ -124,6 +136,10 @@ public final class EncryptionGitStorage {
     }
 
     private byte[] encrypt(byte[] nonce, byte[] data, int offset, int length) {
+        return encrypt(dek, nonce, data, offset, length);
+    }
+
+    private byte[] encrypt(SecretKey dek, byte[] nonce, byte[] data, int offset, int length) {
         try {
             return AesGcmSivCipher.encrypt(dek, nonce, data, offset, length);
         } catch (Exception e) {
@@ -133,8 +149,12 @@ public final class EncryptionGitStorage {
     }
 
     private byte[] decrypt(byte[] nonce, byte[] ciphertext) {
+        return decrypt(dek, nonce, ciphertext);
+    }
+
+    private byte[] decrypt(SecretKey key, byte[] nonce, byte[] ciphertext) {
         try {
-            return AesGcmSivCipher.decrypt(dek, nonce, ciphertext);
+            return AesGcmSivCipher.decrypt(key, nonce, ciphertext);
         } catch (Exception e) {
             throw new EncryptionStorageException(
                     "Failed to decrypt data in " + projectName + '/' + repoName, e);
@@ -150,22 +170,28 @@ public final class EncryptionGitStorage {
         }
 
         final int actualType = ((metadata[NONCE_SIZE_BYTES] & 0xFF) << 24) |
-                               ((metadata[NONCE_SIZE_BYTES + 1] & 0xFF) << 16) |
-                               ((metadata[NONCE_SIZE_BYTES + 2] & 0xFF) << 8) |
-                               (metadata[NONCE_SIZE_BYTES + 3] & 0xFF);
+                                ((metadata[NONCE_SIZE_BYTES + 1] & 0xFF) << 16) |
+                                ((metadata[NONCE_SIZE_BYTES + 2] & 0xFF) << 8) |
+                                (metadata[NONCE_SIZE_BYTES + 3] & 0xFF);
         if (typeHint != OBJ_ANY && actualType != typeHint) {
             throw new IncorrectObjectTypeException(objectId.copy(), typeHint);
         }
 
-        final byte[] nonce = new byte[12];
-        System.arraycopy(metadata, 0, nonce, 0, 12);
+        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
+        System.arraycopy(metadata, 0, nonce, 0, NONCE_SIZE_BYTES);
         final byte[] encryptedKey = encryptObjectId(nonce, objectId);
         final byte[] value = encryptionStorageManager.getObject(encryptedKey, metadataKey);
         if (value == null) {
             return null;
         }
 
-        final byte[] decrypted = decrypt(nonce, value);
+        final int wdekLength = metadata.length - (NONCE_SIZE_BYTES + 4);
+        final byte[] objectWdek = new byte[wdekLength];
+        System.arraycopy(metadata, NONCE_SIZE_BYTES + 4, objectWdek, 0, wdekLength);
+
+        final byte[] objectDek = decrypt(nonce, objectWdek);
+        final SecretKeySpec keySpec = aesSecretKey(objectDek);
+        final byte[] decrypted = decrypt(keySpec, nonce, value);
         return new DecryptedObjectLoader(decrypted, actualType);
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/DefaultEncryptionStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/DefaultEncryptionStorageManager.java
@@ -16,6 +16,7 @@
 package com.linecorp.centraldogma.server.storage.encryption;
 
 import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.NONCE_SIZE_BYTES;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.aesSecretKey;
 import static com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb.EncryptionGitStorage.OBJS;
 import static com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb.EncryptionGitStorage.REFS;
 import static com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb.EncryptionGitStorage.REV2SHA;
@@ -34,7 +35,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
-import javax.crypto.spec.SecretKeySpec;
 
 import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.BloomFilter;
@@ -190,12 +190,14 @@ final class DefaultEncryptionStorageManager implements EncryptionStorageManager 
                     "WDEK of " + projectRepo(projectName, repoName) + " does not exist");
         }
 
+        final byte[] key;
         try {
-            return new SecretKeySpec(keyManagementService.unwrap(wdek).get(10, TimeUnit.SECONDS), "AES");
+            key = keyManagementService.unwrap(wdek).get(10, TimeUnit.SECONDS);
         } catch (Throwable t) {
             throw new EncryptionStorageException(
                     "Failed to unwrap WDEK of " + projectRepo(projectName, repoName), t);
         }
+        return aesSecretKey(key);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorageTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorageTest.java
@@ -15,6 +15,9 @@
  */
 package com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb;
 
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.NONCE_SIZE_BYTES;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.aesSecretKey;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.decrypt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -66,7 +69,6 @@ class EncryptionGitStorageTest {
 
     // Test Data
     private static final ObjectId OBJECT_ID = ObjectId.fromString(Strings.repeat("a", 40));
-    private static final ObjectId OBJECT_ID2 = ObjectId.fromString(Strings.repeat("b", 40));
     private static final byte[] OBJ_DATA = "Object Data 1".getBytes(StandardCharsets.UTF_8);
     private static final Revision REV_1 = new Revision(1);
 
@@ -110,19 +112,24 @@ class EncryptionGitStorageTest {
         final byte[] expectedMetadataKey = storage.objectMetadataKey(OBJECT_ID);
         assertThat(metadataKeyCaptor.getValue()).isEqualTo(expectedMetadataKey);
 
-        // Verify Metadata Entry Value (Nonce + Type)
+        // Verify Metadata Entry Value (Nonce + Type + object WDEK)
         final byte[] actualMetadataValue = metadataValueCaptor.getValue();
-        assertThat(actualMetadataValue.length).isEqualTo(AesGcmSivCipher.NONCE_SIZE_BYTES + 4);
+        assertThat(actualMetadataValue.length).isEqualTo(
+                NONCE_SIZE_BYTES + 4 + 48); // 32 for key 16 for tag
         final byte[] capturedNonce =
-                Arrays.copyOfRange(actualMetadataValue, 0, AesGcmSivCipher.NONCE_SIZE_BYTES);
-        final int capturedType = ByteBuffer.wrap(actualMetadataValue, AesGcmSivCipher.NONCE_SIZE_BYTES, 4)
+                Arrays.copyOfRange(actualMetadataValue, 0, NONCE_SIZE_BYTES);
+        final int capturedType = ByteBuffer.wrap(actualMetadataValue, NONCE_SIZE_BYTES, 4)
                                            .getInt();
         assertThat(capturedType).isEqualTo(Constants.OBJ_BLOB);
 
         final byte[] expectedEncryptedDataKey = encryptObjectIdWithDek(capturedNonce, OBJECT_ID);
         assertThat(dataKeyCaptor.getValue()).isEqualTo(expectedEncryptedDataKey);
 
-        final byte[] expectedEncryptedDataValue = encryptWithDek(capturedNonce, OBJ_DATA);
+        final byte[] objectWdek =
+                Arrays.copyOfRange(actualMetadataValue, NONCE_SIZE_BYTES + 4, actualMetadataValue.length);
+        final byte[] objectDek = decrypt(DEK, capturedNonce, objectWdek);
+
+        final byte[] expectedEncryptedDataValue = encrypt(aesSecretKey(objectDek), capturedNonce, OBJ_DATA);
         assertThat(dataValueCaptor.getValue()).isEqualTo(expectedEncryptedDataValue);
     }
 
@@ -149,10 +156,13 @@ class EncryptionGitStorageTest {
                 .getObject(argThat(key -> !Arrays.equals(key, metadataKey)), any());
 
         final byte[] nonce = AesGcmSivCipher.generateNonce();
-        final byte[] metadataValue = ByteBuffer.allocate(AesGcmSivCipher.NONCE_SIZE_BYTES + 4)
-                                               .put(nonce).putInt(Constants.OBJ_COMMIT).array();
+        final byte[] objeckDek = AesGcmSivCipher.generateAes256Key();
+        final byte[] objectWdek = encryptWithDek(nonce, objeckDek);
+        final byte[] metadataValue = ByteBuffer.allocate(NONCE_SIZE_BYTES + 4 + 48)
+                                               .put(nonce).putInt(Constants.OBJ_COMMIT).put(objectWdek)
+                                               .array();
         final byte[] encryptedObjKey = encryptObjectIdWithDek(nonce, OBJECT_ID);
-        final byte[] encryptedObjValue = encryptWithDek(nonce, OBJ_DATA);
+        final byte[] encryptedObjValue = encrypt(aesSecretKey(objeckDek), nonce, OBJ_DATA);
 
         when(encryptionStorageManager.getMetadata(metadataKey)).thenReturn(metadataValue);
         when(encryptionStorageManager.getObject(encryptedObjKey, metadataKey)).thenReturn(encryptedObjValue);
@@ -175,7 +185,7 @@ class EncryptionGitStorageTest {
         final int wrongTypeHint = Constants.OBJ_COMMIT;
         final byte[] nonce = AesGcmSivCipher.generateNonce();
         final byte[] metadataKey = storage.objectMetadataKey(OBJECT_ID);
-        final byte[] metadataValue = ByteBuffer.allocate(AesGcmSivCipher.NONCE_SIZE_BYTES + 4)
+        final byte[] metadataValue = ByteBuffer.allocate(NONCE_SIZE_BYTES + 4)
                                                .put(nonce).putInt(actualType).array();
 
         when(encryptionStorageManager.getMetadata(metadataKey)).thenReturn(metadataValue);
@@ -193,7 +203,7 @@ class EncryptionGitStorageTest {
         final int type = Constants.OBJ_BLOB;
         final byte[] nonce = AesGcmSivCipher.generateNonce();
         final byte[] metadataKey = storage.objectMetadataKey(OBJECT_ID);
-        final byte[] metadataValue = ByteBuffer.allocate(AesGcmSivCipher.NONCE_SIZE_BYTES + 4)
+        final byte[] metadataValue = ByteBuffer.allocate(NONCE_SIZE_BYTES + 4)
                                                .put(nonce).putInt(type).array();
         final byte[] encryptedObjKey = encryptObjectIdWithDek(nonce, OBJECT_ID);
         // Simulate corrupted data that will cause decrypt to fail
@@ -295,7 +305,7 @@ class EncryptionGitStorageTest {
         final byte[] expectedMetadataKey = refMetadataKey(HEAD_MASTER_REF);
         assertThat(metaKeyCaptor.getValue()).isEqualTo(expectedMetadataKey);
         final byte[] capturedNonce = nonceCaptor.getValue();
-        assertThat(capturedNonce).hasSize(AesGcmSivCipher.NONCE_SIZE_BYTES);
+        assertThat(capturedNonce).hasSize(NONCE_SIZE_BYTES);
 
         final byte[] expectedEncryptedRefNameKey = encryptStringWithDek(capturedNonce, HEAD_MASTER_REF);
         assertThat(refNameKeyCaptor.getValue()).isEqualTo(expectedEncryptedRefNameKey);
@@ -314,7 +324,7 @@ class EncryptionGitStorageTest {
 
         assertThat(metaKeyCaptor.getValue()).isEqualTo(expectedMetadataKey);
         final byte[] capturedNonce2 = nonceCaptor.getValue();
-        assertThat(capturedNonce2).hasSize(AesGcmSivCipher.NONCE_SIZE_BYTES);
+        assertThat(capturedNonce2).hasSize(NONCE_SIZE_BYTES);
 
         final byte[] expectedEncryptedRefNameKey2 = encryptStringWithDek(capturedNonce2, HEAD_MASTER_REF);
         assertThat(refNameKeyCaptor.getValue()).isEqualTo(expectedEncryptedRefNameKey2);
@@ -364,7 +374,7 @@ class EncryptionGitStorageTest {
         final byte[] expectedMetadataKey = refMetadataKey(Constants.HEAD);
         assertThat(metaKeyCaptor.getValue()).isEqualTo(expectedMetadataKey);
         final byte[] capturedNonce = nonceCaptor.getValue();
-        assertThat(capturedNonce).hasSize(AesGcmSivCipher.NONCE_SIZE_BYTES);
+        assertThat(capturedNonce).hasSize(NONCE_SIZE_BYTES);
 
         final byte[] expectedEncryptedRefNameKey = encryptStringWithDek(capturedNonce, Constants.HEAD);
         assertThat(refNameKeyCaptor.getValue()).isEqualTo(expectedEncryptedRefNameKey);
@@ -444,7 +454,7 @@ class EncryptionGitStorageTest {
         // Verify Metadata
         assertThat(metaKeyCaptor.getValue()).isEqualTo(metadataKey);
         final byte[] capturedNonce = nonceCaptor.getValue();
-        assertThat(capturedNonce).hasSize(AesGcmSivCipher.NONCE_SIZE_BYTES);
+        assertThat(capturedNonce).hasSize(NONCE_SIZE_BYTES);
 
         // Verify Encrypted Revision/ID Entry
         final byte[] expectedEncryptedRevKey = encryptWithDek(capturedNonce, revisionBytes(REV_1));
@@ -477,8 +487,12 @@ class EncryptionGitStorageTest {
     }
 
     private static byte[] encryptWithDek(byte[] nonce, byte[] data) {
+        return encrypt(DEK, nonce, data);
+    }
+
+    private static byte[] encrypt(SecretKey key, byte[] nonce, byte[] data) {
         try {
-            return AesGcmSivCipher.encrypt(DEK, nonce, data, 0, data.length);
+            return AesGcmSivCipher.encrypt(key, nonce, data, 0, data.length);
         } catch (Exception e) {
             throw new RuntimeException("Encryption failed in test helper", e);
         }


### PR DESCRIPTION
Motivation:
Currently, if a repository's encryption key is rotated, all stored objects must be decrypted and re-encrypted. This process is expensive and time-consuming. By introducing a per-object Data Encryption Key (DEK), we can enable more efficient key rotation—only rewrapping the DEKs rather than re-encrypting the entire data.

Modifications:
- Updated encryption logic to use object-specific DEKs wrapped by the repository's Data Encryption Key.

Result:
- Will reduce overhead during key rotation by avoiding full data re-encryption.