### PR TITLE
Fix flaky test in HealthCheckServiceTest

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/HealthCheckServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/HealthCheckServiceTest.java
@@ -45,6 +45,7 @@ class HealthCheckServiceTest {
 
         try (CentralDogma dogma = new CentralDogmaBuilder(rootDir.toFile())
                 .port(randomPort, SessionProtocol.HTTP)
+                .gracefulShutdownTimeout(new GracefulShutdownTimeout(1000, 1000))
                 .build()) {
             dogma.start().join();
             final ServerPort serverPort = dogma.activePort();


### PR DESCRIPTION
The client tries to connect the server after the server shuts down. We should specify the graceful shutdown so that the server doesn't shut down right away

Close #1173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of server shutdown and health-check scenarios by configuring a brief graceful shutdown window in tests. This ensures consistent verification that the service becomes unavailable after stopping, reducing test flakiness and improving confidence in shutdown behavior. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->