### PR TITLE
Bump GitHub Actions versions

### DIFF
--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -71,7 +71,7 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v3
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Build with Gradle
       run: |
@@ -162,7 +162,7 @@ jobs:
           java-version: ${{ env.BUILD_JDK_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build with Gradle
         run: |
@@ -186,7 +186,7 @@ jobs:
           java-version: ${{ env.BUILD_JDK_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Run flaky tests
         run: |

--- a/.github/workflows/actions_build.yml
+++ b/.github/workflows/actions_build.yml
@@ -53,7 +53,7 @@ jobs:
         JOB_NAME="build-${{ matrix.os }}-jdk-${{ matrix.java }}${{ matrix.min-java && format('-min-java-{0}', matrix.min-java) || '' }}${{ matrix.coverage && '-coverage' || ''}}${{ matrix.snapshot && '-snapshot' || ''}}"
         echo "JOB_NAME=$JOB_NAME" >> $GITHUB_ENV
       shell: bash
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - id: setup-build-jdk
       name: Set up build JDK ${{ env.BUILD_JDK_VERSION }}
@@ -71,7 +71,7 @@ jobs:
         java-version: ${{ matrix.java }}
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
+      uses: gradle/actions/setup-gradle@v3
 
     - name: Build with Gradle
       run: |
@@ -152,17 +152,17 @@ jobs:
     env:
       GRADLE_OPTS: -Xmx1280m
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: setup-jdk
         name: Set up JDK ${{ env.BUILD_JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.BUILD_JDK_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build with Gradle
         run: |
@@ -176,17 +176,17 @@ jobs:
     env:
       GRADLE_OPTS: -Xmx1280m
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: setup-jdk
         name: Set up JDK ${{ env.BUILD_JDK_VERSION }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ env.BUILD_JDK_VERSION }}
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Run flaky tests
         run: |

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,17 +14,17 @@ jobs:
     if: github.repository == 'line/centraldogma'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - id: setup-jdk-21
         name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build with Gradle
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build with Gradle
         run: |

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -13,7 +13,7 @@ jobs:
     if: github.repository == 'line/centraldogma'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install graphviz
         run: |
@@ -21,13 +21,13 @@ jobs:
 
       - id: setup-jdk-21
         name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Build the site
         run: |

--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -27,7 +27,7 @@ jobs:
           java-version: '21'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build the site
         run: |

--- a/.github/workflows/tag-new-release.yml
+++ b/.github/workflows/tag-new-release.yml
@@ -57,7 +57,7 @@ jobs:
           java-version: '21'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v3
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Bump up version
         run: |

--- a/.github/workflows/tag-new-release.yml
+++ b/.github/workflows/tag-new-release.yml
@@ -51,13 +51,13 @@ jobs:
 
       - id: setup-jdk-21
         name: Set up JDK 21
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Set up Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Bump up version
         run: |

--- a/.github/workflows/update-armeria-version.yml
+++ b/.github/workflows/update-armeria-version.yml
@@ -25,7 +25,7 @@ jobs:
           - armeria-xds
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Wait for Armeria artifacts to be available
         uses: nev7n/wait_for_response@v1
@@ -39,7 +39,7 @@ jobs:
     needs: [ wait-for-armeria-artifacts ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Update Armeria version to ${{ inputs.armeria_version }}
         run: |


### PR DESCRIPTION
To address the comments by coderabbit.
https://github.com/line/centraldogma/pull/1195#discussion_r2450624986 https://github.com/line/centraldogma/pull/1195#discussion_r2450624976

- actions/checkout@v3 -> actions/checkout@v4
- actions/setup-java@v3 -> actions/setup-java@v4
- gradle/gradle-build-action@v2 -> gradle/actions/setup-gradle@v5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to use newer workflow components across build, test, publish, site, release tagging, and Docker pipelines for improved compatibility.
  * Tooling updates only — build, publish and deploy steps keep the same behavior and no public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->