### PR TITLE
Allow uppercase characters in mirror and credential IDs

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/CredentialUtil.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/CredentialUtil.java
@@ -26,12 +26,12 @@ public final class CredentialUtil {
 
     // TODO(minwoox): remove ._ from the ID which violates Google AIP.
     public static final Pattern PROJECT_CREDENTIAL_ID_PATTERN =
-            Pattern.compile("^projects/([^/]+)/credentials/([a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?)$");
+            Pattern.compile("^projects/([^/]+)/credentials/([a-zA-Z](?:[a-zA-Z0-9-_.]{0,61}[a-zA-Z0-9])?)$");
 
     // TODO(minwoox): remove ._ from the ID.
     public static final Pattern REPO_CREDENTIAL_ID_PATTERN =
-            Pattern.compile(
-                    "^projects/([^/]+)/repos/([^/]+)/credentials/([a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?)$");
+            Pattern.compile("^projects/([^/]+)/repos/([^/]+)/credentials/" +
+                            "([a-zA-Z](?:[a-zA-Z0-9-_.]{0,61}[a-zA-Z0-9])?)$");
 
     public static String validateCredentialName(String projectName, String repoName,
                                                 String credentialName) {

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirroringAndCredentialServiceV1Test.java
@@ -158,8 +158,8 @@ class MirroringAndCredentialServiceV1Test {
         assertThat(response.status()).isSameAs(HttpStatus.NO_CONTENT);
 
         final CreateCredentialRequest repoCredentialRequest = new CreateCredentialRequest(
-                "repo-credential", new AccessTokenCredential(
-                        credentialName(FOO_PROJ, BAR_REPO, "repo-credential"), "secret-repo-token")
+                "REPO_CREDENTIAL", new AccessTokenCredential(
+                        credentialName(FOO_PROJ, BAR_REPO, "REPO_CREDENTIAL"), "secret-repo-token")
         );
         final ResponseEntity<PushResultDto> creationResponse =
                 userClient.prepare()
@@ -171,27 +171,26 @@ class MirroringAndCredentialServiceV1Test {
                           .execute();
         assertThat(creationResponse.status()).isEqualTo(HttpStatus.CREATED);
         final CreateCredentialRequest projectCredentialRequest = new CreateCredentialRequest(
-                "project-credential", new AccessTokenCredential(
-                credentialName(FOO_PROJ, "project-credential"), "secret-repo-token")
+                "PROJECT_CREDENTIAL", new AccessTokenCredential(
+                credentialName(FOO_PROJ, "PROJECT_CREDENTIAL"), "secret-repo-token")
         );
         createProjectCredential(projectCredentialRequest);
 
         // Create mirrors.
         final MirrorRequest newMirror1 =
-                newMirror(BAR_REPO, "mirror-1", credentialName(FOO_PROJ, BAR_REPO,
-                                                                              "repo-credential"));
+                newMirror(BAR_REPO, "mirror-1", credentialName(FOO_PROJ, BAR_REPO, "REPO_CREDENTIAL"));
         createMirror(BAR_REPO, newMirror1);
         final MirrorRequest newMirror2 =
-                newMirror(BAR_REPO, "mirror-2", credentialName(FOO_PROJ, "project-credential"));
+                newMirror(BAR_REPO, "mirror-2", credentialName(FOO_PROJ, "PROJECT_CREDENTIAL"));
         createMirror(BAR_REPO, newMirror2);
 
         // Read mirrors.
         final MirrorDto mirror1 = getMirror(BAR_REPO, newMirror1.id());
         assertThat(mirror1.credentialName()).isEqualTo(
-                credentialName(FOO_PROJ, BAR_REPO, "repo-credential"));
+                credentialName(FOO_PROJ, BAR_REPO, "REPO_CREDENTIAL"));
         final MirrorDto mirror2 = getMirror(BAR_REPO, newMirror2.id());
         assertThat(mirror2.credentialName()).isEqualTo(
-                credentialName(FOO_PROJ, "project-credential"));
+                credentialName(FOO_PROJ, "PROJECT_CREDENTIAL"));
     }
 
     private static void rejectInvalidRepositoryUri() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/MirroringServiceV1.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.linecorp.centraldogma.server.internal.mirror.DefaultMirroringServicePlugin.mirrorConfig;
 import static com.linecorp.centraldogma.server.internal.storage.repository.DefaultMetaRepository.mirrorFile;
+import static com.linecorp.centraldogma.server.mirror.MirrorUtil.validateMirrorId;
 
 import java.net.URI;
 import java.util.List;
@@ -170,6 +171,7 @@ public class MirroringServiceV1 extends AbstractService {
                                                          Repository repository,
                                                          MirrorRequest newMirror,
                                                          Author author, User user) {
+        validateMirrorId(newMirror.id());
         return createOrUpdate(projectName, repository.name(), newMirror, author, user, false);
     }
 
@@ -215,6 +217,7 @@ public class MirroringServiceV1 extends AbstractService {
             String projectName, String repoName, MirrorRequest newMirror,
             Author author, User user, boolean update) {
         final MetaRepository metaRepo = metaRepo(projectName);
+
         return metaRepo.createMirrorPushCommand(repoName, newMirror, author, zoneConfig, update).thenCompose(
                 command -> {
                     return executor().execute(command).thenApply(result -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/MirrorUtil.java
@@ -15,12 +15,29 @@
  */
 package com.linecorp.centraldogma.server.mirror;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A utility class for creating a mirroring task.
  */
 public final class MirrorUtil {
+
+    private static final Pattern MIRROR_ID_PATTERN =
+            Pattern.compile("^[a-zA-Z](?:[a-zA-Z0-9-_.]{0,61}[a-zA-Z0-9])?$");
+
+    /**
+     * Validates the specified {@code id} as a mirror ID.
+     */
+    public static void validateMirrorId(String id) {
+        final Matcher matcher = MIRROR_ID_PATTERN.matcher(id);
+        checkArgument(matcher.matches(),
+                      "invalid mirror ID: %s (expected: %s)",
+                      id, MIRROR_ID_PATTERN.pattern());
+    }
 
     /**
      * Normalizes the specified {@code path}. A path which starts and ends with {@code /} would be returned.

--- a/webapp/src/dogma/features/project/settings/credentials/CredentialForm.tsx
+++ b/webapp/src/dogma/features/project/settings/credentials/CredentialForm.tsx
@@ -135,7 +135,7 @@ const CredentialForm = ({
               readOnly={!isNew}
               placeholder="The credential ID"
               defaultValue={defaultValue.id}
-              {...register('id', { required: true, pattern: /^[a-z](?:[a-z0-9-_.]{0,61}[a-z0-9])?$/ })}
+              {...register('id', { required: true, pattern: /^[a-zA-Z](?:[a-zA-Z0-9-_.]{0,61}[a-zA-Z0-9])?$/ })}
             />
             {errors.id ? (
               <FieldErrorMessage error={errors.id} fieldName="credential ID" />


### PR DESCRIPTION
Motivation:
Previously, mirror and credential IDs were restricted to lowercase to align with Google's AIP-122 guidelines for resource names. However, this constraint has proven to be overly strict in practice. Users frequently use uppercase letters in identifiers, particularly for secrets and credentials.

Modifications:
- Updated the validation logic for credential IDs to remove the lowercase-only constraint.
- Added the validation logic for mirror IDs

Result:
- You can now create credentials with IDs that contain uppercase letters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for mirror identifiers during mirror creation.

* **Improvements**
  * Expanded credential ID requirements to accept uppercase letters, enabling more flexible naming conventions for both project and repository credentials.
  * Updated frontend credential form validation to align with new uppercase letter support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->