### PR TITLE
Do not enter readonly mode on lock timeout

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/internal/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/internal/client/armeria/ArmeriaCentralDogma.java
@@ -76,6 +76,7 @@ import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
 import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.RepositoryInfo;
+import com.linecorp.centraldogma.common.ApiRequestTimeoutException;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.AuthorizationException;
 import com.linecorp.centraldogma.common.CentralDogmaException;
@@ -87,6 +88,7 @@ import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.EntryNotFoundException;
 import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.InvalidPushException;
+import com.linecorp.centraldogma.common.LockAcquireTimeoutException;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.MergeQuery;
 import com.linecorp.centraldogma.common.MergedEntry;
@@ -144,6 +146,8 @@ public final class ArmeriaCentralDogma extends AbstractCentralDogma {
                         .put(PermissionException.class.getName(), PermissionException::new)
                         .put(JsonPatchConflictException.class.getName(), JsonPatchConflictException::new)
                         .put(TextPatchConflictException.class.getName(), TextPatchConflictException::new)
+                        .put(ApiRequestTimeoutException.class.getName(), ApiRequestTimeoutException::new)
+                        .put(LockAcquireTimeoutException.class.getName(), LockAcquireTimeoutException::new)
                         .build();
 
     private final WebClient client;

--- a/common/src/main/java/com/linecorp/centraldogma/common/ApiRequestTimeoutException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/ApiRequestTimeoutException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.common;
+
+/**
+ * A {@link CentralDogmaException} that is raised when a request has timed out.
+ */
+public final class ApiRequestTimeoutException extends CentralDogmaException {
+
+    private static final long serialVersionUID = -1921146517835662972L;
+
+    /**
+     * Creates a new instance with the specified {@code message}.
+     */
+    public ApiRequestTimeoutException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public ApiRequestTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/common/src/main/java/com/linecorp/centraldogma/common/LockAcquireTimeoutException.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/LockAcquireTimeoutException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.common;
+
+/**
+ * A {@link CentralDogmaException} that is raised when a server fails to acquire a lock within the specified
+ * timeout.
+ */
+public final class LockAcquireTimeoutException extends CentralDogmaException {
+
+    private static final long serialVersionUID = -2422490288017744893L;
+
+    /**
+     * Creates a new instance.
+     */
+    public LockAcquireTimeoutException(String message) {
+        super(message);
+    }
+
+    /**
+     * Creates a new instance with the specified {@code message} and {@code cause}.
+     */
+    public LockAcquireTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -67,6 +67,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -462,6 +463,12 @@ public class CentralDogma implements AutoCloseable {
             }
         }
         return success;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    CommandExecutor executor() {
+        return executor;
     }
 
     private CommandExecutor startCommandExecutor(

--- a/server/src/test/java/com/linecorp/centraldogma/server/ServerTimeoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ServerTimeoutTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import java.util.concurrent.CompletionException;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.framework.recipes.locks.InterProcessMutex;
+import org.apache.curator.retry.RetryForever;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
+import com.linecorp.centraldogma.common.ApiRequestTimeoutException;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.LockAcquireTimeoutException;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.server.internal.replication.ZooKeeperCommandExecutor;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+
+class ServerTimeoutTest {
+
+    @RegisterExtension
+    static final CentralDogmaReplicationExtension dogma = new CentralDogmaReplicationExtension(3) {
+        @Override
+        protected void configureEach(int serverId, CentralDogmaBuilder builder) {
+            builder.requestTimeoutMillis(7000L);
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    @ValueSource(booleans = { true, false })
+    @ParameterizedTest
+    void testTimeoutException(boolean expectLockTimeout) throws Exception {
+        final CentralDogmaRuleDelegate delegate = dogma.servers().get(0);
+        final com.linecorp.centraldogma.server.CentralDogma server = delegate.dogma();
+        if (expectLockTimeout) {
+            // Set a shorter value than the request timeout.
+            ((ZooKeeperCommandExecutor) server.executor()).setLockTimeoutMillis(3000L);
+        } else {
+            // Set a longer value than the request timeout.
+            ((ZooKeeperCommandExecutor) server.executor()).setLockTimeoutMillis(15000L);
+        }
+        final CentralDogmaConfig config = server.config();
+
+        final ZooKeeperReplicationConfig replicationConfig =
+                (ZooKeeperReplicationConfig) config.replicationConfig();
+        final int clientPort = replicationConfig.serverConfig().clientPort();
+
+        final CuratorFramework curator = CuratorFrameworkFactory.newClient(
+                "127.0.0.1:" + clientPort, new RetryForever(100));
+        curator.start();
+        final InterProcessMutex mutex = new InterProcessMutex(curator, "/dogma/lock/foo/bar");
+
+        final CentralDogma client = delegate.client();
+        client.createProject("foo").join();
+        final CentralDogmaRepository barRepo = client.createRepository("foo", "bar").join();
+        mutex.acquire();
+
+        final Exception caughtException = catchException(() -> {
+            barRepo.commit("Test", Change.ofTextUpsert("/a.txt", "hello"))
+                   .push()
+                   .join();
+        });
+        if (expectLockTimeout) {
+            assertThat(caughtException)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(LockAcquireTimeoutException.class);
+        } else {
+            assertThat(caughtException)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseInstanceOf(ApiRequestTimeoutException.class)
+                    .hasMessageContaining("Request timed out");
+        }
+        mutex.release();
+        Thread.sleep(1000);
+
+        // Make sure the server is still writable after LockAcquireTimeoutException
+        final PushResult pushResult = barRepo.commit("Test", Change.ofTextUpsert("/a.txt", "world"))
+                                             .push()
+                                             .join();
+        assertThat(pushResult.revision().major()).isPositive();
+    }
+}


### PR DESCRIPTION
Motivation:

A lock could be held by a request for a long time when the size is large. While this is not desiable, it isn't necessarily a system error. So, failing the request makes more sense rather than entering readonly mode.

Modifications:

- Do not stop ZooKeeper replication when a lock can be acquired within one minute.
  - Change the log level to `WARN` from `ERROR`.
  - If a request timeout is configured to be longer than the lock timeout, `LockAcquireTimeoutException` will be returned.
- Add `ApiRequestTimeoutException` for converting Armeria `RequestTimeoutException` to a `CentralDogmaException`.
  - Also update the client error factories.

Result:

A lock timeout no longer triggers readonly mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new error messages for request timeouts and lock acquisition timeouts to provide clearer feedback when operations exceed their allowed time.
* **Bug Fixes**
  * Improved server responses for timeout scenarios, returning more appropriate status codes and error details.
* **Tests**
  * Added comprehensive tests to verify correct handling and reporting of timeout-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->