### PR TITLE
Make `DiffEditor` readonly

### DIFF
--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -263,6 +263,7 @@ const FileEditor = ({
               original={fileContent}
               modified={modifiedContent}
               options={{
+                readOnly: true,
                 autoIndent: 'full',
                 formatOnPaste: true,
                 formatOnType: true,


### PR DESCRIPTION
Motivation:

`DiffEditor` was added to preview changes but it was accidently editable. As a result, edits maded in diff view weren't applied to the original content. Also, the diff shown in `Preview with Variables` doesn't represent an actual change.

Modifications:

- Make `DiffEditor` readonly

Result:

The diff tab is now readonly to prevent edits in the file viewer.