### PR TITLE
Log ZooKeeper lock acquisition duration for performance monitoring

### DIFF
--- a/server/src/test/java/com/linecorp/centraldogma/server/ServerTimeoutTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ServerTimeoutTest.java
@@ -72,6 +72,10 @@ class ServerTimeoutTest {
                 (ZooKeeperReplicationConfig) config.replicationConfig();
         final int clientPort = replicationConfig.serverConfig().clientPort();
 
+        // Because push isn't called yet, zookeeper_lock_acquired metric should not be present.
+        String metrics = delegate.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
+        assertThat(metrics).doesNotContain("zookeeper_lock_acquired");
+
         final CuratorFramework curator = CuratorFrameworkFactory.newClient(
                 "127.0.0.1:" + clientPort, new RetryForever(100));
         curator.start();
@@ -105,5 +109,9 @@ class ServerTimeoutTest {
                                              .push()
                                              .join();
         assertThat(pushResult.revision().major()).isPositive();
+
+        // Because push is called, zookeeper_lock_acquired metric should be present.
+        metrics = delegate.httpClient().get("/monitor/metrics").aggregate().join().contentUtf8();
+        assertThat(metrics).contains("zookeeper_lock_acquired");
     }
 }


### PR DESCRIPTION
Motivation:
Without specific metrics, it is difficult to determine if slow operations are caused by lock contention, network issues, or problems within the ZooKeeper ensemble itself.

Modifications:
-   Identified the critical section of code responsible for acquiring a distributed ZooKeeper lock.
- Implemented to record duration for acquiring a ZooKeeper lock.
  - Record only for push commands using projectName to reduce the cardinality

Result:
- The ZooKeeper lock acquision time is now recorded.