### PR TITLE
Assign ownership roles to access tokens when creating projects and repositories

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/Author.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Author.java
@@ -32,12 +32,12 @@ public class Author {
     /**
      * The system author.
      */
-    public static final Author SYSTEM = new Author("System", "system@localhost.localdomain");
+    public static final Author SYSTEM = new Author("system", "system@localhost.localdomain");
 
     /**
      * The default author which is used when security is disabled.
      */
-    public static final Author DEFAULT = new Author("User", "user@localhost.localdomain");
+    public static final Author DEFAULT = new Author("user", "user@localhost.localdomain");
 
     /**
      * An unknown author.

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -37,6 +37,17 @@ import com.jayway.jsonpath.JsonPath;
  */
 public final class Util {
 
+    /**
+     * The domain part when generating an email address for the token.
+     */
+    public static final String TOKEN_EMAIL_SUFFIX = "@dogma-token.local";
+
+    /**
+     * The domain part used when generating an email address for the user if the user did not provide
+     * an email address.
+     */
+    public static final String USER_EMAIL_SUFFIX = "@localhost.localdomain";
+
     private static final Pattern FILE_NAME_PATTERN = Pattern.compile(
             "^(?:[-_0-9a-zA-Z](?:[-_.0-9a-zA-Z]*[-_0-9a-zA-Z])?)+$");
     private static final Pattern FILE_PATH_PATTERN = Pattern.compile(
@@ -223,7 +234,7 @@ public final class Util {
         if (isValidEmailAddress(emailAddr)) {
             return emailAddr;
         }
-        return emailAddr + "@localhost.localdomain";
+        return emailAddr + USER_EMAIL_SUFFIX;
     }
 
     public static String emailToUsername(String emailAddr, String paramName) {

--- a/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/internal/UtilTest.java
@@ -132,6 +132,7 @@ class UtilTest {
 
     @Test
     void testValidEmailAddress() {
+        testValidEmail("dogma@dogma-token.local");
         testValidEmail("dogma@github.com");
         testValidEmail("dogma@127.0.0.1");
         testValidEmail("dogma@10.1.1.1");

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorAccessControlTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorAccessControlTest.java
@@ -128,7 +128,7 @@ class MirrorAccessControlTest {
         assertThat(accessResponse.content().id()).isEqualTo("default");
 
         createMirror();
-        final String listenerKey = TEST_PROJ + '/' + TEST_MIRROR_ID + '/' + Author.SYSTEM.email();
+        final String listenerKey = TEST_PROJ + '/' + TEST_MIRROR_ID + '/' + Author.SYSTEM.name();
         await().untilAsserted(() -> {
             assertThat(creationCount.get("git+ssh://github.com/line/centraldogma-authtest.git"))
                     .isOne();

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestMirrorRunnerListener.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/TestMirrorRunnerListener.java
@@ -45,7 +45,7 @@ public class TestMirrorRunnerListener implements MirrorListener {
     }
 
     private static String key(MirrorTask task) {
-        return task.project().name() + '/' + task.mirror().id() + '/' + task.triggeredBy().login();
+        return task.project().name() + '/' + task.mirror().id() + '/' + task.triggeredBy().name();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/AuthUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/admin/auth/AuthUtil.java
@@ -49,8 +49,14 @@ public final class AuthUtil {
     }
 
     public static Author getAuthor(User user) {
-        return user == User.DEFAULT ? Author.DEFAULT
-                                    : new Author(user.name(), user.email());
+        if (user == User.DEFAULT) {
+            return Author.DEFAULT;
+        }
+        if (user == User.SYSTEM) {
+            return Author.SYSTEM;
+        }
+
+        return new Author(user.name(), user.email());
     }
 
     public static User currentUser(ServiceRequestContext ctx) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MetadataApiService.java
@@ -90,7 +90,7 @@ public class MetadataApiService extends AbstractService {
      * PATCH /metadata/{projectName}/members/{memberId}
      *
      * <p>Updates the {@link ProjectRole} of the specified {@code memberId} in the specified
-     * {@code projectName}.
+     * {@code projectName}.∂
      */
     @RequiresProjectRole(ProjectRole.OWNER)
     @Patch("/metadata/{projectName}/members/{memberId}")

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/ApplicationTokenAuthorizer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/auth/ApplicationTokenAuthorizer.java
@@ -19,8 +19,6 @@ package com.linecorp.centraldogma.server.internal.api.auth;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 
-import java.net.InetSocketAddress;
-import java.net.SocketAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -65,13 +63,8 @@ public class ApplicationTokenAuthorizer extends AbstractAuthorizer {
             final Token appToken = tokenLookupFunc.apply(accessToken);
             if (appToken != null && appToken.isActive()) {
                 final String appId = appToken.appId();
-                final StringBuilder login = new StringBuilder(appId);
-                final SocketAddress ra = ctx.remoteAddress();
-                if (ra instanceof InetSocketAddress) {
-                    login.append('@').append(((InetSocketAddress) ra).getHostString());
-                }
                 ctx.logBuilder().authenticatedUser("app/" + appId);
-                final UserWithToken user = new UserWithToken(login.toString(), appToken);
+                final UserWithToken user = new UserWithToken(appToken);
                 AuthUtil.setCurrentUser(ctx, user);
                 HttpApiUtil.setVerboseResponses(ctx, user);
                 return UnmodifiableFuture.completedFuture(true);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.storage.project;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.linecorp.centraldogma.internal.Util.TOKEN_EMAIL_SUFFIX;
 import static com.linecorp.centraldogma.server.internal.storage.MigratingMetaToDogmaRepositoryService.META_TO_DOGMA_MIGRATED;
 import static com.linecorp.centraldogma.server.internal.storage.MigratingMetaToDogmaRepositoryService.META_TO_DOGMA_MIGRATION_JOB;
 import static com.linecorp.centraldogma.server.metadata.MetadataService.METADATA_JSON;
@@ -24,6 +25,7 @@ import static com.linecorp.centraldogma.server.storage.project.InternalProjectIn
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -60,6 +62,7 @@ import com.linecorp.centraldogma.server.internal.storage.repository.cache.Cachin
 import com.linecorp.centraldogma.server.internal.storage.repository.git.GitRepositoryManager;
 import com.linecorp.centraldogma.server.metadata.Member;
 import com.linecorp.centraldogma.server.metadata.ProjectMetadata;
+import com.linecorp.centraldogma.server.metadata.TokenRegistration;
 import com.linecorp.centraldogma.server.metadata.UserAndTimestamp;
 import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageManager;
 import com.linecorp.centraldogma.server.storage.project.Project;
@@ -229,11 +232,25 @@ public class DefaultProject implements Project {
             logger.info("Initializing metadata of project: {}", name);
 
             final UserAndTimestamp userAndTimestamp = UserAndTimestamp.of(author);
-            final Member member = new Member(author, ProjectRole.OWNER, userAndTimestamp);
+            final Map<String, Member> members;
+            final Map<String, TokenRegistration> tokens;
+            if (author.email().endsWith(TOKEN_EMAIL_SUFFIX)) {
+                members = ImmutableMap.of();
+                // author.name() is the appId of the token.
+                final TokenRegistration tokenRegistration =
+                        new TokenRegistration(author.name(), ProjectRole.OWNER, userAndTimestamp);
+
+                tokens = ImmutableMap.of(tokenRegistration.id(), tokenRegistration);
+            } else {
+                final Member member = new Member(author, ProjectRole.OWNER, userAndTimestamp);
+                members = ImmutableMap.of(member.id(), member);
+                tokens = ImmutableMap.of();
+            }
+
             final ProjectMetadata metadata = new ProjectMetadata(name,
                                                                  ImmutableMap.of(),
-                                                                 ImmutableMap.of(member.id(), member),
-                                                                 ImmutableMap.of(),
+                                                                 members,
+                                                                 tokens,
                                                                  userAndTimestamp, null);
             final CommitResult result =
                     dogmaRepo.commit(headRev, creationTimeMillis, Author.SYSTEM,

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositoryMetadata.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositoryMetadata.java
@@ -54,6 +54,16 @@ public final class RepositoryMetadata implements Identifiable, HasWeight {
     }
 
     /**
+     * Creates a new instance with default properties.
+     */
+    public static RepositoryMetadata of(String name, Roles roles, UserAndTimestamp creation) {
+        requireNonNull(name, "name");
+        requireNonNull(roles, "roles");
+        requireNonNull(creation, "creation");
+        return new RepositoryMetadata(name, roles, creation, null, RepositoryStatus.ACTIVE);
+    }
+
+    /**
      * Creates a new instance.
      */
     public static RepositoryMetadata of(String name, UserAndTimestamp creation, ProjectRoles projectRoles) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/Token.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.internal.Util;
@@ -189,6 +190,31 @@ public final class Token implements Identifiable {
     @JsonIgnore
     public boolean isDeleted() {
         return deletion != null;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(appId, secret, isSystemAdmin, allowGuestAccess, creation, deactivation,
+                                deletion);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Token)) {
+            return false;
+        }
+
+        final Token that = (Token) o;
+        return appId.equals(that.appId) &&
+               Objects.equal(secret, that.secret) &&
+               isSystemAdmin == that.isSystemAdmin &&
+               allowGuestAccess == that.allowGuestAccess &&
+               creation.equals(that.creation) &&
+               Objects.equal(deactivation, that.deactivation) &&
+               Objects.equal(deletion, that.deletion);
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserWithToken.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/UserWithToken.java
@@ -16,14 +16,15 @@
 
 package com.linecorp.centraldogma.server.metadata;
 
+import static com.linecorp.centraldogma.internal.Util.TOKEN_EMAIL_SUFFIX;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.MoreObjects;
 
 /**
- * A {@link User} which accesses the API with a secret.
+ * A {@link User} which accesses the API with a {@link Token}.
  */
-public class UserWithToken extends User {
+public final class UserWithToken extends User {
 
     private static final long serialVersionUID = 6021146546653491444L;
 
@@ -32,8 +33,8 @@ public class UserWithToken extends User {
     /**
      * Creates a new instance.
      */
-    public UserWithToken(String login, Token token) {
-        super(login);
+    public UserWithToken(Token token) {
+        super(token.appId(), token.appId() + TOKEN_EMAIL_SUFFIX);
         this.token = requireNonNull(token, "token");
     }
 
@@ -47,6 +48,27 @@ public class UserWithToken extends User {
     @Override
     public boolean isSystemAdmin() {
         return token.isSystemAdmin();
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() * 31 + token.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof UserWithToken)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        final UserWithToken that = (UserWithToken) o;
+        return token.equals(that.token);
     }
 
     @Override

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeProjectCommandTest.java
@@ -34,7 +34,7 @@ class PurgeProjectCommandTest {
                              "  \"type\": \"PURGE_PROJECT\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PurgeRepositoryCommandTest.java
@@ -34,7 +34,7 @@ class PurgeRepositoryCommandTest {
                              "  \"type\": \"PURGE_REPOSITORY\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveProjectCommandTest.java
@@ -34,7 +34,7 @@ class RemoveProjectCommandTest {
                              "  \"type\": \"REMOVE_PROJECT\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/RemoveRepositoryCommandTest.java
@@ -34,7 +34,7 @@ class RemoveRepositoryCommandTest {
                              "  \"type\": \"REMOVE_REPOSITORY\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveProjectCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveProjectCommandTest.java
@@ -34,7 +34,7 @@ class UnremoveProjectCommandTest {
                              "  \"type\": \"UNREMOVE_PROJECT\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveRepositoryCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/UnremoveRepositoryCommandTest.java
@@ -34,7 +34,7 @@ class UnremoveRepositoryCommandTest {
                              "  \"type\": \"UNREMOVE_REPOSITORY\"," +
                              "  \"timestamp\": 1234," +
                              "  \"author\": {" +
-                             "    \"name\": \"System\"," +
+                             "    \"name\": \"system\"," +
                              "    \"email\": \"system@localhost.localdomain\"" +
                              "  }," +
                              "  \"projectName\": \"foo\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/UserServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/admin/service/UserServiceTest.java
@@ -21,10 +21,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
@@ -58,9 +61,12 @@ class UserServiceTest {
                                 .get("/api/v0/users/me")
                                 .header(HttpHeaderNames.AUTHORIZATION,
                                         "Bearer " + accessToken)
-                                .asJson(User.class)
+                                // Use a new ObjectMapper because the configured object mapper fails
+                                // when the constructor property is missing.
+                                .asJson(User.class, new ObjectMapper())
                                 .execute()
                                 .content();
-        assertThat(user.login()).isEqualTo(TestAuthMessageUtil.USERNAME);
+        assertThat(user.name()).isEqualTo(TestAuthMessageUtil.USERNAME);
+        assertThat(user.email()).isEqualTo(TestAuthMessageUtil.USERNAME + Util.USER_EMAIL_SUFFIX);
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -164,7 +164,7 @@ class ProjectServiceV1ListProjectTest {
                 "   {" +
                 "       \"name\": \"@foo\"," +
                 "       \"creator\": {" +
-                "           \"name\": \"System\"," +
+                "           \"name\": \"system\"," +
                 "           \"email\": \"system@localhost.localdomain\"" +
                 "        }," +
                 "        \"userRole\":\"OWNER\"," +
@@ -174,7 +174,7 @@ class ProjectServiceV1ListProjectTest {
                 "   {" +
                 "       \"name\": \"dogma\"," +
                 "       \"creator\": {" +
-                "           \"name\": \"System\"," +
+                "           \"name\": \"system\"," +
                 "           \"email\": \"system@localhost.localdomain\"" +
                 "        }," +
                 "        \"userRole\":\"OWNER\"," +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1Test.java
@@ -16,13 +16,18 @@
 
 package com.linecorp.centraldogma.server.internal.api;
 
+import static com.linecorp.centraldogma.internal.Util.USER_EMAIL_SUFFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.PROJECTS_PREFIX;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.REPOS;
+import static com.linecorp.centraldogma.server.metadata.RepositoryMetadata.DEFAULT_PROJECT_ROLES;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +35,11 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.InvalidHttpResponseException;
@@ -39,58 +48,119 @@ import com.linecorp.armeria.client.WebClientBuilder;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpRequest;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.ResponseHeaders;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.CentralDogmaRepository;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.ProjectNotFoundException;
+import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.common.ReadOnlyException;
 import com.linecorp.centraldogma.common.RepositoryExistsException;
+import com.linecorp.centraldogma.common.RepositoryRole;
 import com.linecorp.centraldogma.common.RepositoryStatus;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.internal.api.v1.RepositoryDto;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.internal.api.MetadataApiService.IdAndProjectRole;
 import com.linecorp.centraldogma.server.internal.credential.AccessTokenCredential;
+import com.linecorp.centraldogma.server.metadata.ProjectMetadata;
+import com.linecorp.centraldogma.server.metadata.Roles;
+import com.linecorp.centraldogma.server.metadata.Token;
 import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class RepositoryServiceV1Test {
 
     @RegisterExtension
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
         @Override
-        protected void configureHttpClient(WebClientBuilder builder) {
-            builder.addHeader(HttpHeaderNames.AUTHORIZATION, "Bearer anonymous");
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.systemAdministrators(TestAuthMessageUtil.USERNAME);
+            builder.authProviderFactory(new TestAuthProviderFactory());
         }
     };
 
     private static final String REPOS_PREFIX = PROJECTS_PREFIX + "/myPro" + REPOS;
 
+    private static WebClient systemAdminClient;
+    private static WebClient userClient;
+    private static WebClient tokenClient;
+
     @BeforeAll
-    static void setUp() {
-        createProject(dogma);
+    static void setUp() throws JsonProcessingException, UnknownHostException {
+        final URI uri = dogma.httpClient().uri();
+        systemAdminClient = WebClient.builder(uri)
+                                     .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
+                                                                             TestAuthMessageUtil.USERNAME,
+                                                                             TestAuthMessageUtil.PASSWORD)))
+                                     .build();
+        createProject(systemAdminClient);
+        userClient = WebClient.builder(uri)
+                              .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
+                                                                      TestAuthMessageUtil.USERNAME2,
+                                                                      TestAuthMessageUtil.PASSWORD2)))
+                              .build();
+        final QueryParams params = QueryParams.builder()
+                                              .add("appId", "appId1")
+                                              .add("isSystemAdmin", "false")
+                                              .build();
+        final String appToken = userClient.blocking().prepare()
+                                          .post("/api/v1/tokens")
+                                          .content(MediaType.FORM_DATA, params.toQueryString())
+                                          .asJson(Token.class, new ObjectMapper()).execute().content().secret();
+        tokenClient = WebClient.builder(uri)
+                               .auth(AuthToken.ofOAuth2(appToken))
+                               .build();
     }
 
     @Test
     void createRepository() throws IOException {
-        final WebClient client = dogma.httpClient();
-        final AggregatedHttpResponse aRes = createRepository(client, "myRepo");
-        final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
-        assertThat(headers.status()).isEqualTo(HttpStatus.CREATED);
+        // Add a user (foo2) as a member of the project.
+        HttpRequest request = HttpRequest.builder()
+                                         .post("/api/v1/metadata/myPro/members")
+                                         .contentJson(new IdAndProjectRole(
+                                                 TestAuthMessageUtil.USERNAME2, ProjectRole.MEMBER))
+                                         .build();
+        assertThat(systemAdminClient.execute(request).aggregate().join().status()).isSameAs(HttpStatus.OK);
+        // Add a token as a member of the project.
+        request = HttpRequest.builder()
+                             .post("/api/v1/metadata/myPro/tokens")
+                             .contentJson(new IdAndProjectRole("appId1", ProjectRole.MEMBER))
+                             .build();
+        assertThat(systemAdminClient.execute(request).aggregate().join().status()).isSameAs(HttpStatus.OK);
 
-        final String location = headers.get(HttpHeaderNames.LOCATION);
-        assertThat(location).isEqualTo("/api/v1/projects/myPro/repos/myRepo");
+        createRepositoryAndValidate(userClient, "myRepo");
+        createRepositoryAndValidate(tokenClient, "myRepo2");
 
-        final JsonNode jsonNode = Jackson.readTree(aRes.contentUtf8());
-        assertThat(jsonNode.get("name").asText()).isEqualTo("myRepo");
-        assertThat(jsonNode.get("headRevision").asInt()).isOne();
-        assertThat(jsonNode.get("createdAt").asText()).isNotNull();
+        final ProjectMetadata projectMetadata =
+                systemAdminClient.blocking().prepare().get(PROJECTS_PREFIX + "/myPro")
+                                 .asJson(ProjectMetadata.class, new ObjectMapper())
+                                 .execute()
+                                 .content();
+        assertThat(projectMetadata.repo("myRepo").roles()).isEqualTo(
+                new Roles(DEFAULT_PROJECT_ROLES,
+                          ImmutableMap.of(TestAuthMessageUtil.USERNAME2 + USER_EMAIL_SUFFIX,
+                                          RepositoryRole.ADMIN),
+                          ImmutableMap.of()));
+        assertThat(projectMetadata.repo("myRepo2").roles()).isEqualTo(
+                new Roles(DEFAULT_PROJECT_ROLES,
+                          ImmutableMap.of(),
+                          ImmutableMap.of("appId1", RepositoryRole.ADMIN)));
     }
 
     private static AggregatedHttpResponse createRepository(WebClient client, String repoName) {
@@ -101,13 +171,27 @@ class RepositoryServiceV1Test {
         return client.execute(headers, body).aggregate().join();
     }
 
+    private static void createRepositoryAndValidate(
+            WebClient userClient1, String repoName) throws JsonParseException {
+        final AggregatedHttpResponse aRes = createRepository(userClient1, repoName);
+        final ResponseHeaders headers = ResponseHeaders.of(aRes.headers());
+        assertThat(headers.status()).isEqualTo(HttpStatus.CREATED);
+
+        final String location = headers.get(HttpHeaderNames.LOCATION);
+        assertThat(location).isEqualTo("/api/v1/projects/myPro/repos/" + repoName);
+
+        final JsonNode jsonNode = Jackson.readTree(aRes.contentUtf8());
+        assertThat(jsonNode.get("name").asText()).isEqualTo(repoName);
+        assertThat(jsonNode.get("headRevision").asInt()).isOne();
+        assertThat(jsonNode.get("createdAt").asText()).isNotNull();
+    }
+
     @Test
     void createRepositoryWithSameName() {
-        final WebClient client = dogma.httpClient();
-        createRepository(client, "myNewRepo");
+        createRepository(systemAdminClient, "myNewRepo");
 
         // create again with the same name
-        final AggregatedHttpResponse aRes = createRepository(client, "myNewRepo");
+        final AggregatedHttpResponse aRes = createRepository(systemAdminClient, "myNewRepo");
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.CONFLICT);
         final String expectedJson =
                 '{' +
@@ -120,19 +204,17 @@ class RepositoryServiceV1Test {
 
     @Test
     void createRepositoryWithInvalidName() {
-        final WebClient client = dogma.httpClient();
-        final AggregatedHttpResponse aRes = createRepository(client, "myRepo.git");
+        final AggregatedHttpResponse aRes = createRepository(systemAdminClient, "myRepo.git");
         assertThat(aRes.headers().status()).isSameAs(HttpStatus.BAD_REQUEST);
     }
 
     @Test
     void createRepositoryInAbsentProject() {
-        final WebClient client = dogma.httpClient();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST,
                                                          PROJECTS_PREFIX + "/absentProject" + REPOS,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         final String body = "{\"name\": \"myRepo\"}";
-        final AggregatedHttpResponse aRes = client.execute(headers, body).aggregate().join();
+        final AggregatedHttpResponse aRes = systemAdminClient.execute(headers, body).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
         final String expectedJson =
                 '{' +
@@ -145,45 +227,42 @@ class RepositoryServiceV1Test {
 
     @Test
     void removeRepository() {
-        final WebClient client = dogma.httpClient();
-        createRepository(client, "foo");
-        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + "/foo").aggregate().join();
+        createRepository(systemAdminClient, "foo");
+        final AggregatedHttpResponse aRes = systemAdminClient.delete(REPOS_PREFIX + "/foo").aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NO_CONTENT);
     }
 
     @Test
     void removeAbsentRepository() {
-        final WebClient client = dogma.httpClient();
-        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + "/foo").aggregate().join();
+        final AggregatedHttpResponse aRes = systemAdminClient.delete(REPOS_PREFIX + "/foo").aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
     void removeMetaRepository() {
-        final WebClient client = dogma.httpClient();
-        final AggregatedHttpResponse aRes = client.delete(REPOS_PREFIX + '/' + Project.REPO_META)
-                                                  .aggregate().join();
+        final AggregatedHttpResponse aRes = systemAdminClient.delete(REPOS_PREFIX + '/' + Project.REPO_META)
+                                                             .aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
     void unremoveAbsentRepository() {
-        final WebClient client = dogma.httpClient();
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH, REPOS_PREFIX + "/baz",
                                                          HttpHeaderNames.CONTENT_TYPE,
                                                          "application/json-patch+json");
 
         final String unremovePatch = "[{\"op\":\"replace\",\"path\":\"/status\",\"value\":\"active\"}]";
-        final AggregatedHttpResponse aRes = client.execute(headers, unremovePatch).aggregate().join();
+        final AggregatedHttpResponse aRes =
+                systemAdminClient.execute(headers, unremovePatch).aggregate().join();
         assertThat(ResponseHeaders.of(aRes.headers()).status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test
-    void updateRepositoryStatus() {
+    void updateRepositoryStatus() throws UnknownHostException {
         final String repoName = "statusRepo";
-        final AggregatedHttpResponse aRes = createRepository(dogma.httpClient(), repoName);
+        final AggregatedHttpResponse aRes = createRepository(systemAdminClient, repoName);
         assertThat(aRes.status()).isEqualTo(HttpStatus.CREATED);
-        final BlockingWebClient client = dogma.httpClient().blocking();
+        final BlockingWebClient client = systemAdminClient.blocking();
         ResponseEntity<RepositoryDto> responseEntity = client.prepare()
                                                              .get(REPOS_PREFIX + '/' + repoName)
                                                              .asJson(RepositoryDto.class)
@@ -195,7 +274,14 @@ class RepositoryServiceV1Test {
         assertThat(responseEntity.status()).isSameAs(HttpStatus.OK);
         assertThat(responseEntity.content().status()).isSameAs(RepositoryStatus.READ_ONLY);
 
-        final CentralDogmaRepository centralDogmaRepository = dogma.client().forRepo("myPro", "statusRepo");
+        final CentralDogma dogmaClient = new ArmeriaCentralDogmaBuilder()
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
+                .accessToken(getAccessToken(dogma.httpClient(),
+                                            TestAuthMessageUtil.USERNAME,
+                                            TestAuthMessageUtil.PASSWORD))
+                .build();
+
+        final CentralDogmaRepository centralDogmaRepository = dogmaClient.forRepo("myPro", "statusRepo");
         assertThatThrownBy(() -> centralDogmaRepository.commit("commit", Change.ofTextUpsert("/foo.txt", "foo"))
                                                        .push().join())
                 .hasCauseExactlyInstanceOf(ReadOnlyException.class);
@@ -227,8 +313,8 @@ class RepositoryServiceV1Test {
         assertThat(credential.status()).isSameAs(HttpStatus.CREATED);
     }
 
-    ResponseEntity<RepositoryDto> updateStatus(RepositoryStatus status, String repoName) {
-        final BlockingWebClient client = dogma.httpClient().blocking();
+    private static ResponseEntity<RepositoryDto> updateStatus(RepositoryStatus status, String repoName) {
+        final BlockingWebClient client = systemAdminClient.blocking();
         return client.prepare()
                      .put(REPOS_PREFIX + '/' + repoName + "/status")
                      .contentJson(new UpdateRepositoryStatusRequest(status))
@@ -239,11 +325,11 @@ class RepositoryServiceV1Test {
     private static ResponseEntity<PushResultDto> createCredential() {
         final CreateCredentialRequest request = new CreateCredentialRequest(
                 "access-token-credential", new AccessTokenCredential(null, "secret-token-abc-1"));
-        return dogma.blockingHttpClient().prepare()
-                    .post("/api/v1/projects/myPro/credentials")
-                    .contentJson(request)
-                    .asJson(PushResultDto.class)
-                    .execute();
+        return systemAdminClient.blocking().prepare()
+                                .post("/api/v1/projects/myPro/credentials")
+                                .contentJson(request)
+                                .asJson(PushResultDto.class)
+                                .execute();
     }
 
     @Nested
@@ -264,7 +350,7 @@ class RepositoryServiceV1Test {
 
         @BeforeEach
         void setUp() {
-            createProject(dogma);
+            createProject(dogma.httpClient());
         }
 
         @Test
@@ -279,7 +365,7 @@ class RepositoryServiceV1Test {
                     "   {" +
                     "       \"name\": \"dogma\"," +
                     "       \"creator\": {" +
-                    "           \"name\": \"System\"," +
+                    "           \"name\": \"system\"," +
                     "           \"email\": \"system@localhost.localdomain\"" +
                     "       }," +
                     "       \"headRevision\": \"${json-unit.ignore}\"," +
@@ -290,7 +376,7 @@ class RepositoryServiceV1Test {
                     "   {" +
                     "       \"name\": \"meta\"," +
                     "       \"creator\": {" +
-                    "           \"name\": \"System\"," +
+                    "           \"name\": \"system\"," +
                     "           \"email\": \"system@localhost.localdomain\"" +
                     "       }," +
                     "       \"headRevision\": \"${json-unit.ignore}\"," +
@@ -381,13 +467,12 @@ class RepositoryServiceV1Test {
         }
     }
 
-    private static void createProject(CentralDogmaExtension dogma) {
+    private static void createProject(WebClient client) {
         // the default project used for unit tests
         final String body = "{\"name\": \"myPro\"}";
         final RequestHeaders headers = RequestHeaders.of(HttpMethod.POST, PROJECTS_PREFIX,
                                                          HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
 
-        final WebClient client = dogma.httpClient();
         client.execute(headers, body).aggregate().join();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -219,7 +219,10 @@ class MetadataServiceTest {
     void userRepositoryRole() {
         final MetadataService mds = newMetadataService(manager);
 
-        mds.addRepo(author, project1, repo1, ProjectRoles.of(null, null)).join();
+        final RepositoryMetadata repositoryMetadata =
+                RepositoryMetadata.of(repo1, Roles.EMPTY, UserAndTimestamp.of(author));
+
+        mds.addRepo(author, project1, repo1, repositoryMetadata).join();
         await().until(() -> getRepo1(mds) != null);
 
         // Not a member yet.


### PR DESCRIPTION
Motivation:
Currently, when projects or repositories are created using an access token, the token is not automatically granted the corresponding owner/admin roles. This results in inconsistent permissions, as the token that initiated the creation does not have proper control afterward.

Modifications:
- Grant the token project owner role when creating a project.
- Grant the token repository admin role when creating a repository.
  - Since any project member can create a repository, explicit ADMIN permission is required.
- Standardize token user email format by appending `@dogma-token.local` to the token app ID, instead of adding the remote host string.
  - The remote host string was meaningless in this context.
  - This change allows clear distinction between user accounts and token accounts without introducing a separate `AuthorType`, since authors must still be retrieved from Git logs.

Result:
- Access tokens used to create projects and repositories now have appropriate owner/admin roles.
- Improved clarity in author identification between users and tokens.