### PR TITLE
Fix a bug where the delete button on a directory does not work.

### DIFF
--- a/webapp/src/dogma/common/components/editor/DeleteFileModal.tsx
+++ b/webapp/src/dogma/common/components/editor/DeleteFileModal.tsx
@@ -60,7 +60,6 @@ export const DeleteFileModal = ({
         {
           path: path,
           type: 'REMOVE',
-          content: '',
         },
       ],
     };


### PR DESCRIPTION
Motivation:

`content` should be null for `ChangeType.REMOVE`.

Modifications:

- Fix `DeleteFileModal` so it does not to set an empty string for `content`

Result:

The delete button in the file browsers now works correctly.