### PR TITLE
Add Micrometer metrics to track xDS resource snapshot versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,6 @@ typings/
 
 # macOS folder meta-data
 .DS_Store
+
+# Codex
+AGENTS.md

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
@@ -75,34 +75,6 @@ final class CentralDogmaSnapshot extends Snapshot {
         return secrets;
     }
 
-    String clustersVersion() {
-        return version(clusters);
-    }
-
-    String endpointsVersion() {
-        return version(endpoints);
-    }
-
-    String listenersVersion() {
-        return version(listeners);
-    }
-
-    String routesVersion() {
-        return version(routes);
-    }
-
-    String secretsVersion() {
-        return version(secrets);
-    }
-
-    private static String version(SnapshotResources<?> resources) {
-        if (resources instanceof CentralDogmaSnapshotResources) {
-            return ((CentralDogmaSnapshotResources<?>) resources).allResourceVersion();
-        }
-        // For empty resources created via SnapshotResources.create()
-        return resources.version();
-    }
-
     @Override
     public Map<String, VersionedResource<?>> versionedResources(ResourceType resourceType) {
         // Have to override this method because of the type inference.

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
@@ -75,6 +75,36 @@ final class CentralDogmaSnapshot extends Snapshot {
         return secrets;
     }
 
+    String clustersVersion() {
+        return version(clusters);
+    }
+
+    String endpointsVersion() {
+        return version(endpoints);
+    }
+
+    String listenersVersion() {
+        return version(listeners);
+    }
+
+    String routesVersion() {
+        return version(routes);
+    }
+
+    String secretsVersion() {
+        return version(secrets);
+    }
+
+    private static String version(SnapshotResources<?> resources) {
+        if (resources instanceof CentralDogmaSnapshotResources) {
+            return ((CentralDogmaSnapshotResources<?>) resources).allResourceVersion();
+        }
+        // For empty resources created via SnapshotResources.create()
+        return resources.version();
+    }
+
+
+
     @Override
     public Map<String, VersionedResource<?>> versionedResources(ResourceType resourceType) {
         // Have to override this method because of the type inference.

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
@@ -103,8 +103,6 @@ final class CentralDogmaSnapshot extends Snapshot {
         return resources.version();
     }
 
-
-
     @Override
     public Map<String, VersionedResource<?>> versionedResources(ResourceType resourceType) {
         // Have to override this method because of the type inference.

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshot.java
@@ -75,6 +75,34 @@ final class CentralDogmaSnapshot extends Snapshot {
         return secrets;
     }
 
+    String clustersVersion() {
+        return version(clusters);
+    }
+
+    String endpointsVersion() {
+        return version(endpoints);
+    }
+
+    String listenersVersion() {
+        return version(listeners);
+    }
+
+    String routesVersion() {
+        return version(routes);
+    }
+
+    String secretsVersion() {
+        return version(secrets);
+    }
+
+    private static String version(SnapshotResources<?> resources) {
+        if (resources instanceof CentralDogmaSnapshotResources) {
+            return ((CentralDogmaSnapshotResources<?>) resources).allResourceVersion();
+        }
+        // For empty resources created via SnapshotResources.create()
+        return resources.version();
+    }
+
     @Override
     public Map<String, VersionedResource<?>> versionedResources(ResourceType resourceType) {
         // Have to override this method because of the type inference.

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
@@ -104,7 +104,7 @@ final class CentralDogmaSnapshotResources<T extends Message> extends SnapshotRes
         throw new IllegalArgumentException("Requesting all resource isn't allowed for " + resourceType);
     }
 
-    private String allResourceVersion() {
+    String allResourceVersion() {
         if (allResourceVersion != null) {
             return allResourceVersion;
         }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
@@ -104,7 +104,7 @@ final class CentralDogmaSnapshotResources<T extends Message> extends SnapshotRes
         throw new IllegalArgumentException("Requesting all resource isn't allowed for " + resourceType);
     }
 
-    String allResourceVersion() {
+    private String allResourceVersion() {
         if (allResourceVersion != null) {
             return allResourceVersion;
         }

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneMetrics.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneMetrics.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.xds.internal;
+
+import javax.annotation.Nullable;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+final class ControlPlaneMetrics {
+
+    private static final String VERSION_METRIC_NAME = "xds.control.plane.snapshot";
+
+    // 0 = not initialized, 1 = initialized, -1 = stopped
+    private int clustersInit;
+    private int endpointsInit;
+    private int listenersInit;
+    private int routesInit;
+    private int secretsInit;
+
+    @Nullable
+    private String clustersVersion;
+    @Nullable
+    private String endpointsVersion;
+    @Nullable
+    private String listenersVersion;
+    @Nullable
+    private String routesVersion;
+    @Nullable
+    private String secretsVersion;
+
+    private final Counter clustersUpdateCounter;
+    private final Counter endpointsUpdateCounter;
+    private final Counter listenersUpdateCounter;
+    private final Counter routesUpdateCounter;
+    private final Counter secretsUpdateCounter;
+
+    ControlPlaneMetrics(MeterRegistry meterRegistry) {
+        Gauge.builder(VERSION_METRIC_NAME + ".initialized", () -> clustersInit)
+             .tag("resource", "cluster")
+             .register(meterRegistry);
+        Gauge.builder(VERSION_METRIC_NAME + ".initialized", () -> endpointsInit)
+             .tag("resource", "endpoint")
+             .register(meterRegistry);
+        Gauge.builder(VERSION_METRIC_NAME + ".initialized", () -> listenersInit)
+             .tag("resource", "listener")
+             .register(meterRegistry);
+        Gauge.builder(VERSION_METRIC_NAME + ".initialized", () -> routesInit)
+             .tag("resource", "route")
+             .register(meterRegistry);
+        Gauge.builder(VERSION_METRIC_NAME + ".initialized", () -> secretsInit)
+             .tag("resource", "secret")
+             .register(meterRegistry);
+
+        clustersUpdateCounter = Counter.builder(VERSION_METRIC_NAME + ".revision")
+                                       .tag("resource", "cluster")
+                                       .register(meterRegistry);
+        endpointsUpdateCounter = Counter.builder(VERSION_METRIC_NAME + ".revision")
+                                        .tag("resource", "endpoint")
+                                        .register(meterRegistry);
+        listenersUpdateCounter = Counter.builder(VERSION_METRIC_NAME + ".revision")
+                                        .tag("resource", "listener")
+                                        .register(meterRegistry);
+        routesUpdateCounter = Counter.builder(VERSION_METRIC_NAME + ".revision")
+                                     .tag("resource", "route")
+                                     .register(meterRegistry);
+        secretsUpdateCounter = Counter.builder(VERSION_METRIC_NAME + ".revision")
+                                      .tag("resource", "secret")
+                                      .register(meterRegistry);
+    }
+
+    void onSnapshotUpdate(CentralDogmaSnapshot snapshot) {
+        final String clustersVersion = snapshot.clustersVersion();
+        if (!clustersVersion.equals(this.clustersVersion)) {
+            this.clustersVersion = clustersVersion;
+            if ("empty_resources".equals(clustersVersion)) {
+                clustersInit = 0;
+            } else {
+                clustersInit = 1;
+            }
+            clustersUpdateCounter.increment();
+        }
+
+        final String endpointsVersion = snapshot.endpointsVersion();
+        if (!endpointsVersion.equals(this.endpointsVersion)) {
+            this.endpointsVersion = endpointsVersion;
+            if ("empty_resources".equals(endpointsVersion)) {
+                endpointsInit = 0;
+            } else {
+                endpointsInit = 1;
+            }
+            endpointsUpdateCounter.increment();
+        }
+
+        final String listenersVersion = snapshot.listenersVersion();
+        if (!listenersVersion.equals(this.listenersVersion)) {
+            this.listenersVersion = listenersVersion;
+            if ("empty_resources".equals(listenersVersion)) {
+                listenersInit = 0;
+            } else {
+                listenersInit = 1;
+            }
+            listenersUpdateCounter.increment();
+        }
+
+        final String routesVersion = snapshot.routesVersion();
+        if (!routesVersion.equals(this.routesVersion)) {
+            this.routesVersion = routesVersion;
+            if ("empty_resources".equals(routesVersion)) {
+                routesInit = 0;
+            } else {
+                routesInit = 1;
+            }
+            routesUpdateCounter.increment();
+        }
+
+        final String secretsVersion = snapshot.secretsVersion();
+        if (!secretsVersion.equals(this.secretsVersion)) {
+            this.secretsVersion = secretsVersion;
+            if ("empty_resources".equals(secretsVersion)) {
+                secretsInit = 0;
+            } else {
+                secretsInit = 1;
+            }
+            secretsUpdateCounter.increment();
+        }
+    }
+
+    void onStopped() {
+        clustersInit = -1;
+        endpointsInit = -1;
+        listenersInit = -1;
+        routesInit = -1;
+        secretsInit = -1;
+    }
+}

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneMetrics.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneMetrics.java
@@ -27,11 +27,11 @@ final class ControlPlaneMetrics {
     private static final String VERSION_METRIC_NAME = "xds.control.plane.snapshot";
 
     // 0 = not initialized, 1 = initialized, -1 = stopped
-    private int clustersInit;
-    private int endpointsInit;
-    private int listenersInit;
-    private int routesInit;
-    private int secretsInit;
+    private volatile int clustersInit;
+    private volatile int endpointsInit;
+    private volatile int listenersInit;
+    private volatile int routesInit;
+    private volatile int secretsInit;
 
     @Nullable
     private String clustersVersion;

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -238,7 +238,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
     }
 
     private void updateVersionMetrics(CentralDogmaSnapshot snapshot) {
-        final String clustersVersion = snapshot.clusters().version();
+        final String clustersVersion = snapshot.clustersVersion();
         if (clustersVersionGauge == null ||
             !clustersVersion.equals(clustersVersionGauge.getId().getTag("version"))) {
             if (clustersVersionGauge != null) {
@@ -250,7 +250,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                         .register(meterRegistry);
         }
 
-        final String endpointsVersion = snapshot.endpoints().version();
+        final String endpointsVersion = snapshot.endpointsVersion();
         if (endpointsVersionGauge == null ||
             !endpointsVersion.equals(endpointsVersionGauge.getId().getTag("version"))) {
             if (endpointsVersionGauge != null) {
@@ -263,7 +263,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                          .register(meterRegistry);
         }
 
-        final String listenersVersion = snapshot.listeners().version();
+        final String listenersVersion = snapshot.listenersVersion();
         if (listenersVersionGauge == null ||
             !listenersVersion.equals(listenersVersionGauge.getId().getTag("version"))) {
             if (listenersVersionGauge != null) {
@@ -276,7 +276,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                          .register(meterRegistry);
         }
 
-        final String routesVersion = snapshot.routes().version();
+        final String routesVersion = snapshot.routesVersion();
         if (routesVersionGauge == null ||
             !routesVersion.equals(routesVersionGauge.getId().getTag("version"))) {
             if (routesVersionGauge != null) {
@@ -288,7 +288,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                                       .register(meterRegistry);
         }
 
-        final String secretsVersion = snapshot.secrets().version();
+        final String secretsVersion = snapshot.secretsVersion();
         if (secretsVersionGauge == null ||
             !secretsVersion.equals(secretsVersionGauge.getId().getTag("version"))) {
             if (secretsVersionGauge != null) {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/ControlPlaneService.java
@@ -246,7 +246,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                 meterRegistry.remove(clustersVersionGauge);
             }
             clustersVersionGauge = Gauge.builder(VERSION_METRIC_NAME, () -> 1)
-                                        .tags(Tags.of("resource_type", "cluster", "version", clustersVersion))
+                                        .tags(Tags.of("resource", "cluster", "version", clustersVersion))
                                         .register(meterRegistry);
         }
 
@@ -258,7 +258,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                 meterRegistry.remove(endpointsVersionGauge);
             }
             endpointsVersionGauge = Gauge.builder(VERSION_METRIC_NAME, () -> 1)
-                                         .tags(Tags.of("resource_type", "endpoint",
+                                         .tags(Tags.of("resource", "endpoint",
                                                        "version", endpointsVersion))
                                          .register(meterRegistry);
         }
@@ -271,7 +271,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                 meterRegistry.remove(listenersVersionGauge);
             }
             listenersVersionGauge = Gauge.builder(VERSION_METRIC_NAME, () -> 1)
-                                         .tags(Tags.of("resource_type", "listener",
+                                         .tags(Tags.of("resource", "listener",
                                                        "version", listenersVersion))
                                          .register(meterRegistry);
         }
@@ -284,11 +284,11 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                 meterRegistry.remove(routesVersionGauge);
             }
             routesVersionGauge = Gauge.builder(VERSION_METRIC_NAME, () -> 1)
-                                      .tags(Tags.of("resource_type", "route", "version", routesVersion))
+                                      .tags(Tags.of("resource", "route", "version", routesVersion))
                                       .register(meterRegistry);
         }
 
-        final String secretsVersion = snapshot.secretsVersion();
+        final String secretsVersion = snapshot.secrets().version();
         if (secretsVersionGauge == null ||
             !secretsVersion.equals(secretsVersionGauge.getId().getTag("version"))) {
             if (secretsVersionGauge != null) {
@@ -296,7 +296,7 @@ public final class ControlPlaneService extends XdsResourceWatchingService {
                 meterRegistry.remove(secretsVersionGauge);
             }
             secretsVersionGauge = Gauge.builder(VERSION_METRIC_NAME, () -> 1)
-                                       .tags(Tags.of("resource_type", "secret", "version", secretsVersion))
+                                       .tags(Tags.of("resource", "secret", "version", secretsVersion))
                                        .register(meterRegistry);
         }
     }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/XdsSnapshotVersionMetricsTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/XdsSnapshotVersionMetricsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.xds.internal;
+
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.cluster;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createCluster;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.updateCluster;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+
+class XdsSnapshotVersionMetricsTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    @Test
+    void snapshotVersionMetrics() throws Exception {
+        final MeterRegistry meterRegistry = dogma.dogma().meterRegistry().orElseThrow();
+        final WebClient webClient = dogma.httpClient();
+
+        // Initial empty version metrics should be registered with "empty_resources" version
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            assertVersionGaugeExists(meterRegistry, "cluster");
+            assertVersionGaugeExists(meterRegistry, "endpoint");
+            assertVersionGaugeExists(meterRegistry, "listener");
+            assertVersionGaugeExists(meterRegistry, "route");
+            assertVersionGaugeExists(meterRegistry, "secret");
+        });
+
+        final String initialClusterVersion = getVersionFromGauge(meterRegistry, "cluster");
+        final String initialEndpointVersion = getVersionFromGauge(meterRegistry, "endpoint");
+        final String initialListenerVersion = getVersionFromGauge(meterRegistry, "listener");
+        final String initialRouteVersion = getVersionFromGauge(meterRegistry, "route");
+        final String initialSecretVersion = getVersionFromGauge(meterRegistry, "secret");
+
+        // All initial versions should be "empty_resources"
+        assertThat(initialClusterVersion).isEqualTo("empty_resources");
+        assertThat(initialEndpointVersion).isEqualTo("empty_resources");
+        assertThat(initialListenerVersion).isEqualTo("empty_resources");
+        assertThat(initialRouteVersion).isEqualTo("empty_resources");
+        assertThat(initialSecretVersion).isEqualTo("empty_resources");
+
+        // Create a group and cluster
+        createGroup("metrics-test", webClient);
+        final String clusterName = "groups/metrics-test/clusters/test-cluster";
+        final Cluster cluster1 = cluster(clusterName, 1);
+        createCluster("groups/metrics-test", "test-cluster", cluster1, webClient);
+
+        // Version should change after adding a cluster
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            final String newVersion = getVersionFromGauge(meterRegistry, "cluster");
+            assertThat(newVersion).isNotEqualTo(initialClusterVersion);
+            // Version should be a SHA-256 hash (64 characters)
+            assertThat(newVersion.length()).isEqualTo(64);
+        });
+
+        final String versionAfterCreate = getVersionFromGauge(meterRegistry, "cluster");
+
+        // Update the cluster
+        final Cluster cluster2 = cluster(clusterName, 2);
+        updateCluster("groups/metrics-test", "test-cluster", cluster2, webClient);
+
+        // Version should change after updating the cluster
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> {
+            final String newVersion = getVersionFromGauge(meterRegistry, "cluster");
+            assertThat(newVersion).isNotEqualTo(versionAfterCreate);
+        });
+
+        // Verify gauge value is always 1 (info gauge pattern)
+        final Collection<Gauge> clusterGauges = meterRegistry.find("xds.control.plane.snapshot.version")
+                                                             .tag("resource_type", "cluster")
+                                                             .gauges();
+        assertThat(clusterGauges).hasSize(1);
+        assertThat(clusterGauges.iterator().next().value()).isEqualTo(1.0);
+    }
+
+    private static void assertVersionGaugeExists(MeterRegistry meterRegistry, String resourceType) {
+        final Collection<Gauge> gauges = meterRegistry.find("xds.control.plane.snapshot.version")
+                                                      .tag("resource_type", resourceType)
+                                                      .gauges();
+        assertThat(gauges).hasSize(1);
+    }
+
+    private static String getVersionFromGauge(MeterRegistry meterRegistry, String resourceType) {
+        final Collection<Gauge> gauges = meterRegistry.find("xds.control.plane.snapshot.version")
+                                                      .tag("resource_type", resourceType)
+                                                      .gauges();
+        assertThat(gauges).hasSize(1);
+        return gauges.iterator().next().getId().getTag("version");
+    }
+}


### PR DESCRIPTION
Motivation:

To monitor and track xDS resource changes, it's useful to expose the
version of each resource type as Micrometer metrics. This allows
operators to observe version changes in monitoring systems like
Prometheus.

Modifications:

- Added info gauges in `ControlPlaneService` for each resource type
  with version as a tag
  - Metric name: `xds.control.plane.snapshot.version`
  - Tags: `resource` (cluster/endpoint/listener/route),
    `version` (SHA-256 hash)
- Added version getter methods to `CentralDogmaSnapshot`:
  `clustersVersion()`, `endpointsVersion()`, `listenersVersion()`,
  `routesVersion()`
- Made `allResourceVersion()` package-private in
  `CentralDogmaSnapshotResources`

Result:

The version of xDS resources can now be tracked via Micrometer metrics.