### PR TITLE
Update credential pattern from webapp

### DIFF
--- a/webapp/src/dogma/features/project/settings/credentials/CredentialForm.tsx
+++ b/webapp/src/dogma/features/project/settings/credentials/CredentialForm.tsx
@@ -135,7 +135,7 @@ const CredentialForm = ({
               readOnly={!isNew}
               placeholder="The credential ID"
               defaultValue={defaultValue.id}
-              {...register('id', { required: true, pattern: /^[a-zA-Z0-9-_.]+$/ })}
+              {...register('id', { required: true, pattern: /^[a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?$/ })}
             />
             {errors.id ? (
               <FieldErrorMessage error={errors.id} fieldName="credential ID" />


### PR DESCRIPTION
https://github.com/line/centraldogma/blob/29250c7233fc2899388bb250f4055d4c6d59bd13/common/src/main/java/com/linecorp/centraldogma/internal/CredentialUtil.java#L28-L29

On server-side, credential ID pattern is like above, but on webapp pattern is different and can cause error like below

<img width="2536" height="2556" alt="97869" src="https://github.com/user-attachments/assets/ab7b56bd-a114-4648-9c3c-d5a7e072f7bc" />

```json
{
    "exception": "java.lang.IllegalArgumentException",
    "message": "invalid project credentialName: projects/local-proj/credentials/1111 (expected: ^projects/([^/]+)/credentials/([a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?)$)",
    "detail": "java.lang.IllegalArgumentException: invalid project credentialName: projects/local-proj/credentials/1111 (expected: ^projects/([^/]+)/credentials/([a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?)$)\n\tat com.google.common.base.Preconditions.checkArgument(Preconditions.java:446)\n\tat com.linecorp.centraldogma.internal.CredentialUtil.validateProjectCredentialName(CredentialUtil.java:63)\n\..."
}
```