### PR TITLE
Bundle Monaco Editor workers

### DIFF
--- a/webapp/next.config.js
+++ b/webapp/next.config.js
@@ -4,6 +4,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+
 const isDev = process.env.NEXT_ENV === 'development';
 const nextConfig = {
   productionBrowserSourceMaps: isDev,
@@ -13,5 +15,18 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  transpilePackages: ['monaco-editor'],
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      config.plugins.push(
+        new MonacoWebpackPlugin({
+          languages: ['json', 'javascript', 'typescript'],
+          filename: 'static/[name].worker.js',
+        })
+      );
+    }
+    return config;
+  },
+
 };
 module.exports = withBundleAnalyzer(nextConfig);

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -55,6 +55,7 @@
         "eslint-plugin-react-hooks": "^4.6.2",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "monaco-editor-webpack-plugin": "^7.1.1",
         "msw": "^2.3.1",
         "prettier": "^3.3.2",
         "ts-loader": "^9.5.1",
@@ -5587,6 +5588,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6602,6 +6613,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.17.0",
@@ -11461,6 +11482,21 @@
         "node": ">=6.11.5"
       }
     },
+    "node_modules/loader-utils": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+      "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=8.9.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -11682,6 +11718,20 @@
       "integrity": "sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/monaco-editor-webpack-plugin": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-7.1.1.tgz",
+      "integrity": "sha512-WxdbFHS3Wtz4V9hzhe/Xog5hQRSMxmDLkEEYZwqMDHgJlkZo00HVFZR0j5d0nKypjTUkkygH3dDSXERLG4757A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loader-utils": "^2.0.2"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.31.0",
+        "webpack": "^4.5.0 || 5.x"
+      }
     },
     "node_modules/mrmime": {
       "version": "2.0.0",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "monaco-editor-webpack-plugin": "^7.1.1",
     "msw": "^2.3.1",
     "prettier": "^3.3.2",
     "ts-loader": "^9.5.1",

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -27,6 +27,8 @@ import Router from 'next/router';
 import Link from 'next/link';
 import { FaHistory } from 'react-icons/fa';
 import { registerJson5Language } from 'dogma/features/file/Json5Language';
+import { useLocalMonaco } from 'dogma/features/file/MonacoLoader';
+import { Loading } from 'dogma/common/components/Loading';
 
 export type FileEditorProps = {
   projectName: string;
@@ -105,6 +107,12 @@ const FileEditor = ({
   const { colorMode } = useColorMode();
   const [diffSideBySide, setDiffSideBySide] = useState(false);
   const [editorExpanded, setEditorExpanded] = useState(false);
+
+  const monaco = useLocalMonaco();
+  if (!monaco) {
+    return <Loading />;
+  }
+
   return (
     <Box>
       <Flex gap={4}>

--- a/webapp/src/dogma/features/file/MonacoLoader.ts
+++ b/webapp/src/dogma/features/file/MonacoLoader.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { loader } from '@monaco-editor/react';
+
+// Helper to define the worker paths (matches next.config.js)
+const setupMonacoEnv = () => {
+  if (typeof window !== 'undefined' && !window.MonacoEnvironment) {
+    window.MonacoEnvironment = {
+      //eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getWorkerUrl: function (_moduleId: any, label: string) {
+        switch (label) {
+          case 'json':
+            return '/_next/static/json.worker.js';
+          case 'javascript':
+          case 'typescript':
+            return '/_next/static/ts.worker.js';
+          default:
+            return '/_next/static/editor.worker.js';
+        }
+      },
+    };
+  }
+};
+
+export const useLocalMonaco = () => {
+  //eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [monaco, setMonaco] = useState<any>(null);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      setupMonacoEnv();
+
+      import('monaco-editor')
+        .then((monacoInstance) => {
+          // Tell the wrapper to use our local instance instead of CDN
+          loader.config({ monaco: monacoInstance });
+
+          setMonaco(monacoInstance);
+        })
+        .catch((err) => {
+          console.error('Failed to load local monaco-editor:', err);
+        });
+    }
+  }, []);
+
+  return monaco;
+};

--- a/webapp/src/dogma/features/file/NewFile.tsx
+++ b/webapp/src/dogma/features/file/NewFile.tsx
@@ -33,6 +33,8 @@ import JSON5 from 'json5';
 import { isJson, isJson5 } from 'dogma/util/path-util';
 import { extensionToLanguageMap } from 'dogma/common/components/editor/FileEditor';
 import { registerJson5Language } from 'dogma/features/file/Json5Language';
+import { useLocalMonaco } from 'dogma/features/file/MonacoLoader';
+import { Loading } from 'dogma/common/components/Loading';
 
 const FILE_PATH_PATTERN = /^[0-9A-Za-z](?:[-+_0-9A-Za-z\.]*[0-9A-Za-z])?$/;
 
@@ -137,6 +139,12 @@ export const NewFile = ({
     const fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1);
     language = extensionToLanguageMap[fileExtension] || fileExtension;
   }
+
+  const monaco = useLocalMonaco();
+  if (!monaco) {
+    return <Loading />;
+  }
+
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Flex minWidth="max-content" alignItems="center" mb={4}>


### PR DESCRIPTION
Motivation:

Central Dogma should be used in an isolated network environment without accessing the internet. However, Monaco Editor dynamically loads workers from internet. See #1236 for details.

Modifications:

- Use `monaco-editor-webpack-plugin` to load Monaco Editor resources with WebPack.
- Use `loader` from '@monaco-editor/react' to load resources locally instead of CDN
- Lazily loading `monaco-editor` in the client side only to avoid accessing the `window` object on the server.

Result:

- You can now use Central Dogma UI without internet access.
- Closes #1236