### PR TITLE
Abort watching on the initial failure

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -23,6 +23,8 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
+import com.linecorp.armeria.client.retry.RetryRule;
+import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.internal.client.ReplicationLagTolerantCentralDogma;
 import com.linecorp.centraldogma.internal.client.armeria.ArmeriaCentralDogma;
@@ -42,7 +44,10 @@ public final class ArmeriaCentralDogmaBuilder
         final EndpointGroup endpointGroup = endpointGroup();
         final String scheme = "none+" + (isUseTls() ? "https" : "http");
         final ClientBuilder builder =
-                newClientBuilder(scheme, endpointGroup, cb -> cb.decorator(DecodingClient.newDecorator()), "/");
+                newClientBuilder(scheme, endpointGroup, cb -> {
+                    cb.decorator(DecodingClient.newDecorator())
+                      .decorator(RetryingClient.newDecorator(RetryRule.failsafe()));
+                }, "/");
         final int maxRetriesOnReplicationLag = maxNumRetriesOnReplicationLag();
 
         // TODO(ikhoon): Apply ExecutorServiceMetrics for the 'blockingTaskExecutor' once

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaBuilder.java
@@ -23,8 +23,6 @@ import com.linecorp.armeria.client.ClientRequestContext;
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.client.encoding.DecodingClient;
 import com.linecorp.armeria.client.endpoint.EndpointGroup;
-import com.linecorp.armeria.client.retry.RetryRule;
-import com.linecorp.armeria.client.retry.RetryingClient;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.internal.client.ReplicationLagTolerantCentralDogma;
 import com.linecorp.centraldogma.internal.client.armeria.ArmeriaCentralDogma;
@@ -44,10 +42,7 @@ public final class ArmeriaCentralDogmaBuilder
         final EndpointGroup endpointGroup = endpointGroup();
         final String scheme = "none+" + (isUseTls() ? "https" : "http");
         final ClientBuilder builder =
-                newClientBuilder(scheme, endpointGroup, cb -> {
-                    cb.decorator(DecodingClient.newDecorator())
-                      .decorator(RetryingClient.newDecorator(RetryRule.failsafe()));
-                }, "/");
+                newClientBuilder(scheme, endpointGroup, cb -> cb.decorator(DecodingClient.newDecorator()), "/");
         final int maxRetriesOnReplicationLag = maxNumRetriesOnReplicationLag();
 
         // TODO(ikhoon): Apply ExecutorServiceMetrics for the 'blockingTaskExecutor' once

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatchRequestErrorTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatchRequestErrorTest.java
@@ -61,7 +61,7 @@ class WatchRequestErrorTest {
                                             })
                                             .start();
         assertThatThrownBy(() -> {
-            watcher.initialValueFuture().get(2, TimeUnit.SECONDS);
+            watcher.initialValueFuture().get(15, TimeUnit.SECONDS);
         }).isInstanceOf(ExecutionException.class)
           .hasCauseInstanceOf(IllegalStateException.class)
           .hasMessageContaining("Test exception");

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatchRequestErrorTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/WatchRequestErrorTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.client.armeria;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.CentralDogmaRepository;
+import com.linecorp.centraldogma.client.Watcher;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.PathPattern;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class WatchRequestErrorTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
+        @Override
+        protected void scaffold(CentralDogma client) {
+            client.createProject("foo").join();
+            final CentralDogmaRepository repo = client.createRepository("foo", "bar").join();
+            repo.commit("Test", Change.ofTextUpsert("/a.txt", "Hello, world!"))
+                .push().join();
+        }
+    };
+
+    @Test
+    void shouldFailInitialValueFutureForInitialFailure() throws Exception {
+        final CentralDogma client = dogma.client();
+        final CentralDogmaRepository repo = client.forRepo("foo", "bar");
+        final Entry<?> entry = repo.file("/a.txt").get().join();
+        // Make sure the entry is available before testing the watcher.
+        assertThat(entry.contentAsText().trim()).isEqualTo("Hello, world!");
+
+        final Watcher<String> watcher = repo.watcher(PathPattern.of("/a.txt"))
+                                            .<String>map(txt -> {
+                                                throw new IllegalStateException("Test exception");
+                                            })
+                                            .start();
+        assertThatThrownBy(() -> {
+            watcher.initialValueFuture().get(2, TimeUnit.SECONDS);
+        }).isInstanceOf(ExecutionException.class)
+          .hasCauseInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Test exception");
+    }
+}

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractWatcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractWatcher.java
@@ -65,6 +65,8 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
             "centraldogma.client.watcher.latest.received.time";
     private static final AtomicLong WATCHER_ID = new AtomicLong();
 
+    private static final int MAX_INITIAL_FETCH_ATTEMPTS = 2;
+
     private enum State {
         INIT,
         STARTED,
@@ -329,20 +331,20 @@ abstract class AbstractWatcher<T> implements Watcher<T> {
                                      projectName, repositoryName);
                          logged = true;
                      }
-                 } else {
-                     if (cause instanceof CancellationException) {
-                         // Cancelled by close()
-                         return null;
-                     }
+                 }
 
-                     if (!initialValueFuture.isDone()) {
-                         // If the initial fetch failed with non-CentralDogmaException, it is likely that some
-                         // configuration is wrong or the file is malformed. So we complete the
-                         // initialValueFuture exceptionally rather than retrying indefinitely.
-                         initialValueFuture.completeExceptionally(thrown);
-                         close();
-                         return null;
-                     }
+                 if (cause instanceof CancellationException) {
+                     // Cancelled by close()
+                     return null;
+                 }
+
+                 if (!initialValueFuture.isDone() && numAttemptsSoFar >= MAX_INITIAL_FETCH_ATTEMPTS) {
+                     // If the initial fetch fails three times in a row, it is likely that some configuration is
+                     // wrong or the file is malformed. So we complete the initialValueFuture exceptionally
+                     // rather than retrying indefinitely.
+                     initialValueFuture.completeExceptionally(thrown);
+                     close();
+                     return null;
                  }
 
                  if (!logged) {


### PR DESCRIPTION
Motivation:

If the initial fetch of `Watcher` fails with non-`CentralDogmaException`, it is likely that some configuration is wrong or the file is malformed. So earily completing the initialValueFuture with the exception rather than retrying indefinitely would help users to debug the reason.

Modifications:

- Complete `initialValueFuture` exceptionally when:
  - `initialValueFuture` is not completed yet
  - The initial attempts fail three times in a row

Result:

`Watcher` client stops without retrying if the first attempt fails with a non-`CentralDogmaException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved error handling for watcher setup failures by limiting initial fetch retries and providing clearer failure feedback.

* **Tests**
  * Added tests to verify that watcher errors during initialization are correctly propagated to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->