### PR TITLE
Add key version to metadata for encryption key rotation

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/encryption/EncryptionUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/encryption/EncryptionUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage.encryption;
+
+public final class EncryptionUtil {
+
+    public static void putInt(byte[] metadata, int offset, int num) {
+        metadata[offset] = (byte) (num >> 24);
+        metadata[offset + 1] = (byte) (num >> 16);
+        metadata[offset + 2] = (byte) (num >> 8);
+        metadata[offset + 3] = (byte) num;
+    }
+
+    public static int getInt(byte[] metadata, int offset) {
+        return ((metadata[offset] & 0xFF) << 24) |
+               ((metadata[offset + 1] & 0xFF) << 16) |
+               ((metadata[offset + 2] & 0xFF) << 8) |
+               (metadata[offset + 3] & 0xFF);
+    }
+
+    private EncryptionUtil() {}
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/encryption/package-info.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/encryption/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Provides classes for encryption and decryption of data stored in Central Dogma.
+ */
+@NonNullByDefault
+package com.linecorp.centraldogma.server.internal.storage.encryption;
+
+import com.linecorp.centraldogma.common.util.NonNullByDefault;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorage.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/EncryptionGitStorage.java
@@ -26,6 +26,7 @@ import static org.eclipse.jgit.lib.Ref.Storage.NEW;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
@@ -51,6 +52,7 @@ import com.linecorp.centraldogma.common.RevisionNotFoundException;
 import com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher;
 import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageException;
 import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageManager;
+import com.linecorp.centraldogma.server.storage.encryption.SecretKeyWithVersion;
 
 public final class EncryptionGitStorage {
 
@@ -64,7 +66,8 @@ public final class EncryptionGitStorage {
     private final byte[] refsKeyPrefix;
     private final byte[] rev2ShaPrefix;
     private final EncryptionStorageManager encryptionStorageManager;
-    private final SecretKey dek;
+    private final SecretKeyWithVersion currentDek;
+    private final ConcurrentHashMap<Integer, SecretKey> deks = new ConcurrentHashMap<>();
 
     public EncryptionGitStorage(String projectName, String repoName,
                                 EncryptionStorageManager encryptionStorageManager) {
@@ -76,7 +79,8 @@ public final class EncryptionGitStorage {
         refsKeyPrefix = projectRepoPrefix.getBytes(StandardCharsets.UTF_8);
         rev2ShaPrefix = (projectRepoPrefix + REV2SHA).getBytes(StandardCharsets.UTF_8);
         this.encryptionStorageManager = encryptionStorageManager;
-        dek = encryptionStorageManager.getDek(projectName, repoName);
+        currentDek = encryptionStorageManager.getCurrentDek(projectName, repoName);
+        deks.put(currentDek.version(), currentDek.secretKey());
     }
 
     String projectName() {
@@ -85,6 +89,11 @@ public final class EncryptionGitStorage {
 
     String repoName() {
         return repoName;
+    }
+
+    private SecretKey dek(int version) {
+        return deks.computeIfAbsent(version, key -> encryptionStorageManager.getDek(
+                projectName, repoName, version));
     }
 
     ObjectId insertObject(ObjectId objectId, int type, byte[] data, int off, int len) throws IOException {
@@ -96,29 +105,44 @@ public final class EncryptionGitStorage {
             return objectId;
         }
 
+        final SecretKeyWithVersion currentDek = this.currentDek;
+
         final byte[] nonce = AesGcmSivCipher.generateNonce();
         // Generate a new DEK for the data so that we don't decrypt and encrypt the data again when the
         // repository key is rotated.
         final byte[] objectDek = AesGcmSivCipher.generateAes256Key();
-        final byte[] objectWdek = encrypt(nonce, objectDek, 0, KEY_SIZE_BYTES);
+        final byte[] objectWdek = encrypt(currentDek.secretKey(), nonce, objectDek, 0, KEY_SIZE_BYTES);
 
         assert objectWdek.length == KEY_SIZE_BYTES + 16; // 16 bytes for the tag
 
-        final byte[] nonceAndObjectWdek = new byte[NONCE_SIZE_BYTES + 4 + objectWdek.length];
+        // key version(4) + Nonce(20) + type(4) + objectWdek(48)
+        final byte[] metadata = new byte[4 + NONCE_SIZE_BYTES + 4 + objectWdek.length];
 
-        System.arraycopy(nonce, 0, nonceAndObjectWdek, 0, NONCE_SIZE_BYTES);
-        nonceAndObjectWdek[NONCE_SIZE_BYTES] = (byte) (type >> 24);
-        nonceAndObjectWdek[NONCE_SIZE_BYTES + 1] = (byte) (type >> 16);
-        nonceAndObjectWdek[NONCE_SIZE_BYTES + 2] = (byte) (type >> 8);
-        nonceAndObjectWdek[NONCE_SIZE_BYTES + 3] = (byte) type;
-        System.arraycopy(objectWdek, 0, nonceAndObjectWdek, NONCE_SIZE_BYTES + 4, objectWdek.length);
+        putInt(metadata, 0, currentDek.version());
+        System.arraycopy(nonce, 0, metadata, 4, NONCE_SIZE_BYTES);
+        putInt(metadata, 4 + NONCE_SIZE_BYTES, type);
+        System.arraycopy(objectWdek, 0, metadata, 4 + NONCE_SIZE_BYTES + 4, objectWdek.length);
 
         final SecretKeySpec keySpec = aesSecretKey(objectDek);
 
         final byte[] encryptedId = encryptObjectId(keySpec, nonce, objectId);
         final byte[] encryptedValue = encrypt(keySpec, nonce, data, off, len);
-        encryptionStorageManager.putObject(metadataKey, nonceAndObjectWdek, encryptedId, encryptedValue);
+        encryptionStorageManager.putObject(metadataKey, metadata, encryptedId, encryptedValue);
         return objectId;
+    }
+
+    private static void putInt(byte[] metadata, int offset, int num) {
+        metadata[offset] = (byte) (num >> 24);
+        metadata[offset + 1] = (byte) (num >> 16);
+        metadata[offset + 2] = (byte) (num >> 8);
+        metadata[offset + 3] = (byte) num;
+    }
+
+    private static int getInt(byte[] metadata, int offset) {
+        return ((metadata[offset] & 0xFF) << 24) |
+               ((metadata[offset + 1] & 0xFF) << 16) |
+               ((metadata[offset + 2] & 0xFF) << 8) |
+               (metadata[offset + 3] & 0xFF);
     }
 
     @VisibleForTesting
@@ -129,18 +153,10 @@ public final class EncryptionGitStorage {
         return byteBuffer.array();
     }
 
-    private byte[] encryptObjectId(byte[] nonce, ObjectId objectId) {
-        return encryptObjectId(dek, nonce, objectId);
-    }
-
     private byte[] encryptObjectId(SecretKey dek, byte[] nonce, ObjectId objectId) {
         final byte[] idBytes = new byte[20];
         objectId.copyRawTo(idBytes, 0);
         return encrypt(dek, nonce, idBytes, 0, 20);
-    }
-
-    private byte[] encrypt(byte[] nonce, byte[] data, int offset, int length) {
-        return encrypt(dek, nonce, data, offset, length);
     }
 
     private byte[] encrypt(SecretKey dek, byte[] nonce, byte[] data, int offset, int length) {
@@ -150,10 +166,6 @@ public final class EncryptionGitStorage {
             throw new EncryptionStorageException(
                     "Failed to encrypt data in " + projectName + '/' + repoName, e);
         }
-    }
-
-    private byte[] decrypt(byte[] nonce, byte[] ciphertext) {
-        return decrypt(dek, nonce, ciphertext);
     }
 
     private byte[] decrypt(SecretKey key, byte[] nonce, byte[] ciphertext) {
@@ -173,30 +185,30 @@ public final class EncryptionGitStorage {
             return null;
         }
 
-        final int actualType = ((metadata[NONCE_SIZE_BYTES] & 0xFF) << 24) |
-                                ((metadata[NONCE_SIZE_BYTES + 1] & 0xFF) << 16) |
-                                ((metadata[NONCE_SIZE_BYTES + 2] & 0xFF) << 8) |
-                                (metadata[NONCE_SIZE_BYTES + 3] & 0xFF);
+        final int actualType = getInt(metadata, 4 + NONCE_SIZE_BYTES);
         if (typeHint != OBJ_ANY && actualType != typeHint) {
             throw new IncorrectObjectTypeException(objectId.copy(), typeHint);
         }
 
-        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
-        System.arraycopy(metadata, 0, nonce, 0, NONCE_SIZE_BYTES);
-        final int wdekLength = metadata.length - (NONCE_SIZE_BYTES + 4);
-        final byte[] objectWdek = new byte[wdekLength];
-        System.arraycopy(metadata, NONCE_SIZE_BYTES + 4, objectWdek, 0, wdekLength);
+        final int keyVersion = getInt(metadata, 0);
+        final SecretKey dek = dek(keyVersion);
 
-        final byte[] objectDek = decrypt(nonce, objectWdek);
-        final SecretKeySpec keySpec = aesSecretKey(objectDek);
+        final ObjectDekAndNonce objectDekAndNonce;
+        try {
+            objectDekAndNonce = ObjectDekAndNonce.extract(metadata, dek);
+        } catch (Exception e) {
+            throw new EncryptionStorageException(
+                    "Failed to decrypt data in " + projectName + '/' + repoName, e);
+        }
 
-        final byte[] encryptedKey = encryptObjectId(keySpec, nonce, objectId);
+        final byte[] encryptedKey = encryptObjectId(objectDekAndNonce.objectDek(),
+                                                    objectDekAndNonce.nonce(), objectId);
         final byte[] value = encryptionStorageManager.getObject(encryptedKey, metadataKey);
         if (value == null) {
             return null;
         }
 
-        final byte[] decrypted = decrypt(keySpec, nonce, value);
+        final byte[] decrypted = decrypt(objectDekAndNonce.objectDek(), objectDekAndNonce.nonce(), value);
         return new DecryptedObjectLoader(decrypted, actualType);
     }
 
@@ -205,18 +217,22 @@ public final class EncryptionGitStorage {
     public Ref readRef(String refName) {
         final byte[] refNameBytes = refName.getBytes(StandardCharsets.UTF_8);
         final byte[] metadataKey = refMetadataKey(refNameBytes);
-        final byte[] nonce = encryptionStorageManager.getMetadata(metadataKey);
-        if (nonce == null) {
+        final byte[] metadata = encryptionStorageManager.getMetadata(metadataKey);
+        if (metadata == null) {
             return null;
         }
+        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
+        System.arraycopy(metadata, 4, nonce, 0, NONCE_SIZE_BYTES);
+        final int keyVersion = getInt(metadata, 0);
+        final SecretKey dek = dek(keyVersion);
 
-        final byte[] encryptedRefName = encrypt(nonce, refNameBytes, 0, refNameBytes.length);
+        final byte[] encryptedRefName = encrypt(dek, nonce, refNameBytes, 0, refNameBytes.length);
         final byte[] encryptedRefValue = encryptionStorageManager.getObjectId(encryptedRefName, metadataKey);
         if (encryptedRefValue == null) {
             return null;
         }
 
-        final byte[] refValue = decrypt(nonce, encryptedRefValue);
+        final byte[] refValue = decrypt(dek, nonce, encryptedRefValue);
         if (!isSymRef(refValue, refValue.length)) {
             // We don't use annotated tag.
             return new ObjectIdRef.PeeledNonTag(
@@ -242,22 +258,32 @@ public final class EncryptionGitStorage {
 
     Result updateRef(String refName, ObjectId objectId, Result desiredResult) {
         final byte[] refNameBytes = refName.getBytes(StandardCharsets.UTF_8);
-        final byte[] metadataKey = refMetadataKey(refNameBytes);
-        final byte[] nonce = AesGcmSivCipher.generateNonce();
 
-        final byte[] encryptedRefName = encrypt(nonce, refNameBytes, 0, refNameBytes.length);
-        final byte[] encryptedId = encryptObjectId(nonce, objectId);
+        final SecretKeyWithVersion currentDek = this.currentDek;
+        final byte[] metadataKey = refMetadataKey(refNameBytes);
+        final byte[] metadata = new byte[4 + NONCE_SIZE_BYTES];
+        putInt(metadata, 0, currentDek.version());
+        final byte[] nonce = AesGcmSivCipher.generateNonce();
+        System.arraycopy(nonce, 0, metadata, 4, NONCE_SIZE_BYTES);
+
+        final byte[] encryptedRefName =
+                encrypt(currentDek.secretKey(), nonce, refNameBytes, 0, refNameBytes.length);
+        final byte[] encryptedId = encryptObjectId(currentDek.secretKey(), nonce, objectId);
 
         // We should remove the previous ref name if it exists.
 
         final byte[] previousEncryptedRefName;
-        final byte[] previousNonce = encryptionStorageManager.getMetadata(metadataKey);
-        if (previousNonce == null) {
+        final byte[] previousMetadata = encryptionStorageManager.getMetadata(metadataKey);
+        if (previousMetadata == null) {
             previousEncryptedRefName = null;
         } else {
-            previousEncryptedRefName = encrypt(previousNonce, refNameBytes, 0, refNameBytes.length);
+            final byte[] previousNonce = new byte[NONCE_SIZE_BYTES];
+            System.arraycopy(previousMetadata, 4, previousNonce, 0, NONCE_SIZE_BYTES);
+            final SecretKey previousDek = dek(getInt(previousMetadata, 0));
+            previousEncryptedRefName =
+                    encrypt(previousDek, previousNonce, refNameBytes, 0, refNameBytes.length);
         }
-        encryptionStorageManager.putObjectId(metadataKey, nonce, encryptedRefName,
+        encryptionStorageManager.putObjectId(metadataKey, metadata, encryptedRefName,
                                              encryptedId, previousEncryptedRefName);
         return desiredResult;
     }
@@ -273,12 +299,17 @@ public final class EncryptionGitStorage {
     void deleteRef(String refName) {
         final byte[] refNameBytes = refName.getBytes(StandardCharsets.UTF_8);
         final byte[] metadataKey = refMetadataKey(refNameBytes);
-        final byte[] nonce = encryptionStorageManager.getMetadata(metadataKey);
-        if (nonce == null) {
+        final byte[] metadata = encryptionStorageManager.getMetadata(metadataKey);
+        if (metadata == null) {
             return;
         }
 
-        final byte[] encryptedRefName = encrypt(nonce, refNameBytes, 0, refNameBytes.length);
+        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
+        System.arraycopy(metadata, 4, nonce, 0, NONCE_SIZE_BYTES);
+        final int keyVersion = getInt(metadata, 0);
+        final SecretKey dek = dek(keyVersion);
+
+        final byte[] encryptedRefName = encrypt(dek, nonce, refNameBytes, 0, refNameBytes.length);
         encryptionStorageManager.deleteObjectId(metadataKey, encryptedRefName);
     }
 
@@ -286,26 +317,37 @@ public final class EncryptionGitStorage {
         final byte[] refNameBytes = refName.getBytes(StandardCharsets.UTF_8);
         final byte[] metadataKey = refMetadataKey(refNameBytes);
         final byte[] nonce = AesGcmSivCipher.generateNonce();
+        final byte[] metadata = new byte[4 + NONCE_SIZE_BYTES];
+        final SecretKeyWithVersion currentDek = this.currentDek;
+        putInt(metadata, 0, currentDek.version());
+        System.arraycopy(nonce, 0, metadata, 4, NONCE_SIZE_BYTES);
 
-        final byte[] encryptedRefName = encrypt(nonce, refNameBytes, 0, refNameBytes.length);
+        final byte[] encryptedRefName =
+                encrypt(currentDek.secretKey(), nonce, refNameBytes, 0, refNameBytes.length);
         final byte[] encoded = encode(RefDirectory.SYMREF + target);
-        final byte[] encryptedTarget = encrypt(nonce, encoded, 0, encoded.length);
-        encryptionStorageManager.putObjectId(metadataKey, nonce, encryptedRefName, encryptedTarget, null);
+        final byte[] encryptedTarget = encrypt(currentDek.secretKey(), nonce, encoded, 0, encoded.length);
+        encryptionStorageManager.putObjectId(metadataKey, metadata, encryptedRefName, encryptedTarget, null);
     }
 
     @VisibleForTesting
     public ObjectId getRevisionObjectId(Revision revision) {
         final byte[] metadataKey = rev2ShaMetadataKey(revision);
-        final byte[] nonce = encryptionStorageManager.getMetadata(metadataKey);
-        if (nonce == null) {
+        final byte[] metadata = encryptionStorageManager.getMetadata(metadataKey);
+        if (metadata == null) {
             throw new RevisionNotFoundException(revision);
         }
-        final byte[] encryptedKey = encrypt(nonce, Ints.toByteArray(revision.major()), 0, 4);
+        final int keyVersion = getInt(metadata, 0);
+        final SecretKey dek = dek(keyVersion);
+
+        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
+        System.arraycopy(metadata, 4, nonce, 0, NONCE_SIZE_BYTES);
+
+        final byte[] encryptedKey = encrypt(dek, nonce, Ints.toByteArray(revision.major()), 0, 4);
         final byte[] value = encryptionStorageManager.getObjectId(encryptedKey, metadataKey);
         if (value == null) {
             throw new RevisionNotFoundException(revision);
         }
-        final byte[] raw = decrypt(nonce, value);
+        final byte[] raw = decrypt(dek, nonce, value);
         if (raw.length != 20) {
             throw new EncryptionStorageException(
                     "Corrupted commit ID for " + revision + " in " + projectName + '/' + repoName + ": " +
@@ -328,11 +370,16 @@ public final class EncryptionGitStorage {
             throw new EncryptionStorageException(
                     "Revision already exists: " + revision + " in " + projectName + '/' + repoName);
         }
+        final SecretKeyWithVersion currentDek = this.currentDek;
+        final byte[] metadata = new byte[4 + NONCE_SIZE_BYTES];
         final byte[] nonce = AesGcmSivCipher.generateNonce();
+        putInt(metadata, 0, currentDek.version());
+        System.arraycopy(nonce, 0, metadata, 4, NONCE_SIZE_BYTES);
 
-        final byte[] encryptedRevision = encrypt(nonce, Ints.toByteArray(revision.major()), 0, 4);
-        final byte[] encryptedId = encryptObjectId(nonce, objectId);
-        encryptionStorageManager.putObjectId(metadataKey, nonce, encryptedRevision, encryptedId, null);
+        final byte[] encryptedRevision =
+                encrypt(currentDek.secretKey(), nonce, Ints.toByteArray(revision.major()), 0, 4);
+        final byte[] encryptedId = encryptObjectId(currentDek.secretKey(), nonce, objectId);
+        encryptionStorageManager.putObjectId(metadataKey, metadata, encryptedRevision, encryptedId, null);
     }
 
     private static final class DecryptedObjectLoader extends ObjectLoader {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/GitObjectMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/GitObjectMetadata.java
@@ -34,9 +34,9 @@ public final class GitObjectMetadata {
 
     public static GitObjectMetadata fromBytes(byte[] metadata) {
         // metadata: key version(4) + Nonce(12) + type(4) + objectWdek(48)
-        if (metadata.length != 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16) {
-            throw new IllegalArgumentException("Invalid metadata length: expected " +
-                                               (4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16) +
+        final int expectedLength = 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16;
+        if (metadata.length != expectedLength) {
+            throw new IllegalArgumentException("Invalid metadata length: expected " + expectedLength +
                                                ", got " + metadata.length);
         }
         final byte[] nonce = new byte[NONCE_SIZE_BYTES];
@@ -81,7 +81,7 @@ public final class GitObjectMetadata {
     }
 
     public byte[] toBytes() {
-        // key version(4) + Nonce(20) + type(4) + objectWdek(48)
+        // key version(4) + Nonce(12) + type(4) + objectWdek(48)
         final byte[] bytes = new byte[4 + NONCE_SIZE_BYTES + 4 + objectWdek.length];
         int index = 0;
         putInt(bytes, index, keyVersion);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/GitObjectMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/GitObjectMetadata.java
@@ -18,15 +18,21 @@ package com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb
 import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.KEY_SIZE_BYTES;
 import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.NONCE_SIZE_BYTES;
 import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.aesSecretKey;
+import static com.linecorp.centraldogma.server.internal.storage.encryption.EncryptionUtil.getInt;
+import static com.linecorp.centraldogma.server.internal.storage.encryption.EncryptionUtil.putInt;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
 import com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher;
 
-public final class ObjectDekAndNonce {
+public final class GitObjectMetadata {
 
-    public static ObjectDekAndNonce extract(byte[] metadata, SecretKey dek) throws Exception {
+    public static GitObjectMetadata of(int keyVersion, byte[] nonce, int type, byte[] objectWdek) {
+        return new GitObjectMetadata(keyVersion, nonce, type, objectWdek);
+    }
+
+    public static GitObjectMetadata fromBytes(byte[] metadata) {
         // metadata: key version(4) + Nonce(12) + type(4) + objectWdek(48)
         if (metadata.length != 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16) {
             throw new IllegalArgumentException("Invalid metadata length: expected " +
@@ -40,24 +46,56 @@ public final class ObjectDekAndNonce {
         final byte[] objectWdek = new byte[wdekLength];
         System.arraycopy(metadata, 4 + NONCE_SIZE_BYTES + 4, objectWdek, 0, wdekLength);
 
-        final byte[] objectDekRaw = AesGcmSivCipher.decrypt(dek, nonce, objectWdek);
-        final SecretKeySpec objectDek = aesSecretKey(objectDekRaw);
-        return new ObjectDekAndNonce(objectDek, nonce);
+        return new GitObjectMetadata(getInt(metadata, 0),
+                                     nonce,
+                                     getInt(metadata, 4 + NONCE_SIZE_BYTES),
+                                     objectWdek);
     }
 
-    private final SecretKeySpec objectDek;
+    private final int keyVersion;
     private final byte[] nonce;
+    private final int type;
+    private final byte[] objectWdek;
 
-    private ObjectDekAndNonce(SecretKeySpec objectDek, byte[] nonce) {
-        this.objectDek = objectDek;
+    private GitObjectMetadata(int keyVersion, byte[] nonce, int type, byte[] objectWdek) {
+        this.keyVersion = keyVersion;
         this.nonce = nonce;
+        this.type = type;
+        this.objectWdek = objectWdek;
     }
 
-    public SecretKeySpec objectDek() {
-        return objectDek;
+    public int keyVersion() {
+        return keyVersion;
     }
 
     public byte[] nonce() {
         return nonce;
+    }
+
+    public int type() {
+        return type;
+    }
+
+    public byte[] objectWdek() {
+        return objectWdek;
+    }
+
+    public byte[] toBytes() {
+        // key version(4) + Nonce(20) + type(4) + objectWdek(48)
+        final byte[] bytes = new byte[4 + NONCE_SIZE_BYTES + 4 + objectWdek.length];
+        int index = 0;
+        putInt(bytes, index, keyVersion);
+        index += 4;
+        System.arraycopy(nonce, 0, bytes, index, NONCE_SIZE_BYTES);
+        index += NONCE_SIZE_BYTES;
+        putInt(bytes, index, type);
+        index += 4;
+        System.arraycopy(objectWdek, 0, bytes, index, objectWdek.length);
+        return bytes;
+    }
+
+    public SecretKeySpec objectDek(SecretKey dek) throws Exception {
+        final byte[] objectDekRaw = AesGcmSivCipher.decrypt(dek, nonce, objectWdek);
+        return aesSecretKey(objectDekRaw);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/ObjectDekAndNonce.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/ObjectDekAndNonce.java
@@ -28,7 +28,11 @@ public final class ObjectDekAndNonce {
 
     public static ObjectDekAndNonce extract(byte[] metadata, SecretKey dek) throws Exception {
         // metadata: key version(4) + Nonce(12) + type(4) + objectWdek(48)
-        assert metadata.length == 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16;
+        if (metadata.length != 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16) {
+            throw new IllegalArgumentException("Invalid metadata length: expected " +
+                                               (4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16) +
+                                               ", got " + metadata.length);
+        }
         final byte[] nonce = new byte[NONCE_SIZE_BYTES];
 
         System.arraycopy(metadata, 4, nonce, 0, NONCE_SIZE_BYTES);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/ObjectDekAndNonce.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/rocksdb/ObjectDekAndNonce.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.storage.repository.git.rocksdb;
+
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.KEY_SIZE_BYTES;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.NONCE_SIZE_BYTES;
+import static com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher.aesSecretKey;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.linecorp.centraldogma.server.internal.storage.AesGcmSivCipher;
+
+public final class ObjectDekAndNonce {
+
+    public static ObjectDekAndNonce extract(byte[] metadata, SecretKey dek) throws Exception {
+        // metadata: key version(4) + Nonce(12) + type(4) + objectWdek(48)
+        assert metadata.length == 4 + NONCE_SIZE_BYTES + 4 + KEY_SIZE_BYTES + 16;
+        final byte[] nonce = new byte[NONCE_SIZE_BYTES];
+
+        System.arraycopy(metadata, 4, nonce, 0, NONCE_SIZE_BYTES);
+        final int wdekLength = metadata.length - (4 + NONCE_SIZE_BYTES + 4); // 48
+        final byte[] objectWdek = new byte[wdekLength];
+        System.arraycopy(metadata, 4 + NONCE_SIZE_BYTES + 4, objectWdek, 0, wdekLength);
+
+        final byte[] objectDekRaw = AesGcmSivCipher.decrypt(dek, nonce, objectWdek);
+        final SecretKeySpec objectDek = aesSecretKey(objectDekRaw);
+        return new ObjectDekAndNonce(objectDek, nonce);
+    }
+
+    private final SecretKeySpec objectDek;
+    private final byte[] nonce;
+
+    private ObjectDekAndNonce(SecretKeySpec objectDek, byte[] nonce) {
+        this.objectDek = objectDek;
+        this.nonce = nonce;
+    }
+
+    public SecretKeySpec objectDek() {
+        return objectDek;
+    }
+
+    public byte[] nonce() {
+        return nonce;
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/EncryptionStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/EncryptionStorageManager.java
@@ -19,6 +19,7 @@ import static com.linecorp.centraldogma.server.storage.encryption.DefaultEncrypt
 import static java.util.Objects.requireNonNull;
 
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
@@ -75,7 +76,12 @@ public interface EncryptionStorageManager extends SafeCloseable {
     /**
      * Returns the data encryption key (DEK) for the specified project and repository.
      */
-    SecretKey getDek(String projectName, String repoName);
+    SecretKey getDek(String projectName, String repoName, int version);
+
+    /**
+     * Returns the current wrapped data encryption key (WDEK) for the specified project and repository.
+     */
+    SecretKeyWithVersion getCurrentDek(String projectName, String repoName);
 
     /**
      * Stores the wrapped data encryption key (WDEK) for the specified project and repository.
@@ -131,4 +137,12 @@ public interface EncryptionStorageManager extends SafeCloseable {
      * Deletes all data related to the specified project and repository.
      */
     void deleteRepositoryData(String projectName, String repoName);
+
+    /**
+     * Returns all data stored in the encryption storage manager.
+     *
+     * @deprecated Do not use this method for production code as it may return a large amount of data.
+     */
+    @Deprecated
+    Map<String, Map<String, byte[]>> getAllData();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/NoopEncryptionStorageManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/NoopEncryptionStorageManager.java
@@ -15,10 +15,13 @@
  */
 package com.linecorp.centraldogma.server.storage.encryption;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 import javax.crypto.SecretKey;
+
+import com.google.common.collect.ImmutableMap;
 
 /**
  * A no-operation implementation of {@link EncryptionStorageManager} that does not perform any encryption.
@@ -42,7 +45,13 @@ public enum NoopEncryptionStorageManager implements EncryptionStorageManager {
 
     @Nullable
     @Override
-    public SecretKey getDek(String projectName, String repoName) {
+    public SecretKey getDek(String projectName, String repoName, int i) {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public SecretKeyWithVersion getCurrentDek(String projectName, String repoName) {
         return null;
     }
 
@@ -95,6 +104,11 @@ public enum NoopEncryptionStorageManager implements EncryptionStorageManager {
     @Override
     public void deleteRepositoryData(String projectName, String repoName) {
         // No-op
+    }
+
+    @Override
+    public Map<String, Map<String, byte[]>> getAllData() {
+        return ImmutableMap.of();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/SecretKeyWithVersion.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/SecretKeyWithVersion.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.storage.encryption;
+
+import javax.crypto.SecretKey;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * A class that holds a {@link SecretKey} along with its version.
+ */
+public final class SecretKeyWithVersion {
+
+    private final SecretKey secretKey;
+    private final int version;
+
+    /**
+     * Creates a new instance of {@link SecretKeyWithVersion}.
+     */
+    public SecretKeyWithVersion(SecretKey secretKey, int version) {
+        this.secretKey = secretKey;
+        this.version = version;
+    }
+
+    /**
+     * Returns the {@link SecretKey}.
+     */
+    public SecretKey secretKey() {
+        return secretKey;
+    }
+
+    /**
+     * Returns the version of the {@link SecretKey}.
+     */
+    public int version() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(this)
+                          .add("secretKey", "****")
+                          .add("version", version)
+                          .toString();
+    }
+}

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/SecretKeyWithVersion.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/encryption/SecretKeyWithVersion.java
@@ -15,6 +15,9 @@
  */
 package com.linecorp.centraldogma.server.storage.encryption;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
 import javax.crypto.SecretKey;
 
 import com.google.common.base.MoreObjects;
@@ -31,7 +34,8 @@ public final class SecretKeyWithVersion {
      * Creates a new instance of {@link SecretKeyWithVersion}.
      */
     public SecretKeyWithVersion(SecretKey secretKey, int version) {
-        this.secretKey = secretKey;
+        this.secretKey = requireNonNull(secretKey, "secretKey");
+        checkArgument(version >= 1, "version: %s (expected: >= 1)", version);
         this.version = version;
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/storage/encryption/DefaultEncryptionStorageManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/storage/encryption/DefaultEncryptionStorageManagerTest.java
@@ -77,12 +77,12 @@ class DefaultEncryptionStorageManagerTest {
     void storeAndGetDek() throws Exception {
         final byte[] wdek = storageManager.generateWdek().join();
 
-        assertThatThrownBy(() -> storageManager.getDek(PROJECT_NAME, REPO_NAME))
+        assertThatThrownBy(() -> storageManager.getCurrentDek(PROJECT_NAME, REPO_NAME))
                 .isInstanceOf(EncryptionStorageException.class)
                 .hasMessageContaining("WDEK of " + PROJECT_NAME + '/' + REPO_NAME + " does not exist");
 
         storageManager.storeWdek(PROJECT_NAME, REPO_NAME, wdek);
-        final SecretKey dek = storageManager.getDek(PROJECT_NAME, REPO_NAME);
+        final SecretKey dek = storageManager.getDek(PROJECT_NAME, REPO_NAME, 1);
 
         // 4. Verify
         assertThat(dek).isNotNull();
@@ -92,14 +92,14 @@ class DefaultEncryptionStorageManagerTest {
         // Try storing again
         assertThatThrownBy(() -> storageManager.storeWdek(PROJECT_NAME, REPO_NAME, wdek))
                 .isInstanceOf(EncryptionStorageException.class)
-                .hasMessageContaining("WDEK of " + PROJECT_NAME + '/' + REPO_NAME + " already exists");
+                .hasMessageContaining("WDEK of " + PROJECT_NAME + '/' + REPO_NAME + "/1 already exists");
 
-        assertThat(storageManager.getDek(PROJECT_NAME, REPO_NAME)).isNotNull();
+        assertThat(storageManager.getDek(PROJECT_NAME, REPO_NAME, 1)).isNotNull();
 
         storageManager.removeWdek(PROJECT_NAME, REPO_NAME);
 
         // Verify it's gone
-        assertThatThrownBy(() -> storageManager.getDek(PROJECT_NAME, REPO_NAME))
+        assertThatThrownBy(() -> storageManager.getDek(PROJECT_NAME, REPO_NAME, 1))
                 .isInstanceOf(EncryptionStorageException.class);
     }
 


### PR DESCRIPTION
Motivation:
To support encryption key rotation, it's necessary to track which key version was used to encrypt metadata.

Modifications:
- Added a key version integer to the metadata to indicate the encryption key used.

Result:
- Prepares the system for future support of key rotation.