### PR TITLE
Do not redirect to the login page on a 403 Forbidden error.

### DIFF
--- a/webapp/javaTest/java/com/linecorp/centraldogma/webapp/SamlCentralDogmaTestServer.java
+++ b/webapp/javaTest/java/com/linecorp/centraldogma/webapp/SamlCentralDogmaTestServer.java
@@ -52,7 +52,7 @@ final class SamlCentralDogmaTestServer {
         final Path rootDir = Files.createTempDirectory("dogma-test");
         final CentralDogma server = new CentralDogmaBuilder(rootDir.toFile())
                 .webAppEnabled(true)
-                .encryptionAtRest(new EncryptionAtRestConfig(true, true))
+                .encryptionAtRest(new EncryptionAtRestConfig(false, false))
                 .port(PORT, SessionProtocol.HTTP)
                 .systemAdministrators(USERNAME)
                 .cors("http://127.0.0.1:36462", "http://127.0.0.1:3000", "http://localhost:36462",

--- a/webapp/javaTest/java/com/linecorp/centraldogma/webapp/SamlIdpServer.java
+++ b/webapp/javaTest/java/com/linecorp/centraldogma/webapp/SamlIdpServer.java
@@ -114,7 +114,8 @@ final class SamlIdpServer {
                 final String samlRequest = params.get("SAMLRequest");
                 final String relayState = params.get("RelayState");
 
-                if (!("foo".equals(username) && "bar".equals(password))) {
+                if (!("foo".equals(username) && "bar".equals(password)) &&
+                    !("foo2".equals(username) && "bar2".equals(password))) {
                     final String loginFailedHtml =
                             "<html><body><h1>Login Failed</h1><p>Invalid username or password.</p>" +
                             "<a href='javascript:history.back()'>Go Back</a></body></html>";

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -126,7 +126,7 @@ const baseQueryWithReauth: BaseQueryFn<string | FetchArgs, unknown, FetchBaseQue
 ) => {
   const result = await baseQuery(args, api, extraOptions);
 
-  if (result.error && (result.error.status === 401 || result.error.status === 403)) {
+  if (result.error && result.error.status === 401) {
     api.dispatch(clearAuth());
     Router.push(createLoginUrl());
   }


### PR DESCRIPTION
Motivation:
A 403 Forbidden error indicates that the user is authenticated but lacks the necessary permissions to access a specific resource. Redirecting an already logged-in user back to the login page in this scenario is incorrect behavior.

Modification:
- Do not redirect to the login page on a 403 Forbidden error.

Result:
- You are no longer forcibly redirected to the login page when a 403 Forbidden response is received from an API request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined authentication error response handling to improve application stability and consistency

* **Tests**
  * Updated test server infrastructure configuration and authentication credential validation scenarios for enhanced test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->