### PR TITLE
Fix MirrorRunnerTest.triggerMirroring test

### DIFF
--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/MirrorRunnerTest.java
@@ -144,7 +144,7 @@ class MirrorRunnerTest {
             if (i == 0) {
                 assertThat(mirrorResponse.content().mirrorStatus()).isEqualTo(MirrorStatus.SUCCESS);
                 assertThat(mirrorResponse.content().description())
-                        .contains("'git+ssh://github.com/line/centraldogma-authtest.git#main' at 2");
+                        .contains("'git+ssh://github.com/line/centraldogma-authtest.git/#main' at 2");
             } else {
                 assertThat(mirrorResponse.content().mirrorStatus()).isEqualTo(MirrorStatus.UP_TO_DATE);
                 assertThat(mirrorResponse.content().description())


### PR DESCRIPTION
It seems like the test is broken by this line: https://github.com/line/centraldogma/pull/1247/changes#diff-9bc533d9bcb90245b004dd0b3092d1ae04ab10c7bb0493d879525a2d59ec919bR391

```
MirrorRunnerTest > triggerMirroring() FAILED
java.lang.AssertionError: 
Expecting actual:
  "Mirror ab12950, 'git+ssh://github.com/line/centraldogma-authtest.git/#main' to the repository 'bar', revision: 2"
to contain:
  "'git+ssh://github.com/line/centraldogma-authtest.git#main' at 2" 
  at com.linecorp.centraldogma.it.mirror.git.MirrorRunnerTest.triggerMirroring(MirrorRunnerTest.java:147)
```