### PR TITLE
Add `Mirror access control` menu item on user dropdown menu

### DIFF
--- a/webapp/src/dogma/common/components/Navbar.tsx
+++ b/webapp/src/dogma/common/components/Navbar.tsx
@@ -124,6 +124,11 @@ export const Navbar = () => {
                 <MenuItem as={RouteLink} href="/app/settings/tokens">
                   Application tokens
                 </MenuItem>
+                {user.systemAdmin && (
+                  <MenuItem as={RouteLink} href="/app/settings/mirror-access">
+                    Mirror access control
+                  </MenuItem>
+                )}
                 <MenuDivider />
                 <MenuItem
                   onClick={async () => {


### PR DESCRIPTION
<img width="248" height="166" alt="Screenshot 2025-08-12 at 10 49 40 PM" src="https://github.com/user-attachments/assets/59dc7989-1f2e-4eea-8d19-bb43924679fe" />

As-is

Currently only 'Application tokens' menu exists on user dropdown menu.


<img width="259" height="213" alt="Screenshot 2025-08-12 at 10 53 40 PM" src="https://github.com/user-attachments/assets/15f72f4a-0e17-463b-9939-743f6d4dc1a0" />

To-be

Added 'Mirror Access Token' menu also (only shows for system admin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only “Mirror access control” option to the user menu. It is visible only to system administrators, appears after “Application tokens,” and links to the Mirror Access settings screen (/app/settings/mirror-access). This offers quicker navigation for admins managing access controls. No behavior changes for non-admin users. No other user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->