### PR TITLE
Make logback a required implementation dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,28 +78,20 @@ configure(projectsWithFlags('java')) {
         // Jetty ALPN support
         compileOnly libs.jetty.alpn.api
 
-        // Logging
-        if (project.name.startsWith("java-spring-boot3")) {
-            implementation libs.slf4j2.api
-            testImplementation libs.slf4j2.jul.to.slf4j
-            testImplementation libs.slf4j2.jcl.over.slf4j
-            testImplementation libs.slf4j2.log4j.over.slf4j
-            testRuntimeOnly libs.logback15
-            configurations.configureEach {
-                resolutionStrategy {
-                    force libs.slf4j2.api.get()
-                    force libs.slf4j2.jul.to.slf4j.get()
-                    force libs.slf4j2.jcl.over.slf4j.get()
-                    force libs.slf4j2.log4j.over.slf4j.get()
-                    force libs.logback15.get()
-                }
+        // logging
+        implementation libs.slf4j2.api
+        testImplementation libs.slf4j2.jul.to.slf4j
+        testImplementation libs.slf4j2.jcl.over.slf4j
+        testImplementation libs.slf4j2.log4j.over.slf4j
+        testRuntimeOnly libs.logback15
+        configurations.configureEach {
+            resolutionStrategy {
+                force libs.slf4j2.api.get()
+                force libs.slf4j2.jul.to.slf4j.get()
+                force libs.slf4j2.jcl.over.slf4j.get()
+                force libs.slf4j2.log4j.over.slf4j.get()
+                force libs.logback15.get()
             }
-        } else {
-            implementation libs.slf4j1.api
-            testImplementation libs.slf4j1.jul.to.slf4j
-            testImplementation libs.slf4j1.jcl.over.slf4j
-            testImplementation libs.slf4j1.log4j.over.slf4j
-            testRuntimeOnly libs.logback12
         }
 
         // Test-time dependencies

--- a/client/java-spring-boot2-autoconfigure/build.gradle
+++ b/client/java-spring-boot2-autoconfigure/build.gradle
@@ -1,3 +1,10 @@
+configurations.configureEach {
+    resolutionStrategy {
+        force 'org.slf4j:slf4j-api:1.7.36'
+        force 'ch.qos.logback:logback-classic:1.2.13'
+    }
+}
+
 dependencies {
     api project(':client:java-armeria')
     compileOnly libs.javax.validation
@@ -6,6 +13,9 @@ dependencies {
 
     testImplementation libs.spring.boot2.starter.test
     testRuntimeOnly libs.hibernate.validator6
+
+    testImplementation 'org.slf4j:slf4j-api'
+    testImplementation 'ch.qos.logback:logback-classic'
 }
 
 // Use the sources from 'client-spring-boot3-autoconfigure'.

--- a/dependencies.toml
+++ b/dependencies.toml
@@ -53,9 +53,7 @@ jmh-core = "1.37"
 jmh-gradle-plugin = "0.7.3"
 jxr = "0.2.1"
 kubernetes-client = "7.3.1"
-logback12 = { strictly = "1.2.13" }
-logback15 = { strictly = "1.5.7" }
-logback = "1.2.13"
+logback15 = "1.5.7"
 micrometer = "1.15.2"
 mina-sshd = "2.15.0"
 mockito = "5.18.0"
@@ -71,8 +69,7 @@ rocksdb = "10.2.1"
 shadow-gradle-plugin = "7.1.2"
 # Don't update `shiro` version
 shiro = "1.3.2"
-slf4j1 = { strictly = "1.7.36" }
-slf4j2 = { strictly = "2.0.17" }
+slf4j2 = "2.0.17"
 # Ensure that we use the same Snappy version as what Curator depends on.
 # See: https://github.com/apache/curator/blob/master/pom.xml
 snappy = "1.1.10.5"
@@ -323,10 +320,6 @@ module = "io.fabric8:kubernetes-junit-jupiter"
 version.ref = "kubernetes-client"
 exclusions = ["io.fabric8:kubernetes-httpclient-okhttp", "org.slf4j:slf4j-api"]
 
-[libraries.logback12]
-module = "ch.qos.logback:logback-classic"
-version.ref = "logback12"
-javadocs = "https://www.javadoc.io/doc/ch.qos.logback/logback-classic/1.2.13/"
 [libraries.logback15]
 module = "ch.qos.logback:logback-classic"
 version.ref = "logback15"
@@ -400,20 +393,6 @@ version.ref = "shadow-gradle-plugin"
 module = "org.apache.shiro:shiro-core"
 version.ref = "shiro"
 javadocs = "https://shiro.apache.org/static/1.3.2/apidocs/"
-
-[libraries.slf4j1-api]
-module = "org.slf4j:slf4j-api"
-version.ref = "slf4j1"
-javadocs = "https://www.javadoc.io/doc/org.slf4j/slf4j-api/1.7.36/"
-[libraries.slf4j1-jcl-over-slf4j]
-module = "org.slf4j:jcl-over-slf4j"
-version.ref = "slf4j1"
-[libraries.slf4j1-jul-to-slf4j]
-module = "org.slf4j:jul-to-slf4j"
-version.ref = "slf4j1"
-[libraries.slf4j1-log4j-over-slf4j]
-module = "org.slf4j:log4j-over-slf4j"
-version.ref = "slf4j1"
 
 [libraries.slf4j2-api]
 module = "org.slf4j:slf4j-api"

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -15,7 +15,6 @@ plugins {
 
 apply plugin: 'com.bmuschko.docker-remote-api'
 
-import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.google.common.base.CaseFormat
 
 ext {
@@ -34,10 +33,8 @@ dependencies {
     runtimeOnly libs.jcommander
 
     // Logging
-    runtimeOnly libs.logback12
-    runtimeOnly libs.slf4j1.jcl.over.slf4j
-    runtimeOnly libs.slf4j1.jul.to.slf4j
-    runtimeOnly libs.slf4j1.log4j.over.slf4j
+    runtimeOnly libs.slf4j2.jcl.over.slf4j
+    runtimeOnly libs.slf4j2.log4j.over.slf4j
 }
 
 // Do not generate a JAR for this project.

--- a/it/server/build.gradle
+++ b/it/server/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     testImplementation project(':server-auth:shiro')
 
     testImplementation libs.curator.test
+    testImplementation libs.logback15
 }
 
 // To use @SetEnvironmentVariable

--- a/server-auth/saml/build.gradle
+++ b/server-auth/saml/build.gradle
@@ -5,6 +5,4 @@ dependencies {
     }
 
     implementation libs.bouncycastle.bcprov
-    // Declare explicitly to resolve the version conflict.
-    implementation libs.logback12
 }

--- a/server-auth/shiro/build.gradle
+++ b/server-auth/shiro/build.gradle
@@ -4,9 +4,6 @@ dependencies {
     // Caffeine
     implementation libs.caffeine
 
-    // Declare explicitly to resolve the version conflict.
-    implementation libs.logback12
-
     // Shiro
     implementation libs.shiro.core
 }

--- a/server-mirror-git/build.gradle
+++ b/server-mirror-git/build.gradle
@@ -6,8 +6,6 @@ dependencies {
     implementation libs.bouncycastle.bcprov
     implementation libs.eddsa
     implementation libs.jgit6
-    // Declare explicitly to resolve the version conflict.
-    implementation libs.logback12
     implementation libs.mina.sshd.core
     implementation libs.mina.sshd.git
 

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -48,8 +48,9 @@ dependencies {
     implementation libs.snappy
 
     // Logging
-    optionalImplementation libs.logback12
-    optionalImplementation libs.slf4j1.jul.to.slf4j
+    implementation libs.logback15
+    // For Caffiene. See https://github.com/line/centraldogma/pull/499
+    implementation libs.slf4j2.jul.to.slf4j
 
     testImplementation libs.jackson.module.scala
 }

--- a/testing-internal/build.gradle
+++ b/testing-internal/build.gradle
@@ -5,5 +5,5 @@ dependencies {
     api libs.assertj
     api libs.json.unit.fluent
     api libs.junit.pioneer
-    api libs.logback12
+    implementation libs.logback15
 }

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ExpectedExceptionAppender.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ExpectedExceptionAppender.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -29,6 +30,7 @@ import javax.annotation.Nullable;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.slf4j.Marker;
+import org.slf4j.event.KeyValuePair;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -223,6 +225,21 @@ public class ExpectedExceptionAppender extends UnsynchronizedAppenderBase<ILoggi
         }
 
         @Override
+        public int getNanoseconds() {
+            return event.getNanoseconds();
+        }
+
+        @Override
+        public long getSequenceNumber() {
+            return event.getSequenceNumber();
+        }
+
+        @Override
+        public List<KeyValuePair> getKeyValuePairs() {
+            return event.getKeyValuePairs();
+        }
+
+        @Override
         public StackTraceElement[] getCallerData() {
             return event.getCallerData();
         }
@@ -233,8 +250,8 @@ public class ExpectedExceptionAppender extends UnsynchronizedAppenderBase<ILoggi
         }
 
         @Override
-        public Marker getMarker() {
-            return event.getMarker();
+        public List<Marker> getMarkerList() {
+            return event.getMarkerList();
         }
 
         @Override

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -8,8 +8,6 @@ dependencies {
     implementation libs.controlplane.api
     implementation libs.controlplane.cache
     implementation libs.controlplane.server
-    // Declare explicitly to resolve the version conflict.
-    implementation libs.logback12
     implementation libs.reflections
 
     testImplementation libs.armeria.junit5


### PR DESCRIPTION
Motivation:
After introducing `LoggerService`, the logback dependency must not be optional; it should be a required implementation.

Additionally, since Java 8 support has been dropped, we can upgrade to logback 1.5 with SLF4J 2.x.

Modifications:
- Changed logback dependency scope from optional to implementation.
- Upgraded logback to 1.5 (compatible with SLF4J 2.x).

Result:
- Logging is now consistently available without optional dependency issues.