### PR TITLE
Upgrade Java version to 17 in Dockerfile

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -206,10 +206,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Docker Image Build Test
+      - name: Build Docker Image
+        run: ./gradlew :dist:docker --stacktrace -Pversion=test
+
+      - name: Test DockerCompose
         # Make sure Central Dogma docker container can be started and healthy.
         run: |
-          ./gradlew :dist:docker --stacktrace -Pversion=test
           docker compose -f dist/docker-compose-test.yml up --wait -d
           docker compose -f  dist/docker-compose-test.yml down
         shell: bash

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -217,7 +217,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Docker Image
-        run: ./gradlew :dist:docker --stacktrace -Pversion=test
+        run: |
+          ./gradlew :dist:docker --stacktrace -Pversion=test
+          docker images
 
       - name: Test DockerCompose
         # Make sure Central Dogma docker container can be started and healthy.

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -190,3 +190,26 @@ jobs:
         run: |
           ./gradlew --no-daemon --stacktrace check -PnoLint -PflakyTests=true
         shell: bash
+
+  docker-build:
+    if: github.repository == 'line/centraldogma'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GRADLE_OPTS: -Xmx1280m
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Image Build Test
+        # Make sure Central Dogma docker container can be started and healthy.
+        run: |
+          ./gradlew :dist:docker --stacktrace -Pversion=test
+          docker compose -f dist/docker-compose-test.yml up --wait -d
+          docker compose -f  dist/docker-compose-test.yml down
+        shell: bash

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -200,6 +200,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - id: setup-jdk
+        name: Set up JDK ${{ env.BUILD_JDK_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ env.BUILD_JDK_VERSION }}
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -211,5 +211,5 @@ jobs:
         run: |
           ./gradlew :dist:docker --stacktrace -Pversion=test
           docker compose -f dist/docker-compose-test.yml up --wait -d
-          docker compose -f  dist/docker-compose-test.yml down
+          docker compose -f dist/docker-compose-test.yml down
         shell: bash

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -224,6 +224,6 @@ jobs:
       - name: Test DockerCompose
         # Make sure Central Dogma docker container can be started and healthy.
         run: |
-          docker compose -f dist/docker-compose-test.yml up --wait -d
+          docker compose -f dist/docker-compose-test.yml up --pull never --wait -d
           docker compose -f dist/docker-compose-test.yml down
         shell: bash

--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,7 +1,7 @@
 #
 # CentralDogma Dockerfile
 #
-FROM openjdk:11-jre
+FROM eclipse-temurin:17-jre
 
 # Multi-platform build arguments (pre-defined by docker)
 ARG TARGETARCH
@@ -36,6 +36,10 @@ COPY --chmod=755 \
 
 # Expose ports.
 EXPOSE 36462
+
+# Healthcheck – waits for the HTTP API to respond
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=10 \
+  CMD curl -f http://127.0.0.1:36462/monitor/l7check || exit 1
 
 # Entrypoint doesn't allow an environment variable.
 ENTRYPOINT ["/opt/centraldogma/bin/startup", "-nodetach"]

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -213,8 +213,10 @@ task docker(group: 'Build',
         '--platform', platforms.join(','),
     ]
 
