### PR TITLE
Fix flaky `WatchTest.transformingWatcher()`

### DIFF
--- a/it/server/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/WatchTest.java
@@ -437,6 +437,7 @@ class WatchTest {
                                     .join()
                                     .revision();
 
+        await().untilAsserted(() -> assertThat(heavyWatcher.latest().revision()).isEqualTo(rev3));
         Thread.sleep(1100); // DELAY_ON_SUCCESS_MILLIS + epsilon
         assertThat(forExisting.latest()).isEqualTo(new Latest<>(rev2, new TextNode("artichoke")));
         assertThat(watchResult.get()).isEqualTo(forExisting.latest());


### PR DESCRIPTION
Motivation:

The fact that `heavyWatcher` was updated depends on `Thread.sleep(1100)`, so the happen-before relationship may not be guaranteed.
https://github.com/line/centraldogma/blob/144004c87eb1f3a0a21e76f7ff05758d81d6ff40/it/server/src/test/java/com/linecorp/centraldogma/it/WatchTest.java#L440-L444

Modifications:

- Await until `heaveWatcher` receives the latest revision before asserting the latest values.

Result:

Closes #1197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved synchronization in watch tests to ensure proper state propagation before assertions, enhancing test reliability and reducing potential race conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->