### PR TITLE
Introduce scheduler to batch xDS endpoint registration commits

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
@@ -22,6 +22,7 @@ import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN_STRING;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.removePrefix;
 
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -48,9 +49,10 @@ public final class XdsEndpointService extends XdsEndpointServiceImplBase {
     /**
      * Creates a new instance.
      */
-    public XdsEndpointService(XdsResourceManager xdsResourceManager) {
+    public XdsEndpointService(XdsResourceManager xdsResourceManager,
+                              ScheduledExecutorService controlPlaneExecutor) {
         this.xdsResourceManager = xdsResourceManager;
-        xdsEndpointUpdateScheduler = new XdsEndpointUpdateScheduler(xdsResourceManager);
+        xdsEndpointUpdateScheduler = new XdsEndpointUpdateScheduler(xdsResourceManager, controlPlaneExecutor);
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointService.java
@@ -16,40 +16,21 @@
 package com.linecorp.centraldogma.xds.endpoint.v1;
 
 import static com.linecorp.centraldogma.server.internal.admin.auth.AuthUtil.currentAuthor;
-import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
 import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.CLUSTERS_DIRECTORY;
 import static com.linecorp.centraldogma.xds.internal.ControlPlaneService.ENDPOINTS_DIRECTORY;
-import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.RESOURCE_ID_PATTERN_STRING;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.removePrefix;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.protobuf.Empty;
 
-import com.linecorp.armeria.common.util.Exceptions;
-import com.linecorp.centraldogma.common.Author;
-import com.linecorp.centraldogma.common.EntryNotFoundException;
-import com.linecorp.centraldogma.common.EntryType;
-import com.linecorp.centraldogma.common.Markup;
-import com.linecorp.centraldogma.common.Revision;
-import com.linecorp.centraldogma.internal.Jackson;
-import com.linecorp.centraldogma.server.command.Command;
-import com.linecorp.centraldogma.server.command.ContentTransformer;
 import com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceGrpc.XdsEndpointServiceImplBase;
 import com.linecorp.centraldogma.xds.internal.XdsResourceManager;
 
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
-import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Builder;
-import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
-import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 
@@ -62,12 +43,14 @@ public final class XdsEndpointService extends XdsEndpointServiceImplBase {
             Pattern.compile("^groups/([^/]+)/endpoints/(" + RESOURCE_ID_PATTERN_STRING + ")$");
 
     private final XdsResourceManager xdsResourceManager;
+    private final XdsEndpointUpdateScheduler xdsEndpointUpdateScheduler;
 
     /**
      * Creates a new instance.
      */
     public XdsEndpointService(XdsResourceManager xdsResourceManager) {
         this.xdsResourceManager = xdsResourceManager;
+        xdsEndpointUpdateScheduler = new XdsEndpointUpdateScheduler(xdsResourceManager);
     }
 
     @Override
@@ -146,27 +129,9 @@ public final class XdsEndpointService extends XdsEndpointServiceImplBase {
     @Override
     public void registerLocalityLbEndpoint(RegisterLocalityLbEndpointRequest request,
                                            StreamObserver<LocalityLbEndpoint> responseObserver) {
-        final LocalityLbEndpoint localityLbEndpoint = request.getLocalityLbEndpoint();
         final String endpointName = request.getEndpointName();
-        handleRegisterOrDeregister(
-                endpointName,
-                localityLbEndpoint,
-                localityLbEndpoint,
-                responseObserver,
-                "Register locality LB endpoint to " + endpointName + ". endpoint: " + localityLbEndpoint,
-                true,
-                cause -> {
-                    if (cause instanceof EntryNotFoundException) {
-                        responseObserver.onError(
-                                Status.NOT_FOUND.withDescription(
-                                              "Endpoint does not exist: " + endpointName)
-                                                .asRuntimeException());
-                    } else {
-                        responseObserver.onError(
-                                Status.INTERNAL.withCause(cause).asRuntimeException());
-                    }
-                }
-        );
+        final LocalityLbEndpoint localityLbEndpoint = request.getLocalityLbEndpoint();
+        handleRegisterOrDeregister(endpointName, localityLbEndpoint, responseObserver, true);
     }
 
     @Override
@@ -174,194 +139,27 @@ public final class XdsEndpointService extends XdsEndpointServiceImplBase {
                                              StreamObserver<Empty> responseObserver) {
         final String endpointName = request.getEndpointName();
         final LocalityLbEndpoint localityLbEndpoint = request.getLocalityLbEndpoint();
-        handleRegisterOrDeregister(
-                endpointName,
-                localityLbEndpoint,
-                Empty.getDefaultInstance(),
-                responseObserver,
-                "Deregister locality LB endpoint from " + endpointName + ". endpoint: " + localityLbEndpoint,
-                false,
-                cause -> {
-                    if (cause instanceof LocalityLbEndpointNotFoundException) {
-                        responseObserver.onError(
-                                Status.NOT_FOUND.withDescription(
-                                              "Locality LB endpoint does not exist: " +
-                                              localityLbEndpoint)
-                                                .asRuntimeException());
-                    } else if (cause instanceof EntryNotFoundException) {
-                        responseObserver.onError(
-                                Status.NOT_FOUND.withDescription(
-                                              "Endpoint does not exist: " + endpointName)
-                                                .asRuntimeException());
-                    } else {
-                        responseObserver.onError(
-                                Status.INTERNAL.withCause(cause).asRuntimeException());
-                    }
-                }
-        );
+        handleRegisterOrDeregister(endpointName, localityLbEndpoint, responseObserver, false);
     }
 
     private <T> void handleRegisterOrDeregister(String endpointName,
                                                 LocalityLbEndpoint localityLbEndpoint,
-                                                T successResponse,
                                                 StreamObserver<T> responseObserver,
-                                                String commitMessage,
-                                                boolean register,
-                                                Consumer<Throwable> errorConsumer) {
+                                                boolean register) {
         final Matcher matcher = checkEndpointName(endpointName);
         final String group = matcher.group(1);
         xdsResourceManager.checkGroup(group);
 
         final String endpointId = matcher.group(2);
         final String fileName = fileName(endpointId);
-        final Author author = currentAuthor();
-
-        final ContentTransformer<JsonNode> transformer = new ContentTransformer<>(
-                fileName, EntryType.JSON, new RegisterOrDeregisterTransformer(localityLbEndpoint, register));
-
-        xdsResourceManager.updateOrDelete(
-                responseObserver, group, endpointName, fileName, () -> xdsResourceManager
-                        .commandExecutor()
-                        .execute(Command.transform(
-                                null, author, XDS_CENTRAL_DOGMA_PROJECT, group, Revision.HEAD,
-                                commitMessage, "", Markup.PLAINTEXT, transformer))
-                        .handle((result, cause) -> {
-                            if (cause != null) {
-                                final Throwable peeled = Exceptions.peel(cause);
-                                errorConsumer.accept(peeled);
-                                return null;
-                            }
-                            responseObserver.onNext(successResponse);
-                            responseObserver.onCompleted();
-                            return null;
-                        }));
+        xdsEndpointUpdateScheduler.schedule(group, endpointName, fileName,
+                                            localityLbEndpoint, responseObserver, register);
     }
 
-    private static class RegisterOrDeregisterTransformer implements BiFunction<Revision, JsonNode, JsonNode> {
-
-        final LocalityLbEndpoint localityLbEndpoint;
-        private final boolean register;
-
-        RegisterOrDeregisterTransformer(LocalityLbEndpoint localityLbEndpoint, boolean register) {
-            this.localityLbEndpoint = localityLbEndpoint;
-            this.register = register;
-        }
-
-        @Override
-        public JsonNode apply(Revision revision, JsonNode oldJsonNode) {
-            if (oldJsonNode.isNull()) {
-                throw new EntryNotFoundException();
-            }
-            final ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder =
-                    toClusterLoadAssignmentBuilder(oldJsonNode);
-            final int localityIndex =
-                    findLocalityAndPriorityIndex(clusterLoadAssignmentBuilder, localityLbEndpoint);
-            if (localityIndex < 0) {
-                if (register) {
-                    clusterLoadAssignmentBuilder.addEndpoints(
-                            LocalityLbEndpoints.newBuilder()
-                                               .setLocality(localityLbEndpoint.getLocality())
-                                               .setPriority(localityLbEndpoint.getPriority())
-                                               .addLbEndpoints(localityLbEndpoint.getLbEndpoint())
-                                               .build());
-                    return toJsonNode(clusterLoadAssignmentBuilder);
-                }
-                throw LocalityLbEndpointNotFoundException.INSTANCE;
-            }
-            final LocalityLbEndpoints targetLocalityLbEndpoints =
-                    clusterLoadAssignmentBuilder.getEndpoints(localityIndex);
-            // Remove from the endpoints. It will be added again.
-            clusterLoadAssignmentBuilder.removeEndpoints(localityIndex);
-
-            final int lbEndpointIndex =
-                    findLbEndpointIndex(targetLocalityLbEndpoints, localityLbEndpoint);
-            final LocalityLbEndpoints.Builder targetLocalityLbEndpointsBuilder =
-                    targetLocalityLbEndpoints.toBuilder();
-            if (register) {
-                if (lbEndpointIndex >= 0) {
-                    // When the endpoint whose address is the same as the registering endpoint exists,
-                    // remove it and add the registering endpoint because the other fields may be different.
-                    targetLocalityLbEndpointsBuilder.removeLbEndpoints(lbEndpointIndex);
-                }
-                targetLocalityLbEndpointsBuilder.addLbEndpoints(localityLbEndpoint.getLbEndpoint());
-                clusterLoadAssignmentBuilder.addEndpoints(targetLocalityLbEndpointsBuilder.build());
-            } else {
-                if (lbEndpointIndex < 0) {
-                    throw LocalityLbEndpointNotFoundException.INSTANCE;
-                }
-                targetLocalityLbEndpointsBuilder.removeLbEndpoints(lbEndpointIndex);
-                if (targetLocalityLbEndpointsBuilder.getLbEndpointsCount() > 0) {
-                    clusterLoadAssignmentBuilder.addEndpoints(targetLocalityLbEndpointsBuilder.build());
-                }
-            }
-            return toJsonNode(clusterLoadAssignmentBuilder);
-        }
-
-        private static int findLbEndpointIndex(LocalityLbEndpoints targetLocalityLbEndpoints,
-                                               LocalityLbEndpoint localityLbEndpoint) {
-            int sameLbEndpointIndex = -1;
-            final List<LbEndpoint> lbEndpointsList = targetLocalityLbEndpoints.getLbEndpointsList();
-            for (int i = 0; i < lbEndpointsList.size(); i++) {
-                final LbEndpoint lbEndpoint = lbEndpointsList.get(i);
-                if (lbEndpoint.getEndpoint().getAddress().equals(
-                        localityLbEndpoint.getLbEndpoint().getEndpoint().getAddress())) {
-                    sameLbEndpointIndex = i;
-                    break;
-                }
-            }
-            return sameLbEndpointIndex;
-        }
-
-        /**
-         * Find the index of the {@link LocalityLbEndpoints} that has the same locality and priority as the
-         * specified {@link LocalityLbEndpoint}.
-         * If the locality and priority are not found, return -1.
-         */
-        private static int findLocalityAndPriorityIndex(Builder clusterLoadAssignmentBuilder,
-                                                        LocalityLbEndpoint localityLbEndpoint) {
-            int sameLocalityIndex = -1;
-
-            final List<LocalityLbEndpoints> localityLbEndpointsList =
-                    clusterLoadAssignmentBuilder.getEndpointsList();
-            for (int i = 0; i < localityLbEndpointsList.size(); i++) {
-                final LocalityLbEndpoints localityLbEndpoints = localityLbEndpointsList.get(i);
-                if (localityLbEndpoints.getLocality().equals(localityLbEndpoint.getLocality()) &&
-                    localityLbEndpoints.getPriority() == localityLbEndpoint.getPriority()) {
-                    sameLocalityIndex = i;
-                    break;
-                }
-            }
-            return sameLocalityIndex;
-        }
-
-        private static ClusterLoadAssignment.Builder toClusterLoadAssignmentBuilder(JsonNode oldJsonNode) {
-            final Builder clusterLoadAssignmentBuilder =
-                    ClusterLoadAssignment.newBuilder();
-            try {
-                JSON_MESSAGE_MARSHALLER.mergeValue(Jackson.writeValueAsString(oldJsonNode),
-                                                   clusterLoadAssignmentBuilder);
-            } catch (Throwable t) {
-                // Should never reach here.
-                throw new Error();
-            }
-            return clusterLoadAssignmentBuilder;
-        }
-
-        private static JsonNode toJsonNode(ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder) {
-            try {
-                return Jackson.readTree(JSON_MESSAGE_MARSHALLER.writeValueAsString(
-                        clusterLoadAssignmentBuilder.build()));
-            } catch (IOException e) {
-                // Should never reach here
-                throw new Error(e);
-            }
-        }
-    }
-
-    private static final class LocalityLbEndpointNotFoundException extends EntryNotFoundException {
-
-        private static final long serialVersionUID = -4661118144903218907L;
-
-        static final LocalityLbEndpointNotFoundException INSTANCE = new LocalityLbEndpointNotFoundException();
+    /**
+     * Returns the number of tasks that are currently scheduled for batch updates.
+     */
+    public int batchUpdateTaskSize() {
+        return xdsEndpointUpdateScheduler.batchUpdateTaskSize();
     }
 }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointUpdateScheduler.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointUpdateScheduler.java
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.endpoint.v1;
+
+import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FIND_ONE_WITHOUT_CONTENT;
+import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
+import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Empty;
+
+import com.linecorp.armeria.common.util.Exceptions;
+import com.linecorp.armeria.common.util.SafeCloseable;
+import com.linecorp.armeria.common.util.ThreadFactories;
+import com.linecorp.armeria.internal.common.RequestContextUtil;
+import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.EntryNotFoundException;
+import com.linecorp.centraldogma.common.EntryType;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.RedundantChangeException;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.command.ContentTransformer;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.xds.internal.XdsResourceManager;
+
+import io.envoyproxy.envoy.config.core.v3.Address;
+import io.envoyproxy.envoy.config.core.v3.Locality;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment.Builder;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+
+final class XdsEndpointUpdateScheduler {
+
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            ThreadFactories.newThreadFactory("xds-endpoint-update-scheduler", true));
+
+    private final XdsResourceManager xdsResourceManager;
+
+    private final ConcurrentMap<String, BatchUpdateTask> batchUpdateTasks = new ConcurrentHashMap<>();
+
+    XdsEndpointUpdateScheduler(XdsResourceManager xdsResourceManager) {
+        this.xdsResourceManager = xdsResourceManager;
+    }
+
+    int batchUpdateTaskSize() {
+        return batchUpdateTasks.size();
+    }
+
+    void schedule(String group, String endpointName, String fileName,
+                  LocalityLbEndpoint localityLbEndpoint, StreamObserver<?> streamObserver, boolean register) {
+        final EndpointIdentifier identifier = EndpointIdentifier.of(localityLbEndpoint);
+
+        batchUpdateTasks.compute(endpointName, (key, task) -> {
+            if (task == null) {
+                task = new BatchUpdateTask(group, key, fileName);
+            }
+
+            task.addOperationAndSchedule(identifier, register, localityLbEndpoint, streamObserver);
+            return task;
+        });
+    }
+
+    private final class BatchUpdateTask {
+
+        private final String group;
+        private final String endpointName;
+        private final String fileName;
+
+        private final ReentrantShortLock lock = new ReentrantShortLock();
+        private final Map<EndpointIdentifier, PendingUpdate> pendingUpdates = new LinkedHashMap<>();
+        @Nullable
+        private ScheduledFuture<?> scheduledFuture;
+
+        BatchUpdateTask(String group, String endpointName, String fileName) {
+            this.group = group;
+            this.endpointName = endpointName;
+            this.fileName = fileName;
+        }
+
+        void addOperationAndSchedule(EndpointIdentifier identifier, boolean register,
+                                     LocalityLbEndpoint localityLbEndpoint, StreamObserver<?> streamObserver) {
+            final PendingUpdate previous;
+            lock.lock();
+            try {
+                previous = pendingUpdates.put(identifier,
+                                              new PendingUpdate(register, localityLbEndpoint, streamObserver));
+                if (scheduledFuture == null) {
+                    scheduledFuture = scheduler.schedule(this::flush, 3, TimeUnit.SECONDS);
+                }
+            } finally {
+                lock.unlock();
+            }
+
+            if (previous != null) {
+                try (SafeCloseable ignored = RequestContextUtil.pop()) {
+                    previous.streamObserver.onError(
+                            Status.ABORTED
+                                    .withDescription("Aborted due to a new update for the same endpoint")
+                                    .asRuntimeException());
+                }
+            }
+        }
+
+        private void flush() {
+            final List<PendingUpdate> copied;
+            lock.lock();
+            try {
+                assert !pendingUpdates.isEmpty();
+                copied = ImmutableList.copyOf(pendingUpdates.values());
+                pendingUpdates.clear();
+                scheduledFuture = null;
+            } finally {
+                lock.unlock();
+            }
+
+            batchUpdateTasks.computeIfPresent(endpointName, (key, task) -> {
+                lock.lock();
+                try {
+                    if (pendingUpdates.isEmpty()) {
+                        return null; // Remove the task if there are no pending updates.
+                    }
+                    return task; // Keep the task for future updates.
+                } finally {
+                    lock.unlock();
+                }
+            });
+
+            final List<LocalityLbEndpoint> toRegister = new ArrayList<>();
+            final List<LocalityLbEndpoint> toDeregister = new ArrayList<>();
+            for (PendingUpdate pendingUpdate : copied) {
+                if (pendingUpdate.register) {
+                    toRegister.add(pendingUpdate.endpoint);
+                } else {
+                    toDeregister.add(pendingUpdate.endpoint);
+                }
+            }
+
+            final ContentTransformer<JsonNode> transformer = new ContentTransformer<>(
+                    fileName, EntryType.JSON, new BatchUpdateTransformer(toRegister, toDeregister));
+
+            final Repository repository = xdsResourceManager.xdsProject().repos().get(group);
+            repository.find(Revision.HEAD, fileName, FIND_ONE_WITHOUT_CONTENT).handle((entries, cause) -> {
+                if (cause != null) {
+                    copied.forEach(pendingUpdate -> pendingUpdate.streamObserver.onError(cause));
+                    return null;
+                }
+                if (entries.isEmpty()) {
+                    final StatusRuntimeException runtimeException =
+                            Status.NOT_FOUND.withDescription("Resource not found: " + fileName)
+                                            .asRuntimeException();
+                    copied.forEach(pendingUpdate -> pendingUpdate.streamObserver.onError(runtimeException));
+                    return null;
+                }
+                final String commitMessage =
+                        "Batch update for " + endpointName + " in group " + group + ": " +
+                        toRegister.size() + " register, " + toDeregister.size() + " deregister";
+                xdsResourceManager.commandExecutor()
+                                  .execute(Command.transform(
+                                          null, Author.SYSTEM, XDS_CENTRAL_DOGMA_PROJECT, group, Revision.HEAD,
+                                          commitMessage, "", Markup.PLAINTEXT, transformer))
+                                  .handle((result, cause2) -> {
+                                      if (cause2 != null) {
+                                          final Throwable peeled = Exceptions.peel(cause2);
+                                          if (!(peeled instanceof RedundantChangeException)) {
+                                              copied.forEach(pendingUpdate -> pendingUpdate
+                                                      .streamObserver.onError(peeled));
+                                              return null;
+                                          }
+                                          // If the change is redundant, we just ignore it and complete
+                                          // the stream observer without error.
+                                      }
+                                      copied.forEach(pendingUpdate -> {
+                                          final StreamObserver<?> streamObserver = pendingUpdate.streamObserver;
+                                          if (pendingUpdate.register) {
+                                              //noinspection unchecked
+                                              ((StreamObserver<LocalityLbEndpoint> ) streamObserver).onNext(
+                                                      pendingUpdate.endpoint);
+                                          } else {
+                                              //noinspection unchecked
+                                              ((StreamObserver<Empty>) streamObserver).onNext(
+                                                      Empty.getDefaultInstance());
+                                          }
+                                          streamObserver.onCompleted();
+                                      });
+                                      return null;
+                                  });
+                return null;
+            });
+        }
+    }
+
+    private static class PendingUpdate {
+        final boolean register;
+        final LocalityLbEndpoint endpoint;
+        final StreamObserver<?> streamObserver;
+
+        PendingUpdate(boolean register, LocalityLbEndpoint endpoint, StreamObserver<?> streamObserver) {
+            this.register = register;
+            this.endpoint = endpoint;
+            this.streamObserver = streamObserver;
+        }
+    }
+
+    private static final class BatchUpdateTransformer implements BiFunction<Revision, JsonNode, JsonNode> {
+
+        private final List<LocalityLbEndpoint> toRegister;
+        private final List<LocalityLbEndpoint> toDeregister;
+
+        BatchUpdateTransformer(List<LocalityLbEndpoint> toRegister, List<LocalityLbEndpoint> toDeregister) {
+            this.toRegister = toRegister;
+            this.toDeregister = toDeregister;
+        }
+
+        @Override
+        public JsonNode apply(Revision revision, JsonNode oldJsonNode) {
+            if (oldJsonNode.isNull()) {
+                throw new EntryNotFoundException();
+            }
+            final ClusterLoadAssignment.Builder builder = toClusterLoadAssignmentBuilder(oldJsonNode);
+
+            // 1. Deregister endpoints
+            for (LocalityLbEndpoint endpoint : toDeregister) {
+                final int localityIndex = findLocalityAndPriorityIndex(builder, endpoint);
+                if (localityIndex < 0) {
+                    continue;
+                }
+                final LocalityLbEndpoints localityEndpoints = builder.getEndpoints(localityIndex);
+                final int lbEndpointIndex = findLbEndpointIndex(localityEndpoints, endpoint);
+
+                if (lbEndpointIndex >= 0) {
+                    final LocalityLbEndpoints.Builder localityBuilder = localityEndpoints.toBuilder();
+                    localityBuilder.removeLbEndpoints(lbEndpointIndex);
+                    builder.removeEndpoints(localityIndex);
+                    if (localityBuilder.getLbEndpointsCount() > 0) {
+                        builder.addEndpoints(localityBuilder);
+                    }
+                }
+            }
+
+            // 2. Register endpoints
+            for (LocalityLbEndpoint endpoint : toRegister) {
+                final int localityIndex = findLocalityAndPriorityIndex(builder, endpoint);
+                if (localityIndex < 0) {
+                    builder.addEndpoints(
+                            LocalityLbEndpoints.newBuilder()
+                                               .setLocality(endpoint.getLocality())
+                                               .setPriority(endpoint.getPriority())
+                                               .addLbEndpoints(endpoint.getLbEndpoint())
+                                               .build());
+                } else {
+                    final LocalityLbEndpoints localityEndpoints = builder.getEndpoints(localityIndex);
+                    final LocalityLbEndpoints.Builder localityBuilder = localityEndpoints.toBuilder();
+
+                    final int lbEndpointIndex = findLbEndpointIndex(localityEndpoints, endpoint);
+                    if (lbEndpointIndex >= 0) {
+                        localityBuilder.removeLbEndpoints(lbEndpointIndex);
+                    }
+                    localityBuilder.addLbEndpoints(endpoint.getLbEndpoint());
+
+                    builder.removeEndpoints(localityIndex);
+                    builder.addEndpoints(localityBuilder);
+                }
+            }
+
+            return toJsonNode(builder);
+        }
+
+        private static ClusterLoadAssignment.Builder toClusterLoadAssignmentBuilder(JsonNode oldJsonNode) {
+            final Builder clusterLoadAssignmentBuilder =
+                    ClusterLoadAssignment.newBuilder();
+            try {
+                JSON_MESSAGE_MARSHALLER.mergeValue(Jackson.writeValueAsString(oldJsonNode),
+                                                   clusterLoadAssignmentBuilder);
+            } catch (Throwable t) {
+                // Should never reach here.
+                throw new Error();
+            }
+            return clusterLoadAssignmentBuilder;
+        }
+
+        /**
+         * Find the index of the {@link LocalityLbEndpoints} that has the same locality and priority as the
+         * specified {@link LocalityLbEndpoint}.
+         * If the locality and priority are not found, return -1.
+         */
+        private static int findLocalityAndPriorityIndex(Builder clusterLoadAssignmentBuilder,
+                                                        LocalityLbEndpoint localityLbEndpoint) {
+            int sameLocalityIndex = -1;
+
+            final List<LocalityLbEndpoints> localityLbEndpointsList =
+                    clusterLoadAssignmentBuilder.getEndpointsList();
+            for (int i = 0; i < localityLbEndpointsList.size(); i++) {
+                final LocalityLbEndpoints localityLbEndpoints = localityLbEndpointsList.get(i);
+                if (localityLbEndpoints.getLocality().equals(localityLbEndpoint.getLocality()) &&
+                    localityLbEndpoints.getPriority() == localityLbEndpoint.getPriority()) {
+                    sameLocalityIndex = i;
+                    break;
+                }
+            }
+            return sameLocalityIndex;
+        }
+
+        private static int findLbEndpointIndex(LocalityLbEndpoints targetLocalityLbEndpoints,
+                                               LocalityLbEndpoint localityLbEndpoint) {
+            int sameLbEndpointIndex = -1;
+            final List<LbEndpoint> lbEndpointsList = targetLocalityLbEndpoints.getLbEndpointsList();
+            for (int i = 0; i < lbEndpointsList.size(); i++) {
+                final LbEndpoint lbEndpoint = lbEndpointsList.get(i);
+                if (lbEndpoint.getEndpoint().getAddress().equals(
+                        localityLbEndpoint.getLbEndpoint().getEndpoint().getAddress())) {
+                    sameLbEndpointIndex = i;
+                    break;
+                }
+            }
+            return sameLbEndpointIndex;
+        }
+
+        private static JsonNode toJsonNode(ClusterLoadAssignment.Builder clusterLoadAssignmentBuilder) {
+            try {
+                return Jackson.readTree(JSON_MESSAGE_MARSHALLER.writeValueAsString(
+                        clusterLoadAssignmentBuilder.build()));
+            } catch (IOException e) {
+                // Should never reach here
+                throw new Error(e);
+            }
+        }
+    }
+
+    private static final class EndpointIdentifier {
+
+        static EndpointIdentifier of(LocalityLbEndpoint endpoint) {
+            return new EndpointIdentifier(
+                    endpoint.getLocality(),
+                    endpoint.getPriority(),
+                    endpoint.getLbEndpoint().getEndpoint().getAddress());
+        }
+
+        private final Locality locality;
+        private final int priority;
+        private final Address address;
+
+        EndpointIdentifier(Locality locality, int priority, Address address) {
+            this.locality = locality;
+            this.priority = priority;
+            this.address = address;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof EndpointIdentifier)) {
+                return false;
+            }
+            final EndpointIdentifier that = (EndpointIdentifier) obj;
+            return priority == that.priority &&
+                   locality.equals(that.locality) &&
+                   address.equals(that.address);
+        }
+
+        @Override
+        public int hashCode() {
+            return (locality.hashCode() * 31 + priority) * 31 + address.hashCode();
+        }
+
+        @Override
+        public String toString() {
+            return MoreObjects.toStringHelper(this)
+                              .add("locality", locality)
+                              .add("priority", priority)
+                              .add("address", address)
+                              .toString();
+        }
+    }
+}

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointUpdateScheduler.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsEndpointUpdateScheduler.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +40,6 @@ import com.google.protobuf.Empty;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
-import com.linecorp.armeria.common.util.ThreadFactories;
 import com.linecorp.armeria.internal.common.RequestContextUtil;
 import com.linecorp.armeria.internal.common.util.ReentrantShortLock;
 import com.linecorp.centraldogma.common.Author;
@@ -68,15 +66,15 @@ import io.grpc.stub.StreamObserver;
 
 final class XdsEndpointUpdateScheduler {
 
-    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
-            ThreadFactories.newThreadFactory("xds-endpoint-update-scheduler", true));
-
     private final XdsResourceManager xdsResourceManager;
+    private final ScheduledExecutorService scheduler;
 
     private final ConcurrentMap<String, BatchUpdateTask> batchUpdateTasks = new ConcurrentHashMap<>();
 
-    XdsEndpointUpdateScheduler(XdsResourceManager xdsResourceManager) {
+    XdsEndpointUpdateScheduler(XdsResourceManager xdsResourceManager,
+                               ScheduledExecutorService scheduler) {
         this.xdsResourceManager = xdsResourceManager;
+        this.scheduler = scheduler;
     }
 
     int batchUpdateTaskSize() {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -83,6 +83,8 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
     private final ScheduledExecutorService controlPlaneExecutor;
     // Accessed only from controlPlaneExecutor.
     private final CentralDogmaXdsResources centralDogmaXdsResources = new CentralDogmaXdsResources();
+    @Nullable
+    private volatile XdsEndpointService xdsEndpointService;
     private volatile boolean stop;
 
     ControlPlaneService(Project xdsProject, MeterRegistry meterRegistry) {
@@ -108,6 +110,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                                    .build();
         pluginInitContext.serverBuilder().route().build(grpcService);
         final XdsResourceManager xdsResourceManager = new XdsResourceManager(xdsProject(), commandExecutor);
+        xdsEndpointService = new XdsEndpointService(xdsResourceManager);
         final GrpcService xdsApplicationService =
                 GrpcService.builder()
                            .addService(new XdsGroupService(pluginInitContext.projectManager(),
@@ -116,7 +119,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                            .addService(new XdsListenerService(xdsResourceManager))
                            .addService(new XdsRouteService(xdsResourceManager))
                            .addService(new XdsClusterService(xdsResourceManager))
-                           .addService(new XdsEndpointService(xdsResourceManager))
+                           .addService(xdsEndpointService)
                            .addService(new XdsKubernetesService(xdsResourceManager))
                            .exceptionHandler(new ControlPlaneExceptionHandlerFunction())
                            .jsonMarshallerFactory(
@@ -220,6 +223,27 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
 
     void stop() {
         stop = true;
+        final XdsEndpointService xdsEndpointService = this.xdsEndpointService;
+        if (xdsEndpointService != null) {
+            System.err.println(xdsEndpointService.batchUpdateTaskSize());
+            if (xdsEndpointService.batchUpdateTaskSize() > 0) {
+                logger.info("Waiting for {} xDS endpoint batch update tasks to finish up to 5 seconds...",
+                            xdsEndpointService.batchUpdateTaskSize());
+                for (int i = 0; i < 5; i++) {
+                    try {
+                        if (xdsEndpointService.batchUpdateTaskSize() == 0) {
+                            break;
+                        }
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
+            }
+            System.err.println(xdsEndpointService.batchUpdateTaskSize());
+        }
+
         final boolean interrupted = terminate(controlPlaneExecutor);
         if (interrupted) {
             Thread.currentThread().interrupt();

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -110,7 +110,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                                    .build();
         pluginInitContext.serverBuilder().route().build(grpcService);
         final XdsResourceManager xdsResourceManager = new XdsResourceManager(xdsProject(), commandExecutor);
-        xdsEndpointService = new XdsEndpointService(xdsResourceManager);
+        xdsEndpointService = new XdsEndpointService(xdsResourceManager, controlPlaneExecutor);
         final GrpcService xdsApplicationService =
                 GrpcService.builder()
                            .addService(new XdsGroupService(pluginInitContext.projectManager(),

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -225,7 +225,6 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
         stop = true;
         final XdsEndpointService xdsEndpointService = this.xdsEndpointService;
         if (xdsEndpointService != null) {
-            System.err.println(xdsEndpointService.batchUpdateTaskSize());
             if (xdsEndpointService.batchUpdateTaskSize() > 0) {
                 logger.info("Waiting for {} xDS endpoint batch update tasks to finish up to 5 seconds...",
                             xdsEndpointService.batchUpdateTaskSize());
@@ -241,7 +240,6 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                     }
                 }
             }
-            System.err.println(xdsEndpointService.batchUpdateTaskSize());
         }
 
         final boolean interrupted = terminate(controlPlaneExecutor);

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/endpoint/v1/XdsRegisterEndpointTest.java
@@ -17,6 +17,7 @@ package com.linecorp.centraldogma.xds.endpoint.v1;
 
 import static com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceTest.assertOk;
 import static com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceTest.checkEndpointsViaDiscoveryRequest;
+import static com.linecorp.centraldogma.xds.internal.ControlPlanePlugin.XDS_CENTRAL_DOGMA_PROJECT;
 import static com.linecorp.centraldogma.xds.internal.XdsResourceManager.JSON_MESSAGE_MARSHALLER;
 import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createEndpoint;
 import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
@@ -24,6 +25,7 @@ import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.endpoint;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,8 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 import io.envoyproxy.envoy.config.core.v3.Locality;
@@ -67,72 +71,116 @@ public class XdsRegisterEndpointTest {
         assertOk(response);
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
-        // Register another endpoint to the same locality endpoint.
+        final Repository fooRepository =
+                dogma.projectManager().get(XDS_CENTRAL_DOGMA_PROJECT).repos().get("foo");
+        int prevMajor = fooRepository.normalizeNow(Revision.HEAD).major();
+
+        // Register endpoints to the same locality endpoint.
         final LocalityLbEndpoint localityLbEndpoint1 =
                 LocalityLbEndpoint.newBuilder().setLocality(locality1)
                                   .setLbEndpoint(endpoint("127.0.0.1", 8081))
                                   .build();
-        response = registerOrDeregister(endpointName, localityLbEndpoint1, true);
-        assertOk(response);
+        final LocalityLbEndpoint localityLbEndpoint2 =
+                LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                  .setLbEndpoint(endpoint("127.0.0.1", 8082))
+                                  .build();
+        final CompletableFuture<AggregatedHttpResponse> registerFuture1 =
+                registerOrDeregisterAsync(endpointName, localityLbEndpoint1, true);
+        // The service collects the request during 3 seconds.
+        Thread.sleep(1000);
+        final CompletableFuture<AggregatedHttpResponse> registerFuture2 =
+                registerOrDeregisterAsync(endpointName, localityLbEndpoint2, true);
+        assertOk(registerFuture1.join());
+        assertOk(registerFuture2.join());
+        // localityLbEndpoint1 and localityLbEndpoint2 are registered together so the major version should
+        // be incremented by 1.
+        assertThat(fooRepository.normalizeNow(Revision.HEAD).major()).isEqualTo(prevMajor + 1);
+
         endpoint = endpoint.toBuilder()
                            .removeEndpoints(0)
                            .addEndpoints(LocalityLbEndpoints.newBuilder()
                                                             .setLocality(locality1)
                                                             .addLbEndpoints(endpoint("127.0.0.1", 8080))
-                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081)))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8082)))
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
+        prevMajor = fooRepository.normalizeNow(Revision.HEAD).major();
+
         // Register another endpoint with different priority.
-        final LocalityLbEndpoint localityLbEndpoint2 =
+        final LocalityLbEndpoint localityLbEndpoint3 =
                 LocalityLbEndpoint.newBuilder().setLocality(locality1)
                                   .setPriority(1)
-                                  .setLbEndpoint(endpoint("127.0.0.1", 8082))
+                                  .setLbEndpoint(endpoint("127.0.0.1", 8083))
                                   .build();
-        response = registerOrDeregister(endpointName, localityLbEndpoint2, true);
-        assertOk(response);
+
+        final CompletableFuture<AggregatedHttpResponse> registerFuture3 =
+                registerOrDeregisterAsync(endpointName, localityLbEndpoint3, true);
+
+        final LocalityLbEndpoint notRegistered =
+                LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                  .setPriority(1)
+                                  .setLbEndpoint(endpoint("127.0.0.1", 9000))
+                                  .build();
+
+        // Try to register and deregister the same endpoint.
+        final CompletableFuture<AggregatedHttpResponse> notRegisterFuture1 =
+                registerOrDeregisterAsync(endpointName, notRegistered, true);
+        // Sleep so that the next call is sent after the previous one.
+        Thread.sleep(500);
+        final CompletableFuture<AggregatedHttpResponse> notRegisterFuture2 =
+                registerOrDeregisterAsync(endpointName, notRegistered, false);
+
+        assertOk(registerFuture3.join());
+        // Aborted by the next call.
+        assertThat(notRegisterFuture1.join().status()).isSameAs(HttpStatus.CONFLICT);
+        assertThat(notRegisterFuture2.join().status()).isSameAs(HttpStatus.OK);
+
+        assertThat(fooRepository.normalizeNow(Revision.HEAD).major()).isEqualTo(prevMajor + 1);
+
         endpoint = endpoint.toBuilder()
                            .addEndpoints(LocalityLbEndpoints.newBuilder()
                                                             .setLocality(locality1)
                                                             .setPriority(1)
-                                                            .addLbEndpoints(endpoint("127.0.0.1", 8082)))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8083)))
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
         // Register another endpoint with different locality.
         final Locality locality2 = Locality.newBuilder().setRegion("region2").setZone("zone2").build();
-        LbEndpoint endpoint8083 = endpoint("127.0.0.1", 8083);
-        final LocalityLbEndpoint localityLbEndpoint3 =
+        LbEndpoint endpoint8084 = endpoint("127.0.0.1", 8084);
+        final LocalityLbEndpoint localityLbEndpoint4 =
                 LocalityLbEndpoint.newBuilder().setLocality(locality2)
-                                  .setLbEndpoint(endpoint8083)
+                                  .setLbEndpoint(endpoint8084)
                                   .build();
-        response = registerOrDeregister(endpointName, localityLbEndpoint3, true);
+        response = registerOrDeregister(endpointName, localityLbEndpoint4, true);
         assertOk(response);
         endpoint = endpoint.toBuilder()
                            .addEndpoints(LocalityLbEndpoints.newBuilder()
                                                             .setLocality(locality2)
-                                                            .addLbEndpoints(endpoint8083))
+                                                            .addLbEndpoints(endpoint8084))
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
         // Register the same endpoint with different property. This will replace the existing one.
-        endpoint8083 = endpoint8083.toBuilder().setLoadBalancingWeight(UInt32Value.of(200)).build();
-        final LocalityLbEndpoint localityLbEndpoint4 =
+        endpoint8084 = endpoint8084.toBuilder().setLoadBalancingWeight(UInt32Value.of(200)).build();
+        final LocalityLbEndpoint localityLbEndpoint5 =
                 LocalityLbEndpoint.newBuilder().setLocality(locality2)
-                                  .setLbEndpoint(endpoint8083)
+                                  .setLbEndpoint(endpoint8084)
                                   .build();
-        response = registerOrDeregister(endpointName, localityLbEndpoint4, true);
+        response = registerOrDeregister(endpointName, localityLbEndpoint5, true);
         assertOk(response);
         endpoint = endpoint.toBuilder()
                            .removeEndpoints(2)
                            .addEndpoints(LocalityLbEndpoints.newBuilder()
                                                             .setLocality(locality2)
-                                                            .addLbEndpoints(endpoint8083))
+                                                            .addLbEndpoints(endpoint8084))
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
         // Deregister the endpoint.
-        response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
+        response = registerOrDeregister(endpointName, localityLbEndpoint4, false);
         assertOk(response);
         assertThat(response.contentUtf8()).isEqualTo("{}");
         endpoint = endpoint.toBuilder()
@@ -141,11 +189,10 @@ public class XdsRegisterEndpointTest {
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
         // Try to deregister a non-existent endpoint.
-        response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
-        assertThat(response.status()).isSameAs(HttpStatus.NOT_FOUND);
-        assertThat(response.contentUtf8()).contains("Locality LB endpoint does not exist");
+        response = registerOrDeregister(endpointName, localityLbEndpoint4, false);
+        assertThat(response.status()).isSameAs(HttpStatus.OK); // It's OK to deregister a non-existent endpoint.
 
-        response = registerOrDeregister(endpointName, localityLbEndpoint2, false);
+        response = registerOrDeregister(endpointName, localityLbEndpoint3, false);
         assertOk(response);
         assertThat(response.contentUtf8()).isEqualTo("{}");
         endpoint = endpoint.toBuilder()
@@ -155,8 +202,8 @@ public class XdsRegisterEndpointTest {
 
         response = registerOrDeregister(endpointName,
                                         LocalityLbEndpoint.newBuilder().setLocality(locality1)
-                                                      .setLbEndpoint(endpoint("127.0.0.1", 8080))
-                                                      .build(),
+                                                          .setLbEndpoint(endpoint("127.0.0.1", 8080))
+                                                          .build(),
                                         false);
         assertOk(response);
         assertThat(response.contentUtf8()).isEqualTo("{}");
@@ -164,17 +211,32 @@ public class XdsRegisterEndpointTest {
                            .removeEndpoints(0)
                            .addEndpoints(LocalityLbEndpoints.newBuilder()
                                                             .setLocality(locality1)
-                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081)))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8081))
+                                                            .addLbEndpoints(endpoint("127.0.0.1", 8082)))
                            .build();
         checkEndpointsViaDiscoveryRequest(dogma.httpClient().uri(), endpoint, clusterName);
 
-        response = registerOrDeregister(endpointName,
-                                        LocalityLbEndpoint.newBuilder().setLocality(locality1)
-                                                          .setLbEndpoint(endpoint("127.0.0.1", 8081))
-                                                          .build(),
-                                        false);
-        assertOk(response);
-        assertThat(response.contentUtf8()).isEqualTo("{}");
+        prevMajor = fooRepository.normalizeNow(Revision.HEAD).major();
+        final CompletableFuture<AggregatedHttpResponse> deregisterFuture1 =
+                registerOrDeregisterAsync(endpointName,
+                                          LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                                            .setLbEndpoint(endpoint("127.0.0.1", 8081))
+                                                            .build(),
+                                          false);
+        Thread.sleep(1000);
+        final CompletableFuture<AggregatedHttpResponse> deregisterFuture2 =
+                registerOrDeregisterAsync(endpointName,
+                                          LocalityLbEndpoint.newBuilder().setLocality(locality1)
+                                                            .setLbEndpoint(endpoint("127.0.0.1", 8082))
+                                                            .build(),
+                                          false);
+        assertOk(deregisterFuture1.join());
+        assertOk(deregisterFuture2.join());
+
+        assertThat(fooRepository.normalizeNow(Revision.HEAD).major()).isEqualTo(prevMajor + 1);
+
+        assertThat(deregisterFuture1.join().contentUtf8()).isEqualTo("{}");
+        assertThat(deregisterFuture2.join().contentUtf8()).isEqualTo("{}");
         endpoint = endpoint.toBuilder()
                            .removeEndpoints(0)
                            .build();
@@ -182,6 +244,11 @@ public class XdsRegisterEndpointTest {
     }
 
     private static AggregatedHttpResponse registerOrDeregister(
+            String endpointName, LocalityLbEndpoint localityLbEndpoint, boolean register) throws IOException {
+        return registerOrDeregisterAsync(endpointName, localityLbEndpoint, register).join();
+    }
+
+    private static CompletableFuture<AggregatedHttpResponse> registerOrDeregisterAsync(
             String endpointName, LocalityLbEndpoint localityLbEndpoint, boolean register) throws IOException {
         final RequestHeaders headers =
                 RequestHeaders.builder(register ? HttpMethod.PATCH : HttpMethod.DELETE,
@@ -192,10 +259,10 @@ public class XdsRegisterEndpointTest {
                               .contentType(MediaType.JSON_UTF_8).build();
         return dogma.httpClient().execute(headers,
                                           JSON_MESSAGE_MARSHALLER.writeValueAsString(localityLbEndpoint))
-                    .aggregate().join();
+                    .aggregate();
     }
 
-    private static ClusterLoadAssignment loadAssignment(String clusterName, Locality locality,
+        private static ClusterLoadAssignment loadAssignment(String clusterName, Locality locality,
                                                         LbEndpoint endpoint) {
         return ClusterLoadAssignment.newBuilder()
                                     .setClusterName(clusterName)


### PR DESCRIPTION
Motivation:
Writing commits in Central Dogma can be slow, which becomes problematic when multiple xDS endpoint registration API calls occur simultaneously. To mitigate this, we batch registration updates within a short time window to reduce the number of commits.

Modifications:
- Introduced `XdsEndpointUpdateScheduler` that accumulates xDS registration calls over a 2-second window.
- The scheduler consolidates the updates and pushes them as a single commit.

Result:
- Reduces the number of commits for frequent xDS endpoint registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced batch processing for endpoint registration and deregistration, reducing redundant updates and improving efficiency.
  * Added visibility into the number of pending batch update tasks.

* **Improvements**
  * Enhanced shutdown process to ensure pending endpoint updates are completed before stopping the service.

* **Bug Fixes**
  * Improved handling of concurrent registration and deregistration requests, including proper conflict resolution and updated response codes.

* **Tests**
  * Expanded tests to cover asynchronous and concurrent endpoint operations, ensuring correct behavior and repository versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->