-    if (imageVersion != 'test') {
-       buildArgs.add('--push')
+    if (imageVersion == 'test') {
+       buildArgs.add('--load')
+    } else {
+        buildArgs.add('--push')
     }
 
     buildArgs.add("--tag")

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -219,7 +219,7 @@ task docker(group: 'Build',
 
     buildArgs.add("--tag")
     buildArgs.add("${imageName}:${imageVersion}")
-    if (!(project.version =~ /-SNAPSHOT$/)) {
+    if (imageVersion != 'test' && !(project.version =~ /-SNAPSHOT$/)) {
         buildArgs.add("--tag")
         buildArgs.add("${imageName}:latest")
     }

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -211,8 +211,11 @@ task docker(group: 'Build',
     def buildArgs = [
         'buildx', 'build',
         '--platform', platforms.join(','),
-        '--push'
     ]
+
+    if (imageVersion != 'test') {
+       buildArgs.add('--push')
+    }
 
     buildArgs.add("--tag")
     buildArgs.add("${imageName}:${imageVersion}")

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -40,8 +40,8 @@ dependencies {
 tasks.jar.enabled = false
 
 task copyLicenses(group: 'Build',
-                  description: "Copies license information into ${project.ext.relativeDistDir}/licenses",
-                  type: Copy) {
+        description: "Copies license information into ${project.ext.relativeDistDir}/licenses",
+        type: Copy) {
 
     from "${rootProject.projectDir}"
     into "${project.ext.distDir}"
@@ -52,9 +52,9 @@ task copyLicenses(group: 'Build',
 }
 
 task copyLib(group: 'Build',
-             description: "Copies JARs into ${project.ext.relativeDistDir}/lib",
-             dependsOn: project(':server').tasks.jar,
-             type: Copy) {
+        description: "Copies JARs into ${project.ext.relativeDistDir}/lib",
+        dependsOn: project(':server').tasks.jar,
+        type: Copy) {
 
     from configurations.runtimeClasspath
     File libDir = new File("${project.ext.distDir}/lib")
@@ -159,8 +159,8 @@ task distDirWithoutClientBinaries(group: 'Build',
 }
 
 task distDir(group: 'Build',
-             description: "Builds a distribution directory (${project.ext.relativeDistDir})",
-             dependsOn: [tasks.copyLicenses, tasks.copyLib, tasks.copyClientBinaries])
+        description: "Builds a distribution directory (${project.ext.relativeDistDir})",
+        dependsOn: [tasks.copyLicenses, tasks.copyLib, tasks.copyClientBinaries])
 
 // Create the tasks that copy each directory under src/ into dist/
 ['bin', 'conf'].each { dirName ->
@@ -174,9 +174,9 @@ task distDir(group: 'Build',
 }
 
 task tarball(group: 'Build',
-             description: "Builds a tarball from the distribution directory (${project.ext.relativeDistDir})",
-             dependsOn: tasks.distDir,
-             type: Tar) {
+        description: "Builds a tarball from the distribution directory (${project.ext.relativeDistDir})",
+        dependsOn: tasks.distDir,
+        type: Tar) {
 
     archiveBaseName = rootProject.name
     destinationDirectory = project.file("${project.buildDir}")
@@ -196,35 +196,34 @@ tasks.assemble.dependsOn(tasks.tarball)
 
 // Tasks for building docker image
 task docker(group: 'Build',
-            description: "Builds multiplatform docker image from the distribution directory" +
-                    " (${project.ext.relativeDistDir})",
-            dependsOn: tasks.distDir,
-            type: Exec) {
+        description: "Builds multiplatform docker image from the distribution directory" +
+                " (${project.ext.relativeDistDir})",
+        dependsOn: tasks.distDir,
+        type: Exec) {
 
     workingDir = file('.')
     executable 'docker'
 
     def imageName = 'ghcr.io/line/centraldogma'
     def imageVersion = project.hasProperty('version') ? project.getProperty('version') : project.version
-    def platforms = ['linux/amd64', 'linux/arm64']
-
-    def buildArgs = [
-        'buildx', 'build',
-        '--platform', platforms.join(','),
-    ]
-
+    def buildArgs = ['buildx', 'build']
     if (imageVersion == 'test') {
-       buildArgs.add('--load')
+        buildArgs.addAll([
+                '--platform', 'linux/amd64',
+                '--load',
+                "--tag", "${imageName}:${imageVersion}"
+        ])
     } else {
-        buildArgs.add('--push')
+        buildArgs.addAll([
+                '--platform', 'linux/amd64,linux/arm64',
+                '--push',
+                "--tag", "${imageName}:${imageVersion}"
+        ])
+        if (!(project.version =~ /-SNAPSHOT$/)) {
+            buildArgs.addAll(["--tag", "${imageName}:latest"])
+        }
     }
 
-    buildArgs.add("--tag")
-    buildArgs.add("${imageName}:${imageVersion}")
-    if (imageVersion != 'test' && !(project.version =~ /-SNAPSHOT$/)) {
-        buildArgs.add("--tag")
-        buildArgs.add("${imageName}:latest")
-    }
     buildArgs.add('.')
 
     args = buildArgs
@@ -232,16 +231,16 @@ task docker(group: 'Build',
 
 // Tasks for running Central Dogma conveniently.
 task startup(group: 'Execution',
-             description: "Starts up Central Dogma at ${project.ext.relativeDistDir}",
-             dependsOn: tasks.distDir,
-             type: Exec) {
+        description: "Starts up Central Dogma at ${project.ext.relativeDistDir}",
+        dependsOn: tasks.distDir,
+        type: Exec) {
 
     commandLine "${project.ext.distDir}/bin/startup"
 }
 
 task shutdown(group: 'Execution',
-              description: "Shuts down Central Dogma at ${project.ext.relativeDistDir}",
-              type: Exec) {
+        description: "Shuts down Central Dogma at ${project.ext.relativeDistDir}",
+        type: Exec) {
 
     commandLine "${project.ext.distDir}/bin/shutdown"
 }
@@ -249,5 +248,5 @@ task shutdown(group: 'Execution',
 tasks.startup.mustRunAfter(tasks.shutdown)
 
 task restart(group: 'Execution',
-             description: "Restarts Central Dogma at ${project.ext.relativeDistDir}",
-             dependsOn: [tasks.shutdown, tasks.startup])
+        description: "Restarts Central Dogma at ${project.ext.relativeDistDir}",
+        dependsOn: [tasks.shutdown, tasks.startup])

--- a/dist/docker-compose-test.yml
+++ b/dist/docker-compose-test.yml
@@ -1,0 +1,3 @@
+services:
+  centraldogma:
+    image: ghcr.io/line/centraldogma:test


### PR DESCRIPTION
Motivation:

The latest Central Dogma docker image failes to start up on the `ubuntu-latest` image of GitHub Actions due to the following NPE:
```
Error: -20 09:22:41.518 [ERROR](c.l.c.s.Main) [main] Failed to start the Central Dogma:
java.util.concurrent.ExecutionException: java.lang.NullPointerException
	at java.base/java.util.concurrent.CompletableFuture.reportGet(Unknown Source)
	at java.base/java.util.concurrent.CompletableFuture.get(Unknown Source)
	at com.linecorp.armeria.common.util.EventLoopCheckingFuture.get(EventLoopCheckingFuture.java:73)
	at com.linecorp.centraldogma.server.Main.start(Main.java:138)
	at com.linecorp.centraldogma.server.Main.main(Main.java:238)
Caused by: java.lang.NullPointerException: null
	at java.base/jdk.internal.platform.cgroupv2.CgroupV2Subsystem.getInstance(Unknown Source)
	at java.base/jdk.internal.platform.CgroupSubsystemFactory.create(Unknown Source)
	at java.base/jdk.internal.platform.CgroupMetrics.getInstance(Unknown Source)
	at java.base/jdk.internal.platform.SystemMetrics.instance(Unknown Source)
	at java.base/jdk.internal.platform.Metrics.systemMetrics(Unknown Source)
	at java.base/jdk.internal.platform.Container.metrics(Unknown Source)
	at jdk.management/com.sun.management.internal.OperatingSystemImpl.<init>(Unknown Source)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl.getOperatingSystemMXBean(Unknown Source)
	at jdk.management/com.sun.management.internal.PlatformMBeanProviderImpl$3.nameToMBeanMap(Unknown Source)
	at java.management/sun.management.spi.PlatformMBeanProvider$PlatformComponent.getMBeans(Unknown Source)
	at java.management/java.lang.management.ManagementFactory.getPlatformMXBean(Unknown Source)
	at java.management/java.lang.management.ManagementFactory.getOperatingSystemMXBean(Unknown Source)
	at io.micrometer.core.instrument.binder.system.FileDescriptorMetrics.<init>(FileDescriptorMetrics.java:78)
	at io.micrometer.core.instrument.binder.system.FileDescriptorMetrics.<init>(FileDescriptorMetrics.java:74)
	at com.linecorp.centraldogma.server.CentralDogma.configureMetrics(CentralDogma.java:1130)
	at com.linecorp.centraldogma.server.CentralDogma.startServer(CentralDogma.java:772)
	at com.linecorp.centraldogma.server.CentralDogma.doStart(CentralDogma.java:474)
	at com.linecorp.centraldogma.server.CentralDogma.access$800(CentralDogma.java:198)
	at com.linecorp.centraldogma.server.CentralDogma$CentralDogmaStartStop.lambda$doStart$0(CentralDogma.java:1306)
	at com.linecorp.centraldogma.server.CentralDogma$CentralDogmaStartStop.lambda$execute$2(CentralDogma.java:1345)
	at java.base/java.lang.Thread.run(Unknown Source)
```
The exception seems fixed by https://bugs.openjdk.org/browse/JDK-8287073, so upgrading Java version will solve the issue.

Related: https://github.com/line/centraldogma-python/pull/70

Modifications:

- Upgrade the JRE version of the Docker image to 17
- Add a CI test to check if Central Dogma docker images start successfully.

Result:

Central Dogma Docker image now starts up properly in GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow that builds Docker images and verifies them by bringing up and health-checking the compose services.
  * Updated the build environment to use a modern JDK, configured build tooling, and increased job timeout to support image builds and integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->