### PR TITLE
Support docker image multiplatform build

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
-      - name: Build Docker image
-        run: ./gradlew :dist:docker --stacktrace
-        shell: bash
-
       - name: Extract release version
         id: release-version
         uses: actions/github-script@v4
@@ -50,8 +46,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push Docker image
-        run: |
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.release-version.outputs.result }}
-          docker push ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+      - name: Build and Push Docker image
+        run: ./gradlew :dist:docker --stacktrace -Pversion=${{ steps.release-version.outputs.result }}
         shell: bash

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -43,7 +43,7 @@ jobs:
           result-encoding: string
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -26,7 +26,10 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Extract release version
         id: release-version

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -165,15 +165,33 @@ tasks.assemble.dependsOn(tasks.tarball)
 
 // Tasks for building docker image
 task docker(group: 'Build',
-            description: "Builds a docker image from the distribution directory (${project.ext.relativeDistDir})",
+            description: "Builds multiplatform docker image from the distribution directory" +
+                    " (${project.ext.relativeDistDir})",
             dependsOn: tasks.distDir,
-            type: DockerBuildImage) {
-    inputDir = file('.')
-    def name = 'ghcr.io/line/centraldogma:'
-    images = [name + "${project.version}"]
+            type: Exec) {
+
+    workingDir = file('.')
+    executable 'docker'
+
+    def imageName = 'ghcr.io/line/centraldogma'
+    def imageVersion = project.hasProperty('version') ? project.project('version') : project.version
+    def platforms = ['linux/amd64', 'linux/arm64']
+
+    def buildArgs = [
+        'buildx', 'build',
+        '--platform', platforms.join(','),
+        '--push'
+    ]
+
+    buildArgs.add("--tag")
+    buildArgs.add("${imageName}:${imageVersion}")
     if (!(project.version =~ /-SNAPSHOT$/)) {
-        images.add(name + "latest")
+        buildArgs.add("--tag")
+        buildArgs.add("${imageName}:latest")
     }
+    buildArgs.add('.')
+
+    args = buildArgs
 }
 
 // Tasks for running Central Dogma conveniently.

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -174,7 +174,7 @@ task docker(group: 'Build',
     executable 'docker'
 
     def imageName = 'ghcr.io/line/centraldogma'
-    def imageVersion = project.hasProperty('version') ? project.project('version') : project.version
+    def imageVersion = project.hasProperty('version') ? project.getProperty('version') : project.version
     def platforms = ['linux/amd64', 'linux/arm64']
 
     def buildArgs = [


### PR DESCRIPTION
Modification:
- Modify `:dist:docker` task to build and push multi-platform docker image, using docker buildx
  - buildx's `--load` option builds multi-platform images, but only saves one platform that matches current machine's and discard other one. So used `--push` option.
- Update action versions

Result:
- Resolves #1125 
  - Tested on fork (https://github.com/sh-cho/centraldogma/actions/runs/16598432938/job/46951034721) and ran it locally, looks ok to me.
  - test image (docker hub): https://hub.docker.com/layers/seonghyeon/centraldogma-multiplatform-test/0.0.3/images/sha256-511adefb8af26445e0b959589fd47cdb1f90c95708e8d2d88d5f00790346a70a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Chores**
  * Updated the workflow for publishing Docker images to use newer versions of GitHub Actions.
  * Consolidated Docker build and push steps into a single Gradle command for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->