### PR TITLE
Add HTTP API to migrate an existing repository into an encrypted repository

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -246,7 +246,8 @@ public class CentralDogma implements AutoCloseable {
     private final PluginGroup pluginsForZoneLeaderOnly;
 
     private final CentralDogmaConfig cfg;
-    private final EncryptionStorageManager encryptionStorageManager;
+    @Nullable
+    private volatile EncryptionStorageManager encryptionStorageManager;
     @Nullable
     private volatile ProjectManager pm;
     @Nullable
@@ -273,7 +274,6 @@ public class CentralDogma implements AutoCloseable {
 
     CentralDogma(CentralDogmaConfig cfg, MeterRegistry meterRegistry, List<Plugin> plugins) {
         this.cfg = requireNonNull(cfg, "cfg");
-        encryptionStorageManager = EncryptionStorageManager.of(cfg);
         pluginGroups = PluginGroup.loadPlugins(CentralDogma.class.getClassLoader(), cfg, plugins);
         pluginsForAllReplicas = pluginGroups.get(PluginTarget.ALL_REPLICAS);
         pluginsForLeaderOnly = pluginGroups.get(PluginTarget.LEADER_ONLY);
@@ -404,6 +404,7 @@ public class CentralDogma implements AutoCloseable {
         boolean success = false;
         ExecutorService repositoryWorker = null;
         ScheduledExecutorService purgeWorker = null;
+        EncryptionStorageManager encryptionStorageManager = null;
         ProjectManager pm = null;
         CommandExecutor executor = null;
         Server server = null;
@@ -425,6 +426,8 @@ public class CentralDogma implements AutoCloseable {
             purgeWorker = Executors.newSingleThreadScheduledExecutor(
                     new DefaultThreadFactory("purge-worker", true));
 
+            encryptionStorageManager = EncryptionStorageManager.of(cfg);
+
             pm = new DefaultProjectManager(cfg.dataDir(), repositoryWorker, purgeWorker,
                                            meterRegistry, cfg.repositoryCacheSpec(), encryptionStorageManager);
 
@@ -436,7 +439,7 @@ public class CentralDogma implements AutoCloseable {
 
             logger.info("Starting the command executor ..");
             executor = startCommandExecutor(pm, repositoryWorker, purgeWorker,
-                                            meterRegistry, sessionManager);
+                                            meterRegistry, sessionManager, encryptionStorageManager);
             // The projectInitializer is set in startCommandExecutor.
             assert projectInitializer != null;
             if (executor.isWritable()) {
@@ -445,7 +448,7 @@ public class CentralDogma implements AutoCloseable {
 
             logger.info("Starting the RPC server.");
             server = startServer(pm, executor, purgeWorker, meterRegistry, sessionManager,
-                                 projectInitializer);
+                                 projectInitializer, encryptionStorageManager);
             logger.info("Started the RPC server at: {}", server.activePorts());
             logger.info("Started the Central Dogma successfully.");
             success = true;
@@ -453,12 +456,14 @@ public class CentralDogma implements AutoCloseable {
             if (success) {
                 this.repositoryWorker = repositoryWorker;
                 this.purgeWorker = purgeWorker;
+                this.encryptionStorageManager = encryptionStorageManager;
                 this.pm = pm;
                 this.executor = executor;
                 this.server = server;
                 this.sessionManager = sessionManager;
             } else {
-                doStop(server, executor, pm, repositoryWorker, purgeWorker, sessionManager, mirrorRunner);
+                doStop(server, executor, pm, repositoryWorker, purgeWorker, sessionManager, mirrorRunner,
+                       encryptionStorageManager);
             }
         }
         return success;
@@ -467,7 +472,7 @@ public class CentralDogma implements AutoCloseable {
     private CommandExecutor startCommandExecutor(
             ProjectManager pm, Executor repositoryWorker,
             ScheduledExecutorService purgeWorker, MeterRegistry meterRegistry,
-            @Nullable SessionManager sessionManager) {
+            @Nullable SessionManager sessionManager, EncryptionStorageManager encryptionStorageManager) {
 
         final Consumer<CommandExecutor> onTakeLeadership = exec -> {
             if (pluginsForLeaderOnly != null) {
@@ -647,7 +652,8 @@ public class CentralDogma implements AutoCloseable {
     private Server startServer(ProjectManager pm, CommandExecutor executor,
                                ScheduledExecutorService purgeWorker, MeterRegistry meterRegistry,
                                @Nullable SessionManager sessionManager,
-                               InternalProjectInitializer projectInitializer) {
+                               InternalProjectInitializer projectInitializer,
+                               EncryptionStorageManager encryptionStorageManager) {
         final ServerBuilder sb = Server.builder();
         cfg.ports().forEach(sb::port);
 
@@ -719,7 +725,7 @@ public class CentralDogma implements AutoCloseable {
         final Function<? super HttpService, AuthService> authService =
                 authService(mds, authProvider, sessionManager);
         configureHttpApi(sb, projectApiManager, executor, watchService, mds, authProvider, authService,
-                         meterRegistry);
+                         meterRegistry, encryptionStorageManager);
 
         configureMetrics(sb, meterRegistry);
         // Add the CORS service as the last decorator(executed first) so that the CORS service is applied
@@ -881,7 +887,8 @@ public class CentralDogma implements AutoCloseable {
                                   WatchService watchService, MetadataService mds,
                                   @Nullable AuthProvider authProvider,
                                   Function<? super HttpService, AuthService> authService,
-                                  MeterRegistry meterRegistry) {
+                                  MeterRegistry meterRegistry,
+                                  EncryptionStorageManager encryptionStorageManager) {
         final DependencyInjector dependencyInjector = DependencyInjector.ofSingletons(
                 // Use the default ObjectMapper without any configuration.
                 // See JacksonRequestConverterFunctionTest
@@ -1123,6 +1130,7 @@ public class CentralDogma implements AutoCloseable {
         final Server server = this.server;
         final CommandExecutor executor = this.executor;
         final ProjectManager pm = this.pm;
+        final EncryptionStorageManager encryptionStorageManager = this.encryptionStorageManager;
         final ExecutorService repositoryWorker = this.repositoryWorker;
         final ExecutorService purgeWorker = this.purgeWorker;
         final SessionManager sessionManager = this.sessionManager;
@@ -1130,6 +1138,7 @@ public class CentralDogma implements AutoCloseable {
 
         this.server = null;
         this.executor = null;
+        this.encryptionStorageManager = null;
         this.pm = null;
         this.repositoryWorker = null;
         this.sessionManager = null;
@@ -1142,7 +1151,8 @@ public class CentralDogma implements AutoCloseable {
         }
 
         logger.info("Stopping the Central Dogma ..");
-        if (!doStop(server, executor, pm, repositoryWorker, purgeWorker, sessionManager, mirrorRunner)) {
+        if (!doStop(server, executor, pm, repositoryWorker, purgeWorker, sessionManager, mirrorRunner,
+                    encryptionStorageManager)) {
             logger.warn("Stopped the Central Dogma with failure.");
         } else {
             logger.info("Stopped the Central Dogma successfully.");
@@ -1153,7 +1163,8 @@ public class CentralDogma implements AutoCloseable {
             @Nullable Server server, @Nullable CommandExecutor executor,
             @Nullable ProjectManager pm,
             @Nullable ExecutorService repositoryWorker, @Nullable ExecutorService purgeWorker,
-            @Nullable SessionManager sessionManager, @Nullable MirrorRunner mirrorRunner) {
+            @Nullable SessionManager sessionManager, @Nullable MirrorRunner mirrorRunner,
+            @Nullable EncryptionStorageManager encryptionStorageManager) {
 
         boolean success = true;
 
@@ -1200,6 +1211,17 @@ public class CentralDogma implements AutoCloseable {
         } catch (Throwable t) {
             success = false;
             logger.warn("Failed to stop the command executor:", t);
+        }
+
+        try {
+            if (encryptionStorageManager != null) {
+                logger.info("Stopping the encryption storage manager ..");
+                encryptionStorageManager.close();
+                logger.info("Stopped the encryption storage manager.");
+            }
+        } catch (Throwable t) {
+            success = false;
+            logger.warn("Failed to stop the encryption storage manager:", t);
         }
 
         final BiFunction<ExecutorService, String, Boolean> stopWorker = (worker, name) -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/Command.java
@@ -51,6 +51,7 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
         @Type(value = RemoveRepositoryCommand.class, name = "REMOVE_REPOSITORY"),
         @Type(value = PurgeRepositoryCommand.class, name = "PURGE_REPOSITORY"),
         @Type(value = UnremoveRepositoryCommand.class, name = "UNREMOVE_REPOSITORY"),
+        @Type(value = MigrateToEncryptedRepositoryCommand.class, name = "MIGRATE_TO_ENCRYPTED_REPOSITORY"),
         @Type(value = NormalizingPushCommand.class, name = "NORMALIZING_PUSH"),
         @Type(value = PushAsIsCommand.class, name = "PUSH"),
         @Type(value = CreateSessionCommand.class, name = "CREATE_SESSIONS"),
@@ -287,6 +288,15 @@ public interface Command<T> {
                                          String projectName, String repositoryName) {
         requireNonNull(author, "author");
         return new PurgeRepositoryCommand(timestamp, author, projectName, repositoryName);
+    }
+
+    /**
+     * Returns a new {@link Command} which is used to migrate a repository to an encrypted repository.
+     */
+    static Command<Void> migrateToEncryptedRepository(@Nullable Long timestamp, Author author,
+                                                      String projectName, String repositoryName, byte[] wdek) {
+        requireNonNull(author, "author");
+        return new MigrateToEncryptedRepositoryCommand(timestamp, author, projectName, repositoryName, wdek);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/CommandType.java
@@ -29,6 +29,7 @@ public enum CommandType {
     RESET_META_REPOSITORY(Void.class),
     REMOVE_REPOSITORY(Void.class),
     UNREMOVE_REPOSITORY(Void.class),
+    MIGRATE_TO_ENCRYPTED_REPOSITORY(Void.class),
     NORMALIZING_PUSH(CommitResult.class),
     TRANSFORM(CommitResult.class),
     PUSH(Revision.class),

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/MigrateToEncryptedRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/MigrateToEncryptedRepositoryCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects.ToStringHelper;
+
+import com.linecorp.centraldogma.common.Author;
+
+/**
+ * A {@link Command} which is used for migrating a repository to an encrypted repository.
+ */
+public final class MigrateToEncryptedRepositoryCommand extends ProjectCommand<Void> {
+
+    private final String repositoryName;
+    private final byte[] wdek;
+
+    @JsonCreator
+    MigrateToEncryptedRepositoryCommand(@JsonProperty("timestamp") @Nullable Long timestamp,
+                                        @JsonProperty("author") @Nullable Author author,
+                                        @JsonProperty("projectName") String projectName,
+                                        @JsonProperty("repositoryName") String repositoryName,
+                                        @JsonProperty("wdek") byte[] wdek) {
+        super(CommandType.MIGRATE_TO_ENCRYPTED_REPOSITORY, timestamp, author, projectName);
+        this.repositoryName = requireNonNull(repositoryName, "repositoryName");
+        this.wdek = requireNonNull(wdek, "wdek");
+    }
+
+    /**
+     * Return the repository name.
+     */
+    @JsonProperty
+    public String repositoryName() {
+        return repositoryName;
+    }
+
+    /**
+     * Returns the WDEK of the repository.
+     */
+    @JsonProperty
+    public byte[] wdek() {
+        return wdek.clone();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof MigrateToEncryptedRepositoryCommand)) {
+            return false;
+        }
+
+        final MigrateToEncryptedRepositoryCommand that = (MigrateToEncryptedRepositoryCommand) obj;
+        return super.equals(obj) &&
+               repositoryName.equals(that.repositoryName) &&
+               Arrays.equals(wdek, that.wdek);
+    }
+
+    @Override
+    public int hashCode() {
+        return ((repositoryName.hashCode() * 31) + wdek.hashCode()) * 31 + super.hashCode();
+    }
+
+    @Override
+    ToStringHelper toStringHelper() {
+        return super.toStringHelper()
+                    .add("repositoryName", repositoryName)
+                    .add("wdek", "[***]");
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/MigrateToEncryptedRepositoryCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/MigrateToEncryptedRepositoryCommand.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.command;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Arrays;
@@ -45,6 +46,7 @@ public final class MigrateToEncryptedRepositoryCommand extends ProjectCommand<Vo
         super(CommandType.MIGRATE_TO_ENCRYPTED_REPOSITORY, timestamp, author, projectName);
         this.repositoryName = requireNonNull(repositoryName, "repositoryName");
         this.wdek = requireNonNull(wdek, "wdek");
+        checkArgument(wdek.length > 0, "wdek must not be empty");
     }
 
     /**
@@ -81,7 +83,7 @@ public final class MigrateToEncryptedRepositoryCommand extends ProjectCommand<Vo
 
     @Override
     public int hashCode() {
-        return ((repositoryName.hashCode() * 31) + wdek.hashCode()) * 31 + super.hashCode();
+        return ((repositoryName.hashCode() * 31) + Arrays.hashCode(wdek)) * 31 + super.hashCode();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -347,8 +347,8 @@ public class RepositoryServiceV1 extends AbstractService {
         if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) ||
             Project.REPO_DOGMA.equals(repository.name())) {
             throw new IllegalArgumentException(
-                    "Cannot migrate the internal project or repository to an encrypted repository. project: "
-                    + project.name() + ", repository: " + repository.name());
+                    "Cannot migrate the internal project or repository to an encrypted repository. project: " +
+                    project.name() + ", repository: " + repository.name());
         }
 
         final RepositoryStatus currentStatus = repositoryStatus(repository);
@@ -370,8 +370,8 @@ public class RepositoryServiceV1 extends AbstractService {
         if (currentStatus == RepositoryStatus.READ_ONLY) {
             HttpApiUtil.throwResponse(
                     ctx, HttpStatus.CONFLICT,
-                    "Cannot migrate a read-only repository to an encrypted repository. "
-                    + "Please change the status to ACTIVE first.");
+                    "Cannot migrate a read-only repository to an encrypted repository. " +
+                    "Please change the status to ACTIVE first.");
         }
     }
 
@@ -427,7 +427,8 @@ public class RepositoryServiceV1 extends AbstractService {
                                          }
                                          final Repository updatedRepository =
                                                  project.repos().get(repository.name());
-                                         return DtoConverter.convert(updatedRepository, RepositoryStatus.ACTIVE);
+                                         return DtoConverter.convert(updatedRepository,
+                                                                     RepositoryStatus.ACTIVE);
                                      });
                          }).thenCompose(Function.identity());
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -410,21 +410,14 @@ public class RepositoryServiceV1 extends AbstractService {
                              if (cause != null) {
                                  logger.warn("failed to migrate repository to an encrypted repository: " +
                                              "project={}, repository={}", projectName, repoName, cause);
-                                 return Exceptions.throwUnsafely(cause);
-                             } else {
-                                 logger.info("Successfully migrated repository to an encrypted repository: " +
-                                             "project={}, repository={}", projectName, repoName);
+                                 return setRepositoryStatus(author, project, repository,
+                                                            RepositoryStatus.ACTIVE)
+                                         .thenApply(unused1 -> (RepositoryDto) Exceptions.throwUnsafely(cause));
                              }
-                             return null;
-                         })
-                         .handle((unused, cause) -> {
-                             // Whether the migration succeeded or failed,
-                             // we need to change the repository status to ACTIVE.
+                             logger.info("Successfully migrated repository to an encrypted repository: " +
+                                         "project={}, repository={}", projectName, repoName);
                              return setRepositoryStatus(author, project, repository, RepositoryStatus.ACTIVE)
-                                     .thenApply(v -> {
-                                         if (cause != null) {
-                                             return Exceptions.throwUnsafely(cause);
-                                         }
+                                     .thenApply(unused1 -> {
                                          final Repository updatedRepository =
                                                  project.repos().get(repository.name());
                                          return DtoConverter.convert(updatedRepository,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -25,8 +25,13 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
@@ -34,6 +39,7 @@ import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.logging.RequestOnlyLog;
+import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.server.ServiceRequestContext;
 import com.linecorp.armeria.server.annotation.Consumes;
 import com.linecorp.armeria.server.annotation.Delete;
@@ -56,6 +62,7 @@ import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresProjectRole;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresRepositoryRole;
+import com.linecorp.centraldogma.server.internal.api.auth.RequiresSystemAdministrator;
 import com.linecorp.centraldogma.server.internal.api.converter.CreateApiResponseConverter;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.server.metadata.ProjectMetadata;
@@ -73,6 +80,8 @@ import io.micrometer.core.instrument.Tag;
  */
 @ProducesJson
 public class RepositoryServiceV1 extends AbstractService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RepositoryServiceV1.class);
 
     private final MetadataService mds;
     private final EncryptionStorageManager encryptionStorageManager;
@@ -277,7 +286,7 @@ public class RepositoryServiceV1 extends AbstractService {
     @Get("/projects/{projectName}/repos/{repoName}")
     @RequiresRepositoryRole(RepositoryRole.ADMIN)
     public RepositoryDto status(Project project, Repository repository) {
-        validateDogmaProject(project);
+        rejectIfDogmaProject(project);
         return DtoConverter.convert(repository, repositoryStatus(repository));
     }
 
@@ -292,9 +301,8 @@ public class RepositoryServiceV1 extends AbstractService {
     public CompletableFuture<RepositoryDto> updateStatus(Project project,
                                                          Repository repository,
                                                          Author author,
-                                                         UpdateRepositoryStatusRequest statusRequest)
-            throws Exception {
-        validateDogmaProject(project);
+                                                         UpdateRepositoryStatusRequest statusRequest) {
+        rejectIfDogmaProject(project);
         final RepositoryStatus oldStatus = repositoryStatus(repository);
         final RepositoryStatus newStatus = statusRequest.status();
         if (oldStatus == newStatus) {
@@ -305,6 +313,123 @@ public class RepositoryServiceV1 extends AbstractService {
         return mds.updateRepositoryStatus(author, project.name(),
                                           normalizeRepositoryName(repository), newStatus)
                   .thenApply(unused -> DtoConverter.convert(repository, newStatus));
+    }
+
+    /**
+     * POST /projects/{projectName}/repos/{repoName}/migrate/encrypted
+     *
+     * <p>Migrates the repository to an encrypted repository.
+     */
+    @Post("/projects/{projectName}/repos/{repoName}/migrate/encrypted")
+    @RequiresSystemAdministrator
+    public CompletableFuture<RepositoryDto> migrateToEncryptedRepository(ServiceRequestContext ctx,
+                                                                         Project project,
+                                                                         Repository repository,
+                                                                         Author author) {
+        validateMigrationPrerequisites(ctx, project, repository);
+        ctx.setRequestTimeoutMillis(Long.MAX_VALUE); // Disable the request timeout for migration.
+
+        return encryptionStorageManager
+                .generateWdek()
+                .thenCompose(wdek -> setRepositoryStatus(author, project, repository,
+                                                         RepositoryStatus.READ_ONLY)
+                        .thenCompose(unused -> migrate(author, project, repository, wdek)));
+    }
+
+    private void validateMigrationPrerequisites(ServiceRequestContext ctx, Project project,
+                                                Repository repository) {
+        if (!encryptionStorageManager.enabled()) {
+            throw new IllegalArgumentException(
+                    "Encryption is not enabled in the server. Cannot migrate to an encrypted repository.");
+        }
+
+        // TODO(minwoox): Dogma project and dogma repository will be migrated one day later by a plugin.
+        if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) ||
+            Project.REPO_DOGMA.equals(repository.name())) {
+            throw new IllegalArgumentException(
+                    "Cannot migrate the internal project or repository to an encrypted repository. project: "
+                    + project.name() + ", repository: " + repository.name());
+        }
+
+        final RepositoryStatus currentStatus = repositoryStatus(repository);
+        if (repository.isEncrypted()) {
+            throw new IllegalArgumentException(
+                    "The repository is already encrypted. Cannot migrate to an encrypted repository again." +
+                    " project: " + project.name() + ", repository: " + repository.name());
+        }
+
+        final Revision normalizeNow = repository.normalizeNow(Revision.HEAD);
+        if (normalizeNow.major() > 1000) {
+            // Prohibit migration to an encrypted repository if the repository has more than 1000 revisions.
+            // After we implement the repository history rollover feature,
+            // the repository can be migrated to an encrypted repository.
+            throw new IllegalArgumentException(
+                    "Cannot migrate a repository with more than 1000 revisions to an encrypted repository.");
+        }
+
+        if (currentStatus == RepositoryStatus.READ_ONLY) {
+            HttpApiUtil.throwResponse(
+                    ctx, HttpStatus.CONFLICT,
+                    "Cannot migrate a read-only repository to an encrypted repository. "
+                    + "Please change the status to ACTIVE first.");
+        }
+    }
+
+    private CompletableFuture<Void> setRepositoryStatus(Author author, Project project, Repository repository,
+                                                        RepositoryStatus status) {
+        final String projectName = project.name();
+        final String repoName = repository.name();
+        logger.info("Changing repository status: project={}, repository={}, status={}",
+                    projectName, repoName, status);
+        return mds.updateRepositoryStatus(author, projectName, repoName, status)
+                  .handle((unused, cause) -> {
+                      if (cause != null) {
+                          logger.warn("Failed to change the repository status: project={}, repository={}, " +
+                                      "status={}", projectName, repoName, status, cause);
+                          Exceptions.throwUnsafely(cause);
+                      } else {
+                          logger.info("Changed repository status: project={}, repository={}, status={}",
+                                      projectName, repoName, status);
+                      }
+                      return null;
+                  });
+    }
+
+    private CompletionStage<RepositoryDto> migrate(Author author, Project project,
+                                                   Repository repository, byte[] wdek) {
+        final String projectName = project.name();
+        final String repoName = repository.name();
+        logger.info("Starting repository encryption migration: project={}, repository={}",
+                    projectName, repoName);
+
+        final Command<Void> command = Command.migrateToEncryptedRepository(
+                null, author, projectName, repoName, wdek);
+
+        return executor().execute(command)
+                         .handle((unused, cause) -> {
+                             if (cause != null) {
+                                 logger.warn("failed to migrate repository to an encrypted repository: " +
+                                             "project={}, repository={}", projectName, repoName, cause);
+                                 return Exceptions.throwUnsafely(cause);
+                             } else {
+                                 logger.info("Successfully migrated repository to an encrypted repository: " +
+                                             "project={}, repository={}", projectName, repoName);
+                             }
+                             return null;
+                         })
+                         .handle((unused, cause) -> {
+                             // Whether the migration succeeded or failed,
+                             // we need to change the repository status to ACTIVE.
+                             return setRepositoryStatus(author, project, repository, RepositoryStatus.ACTIVE)
+                                     .thenApply(v -> {
+                                         if (cause != null) {
+                                             return Exceptions.throwUnsafely(cause);
+                                         }
+                                         final Repository updatedRepository =
+                                                 project.repos().get(repository.name());
+                                         return DtoConverter.convert(updatedRepository, RepositoryStatus.ACTIVE);
+                                     });
+                         }).thenCompose(Function.identity());
     }
 
     static void increaseCounterIfOldRevisionUsed(ServiceRequestContext ctx, Repository repository,
@@ -344,7 +469,7 @@ public class RepositoryServiceV1 extends AbstractService {
                            Tag.of("method", log.name()));
     }
 
-    private static void validateDogmaProject(Project project) {
+    private static void rejectIfDogmaProject(Project project) {
         if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name())) {
             throw new IllegalArgumentException(
                     "Cannot update the status of the internal project: " + project.name());

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -345,7 +345,7 @@ public class RepositoryServiceV1 extends AbstractService {
 
         // TODO(minwoox): Dogma project and dogma repository will be migrated one day later by a plugin.
         if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) ||
-            Project.REPO_DOGMA.equals(repository.name())) {
+            project.name().startsWith("@") || Project.REPO_DOGMA.equals(repository.name())) {
             throw new IllegalArgumentException(
                     "Cannot migrate the internal project or repository to an encrypted repository. project: " +
                     project.name() + ", repository: " + repository.name());

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/DirectoryBasedStorageManager.java
@@ -161,6 +161,10 @@ public abstract class DirectoryBasedStorageManager<T> implements StorageManager<
         }
     }
 
+    protected boolean replaceChild(String name, T oldChild, T newChild) {
+        return children.replace(name, oldChild, newChild);
+    }
+
     protected abstract T openChild(File childDir) throws Exception;
 
     protected abstract T createChild(

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -58,6 +58,12 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     }
 
     @Override
+    public void migrateToEncryptedRepository(String repositoryName) {
+        delegate.migrateToEncryptedRepository(repositoryName);
+        repos.replace(repositoryName, repoWrapper.apply(delegate.get(repositoryName)));
+    }
+
+    @Override
     public void close(Supplier<CentralDogmaException> failureCauseSupplier) {
         delegate.close(failureCauseSupplier);
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryWrapper.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.storage.repository;
 
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -63,6 +64,11 @@ public class RepositoryWrapper implements Repository {
     @Override
     public Project parent() {
         return unwrap().parent();
+    }
+
+    @Override
+    public File repoDir() {
+        return unwrap().repoDir();
     }
 
     @Override
@@ -224,6 +230,11 @@ public class RepositoryWrapper implements Repository {
     @Override
     public void addListener(RepositoryListener listener) {
         unwrap().addListener(listener);
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return unwrap().isEncrypted();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/cache/CachingRepository.java
@@ -22,6 +22,7 @@ import static com.linecorp.centraldogma.server.internal.api.HttpApiUtil.throwUns
 import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FIND_ALL_WITH_CONTENT;
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -296,6 +297,11 @@ final class CachingRepository implements Repository {
     }
 
     @Override
+    public File repoDir() {
+        return repo.repoDir();
+    }
+
+    @Override
     public String name() {
         return repo.name();
     }
@@ -331,6 +337,11 @@ final class CachingRepository implements Repository {
                                                   String summary, String detail, Markup markup,
                                                   ContentTransformer<?> transformer) {
         return repo.commit(baseRevision, commitTimeMillis, author, summary, detail, markup, transformer);
+    }
+
+    @Override
+    public boolean isEncrypted() {
+        return repo.isEncrypted();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
@@ -29,7 +29,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
@@ -48,6 +52,8 @@ import com.google.common.annotations.VisibleForTesting;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.common.Revision;
@@ -68,7 +74,7 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
 
     private static final Logger logger = LoggerFactory.getLogger(GitRepositoryManager.class);
 
-    private static final String ENCRYPTION_REPO_PLACEHOLDER_FILE = ".encryption-repo-placeholder";
+    private static final String ENCRYPTED_REPO_PLACEHOLDER_FILE = ".encryption-repo-placeholder";
 
     private final Project parent;
     private final Executor repositoryWorker;
@@ -92,6 +98,80 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
     }
 
     @Override
+    public void migrateToEncryptedRepository(String repositoryName) {
+        logger.info("Starting to migrate the repository '{}' to an encrypted repository.", repositoryName);
+        final long startTime = System.nanoTime();
+        final Repository oldRepository = get(repositoryName);
+
+        final GitRepository encryptedRepository;
+        final EncryptionStorageManager encryptionStorageManager = encryptionStorageManager();
+        try {
+            encryptedRepository = createEncryptedRepository(parent, oldRepository.repoDir(),
+                                                            oldRepository.author(),
+                                                            oldRepository.creationTimeMillis(),
+                                                            repositoryWorker, cache,
+                                                            encryptionStorageManager);
+        } catch (Throwable t) {
+            throw new StorageException("failed to create the repository while migrating. " +
+                                       "repositoryName: " + repositoryName, t);
+        }
+
+        final Revision headRevision = oldRepository.normalizeNow(Revision.HEAD);
+        Revision baseRevision = null;
+        try {
+            for (int i = 2; i <= headRevision.major(); i++) {
+                baseRevision = new Revision(i - 1);
+                final Revision revision = new Revision(i);
+                final CompletableFuture<List<Commit>> historyFuture =
+                        oldRepository.history(revision, revision, "/**");
+                final CompletableFuture<Map<String, Change<?>>> changesFuture =
+                        oldRepository.diff(baseRevision, revision, "/**");
+                CompletableFuture.allOf(historyFuture, changesFuture).join();
+                final List<Commit> commits = historyFuture.join();
+                assert commits.size() == 1;
+                final Commit commit = commits.get(0);
+                encryptedRepository.commit(baseRevision, commit.when(), commit.author(), commit.summary(),
+                                           changesFuture.join().values()).join();
+            }
+        } catch (Throwable t) {
+            encryptedRepository.internalClose();
+            encryptionStorageManager.deleteRepositoryData(parent.name(), repositoryName);
+            throw new StorageException("failed to migrate the contents of the repository '" +
+                                       repositoryName + "' to an encrypted repository. baseRevision: " +
+                                       baseRevision, t);
+        }
+
+        // Simply create the placeholder file to indicate that this repository is encrypted.
+        // TODO(minwoox): remove the old content of the repository using a plugin.
+        try {
+            Files.createFile(Paths.get(oldRepository.repoDir().getPath(), ENCRYPTED_REPO_PLACEHOLDER_FILE));
+        } catch (IOException e) {
+            encryptedRepository.internalClose();
+            encryptionStorageManager.deleteRepositoryData(parent.name(), repositoryName);
+            throw new StorageException("failed to create the encrypted repository placeholder file at: " +
+                                       oldRepository.repoDir(), e);
+        }
+
+        if (!replaceChild(repositoryName, oldRepository, encryptedRepository)) {
+            encryptedRepository.internalClose();
+            encryptionStorageManager.deleteRepositoryData(parent.name(), repositoryName);
+            try {
+                Files.delete(Paths.get(oldRepository.repoDir().getPath(), ENCRYPTED_REPO_PLACEHOLDER_FILE));
+            } catch (IOException e) {
+                logger.warn("Failed to delete the encrypted repository placeholder file at: {}",
+                            oldRepository.repoDir(), e);
+            }
+            throw new StorageException("failed to replace the old repository with the encrypted repository. " +
+                                       "repositoryName: " + repositoryName);
+        }
+        logger.info("Migrated the repository '{}' to an encrypted repository in {} seconds.",
+                    repositoryName, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime));
+        // We don't add repository listeners to the encrypted repository so just close the old repository.
+        ((GitRepository) oldRepository).close(() -> new CentralDogmaException(
+                "repository is migrated to an encrypted repository: " + repositoryName));
+    }
+
+    @Override
     protected Repository openChild(File childDir) throws Exception {
         requireNonNull(childDir, "childDir");
         if (isEncryptedRepository(childDir)) {
@@ -103,7 +183,7 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
     }
 
     public static boolean isEncryptedRepository(File dir) {
-        return Files.exists(dir.toPath().resolve(ENCRYPTION_REPO_PLACEHOLDER_FILE));
+        return Files.exists(dir.toPath().resolve(ENCRYPTED_REPO_PLACEHOLDER_FILE));
     }
 
     @VisibleForTesting
@@ -200,28 +280,37 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
             Project parent, File repoDir, Author author, long creationTimeMillis,
             Executor repositoryWorker, @Nullable RepositoryCache cache,
             EncryptionStorageManager encryptionStorageManager) throws IOException {
+        if (!repoDir.mkdirs()) {
+            throw new StorageException(
+                    "failed to create a repository at: " + repoDir + " (exists already)");
+        }
         try {
-            if (!repoDir.mkdirs()) {
-                throw new StorageException(
-                        "failed to create a repository at: " + repoDir + " (exists already)");
-            }
-            Files.createFile(Paths.get(repoDir.getPath(), ENCRYPTION_REPO_PLACEHOLDER_FILE));
-            final EncryptionGitStorage encryptionGitStorage =
-                    new EncryptionGitStorage(parent.name(), repoDir.getName(), encryptionStorageManager);
-            final RocksDbRepository rocksDbRepository = new RocksDbRepository(encryptionGitStorage);
-            // Initialize the master branch.
-            final RefUpdate head = rocksDbRepository.updateRef(Constants.HEAD);
-            head.disableRefLog();
-            head.link(R_HEADS_MASTER);
-            final RocksDbCommitIdDatabase commitIdDatabase =
-                    new RocksDbCommitIdDatabase(encryptionGitStorage, null);
-            return new GitRepository(parent, repoDir, repositoryWorker,
-                                     creationTimeMillis, author, cache,
-                                     rocksDbRepository, commitIdDatabase);
+            Files.createFile(Paths.get(repoDir.getPath(), ENCRYPTED_REPO_PLACEHOLDER_FILE));
+            return createEncryptedRepository(parent, repoDir, author, creationTimeMillis, repositoryWorker,
+                                             cache, encryptionStorageManager);
         } catch (Throwable t) {
             deleteCruft(repoDir);
             throw new StorageException("failed to create a repository at: " + repoDir, t);
         }
+    }
+
+    private static GitRepository createEncryptedRepository(
+            Project parent, File repoDir, Author author,
+            long creationTimeMillis, Executor repositoryWorker,
+            @Nullable RepositoryCache cache,
+            EncryptionStorageManager encryptionStorageManager) throws IOException {
+        final EncryptionGitStorage encryptionGitStorage =
+                new EncryptionGitStorage(parent.name(), repoDir.getName(), encryptionStorageManager);
+        final RocksDbRepository rocksDbRepository = new RocksDbRepository(encryptionGitStorage);
+        // Initialize the master branch.
+        final RefUpdate head = rocksDbRepository.updateRef(Constants.HEAD);
+        head.disableRefLog();
+        head.link(R_HEADS_MASTER);
+        final RocksDbCommitIdDatabase commitIdDatabase =
+                new RocksDbCommitIdDatabase(encryptionGitStorage, null);
+        return new GitRepository(parent, repoDir, repositoryWorker,
+                                 creationTimeMillis, author, cache,
+                                 rocksDbRepository, commitIdDatabase);
     }
 
     @VisibleForTesting

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/Repository.java
@@ -25,6 +25,7 @@ import static com.linecorp.centraldogma.server.storage.repository.RepositoryUtil
 import static com.linecorp.centraldogma.server.storage.repository.RepositoryUtil.mergeEntries;
 import static java.util.Objects.requireNonNull;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -78,6 +79,11 @@ public interface Repository {
      * Returns the parent {@link Project} of this {@link Repository}.
      */
     Project parent();
+
+    /**
+     * Returns the directory where this {@link Repository} is stored.
+     */
+    File repoDir();
 
     /**
      * Returns the name of this {@link Repository}.
@@ -573,4 +579,9 @@ public interface Repository {
      * {@link RepositoryListener#pathPattern()} are pushed to this {@link Repository}.
      */
     void addListener(RepositoryListener listener);
+
+    /**
+     * Tells whether this {@link Repository} is encrypted or not.
+     */
+    boolean isEncrypted();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
@@ -27,4 +27,6 @@ public interface RepositoryManager extends StorageManager<Repository> {
      * Returns the project that the repositories belong to.
      */
     Project parent();
+
+    void migrateToEncryptedRepository(String repositoryName);
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
@@ -28,5 +28,8 @@ public interface RepositoryManager extends StorageManager<Repository> {
      */
     Project parent();
 
+    /**
+     * Migrates the specified repository to an encrypted repository.
+     */
     void migrateToEncryptedRepository(String repositoryName);
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.api;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
@@ -42,5 +43,26 @@ class HttpApiUtilTest {
         assertThatJson(response.contentUtf8())
                 .isEqualTo("{\"exception\":\"java.lang.IllegalArgumentException\"," +
                            "\"message\":\"Invalid input\"}");
+    }
+
+    @Test
+    void foo() throws InterruptedException {
+        final CompletableFuture<String> future1 = new CompletableFuture<>();
+        future1.thenCompose(str -> {
+            System.err.println("str1 = " + str);
+            return new CompletableFuture<>();
+        }).thenCompose(str -> {
+            System.err.println("str2 = " + str);
+            return CompletableFuture.completedFuture("done");
+        }).handle((result, throwable) -> {
+            System.err.println("str3 = " + result);
+            if (throwable != null) {
+                return "error";
+            }
+            return result;
+        });
+
+        future1.completeExceptionally(new IllegalArgumentException("Invalid input"));
+        Thread.sleep(1000);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/HttpApiUtilTest.java
@@ -18,7 +18,6 @@ package com.linecorp.centraldogma.server.internal.api;
 
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 
 import org.junit.jupiter.api.Test;
@@ -43,26 +42,5 @@ class HttpApiUtilTest {
         assertThatJson(response.contentUtf8())
                 .isEqualTo("{\"exception\":\"java.lang.IllegalArgumentException\"," +
                            "\"message\":\"Invalid input\"}");
-    }
-
-    @Test
-    void foo() throws InterruptedException {
-        final CompletableFuture<String> future1 = new CompletableFuture<>();
-        future1.thenCompose(str -> {
-            System.err.println("str1 = " + str);
-            return new CompletableFuture<>();
-        }).thenCompose(str -> {
-            System.err.println("str2 = " + str);
-            return CompletableFuture.completedFuture("done");
-        }).handle((result, throwable) -> {
-            System.err.println("str3 = " + result);
-            if (throwable != null) {
-                return "error";
-            }
-            return result;
-        });
-
-        future1.completeExceptionally(new IllegalArgumentException("Invalid input"));
-        Thread.sleep(1000);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MigrateToEncryptedRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MigrateToEncryptedRepositoryTest.java
@@ -16,52 +16,36 @@
 
 package com.linecorp.centraldogma.server.internal.api;
 
-import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
-import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
-import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static com.linecorp.centraldogma.server.internal.storage.MigratingMetaToDogmaRepositoryService.META_TO_DOGMA_MIGRATION_JOB;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
+import org.eclipse.jgit.internal.storage.file.FileRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.client.BlockingWebClient;
-import com.linecorp.armeria.client.InvalidHttpResponseException;
-import com.linecorp.armeria.client.WebClient;
-import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
-import com.linecorp.armeria.common.HttpHeaderNames;
-import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
-import com.linecorp.armeria.common.MediaType;
-import com.linecorp.armeria.common.RequestHeaders;
-import com.linecorp.armeria.common.ResponseEntity;
-import com.linecorp.armeria.common.ResponseHeaders;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.CentralDogmaRepository;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Change;
-import com.linecorp.centraldogma.common.ProjectNotFoundException;
-import com.linecorp.centraldogma.common.PushResult;
-import com.linecorp.centraldogma.common.ReadOnlyException;
-import com.linecorp.centraldogma.common.RepositoryExistsException;
-import com.linecorp.centraldogma.common.RepositoryStatus;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
-import com.linecorp.centraldogma.internal.api.v1.RepositoryDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.EncryptionAtRestConfig;
-import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
-import com.linecorp.centraldogma.server.internal.credential.AccessTokenCredential;
+import com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb.RocksDbRepository;
+import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class MigrateToEncryptedRepositoryTest {
@@ -76,6 +60,14 @@ class MigrateToEncryptedRepositoryTest {
 
         @Override
         protected void scaffold(CentralDogma client) {
+            // Commit the META_TO_DOGMA_MIGRATION_JOB file to the dogma/dogma repository so that
+            // a meta repository is not created when creating a project.
+            // This will be removed once meta repository migration is done.
+            final Project project = projectManager().get(InternalProjectInitializer.INTERNAL_PROJECT_DOGMA);
+            project.repos().get(Project.REPO_DOGMA).commit(
+                    Revision.HEAD, 0, Author.SYSTEM, "Add",
+                    Change.ofJsonUpsert(META_TO_DOGMA_MIGRATION_JOB, "{ \"a\": \"b\" }")).join();
+
             client.createProject("foo").join();
             client.createRepository("foo", "bar")
                   .join()
@@ -91,10 +83,60 @@ class MigrateToEncryptedRepositoryTest {
     };
 
     @Test
-    void foo() {
+    void migrate() {
+        final Repository oldRepository = dogma.projectManager().get("foo").repos().get("bar");
+        assertThat(oldRepository.isEncrypted()).isFalse();
+        assertThat(oldRepository.jGitRepository()).isInstanceOf(FileRepository.class);
+        assertThat(oldRepository.normalizeNow(Revision.HEAD)).isEqualTo(new Revision(3));
+
+        final CentralDogmaRepository centralDogmaRepository = dogma.client().forRepo("foo", "bar");
+        final Map<String, Entry<?>> oldRevision2 = getFiles(centralDogmaRepository, 2);
+        final Map<String, Entry<?>> oldRevision3 = getFiles(centralDogmaRepository, 3);
+        assertThat(oldRevision2).hasSize(1);
+        assertThat(oldRevision2.get("/foo.json").contentAsText()).isEqualTo("{\"a\":\"b\"}");
+        assertThat(oldRevision3).hasSize(2);
+        assertThat(oldRevision3.get("/foo.json").contentAsText()).isEqualTo("{\"a\":\"b\"}");
+        assertThat(oldRevision3.get("/bar.json").contentAsText()).isEqualTo("{\"a\":\"c\"}");
+
+        final CompletableFuture<? extends Entry<?>> watch = centralDogmaRepository.watch("/foo.json")
+                                                                                  .start();
         final BlockingWebClient client = dogma.blockingHttpClient();
         final AggregatedHttpResponse response =
                 client.post("/api/v1/projects/foo/repos/bar/migrate/encrypted", "{}");
-        System.err.println(response.status());
+        assertThat(response.status()).isSameAs(HttpStatus.OK);
+
+        // Watch fails when the migration happens.
+        assertThatThrownBy(watch::join)
+                .hasCauseInstanceOf(CentralDogmaException.class)
+                .hasMessageContaining("foo/bar is migrated to an encrypted repository. Try again.");
+
+        final Repository encrypted = dogma.projectManager().get("foo").repos().get("bar");
+        assertThat(encrypted.jGitRepository()).isInstanceOf(RocksDbRepository.class);
+        assertThat(encrypted.isEncrypted()).isTrue();
+        assertThat(encrypted.normalizeNow(Revision.HEAD)).isEqualTo(new Revision(3));
+
+        // The content of the files should be the same as before migration.
+        assertThat(getFiles(centralDogmaRepository, 2)).isEqualTo(oldRevision2);
+        assertThat(getFiles(centralDogmaRepository, 3)).isEqualTo(oldRevision3);
+
+        centralDogmaRepository.commit("commit4",
+                                      ImmutableList.of(Change.ofJsonUpsert("/baz.json", "{ \"a\": \"d\" }")))
+                              .push()
+                              .join();
+
+        // Even though the repository is closed, we can still query the normalizeNow.
+        assertThat(oldRepository.normalizeNow(Revision.HEAD)).isEqualTo(new Revision(3));
+        assertThat(encrypted.normalizeNow(Revision.HEAD)).isEqualTo(new Revision(4));
+
+        // Cannot migrate again.
+        assertThat(client.post("/api/v1/projects/foo/repos/bar/migrate/encrypted", "{}").status())
+                .isSameAs(HttpStatus.BAD_REQUEST);
+    }
+
+    private static Map<String, Entry<?>> getFiles(
+            CentralDogmaRepository centralDogmaRepository, int revision) {
+        return centralDogmaRepository.file(PathPattern.all())
+                                     .get(new Revision(revision))
+                                     .join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MigrateToEncryptedRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/MigrateToEncryptedRepositoryTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
+import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.client.InvalidHttpResponseException;
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.client.WebClientBuilder;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.ProjectNotFoundException;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.ReadOnlyException;
+import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryStatus;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
+import com.linecorp.centraldogma.internal.api.v1.RepositoryDto;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.EncryptionAtRestConfig;
+import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.internal.credential.AccessTokenCredential;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class MigrateToEncryptedRepositoryTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.encryptionAtRest(new EncryptionAtRestConfig(true));
+        }
+
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("foo").join();
+            client.createRepository("foo", "bar")
+                  .join()
+                  .commit("commit2", ImmutableList.of(Change.ofJsonUpsert("/foo.json", "{ \"a\": \"b\" }")))
+                  .push()
+                  .join();
+
+            client.forRepo("foo", "bar")
+                  .commit("commit3", ImmutableList.of(Change.ofJsonUpsert("/bar.json", "{ \"a\": \"c\" }")))
+                  .push()
+                  .join();
+        }
+    };
+
+    @Test
+    void foo() {
+        final BlockingWebClient client = dogma.blockingHttpClient();
+        final AggregatedHttpResponse response =
+                client.post("/api/v1/projects/foo/repos/bar/migrate/encrypted", "{}");
+        System.err.println(response.status());
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorageTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorageTest.java
@@ -66,7 +66,6 @@ class EncryptionGitStorageTest {
 
     // Test Data
     private static final ObjectId OBJECT_ID = ObjectId.fromString(Strings.repeat("a", 40));
-    private static final ObjectId OBJECT_ID2 = ObjectId.fromString(Strings.repeat("b", 40));
     private static final byte[] OBJ_DATA = "Object Data 1".getBytes(StandardCharsets.UTF_8);
     private static final Revision REV_1 = new Revision(1);
 

--- a/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
+++ b/testing/common/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaRuleDelegate.java
@@ -161,9 +161,7 @@ public class CentralDogmaRuleDelegate {
             final String protocol = serverPort.hasHttp() ? "h2c" : "h2";
             final String uri = protocol +  "://127.0.0.1:" + serverPort.localAddress().getPort();
             final WebClientBuilder webClientBuilder = WebClient.builder(uri);
-            if (accessToken != null) {
-                webClientBuilder.auth(AuthToken.ofOAuth2(accessToken));
-            }
+            webClientBuilder.auth(AuthToken.ofOAuth2(accessToken));
             configureHttpClient(webClientBuilder);
             webClient = webClientBuilder.build();
         });


### PR DESCRIPTION
Motivation:
Users might want to migrate their existing repositories into encrypted repositories to benefit from encryption at rest.

Modifications:
- Introduced an HTTP API for migrating a repository to an encrypted one.
  - Currently restricted to system admins to ensure the operation is monitored and controlled.
  - Only repositories with fewer than 1000 commits are eligible for migration at this time.
  - The original repository data is encrypted and stored.

Result:
- System admins can now migrate eligible repositories to encrypted repositories via the provided HTTP API.