### PR TITLE
Avoid including raw content in `AbstractPushCommand.toString()`

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/Watcher.java
@@ -49,10 +49,10 @@ public interface Watcher<T> extends AutoCloseable {
     /**
      * Creates a forked {@link Watcher} based on an existing {@link JsonNode}-watching {@link Watcher}.
      *
-     * @param jsonPointer a <a href="https://tools.ietf.org/html/rfc6901">JSON pointer</a> that is encoded
+     * @param jsonPointer a <a href="https://datatracker.ietf.org/doc/html/rfc6901">JSON pointer</a> that is encoded
      *
      * @return A new child {@link Watcher}, whose transformation is a
-     *         <a href="https://tools.ietf.org/html/rfc6901">JSON pointer</a> query.
+     *         <a href="https://datatracker.ietf.org/doc/html/rfc6901">JSON pointer</a> query.
      */
     static Watcher<JsonNode> atJsonPointer(Watcher<JsonNode> watcher, String jsonPointer) {
         requireNonNull(watcher, "watcher");

--- a/common/src/main/java/com/linecorp/centraldogma/common/Change.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/Change.java
@@ -231,7 +231,7 @@ public interface Change<T> {
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_JSON_PATCH}.
      *
      * @param path the path of the file
-     * @param jsonPatch the patch in <a href="https://tools.ietf.org/html/rfc6902">JSON patch format</a>
+     * @param jsonPatch the patch in <a href="https://datatracker.ietf.org/doc/html/rfc6902">JSON patch format</a>
      */
     static Change<JsonNode> ofJsonPatch(String path, JsonPatchOperation jsonPatch) {
         requireNonNull(path, "path");
@@ -243,7 +243,7 @@ public interface Change<T> {
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_JSON_PATCH}.
      *
      * @param path the path of the file
-     * @param jsonPatches the list of patches in <a href="https://tools.ietf.org/html/rfc6902">JSON patch format</a>
+     * @param jsonPatches the list of patches in <a href="https://datatracker.ietf.org/doc/html/rfc6902">JSON patch format</a>
      */
     static Change<JsonNode> ofJsonPatch(String path, JsonPatchOperation... jsonPatches) {
         requireNonNull(jsonPatches, "jsonPatches");
@@ -254,7 +254,7 @@ public interface Change<T> {
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_JSON_PATCH}.
      *
      * @param path the path of the file
-     * @param jsonPatches the list of patches in <a href="https://tools.ietf.org/html/rfc6902">JSON patch format</a>
+     * @param jsonPatches the list of patches in <a href="https://datatracker.ietf.org/doc/html/rfc6902">JSON patch format</a>
      */
     static Change<JsonNode> ofJsonPatch(String path, Iterable<? extends JsonPatchOperation> jsonPatches) {
         requireNonNull(path, "path");
@@ -268,7 +268,7 @@ public interface Change<T> {
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_JSON_PATCH}.
      *
      * @param path the path of the file
-     * @param jsonPatchText the patch in <a href="https://tools.ietf.org/html/rfc6902">JSON patch format</a>
+     * @param jsonPatchText the patch in <a href="https://datatracker.ietf.org/doc/html/rfc6902">JSON patch format</a>
      *
      * @throws ChangeFormatException if the specified {@code jsonPatchText} is not a valid JSON
      */
@@ -289,7 +289,7 @@ public interface Change<T> {
      * Returns a newly-created {@link Change} whose type is {@link ChangeType#APPLY_JSON_PATCH}.
      *
      * @param path the path of the file
-     * @param jsonPatchNode the patch in <a href="https://tools.ietf.org/html/rfc6902">JSON patch format</a>
+     * @param jsonPatchNode the patch in <a href="https://datatracker.ietf.org/doc/html/rfc6902">JSON patch format</a>
      */
     static Change<JsonNode> ofJsonPatch(String path, JsonNode jsonPatchNode) {
         requireNonNull(jsonPatchNode, "jsonPatchNode");

--- a/common/src/main/java/com/linecorp/centraldogma/common/ChangeType.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/ChangeType.java
@@ -50,7 +50,7 @@ public enum ChangeType {
 
     /**
      * Applies a JSON patch to a JSON file. The {@link Change#content()} of this type is a JSON patch object,
-     * as defined in <a href="https://tools.ietf.org/html/rfc6902">RFC 6902</a>.
+     * as defined in <a href="https://datatracker.ietf.org/doc/html/rfc6902">RFC 6902</a>.
      */
     APPLY_JSON_PATCH(JsonNode.class),
 

--- a/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/Util.java
@@ -444,7 +444,7 @@ public final class Util {
 
                     // Verify this address is of the correct structure to contain an IPv4 address.
                     // It must be IPv4-Mapped or IPv4-Compatible
-                    // (see https://tools.ietf.org/html/rfc4291#section-2.5.5).
+                    // (see  https://datatracker.ietf.org/doc/html/rfc4291#section-2.5.5).
                     final int ipv4Start = i - wordLen;
                     int j = ipv4Start - 2; // index of character before the previous ':'.
                     if (isValidIPv4MappedChar(ip.charAt(j))) {

--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/AccessToken.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/AccessToken.java
@@ -30,7 +30,7 @@ import com.google.common.base.MoreObjects;
 /**
  * An OAuth 2.0 access token.
  *
- * @see <a href="https://tools.ietf.org/html/rfc6749#section-4.2.2">Access Token Response</a>
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-4.2.2">Access Token Response</a>
  */
 public class AccessToken {
 

--- a/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatchUtil.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/jsonpatch/JsonPatchUtil.java
@@ -25,7 +25,7 @@ public final class JsonPatchUtil {
 
     /**
      * Adds a leading slash and replaces '/' and '~' with '~1' and '~0' respectively.
-     * See <a href="https://tools.ietf.org/html/rfc6901">rfc6901</a> for more information.
+     * See <a href="https://datatracker.ietf.org/doc/html/rfc6901">rfc6901</a> for more information.
      */
     public static String encodeSegment(String segment) {
         requireNonNull(segment, "segment");

--- a/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
+++ b/server-auth/shiro/src/main/java/com/linecorp/centraldogma/server/auth/shiro/LoginService.java
@@ -154,7 +154,7 @@ final class LoginService extends AbstractHttpService {
      * Returns {@link UsernamePasswordToken} which holds a username and a password.
      */
     private UsernamePasswordToken usernamePassword(ServiceRequestContext ctx, AggregatedHttpRequest req) {
-        // check the Basic HTTP authentication first (https://tools.ietf.org/html/rfc7617)
+        // check the Basic HTTP authentication first (https://datatracker.ietf.org/doc/html/rfc7617)
         final BasicToken basicToken = AuthTokenExtractors.basic().apply(RequestHeaders.of(req.headers()));
         if (basicToken != null) {
             return new UsernamePasswordToken(basicToken.username(), basicToken.password());

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogmaBuilder.java
@@ -194,7 +194,7 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Adds addresses or ranges of <a href="https://tools.ietf.org/html/rfc4632">
+     * Adds addresses or ranges of <a href="https://datatracker.ietf.org/doc/html/rfc4632">
      * Classless Inter-domain Routing (CIDR)</a> blocks of trusted proxy servers.
      *
      * @param exactOrCidrAddresses a list of addresses and CIDR blocks, e.g. {@code 10.0.0.1} for a single
@@ -207,7 +207,7 @@ public final class CentralDogmaBuilder {
     }
 
     /**
-     * Adds addresses or ranges of <a href="https://tools.ietf.org/html/rfc4632">
+     * Adds addresses or ranges of <a href="https://datatracker.ietf.org/doc/html/rfc4632">
      * Classless Inter-domain Routing (CIDR)</a> blocks of trusted proxy servers.
      *
      * @param exactOrCidrAddresses a list of addresses and CIDR blocks, e.g. {@code 10.0.0.1} for a single

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
@@ -81,6 +81,9 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
         return started;
     }
 
+    /**
+     * Returns {@code true} if the {@link CommandExecutor} is in the process of stopping.
+     */
     protected final boolean isStopping() {
         return numPendingStopRequests.get() > 0;
     }
@@ -95,6 +98,9 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
         });
     }
 
+    /**
+     * Starts the {@link CommandExecutor}.
+     */
     protected abstract void doStart(@Nullable Runnable onTakeLeadership,
                                     @Nullable Runnable onReleaseLeadership,
                                     @Nullable Runnable onTakeZoneLeadership,
@@ -107,6 +113,9 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
         return startStop.stop().thenRun(numPendingStopRequests::decrementAndGet);
     }
 
+    /**
+     * Stops the {@link CommandExecutor}.
+     */
     protected abstract void doStop(@Nullable Runnable onReleaseLeadership,
                                    @Nullable Runnable onReleaseZoneLeadership) throws Exception;
 
@@ -142,6 +151,9 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
         }
     }
 
+    /**
+     * Executes the specified {@link Command}.
+     */
     protected abstract <T> CompletableFuture<T> doExecute(Command<T> command) throws Exception;
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractPushCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractPushCommand.java
@@ -143,7 +143,6 @@ public abstract class AbstractPushCommand<T> extends RepositoryCommand<T> {
                     .add("summary", summary)
                     .add("detail", detail)
                     .add("markup", markup)
-                    .add("numChanges", changes.size())
                     .add("changes", changesBuilder.toString());
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractPushCommand.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractPushCommand.java
@@ -122,11 +122,28 @@ public abstract class AbstractPushCommand<T> extends RepositoryCommand<T> {
 
     @Override
     ToStringHelper toStringHelper() {
+        // Build a summary of changes to avoid overly long toString() result.
+        final StringBuilder changesBuilder = new StringBuilder("[");
+        for (int i = 0; i < changes.size(); i++) {
+            final Change<?> change = changes.get(i);
+            final String content = change.contentAsText();
+            changesBuilder.append("{type: ").append(change.type())
+                          .append(", path: ").append(change.path())
+                          .append(", contentLength: ")
+                          .append(content != null ? content.length() : 0)
+                          .append('}');
+            if (i != changes.size() - 1) {
+                changesBuilder.append(", ");
+            }
+        }
+        changesBuilder.append(']');
+
         return super.toStringHelper()
                     .add("baseRevision", baseRevision)
                     .add("summary", summary)
                     .add("detail", detail)
                     .add("markup", markup)
-                    .add("changes", changes);
+                    .add("numChanges", changes.size())
+                    .add("changes", changesBuilder.toString());
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/PushCommandTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/PushCommandTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.Revision;
+
+class PushCommandTest {
+
+    @Test
+    void shouldNotContainRawContentInToString() {
+        final Change<JsonNode> json = Change.ofJsonUpsert("/a.json", "{ \"foo\": \"bar\" }");
+        final Change<String> text = Change.ofTextUpsert("/a.txt", "Hello");
+        final Change<Void> removal = Change.ofRemoval("/b.txt");
+        final List<Change<?>> changes = ImmutableList.of(json, text, removal);
+
+        final Command<CommitResult> pushCommand =
+                Command.push(Author.SYSTEM, "myProject", "myRepo",
+                             Revision.HEAD,
+                             "summary", "detail",
+                             Markup.PLAINTEXT, changes);
+        assertThat(pushCommand.toString()).contains(
+                "changes=[{type: UPSERT_JSON, path: /a.json, contentLength: " + json.contentAsText().length() +
+                "}, {type: UPSERT_TEXT, path: /a.txt, contentLength: " + text.contentAsText().length() +
+                "}, {type: REMOVE, path: /b.txt, contentLength: 0}]");
+    }
+}

--- a/settings/checkstyle/checkstyle.xml
+++ b/settings/checkstyle/checkstyle.xml
@@ -31,7 +31,7 @@
   <!-- Copyright headers -->
   <module name="RegexpSingleline">
     <property name="id" value="CopyrightHeader"/>
-    <property name="format" value="^(?:\s|\*)*Copyright\s+[0-9]+\s+LINE Corporation\s*$"/>
+    <property name="format" value="^(?:\s|\*)*Copyright\s+[0-9]+\s+(LINE|LY) Corporation\s*$"/>
     <property name="minimum" value="1"/>
     <property name="maximum" value="1"/>
     <property name="message" value="missing copyright header"/>
@@ -60,6 +60,11 @@
   <module name="RegexpSingleline">
     <property name="format" value="File \| Settings \| File Templates"/>
     <property name="message" value="IDE-generated comment"/>
+  </module>
+  <!-- Use datatracker.ietf.org if possible. -->
+  <module name="RegexpSingleline">
+    <property name="format" value="(http://datatracker\.ietf\.org|tools\.ietf\.org|rfc-editor\.org|(www\.ietf\.org|httpwg\.org|w3\.org)/[^ ]+/rfc)"/>
+    <property name="message" value="Use https://datatracker.ietf.org/ instead."/>
   </module>
   <!-- Trailing spaces -->
   <module name="RegexpSingleline">
@@ -186,7 +191,9 @@
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>
     </module>
-    <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocMethod">
+      <property name="scope" value="protected"/>
+    </module>
     <module name="MissingJavadocPackage"/>
     <module name="MissingJavadocType"/>
     <module name="JavadocParagraph"/>


### PR DESCRIPTION
Motivation:

Some push requests may contain large content exceeding 1MB. Including such large values in `AbstractPushCommand.toString()` is risky. It could overwhelm the logging buffer or even cause memory leaks if cached.

Modifications:

- Include only contentLength when generating a string representation of a push command.

Result:

`*PushCommand.toString()` no longer includes raw content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved push operation logging to show concise change summaries (type, path, content length) without exposing raw content.
* **Tests**
  * Added unit tests to verify the new push log formatting and content-length reporting.
* **Documentation**
  * Updated various RFC reference links in docs/Javadoc to use the datatracker.ietf.org URLs.
* **Chores**
  * Tightened style checks and adjusted header/Javadoc checkstyle rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->