### PR TITLE
Fix artifact names for Spring Boot 4 integration modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ ext {
         ':client:java-spring-boot2-starter': "${rootProject.name}-client-spring-boot2-starter",
         ':client:java-spring-boot3-autoconfigure': "${rootProject.name}-client-spring-boot3-autoconfigure",
         ':client:java-spring-boot3-starter': "${rootProject.name}-client-spring-boot3-starter",
+        ':client:java-spring-boot4-autoconfigure': "${rootProject.name}-client-spring-boot4-autoconfigure",
+        ':client:java-spring-boot4-starter': "${rootProject.name}-client-spring-boot4-starter",
         // Set the correct artifactId of 'testing-common'.
         ':testing:testing-common': "${rootProject.name}-testing-common"
     ]


### PR DESCRIPTION
***Motivation**

I've missed specifying `artifactIdOverrides` when adding the new modules

```
user@AL02437565 centraldogma % ls -lah client/java-spring-boot3-starter/build/libs 
total 40
drwxr-xr-x  7 user  staff   224B  1 28 10:23 .
drwxr-xr-x  5 user  staff   160B  1 28 10:23 ..
-rw-r--r--  1 user  staff   261B  1 28 10:23 centraldogma-client-spring-boot3-starter-0.79.1-SNAPSHOT-javadoc.jar
-rw-r--r--  1 user  staff   675B  1 28 10:23 centraldogma-client-spring-boot3-starter-0.79.1-SNAPSHOT-shaded.jar
-rw-r--r--  1 user  staff   627B  1 28 10:23 centraldogma-client-spring-boot3-starter-0.79.1-SNAPSHOT-sources.jar
-rw-r--r--  1 user  staff   627B  1 28 10:23 centraldogma-client-spring-boot3-starter-0.79.1-SNAPSHOT.jar
-rw-r--r--  1 user  staff   293B  1 28 10:23 test-centraldogma-client-spring-boot3-starter-shaded-0.79.1-SNAPSHOT.jar
user@AL02437565 centraldogma % ls -lah client/java-spring-boot4-starter/build/libs
total 40
drwxr-xr-x  7 user  staff   224B  1 28 10:23 .
drwxr-xr-x  5 user  staff   160B  1 28 10:23 ..
-rw-r--r--  1 user  staff   261B  1 28 10:23 centraldogma-client-spring-boot4-starter-0.79.1-SNAPSHOT-javadoc.jar
-rw-r--r--  1 user  staff   676B  1 28 10:23 centraldogma-client-spring-boot4-starter-0.79.1-SNAPSHOT-shaded.jar
-rw-r--r--  1 user  staff   628B  1 28 10:23 centraldogma-client-spring-boot4-starter-0.79.1-SNAPSHOT-sources.jar
-rw-r--r--  1 user  staff   628B  1 28 10:23 centraldogma-client-spring-boot4-starter-0.79.1-SNAPSHOT.jar
-rw-r--r--  1 user  staff   293B  1 28 10:23 test-centraldogma-client-spring-boot4-starter-shaded-0.79.1-SNAPSHOT.jar
user@AL02437565 centraldogma % 
```