### PR TITLE
Truncate large content in `DefaultChange.toString()`

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/DefaultChange.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/DefaultChange.java
@@ -177,10 +177,19 @@ final class DefaultChange<T> implements Change<T> {
 
     @Override
     public String toString() {
+        String contentString;
+        if (content == null) {
+            contentString = "null";
+        } else {
+            contentString = content.toString();
+            if (contentString.length() > 128) {
+                contentString = contentString.substring(0, 128) + "...(length: " + contentString.length() + ')';
+            }
+        }
         return MoreObjects.toStringHelper(Change.class)
                           .add("type", type)
                           .add("path", path)
-                          .add("content", content)
+                          .add("content", contentString)
                           .toString();
     }
 }


### PR DESCRIPTION
Motivation:

The changes in `RedudantChangeException` are sent as a response and may be logged. If a large input (e.g, over 5MB) is received, recoding the log or resending it as a resonse could put additional load on the server.
https://github.com/line/centraldogma/blob/3f53a53a402c8060bf78223c1dd71b0a4478b129/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/CommitExecutor.java#L157-L160

Modifications:

- `DefaultChange.toString()` truncates the content of `Change` if its length is greater than 128.

Result:

`RedudantChangeException` no longer contains large changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced content representation with improved null handling and automatic truncation to ensure cleaner data displays and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->