### PR TITLE
Optimize docker image

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -18,7 +18,6 @@ curator = "5.9.0"
 # Do not upgrade cron-utils until there's another CVE or Armeria's SLF4J and Logback are upgraded.
 cron-utils = "9.2.0"
 diffutils = "1.3.0"
-docker = "9.4.0"
 download = "5.6.0"
 dropwizard-metrics = "4.2.33"
 eddsa = "0.3.0"
@@ -462,7 +461,6 @@ exclusions = [
     "org.slf4j:slf4j-log4j12"]
 
 [plugins]
-docker = { id = "com.bmuschko.docker-remote-api", version.ref = "docker" }
 download = { id = "de.undercouch.download", version.ref = "download" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh-gradle-plugin" }
 jxr = { id = "net.davidecavestro.gradle.jxr", version.ref = "jxr" }

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -3,6 +3,9 @@
 #
 FROM openjdk:11-jre
 
+# Multi-platform build arguments (pre-defined by docker)
+ARG TARGETARCH
+
 # Environment variables.
 ENV CENTRALDOGMA_HOME "/opt/centraldogma"
 ENV CENTRALDOGMA_OPTS ""
@@ -21,11 +24,15 @@ RUN mkdir -p                      \
 COPY build/dist/LICENSE.txt  "$CENTRALDOGMA_HOME"/
 COPY build/dist/NOTICE.txt   "$CENTRALDOGMA_HOME"/
 COPY build/dist/README.md    "$CENTRALDOGMA_HOME"/
-COPY build/dist/bin/*        "$CENTRALDOGMA_HOME"/bin/
-COPY build/dist/bin/native/* "$CENTRALDOGMA_HOME"/bin/native/
+COPY build/dist/bin/common* build/dist/bin/dogma build/dist/bin/shutdown build/dist/bin/startup \
+  "$CENTRALDOGMA_HOME"/bin/
 COPY build/dist/conf/*       "$CENTRALDOGMA_HOME"/conf/
 COPY build/dist/lib/*        "$CENTRALDOGMA_HOME"/lib/
 COPY build/dist/licenses/*   "$CENTRALDOGMA_HOME"/licenses/
+
+COPY --chmod=755 \
+  build/dist/bin/native/dogma.linux_${TARGETARCH} \
+  "$CENTRALDOGMA_HOME"/bin/native/
 
 # Expose ports.
 EXPOSE 36462

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -9,11 +9,8 @@ buildscript {
 }
 
 plugins {
-    alias libs.plugins.docker apply false
     alias libs.plugins.download
 }
-
-apply plugin: 'com.bmuschko.docker-remote-api'
 
 import com.google.common.base.CaseFormat
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -66,7 +66,7 @@ task copyLib(group: 'Build',
     }
 }
 
-def cliVersion = "0.1.0"
+def cliVersion = "0.1.1"
 
 task downloadClientBinaries(group: 'Build',
         description: "Downloads client binaries into ${project.ext.cliDownloadDir}") {
@@ -74,23 +74,72 @@ task downloadClientBinaries(group: 'Build',
     outputs.dir("${project.ext.cliDownloadDir}/$cliVersion")
 
     doLast {
-        ["darwin-amd64", "darwin-arm64", "linux-amd64", "windows-amd64.exe"].each { platform ->
+        ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64", "windows_amd64"].each { platform ->
+            def baseFileName = "dogma_${cliVersion}_${platform}"
+            def fileExtension
+            def extractor
+
+            if (platform.startsWith("windows")) {
+                fileExtension = "zip"
+                extractor = { path -> zipTree(path) }
+            } else {
+                fileExtension = "tar.gz"
+                extractor = { path -> tarTree(path) }
+            }
+
+            def archiveFile = "${baseFileName}.${fileExtension}"
+
             download.run {
-                src "https://github.com/line/centraldogma-go/releases/download/$cliVersion/dogma.$platform"
-                dest "${project.ext.cliDownloadDir}/$cliVersion/dogma.$platform"
+                src "https://github.com/line/centraldogma-go/releases/download/$cliVersion/$archiveFile"
+                dest "${project.ext.cliDownloadDir}/$cliVersion/$archiveFile"
                 overwrite false
+            }
+
+            def archivePath = "${project.ext.cliDownloadDir}/$cliVersion/$archiveFile"
+            def extractDir = "${project.ext.cliDownloadDir}/$cliVersion/extracted_${platform}"
+
+            project.mkdir(extractDir)
+            copy {
+                from extractor(archivePath)
+                into extractDir
             }
         }
     }
 }
 
 task copyClientBinaries(group: 'Build',
-        description: "Copies client binaries into ${project.ext.relativeDistDir}/bin/native", type: Copy) {
+        description: "Copies client binaries into ${project.ext.relativeDistDir}/bin/native") {
     dependsOn tasks.downloadClientBinaries
 
-    from "${project.ext.cliDownloadDir}/$cliVersion"
-    into "${project.ext.distDir}/bin/native"
-    fileMode 0755
+    doLast {
+        def nativeDir = "${project.ext.distDir}/bin/native"
+        project.mkdir(nativeDir)
+
+        ["linux_amd64", "linux_arm64", "darwin_amd64", "darwin_arm64", "windows_amd64"].each { platform ->
+            def extractDir = "${project.ext.cliDownloadDir}/$cliVersion/extracted_${platform}"
+            def sourceFile
+            def targetFileName
+
+            if (platform.startsWith("windows")) {
+                sourceFile = "${extractDir}/dogma.exe"
+                targetFileName = "dogma.${platform}.exe"
+            } else {
+                sourceFile = "${extractDir}/dogma"
+                targetFileName = "dogma.${platform}"
+            }
+
+            if (!file(sourceFile).exists()) {
+                throw new GradleException("Source binary not found: $sourceFile")
+            }
+
+            copy {
+                from sourceFile
+                into nativeDir
+                rename { targetFileName }
+                fileMode 0755
+            }
+        }
+    }
 }
 
 task distDirWithoutClientBinaries(group: 'Build',

--- a/dist/src/bin/dogma
+++ b/dist/src/bin/dogma
@@ -7,18 +7,20 @@ DOGMA_BIN="$(dirname "$0")/native"
 
 if [[ "${OS}" == 'Darwin' ]]; then
   if [[ "${MACH}" == 'x86_64' ]]; then
-    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin-amd64"
+    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin_amd64"
   elif [[ "${MACH}" == 'arm64' ]]; then
-    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin-arm64"
+    DOGMA_BIN="${DOGMA_BIN}/dogma.darwin_arm64"
   else
-    echo "32-bit OS is not supported by default: ${OS}-${MACH}"
+    echo "Architecture not supported by default: ${OS}-${MACH}"
     exit 1
   fi
 elif [[ "${OS}" == 'Linux' ]]; then
   if [[ "${MACH}" == 'x86_64' ]]; then
-    DOGMA_BIN="${DOGMA_BIN}/dogma.linux-amd64"
+    DOGMA_BIN="${DOGMA_BIN}/dogma.linux_amd64"
+  elif [[ "${MACH}" == 'aarch64' ]]; then
+    DOGMA_BIN="${DOGMA_BIN}/dogma.linux_arm64"
   else
-    echo "32-bit OS is not supported by default: ${OS}-${MACH}"
+    echo "Architecture not supported by default: ${OS}-${MACH}"
     exit 1
   fi
 else
@@ -27,4 +29,3 @@ else
 fi
 
 exec "$DOGMA_BIN" "$@"
-


### PR DESCRIPTION
Motivation:

Currently docker image has all client binaries inside, also copied twice under `bin/*` and `bin/native/*`. Only single client binary file is enough. Image below is layer info inside `ghcr.io/line/centraldogma:0.77.2` (used [dive](https://github.com/wagoodman/dive))
Also linux/arm64 image doesn't have linux/arm64 client binary.

<img width="1304" height="966" alt="77055" src="https://github.com/user-attachments/assets/ff34cc30-0b31-4dec-b2dd-effe183e5fa5" />


Modification:

- Use centraldogma-go 0.1.1 version. Since 0.1.1, `linux/arm64` binary is available.
- In dockerfile, copy only one client binary for same target architecture
- Other changes
  - Remove gradle docker plugin, as it is not used since #1158
  - Client binary name is changed. It uses underscore now. (ex. `dogma.linux-amd64` -> `dogma.linux_amd64`)


Result:

- Only one client binary is included in docker image. image size is shrinked from 379M to 331M (-12.6%, checked with `docker inspect`)

<img width="1454" height="926" alt="41844" src="https://github.com/user-attachments/assets/7eeae17c-c9be-4365-8d13-4dfd9adf331e" />

- linux/arm64 image contains linux/arm64 client binary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Removed Docker-related entries from the build configuration to streamline the toolchain and reduce maintenance.
  * May slightly improve build times and avoid fetching unused artifacts in local and CI environments.
  * No user-facing functionality or interfaces were changed; application behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->