### PR TITLE
Hide unnecessary Dogma repository metadata from users

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
@@ -148,7 +148,9 @@ public class ProjectServiceV1 extends AbstractService {
     @Get("/projects/{projectName}")
     @RequiresProjectRole(ProjectRole.MEMBER)
     public CompletableFuture<ProjectMetadata> getProjectMetadata(@Param String projectName) {
-        return projectApiManager.getProjectMetadata(projectName);
+        // Remove the Dogma repository from the metadata to avoid exposing it to the user.
+        return projectApiManager.getProjectMetadata(projectName)
+                                .thenApply(ProjectMetadata::withoutDogmaRepo);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Member.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Member.java
@@ -18,6 +18,8 @@ package com.linecorp.centraldogma.server.metadata;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
@@ -106,6 +108,25 @@ public class Member implements Identifiable, HasWeight {
     @JsonProperty
     public UserAndTimestamp creation() {
         return creation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Member)) {
+            return false;
+        }
+        final Member that = (Member) o;
+        return login.equals(that.login) &&
+               role == that.role &&
+               creation.equals(that.creation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(login, role, creation);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
@@ -240,15 +240,14 @@ public class ProjectMetadata implements Identifiable, HasWeight {
         if (!repos().containsKey(Project.REPO_DOGMA)) {
             return this;
         }
-        final Map<String, RepositoryMetadata> repos =
-                repos().entrySet().stream().filter(key -> !key.getKey().equals(Project.REPO_DOGMA))
+        final Map<String, RepositoryMetadata> filtered =
+                repos().entrySet().stream().filter(entry -> !Project.REPO_DOGMA.equals(entry.getKey()))
                        .collect(toImmutableMap(Entry::getKey, Entry::getValue));
         return new ProjectMetadata(name(),
-                                   repos,
+                                   filtered,
                                    members(),
                                    tokens(),
                                    creation(),
-                                   removal()) {
-        };
+                                   removal());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/ProjectMetadata.java
@@ -16,9 +16,12 @@
 
 package com.linecorp.centraldogma.server.metadata;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
@@ -28,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.common.RepositoryNotFoundException;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -82,9 +86,9 @@ public class ProjectMetadata implements Identifiable, HasWeight {
                            @JsonProperty("creation") UserAndTimestamp creation,
                            @JsonProperty("removal") @Nullable UserAndTimestamp removal) {
         this.name = requireNonNull(name, "name");
-        this.repos = requireNonNull(repos, "repos");
-        this.members = requireNonNull(members, "members");
-        this.tokens = requireNonNull(tokens, "tokens");
+        this.repos = ImmutableMap.copyOf(requireNonNull(repos, "repos"));
+        this.members = ImmutableMap.copyOf(requireNonNull(members, "members"));
+        this.tokens = ImmutableMap.copyOf(requireNonNull(tokens, "tokens"));
         this.creation = requireNonNull(creation, "creation");
         this.removal = removal;
     }
@@ -196,6 +200,28 @@ public class ProjectMetadata implements Identifiable, HasWeight {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ProjectMetadata)) {
+            return false;
+        }
+        final ProjectMetadata that = (ProjectMetadata) o;
+        return name.equals(that.name) &&
+               repos.equals(that.repos) &&
+               members.equals(that.members) &&
+               tokens.equals(that.tokens) &&
+               creation.equals(that.creation) &&
+               Objects.equals(removal, that.removal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, repos, members, tokens, creation, removal);
+    }
+
+    @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                           .add("name", name())
@@ -205,5 +231,24 @@ public class ProjectMetadata implements Identifiable, HasWeight {
                           .add("creation", creation())
                           .add("removal", removal())
                           .toString();
+    }
+
+    /**
+     * Returns a new {@link ProjectMetadata} without the Dogma repository.
+     */
+    public ProjectMetadata withoutDogmaRepo() {
+        if (!repos().containsKey(Project.REPO_DOGMA)) {
+            return this;
+        }
+        final Map<String, RepositoryMetadata> repos =
+                repos().entrySet().stream().filter(key -> !key.getKey().equals(Project.REPO_DOGMA))
+                       .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+        return new ProjectMetadata(name(),
+                                   repos,
+                                   members(),
+                                   tokens(),
+                                   creation(),
+                                   removal()) {
+        };
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/TokenRegistration.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/TokenRegistration.java
@@ -18,6 +18,8 @@ package com.linecorp.centraldogma.server.metadata;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -92,6 +94,25 @@ public class TokenRegistration implements Identifiable, HasWeight {
     @Override
     public int weight() {
         return appId.length() + role.name().length();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TokenRegistration)) {
+            return false;
+        }
+        final TokenRegistration that = (TokenRegistration) o;
+        return appId.equals(that.appId) &&
+               role == that.role &&
+               creation.equals(that.creation);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(appId, role, creation);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/model/SerializationTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.centraldogma.common.ProjectRole;
+import com.linecorp.centraldogma.common.RepositoryStatus;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.metadata.Member;
 import com.linecorp.centraldogma.server.metadata.ProjectMetadata;
@@ -36,6 +37,7 @@ import com.linecorp.centraldogma.server.metadata.RepositoryMetadata;
 import com.linecorp.centraldogma.server.metadata.Token;
 import com.linecorp.centraldogma.server.metadata.TokenRegistration;
 import com.linecorp.centraldogma.server.metadata.UserAndTimestamp;
+import com.linecorp.centraldogma.server.storage.project.Project;
 
 class SerializationTest {
 
@@ -67,9 +69,12 @@ class SerializationTest {
         final RepositoryMetadata repositoryMetadata = RepositoryMetadata.of("sample", newCreationTag());
         final Token token = new Token("testApp", "testSecret", false, false, true, newCreationTag(), null,
                                       null);
+
+        final RepositoryMetadata dogmaRepo = RepositoryMetadata.ofDogma(RepositoryStatus.ACTIVE);
         final ProjectMetadata metadata =
                 new ProjectMetadata("test",
-                                    ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata),
+                                    ImmutableMap.of(repositoryMetadata.name(), repositoryMetadata,
+                                                    Project.REPO_DOGMA, dogmaRepo),
                                     ImmutableMap.of(member.id(), member),
                                     ImmutableMap.of(token.id(),
                                                     new TokenRegistration(token.id(),
@@ -77,56 +82,116 @@ class SerializationTest {
                                                                           newCreationTag())),
                                     newCreationTag(),
                                     null);
-        assertThatJson(metadata).isEqualTo("{\n" +
-                                           "  \"name\" : \"test\",\n" +
-                                           "  \"repos\" : {\n" +
-                                           "    \"sample\" : {\n" +
-                                           "      \"name\" : \"sample\",\n" +
-                                           "      \"roles\" : {\n" +
-                                           "        \"projects\": {" +
-                                           "           \"member\": \"WRITE\"," +
-                                           "           \"guest\": null" +
-                                           "        }," +
-                                           "        \"users\" : { },\n" +
-                                           "        \"tokens\" : { }\n" +
-                                           "      },\n" +
-                                           "      \"creation\" : {\n" +
-                                           "        \"user\" : \"editor@dogma.org\",\n" +
-                                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
-                                           "      },\n" +
-                                           "      \"status\" : \"ACTIVE\"\n" +
-                                           "    }\n" +
-                                           "  },\n" +
-                                           "  \"members\" : {\n" +
-                                           "    \"armeria@dogma.org\" : {\n" +
-                                           "      \"login\" : \"armeria@dogma.org\",\n" +
-                                           "      \"role\" : \"MEMBER\",\n" +
-                                           "      \"creation\" : {\n" +
-                                           "        \"user\" : \"editor@dogma.org\",\n" +
-                                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
-                                           "      }\n" +
-                                           "    }\n" +
-                                           "  },\n" +
-                                           "  \"tokens\" : {\n" +
-                                           "    \"testApp\" : {\n" +
-                                           "      \"appId\" : \"testApp\",\n" +
-                                           "      \"role\" : \"MEMBER\",\n" +
-                                           "      \"creation\" : {\n" +
-                                           "        \"user\" : \"editor@dogma.org\",\n" +
-                                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
-                                           "      }\n" +
-                                           "    }\n" +
-                                           "  },\n" +
-                                           "  \"creation\" : {\n" +
-                                           "    \"user\" : \"editor@dogma.org\",\n" +
-                                           "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
-                                           "  }\n" +
-                                           '}');
+        assertThatJson(metadata)
+                .isEqualTo("{\n" +
+                           "  \"name\" : \"test\",\n" +
+                           "  \"repos\" : {\n" +
+                           "    \"sample\" : {\n" +
+                           "      \"name\" : \"sample\",\n" +
+                           "      \"roles\" : {\n" +
+                           "        \"projects\": {" +
+                           "           \"member\": \"WRITE\"," +
+                           "           \"guest\": null" +
+                           "        }," +
+                           "        \"users\" : { },\n" +
+                           "        \"tokens\" : { }\n" +
+                           "      },\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      },\n" +
+                           "      \"status\" : \"ACTIVE\"\n" +
+                           "    },\n" +
+                           "    \"dogma\" : {\n" +
+                           "      \"name\" : \"dogma\",\n" +
+                           "      \"roles\" : {\n" +
+                           "        \"projects\": {" +
+                           "           \"member\": null," +
+                           "           \"guest\": null" +
+                           "        }," +
+                           "        \"users\" : { },\n" +
+                           "        \"tokens\" : { }\n" +
+                           "      },\n" +
+                           "      \"status\" : \"ACTIVE\"\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"members\" : {\n" +
+                           "    \"armeria@dogma.org\" : {\n" +
+                           "      \"login\" : \"armeria@dogma.org\",\n" +
+                           "      \"role\" : \"MEMBER\",\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      }\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"tokens\" : {\n" +
+                           "    \"testApp\" : {\n" +
+                           "      \"appId\" : \"testApp\",\n" +
+                           "      \"role\" : \"MEMBER\",\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      }\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"creation\" : {\n" +
+                           "    \"user\" : \"editor@dogma.org\",\n" +
+                           "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "  }\n" +
+                           '}');
+
+        assertThatJson(metadata.withoutDogmaRepo())
+                .isEqualTo("{\n" +
+                           "  \"name\" : \"test\",\n" +
+                           "  \"repos\" : {\n" +
+                           "    \"sample\" : {\n" +
+                           "      \"name\" : \"sample\",\n" +
+                           "      \"roles\" : {\n" +
+                           "        \"projects\": {" +
+                           "           \"member\": \"WRITE\"," +
+                           "           \"guest\": null" +
+                           "        }," +
+                           "        \"users\" : { },\n" +
+                           "        \"tokens\" : { }\n" +
+                           "      },\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      },\n" +
+                           "      \"status\" : \"ACTIVE\"\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"members\" : {\n" +
+                           "    \"armeria@dogma.org\" : {\n" +
+                           "      \"login\" : \"armeria@dogma.org\",\n" +
+                           "      \"role\" : \"MEMBER\",\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      }\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"tokens\" : {\n" +
+                           "    \"testApp\" : {\n" +
+                           "      \"appId\" : \"testApp\",\n" +
+                           "      \"role\" : \"MEMBER\",\n" +
+                           "      \"creation\" : {\n" +
+                           "        \"user\" : \"editor@dogma.org\",\n" +
+                           "        \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "      }\n" +
+                           "    }\n" +
+                           "  },\n" +
+                           "  \"creation\" : {\n" +
+                           "    \"user\" : \"editor@dogma.org\",\n" +
+                           "    \"timestamp\" : \"2017-01-01T00:00:00Z\"\n" +
+                           "  }\n" +
+                           '}');
 
         final ProjectMetadata obj = Jackson.readValue(Jackson.writeValueAsString(metadata),
                                                       ProjectMetadata.class);
         assertThat(obj.name()).isEqualTo("test");
-        assertThat(obj.repos().size()).isOne();
+        assertThat(obj.repos().size()).isEqualTo(2);
         assertThat(obj.members().size()).isOne();
         assertThat(obj.members().get(userLogin).role()).isEqualTo(ProjectRole.MEMBER);
         assertThat(obj.tokens().size()).isOne();

--- a/webapp/src/dogma/features/project/settings/repositories/RepoMetaList.tsx
+++ b/webapp/src/dogma/features/project/settings/repositories/RepoMetaList.tsx
@@ -49,14 +49,14 @@ const RepoMetaList = <Data extends object>({ data, projectName }: RepoListProps<
             <DeleteRepo
               projectName={projectName}
               repoName={info.getValue()}
-              hidden={info.row.original.removal !== undefined}
+              hidden={info.row.original.removal != null}
               buttonVariant={'solid'}
               buttonSize={'sm'}
             />
             <RestoreRepo
               projectName={projectName}
               repoName={info.getValue()}
-              hidden={info.row.original.removal === undefined}
+              hidden={info.row.original.removal == null}
             />
           </Wrap>
         ),

--- a/webapp/src/dogma/features/project/settings/repositories/RepoMetaList.tsx
+++ b/webapp/src/dogma/features/project/settings/repositories/RepoMetaList.tsx
@@ -44,23 +44,22 @@ const RepoMetaList = <Data extends object>({ data, projectName }: RepoListProps<
         header: 'Created',
       }),
       columnHelper.accessor((row: RepositoryMetadataDto) => row.name, {
-        cell: (info) =>
-          info.getValue() !== 'meta' && (
-            <Wrap>
-              <DeleteRepo
-                projectName={projectName}
-                repoName={info.getValue()}
-                hidden={info.row.original.removal !== undefined}
-                buttonVariant={'solid'}
-                buttonSize={'sm'}
-              />
-              <RestoreRepo
-                projectName={projectName}
-                repoName={info.getValue()}
-                hidden={info.row.original.removal === undefined}
-              />
-            </Wrap>
-          ),
+        cell: (info) => (
+          <Wrap>
+            <DeleteRepo
+              projectName={projectName}
+              repoName={info.getValue()}
+              hidden={info.row.original.removal !== undefined}
+              buttonVariant={'solid'}
+              buttonSize={'sm'}
+            />
+            <RestoreRepo
+              projectName={projectName}
+              repoName={info.getValue()}
+              hidden={info.row.original.removal === undefined}
+            />
+          </Wrap>
+        ),
         header: 'Actions',
         enableSorting: false,
       }),


### PR DESCRIPTION
Motivation:
The Dogma repository metadata is internal and should not be exposed to end users. Currently, it is included in the `getProjectMetadata` API response unnecessarily.

Modifications:
- Excluded Dogma repository metadata from the `getProjectMetadata` API response.

Result:
- Users no longer see internal Dogma repository metadata in project metadata responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Project metadata API now excludes the internal system repository from responses.
  - Repository list shows Delete/Restore actions consistently for all repositories when applicable.
  - Improved consistency and stability of project/member/token metadata handling to reduce unexpected differences.

- Tests
  - Expanded serialization tests to cover projects containing the system repository and its filtered view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->