### PR TITLE
Remove JGit5

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -40,7 +40,6 @@ jcommander = "1.82"
 jetty-alpn-api = "1.1.3.v20160715"
 jetty-alpn-agent = "2.0.10"
 # JGit 7.x.x requires Java 17
-jgit = "5.13.3.202401111512-r"
 jgit6 = "6.10.0.202406032230-r"
 junit4 = "4.13.2"
 junit5 = "5.12.0"
@@ -255,13 +254,6 @@ version.ref = "jetty-alpn-api"
 [libraries.jetty-alpn-agent]
 module = "org.mortbay.jetty.alpn:jetty-alpn-agent"
 version.ref = "jetty-alpn-agent"
-
-[libraries.jgit]
-module = "org.eclipse.jgit:org.eclipse.jgit"
-version.ref = "jgit"
-[libraries.jgit-ssh-jsch]
-module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch"
-version.ref = "jgit"
 
 [libraries.jgit6]
 module = "org.eclipse.jgit:org.eclipse.jgit"

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -67,15 +67,6 @@ task copyLib(group: 'Build',
     doLast {
         // Create an empty directory for keeping external JARs such as authentication module.
         project.mkdir("${libDir}/ext")
-
-        // Check if only JGit 6.x JARs are included.
-        FileCollection jgits = layout.files { libDir.listFiles() }.filter { File file ->
-            file.name.contains("jgit")
-        }
-        // org.eclipse.jgit-6.x is required.
-        if (jgits.size() != 1 || !jgits.first().name.startsWith("org.eclipse.jgit-6")) {
-            throw new IllegalStateException("Unexpected JGit JARs: $jgits.files")
-        }
     }
 }
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -33,14 +33,7 @@ dependencies {
     // jCommander. optionalImplementation must be also added to the :dist dependencies.
     optionalImplementation libs.jcommander
 
-    // Because the default targetJavaVersion is 8, jgit5 is chosen and published with the server artifact.
-    // It's inevitable because users who use JDK8 cannot use jgit6 when implementing IT tests.
-    // We will switch to jgit6 completely when we drop JDK8 support.
-    if (project.ext.targetJavaVersion >= 11) {
-        implementation libs.jgit6
-    } else {
-        implementation libs.jgit
-    }
+    implementation libs.jgit6
 
     // Micrometer
     implementation libs.micrometer.core


### PR DESCRIPTION
Motivation:
Because we updated the minimum JDK requirement to 11, we no longer need JGit5