### PR TITLE
Compress ZooKeeper replication logs

### DIFF
--- a/dependencies.toml
+++ b/dependencies.toml
@@ -83,6 +83,7 @@ thrift09 = { strictly = "0.9.3-1" }
 # See: https://github.com/apache/curator/blob/master/pom.xml
 #      (Switch to the right tag to find out the right version.)
 zookeeper = "3.9.3"
+zstd = "1.5.7-4"
 
 [boms]
 armeria = { module = "com.linecorp.armeria:armeria-bom", version.ref = "armeria" }
@@ -464,6 +465,10 @@ exclusions = [
     "log4j:log4j",
     "org.apache.yetus:audience-annotations",
     "org.slf4j:slf4j-log4j12"]
+
+[libraries.zstd]
+module = "com.github.luben:zstd-jni"
+version.ref = "zstd"
 
 [plugins]
 download = { id = "de.undercouch.download", version.ref = "download" }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -47,6 +47,8 @@ dependencies {
     // Snappy
     implementation libs.snappy
 
+    implementation libs.zstd
+
     // Logging
     optionalImplementation libs.logback15
     // For Caffiene. See https://github.com/line/centraldogma/pull/499


### PR DESCRIPTION
Motivation:

When a file is newly created or has a large diff, the replication log size can grow significantly. With compression, up to about 7–8 MB of data can be stored in a single znode, improving replication performance.

Modifcations:

- Add `zstd-jni` dependency to the server module.
- Compress replication logs using zstd before storing them in ZooKeeper.
- Decompress replication logs when compressed prior to replay.

Result:

Central Dogma server now compresses replication logs with zstd.