### PR TITLE
Fix stale repository references after encryption migration

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/project/DefaultProject.java
@@ -111,6 +111,7 @@ public class DefaultProject implements Project {
                 author = Author.ofEmail(creation.user());
                 attachMetadataListener();
                 metaRepo = new DefaultMetaRepository(repos.get(REPO_DOGMA));
+                registerMigrationCallback();
             } else {
                 creationTimeMillis = repos.get(REPO_DOGMA).creationTimeMillis();
                 author = repos.get(REPO_DOGMA).author();
@@ -150,6 +151,7 @@ public class DefaultProject implements Project {
                 initializeMetadata(creationTimeMillis, author);
                 attachMetadataListener();
                 metaRepo = new DefaultMetaRepository(repos.get(REPO_DOGMA));
+                registerMigrationCallback();
             }
             this.creationTimeMillis = creationTimeMillis;
             this.author = author;
@@ -170,6 +172,14 @@ public class DefaultProject implements Project {
                 new GitRepositoryManager(this, rootDir, repositoryWorker, purgeWorker, cache,
                                          encryptionStorageManager);
         return cache == null ? gitRepos : new CachingRepositoryManager(gitRepos, cache);
+    }
+
+    private void registerMigrationCallback() {
+        repos.setPostMigrationCallback((repoName, newRepo) -> {
+            if (REPO_DOGMA.equals(repoName)) {
+                metaRepo = new DefaultMetaRepository(newRepo);
+            }
+        });
     }
 
     private void createReservedRepos(long creationTimeMillis, boolean encryptDogmaRepo) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/RepositoryManagerWrapper.java
@@ -26,8 +26,11 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.CentralDogmaException;
@@ -41,6 +44,8 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     private final RepositoryManager delegate;
     private final Function<Repository, Repository> repoWrapper;
     private final ConcurrentMap<String, Repository> repos = new ConcurrentHashMap<>();
+    @Nullable
+    private volatile BiConsumer<String, Repository> postMigrationCallback;
 
     public RepositoryManagerWrapper(RepositoryManager repoManager,
                                     Function<Repository, Repository> repoWrapper) {
@@ -53,6 +58,11 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     }
 
     @Override
+    public void setPostMigrationCallback(BiConsumer<String, Repository> callback) {
+        postMigrationCallback = callback;
+    }
+
+    @Override
     public Project parent() {
         return delegate.parent();
     }
@@ -61,12 +71,20 @@ public class RepositoryManagerWrapper implements RepositoryManager {
     public void migrateToEncryptedRepository(String repositoryName) {
         delegate.migrateToEncryptedRepository(repositoryName);
         repos.replace(repositoryName, repoWrapper.apply(delegate.get(repositoryName)));
+        final BiConsumer<String, Repository> callback = postMigrationCallback;
+        if (callback != null) {
+            callback.accept(repositoryName, repos.get(repositoryName));
+        }
     }
 
     @Override
     public void fallbackToFileRepository(String repositoryName) {
         delegate.fallbackToFileRepository(repositoryName);
         repos.replace(repositoryName, repoWrapper.apply(delegate.get(repositoryName)));
+        final BiConsumer<String, Repository> callback = postMigrationCallback;
+        if (callback != null) {
+            callback.accept(repositoryName, repos.get(repositoryName));
+        }
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepository.java
@@ -172,6 +172,10 @@ class GitRepository implements Repository {
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
     private final List<RepositoryListener> listeners = new CopyOnWriteArrayList<>();
 
+    List<RepositoryListener> listeners() {
+        return listeners;
+    }
+
     /**
      * The current head revision. Initialized by the constructor and updated by commit().
      */

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import org.eclipse.jgit.lib.Constants;
@@ -68,6 +69,7 @@ import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageMana
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.DiffResultType;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.server.storage.repository.RepositoryListener;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryManager;
 
 public final class GitRepositoryManager extends DirectoryBasedStorageManager<Repository>
@@ -82,6 +84,8 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
 
     @Nullable
     private final RepositoryCache cache;
+    @Nullable
+    private volatile BiConsumer<String, Repository> postMigrationCallback;
 
     public GitRepositoryManager(Project parent, File rootDir, Executor repositoryWorker,
                                 Executor purgeWorker, @Nullable RepositoryCache cache,
@@ -96,6 +100,11 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
     @Override
     public Project parent() {
         return parent;
+    }
+
+    @Override
+    public void setPostMigrationCallback(@Nullable BiConsumer<String, Repository> callback) {
+        postMigrationCallback = callback;
     }
 
     private String projectRepositoryName(String name) {
@@ -173,7 +182,14 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
         logger.info("Migrated the repository '{}' to an encrypted repository in {} seconds.",
                     projectRepositoryName(repositoryName),
                     TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime));
-        // We didn't add repository listeners to the repository so don't have to add the listener here.
+        // Transfer listeners from the old repository to the new encrypted repository.
+        for (RepositoryListener listener : ((GitRepository) oldRepository).listeners()) {
+            encryptedRepository.addListener(listener);
+        }
+        final BiConsumer<String, Repository> callback = postMigrationCallback;
+        if (callback != null) {
+            callback.accept(repositoryName, encryptedRepository);
+        }
         ((GitRepository) oldRepository).close(() -> new CentralDogmaException(
                 projectRepositoryName(repositoryName) + " is migrated to an encrypted repository. Try again."));
     }
@@ -234,6 +250,14 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
         logger.info("Fallback the repository '{}' to a file-based repository in {} seconds.",
                     projectRepositoryName(repositoryName),
                     TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime));
+        // Transfer listeners from the encrypted repository to the file-based repository.
+        for (RepositoryListener listener : ((GitRepository) encryptedRepository).listeners()) {
+            fileRepository.addListener(listener);
+        }
+        final BiConsumer<String, Repository> callback = postMigrationCallback;
+        if (callback != null) {
+            callback.accept(repositoryName, fileRepository);
+        }
         ((GitRepository) encryptedRepository).close(() -> new CentralDogmaException(
                 projectRepositoryName(repositoryName) +
                 " is fallback to a file-based repository. Try again."));

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryManager.java
@@ -103,7 +103,7 @@ public final class GitRepositoryManager extends DirectoryBasedStorageManager<Rep
     }
 
     @Override
-    public void setPostMigrationCallback(@Nullable BiConsumer<String, Repository> callback) {
+    public void setPostMigrationCallback(BiConsumer<String, Repository> callback) {
         postMigrationCallback = callback;
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
@@ -46,5 +46,5 @@ public interface RepositoryManager extends StorageManager<Repository> {
      * Sets a callback that is invoked after a repository is migrated or fallen back.
      * The callback receives the repository name and the new {@link Repository} instance.
      */
-    void setPostMigrationCallback(@Nullable BiConsumer<String, Repository> callback);
+    void setPostMigrationCallback(BiConsumer<String, Repository> callback);
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
@@ -18,8 +18,6 @@ package com.linecorp.centraldogma.server.storage.repository;
 
 import java.util.function.BiConsumer;
 
-import org.jspecify.annotations.Nullable;
-
 import com.linecorp.centraldogma.server.storage.StorageManager;
 import com.linecorp.centraldogma.server.storage.project.Project;
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/repository/RepositoryManager.java
@@ -16,6 +16,10 @@
 
 package com.linecorp.centraldogma.server.storage.repository;
 
+import java.util.function.BiConsumer;
+
+import org.jspecify.annotations.Nullable;
+
 import com.linecorp.centraldogma.server.storage.StorageManager;
 import com.linecorp.centraldogma.server.storage.project.Project;
 
@@ -37,4 +41,10 @@ public interface RepositoryManager extends StorageManager<Repository> {
      * Falls back the specified encrypted repository to a file-based repository.
      */
     void fallbackToFileRepository(String repositoryName);
+
+    /**
+     * Sets a callback that is invoked after a repository is migrated or fallen back.
+     * The callback receives the repository name and the new {@link Repository} instance.
+     */
+    void setPostMigrationCallback(@Nullable BiConsumer<String, Repository> callback);
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/FallbackToFileRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/FallbackToFileRepositoryTest.java
@@ -26,6 +26,9 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +52,7 @@ import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageMana
 import com.linecorp.centraldogma.server.storage.encryption.WrappedDekDetails;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.server.storage.repository.RepositoryListener;
 
 class FallbackToFileRepositoryTest {
 
@@ -291,6 +295,80 @@ class FallbackToFileRepositoryTest {
         assertThat(history).hasSize(2);
         assertThat(history.get(0).summary()).isEqualTo("Add tokens");
         assertThat(history.get(1).summary()).isEqualTo("Add credentials");
+    }
+
+    @Test
+    void migrateTransfersListeners() throws Exception {
+        final Repository fileRepo = gitRepositoryManager.create(REPO_NAME, 0, Author.SYSTEM, false);
+        final BlockingQueue<String> updates = new LinkedBlockingQueue<>();
+        fileRepo.addListener(RepositoryListener.of("/foo.json",
+                                                   entries -> updates.add("updated")));
+
+        // Commit before migration to verify listener works.
+        fileRepo.commit(Revision.INIT, 0, Author.SYSTEM, "Add foo",
+                        ImmutableList.of(Change.ofJsonUpsert("/foo.json", "{\"a\":\"b\"}"))).join();
+        assertThat(updates.poll(5, TimeUnit.SECONDS)).isEqualTo("updated");
+
+        // Migrate to encrypted.
+        storeWdekAndMigrate(REPO_NAME);
+        final Repository encryptedRepo = gitRepositoryManager.get(REPO_NAME);
+        assertThat(encryptedRepo.isEncrypted()).isTrue();
+
+        // Commit after migration and verify the listener still receives updates.
+        encryptedRepo.commit(encryptedRepo.normalizeNow(Revision.HEAD), 0, Author.SYSTEM, "Update foo",
+                             ImmutableList.of(Change.ofJsonUpsert("/foo.json", "{\"a\":\"c\"}"))).join();
+        assertThat(updates.poll(5, TimeUnit.SECONDS)).isEqualTo("updated");
+    }
+
+    @Test
+    void fallbackTransfersListeners() throws Exception {
+        final Repository fileRepo = gitRepositoryManager.create(REPO_NAME, 0, Author.SYSTEM, false);
+        storeWdekAndMigrate(REPO_NAME);
+
+        final Repository encryptedRepo = gitRepositoryManager.get(REPO_NAME);
+        final BlockingQueue<String> updates = new LinkedBlockingQueue<>();
+        encryptedRepo.addListener(RepositoryListener.of("/bar.json",
+                                                        entries -> updates.add("updated")));
+
+        encryptedRepo.commit(encryptedRepo.normalizeNow(Revision.HEAD), 0, Author.SYSTEM, "Add bar",
+                             ImmutableList.of(Change.ofJsonUpsert("/bar.json", "{\"x\":1}"))).join();
+        assertThat(updates.poll(5, TimeUnit.SECONDS)).isEqualTo("updated");
+
+        // Fallback to file-based.
+        gitRepositoryManager.fallbackToFileRepository(REPO_NAME);
+        final Repository restoredRepo = gitRepositoryManager.get(REPO_NAME);
+        assertThat(restoredRepo.isEncrypted()).isFalse();
+
+        // Commit after fallback and verify the listener still receives updates.
+        restoredRepo.commit(restoredRepo.normalizeNow(Revision.HEAD), 0, Author.SYSTEM, "Update bar",
+                            ImmutableList.of(Change.ofJsonUpsert("/bar.json", "{\"x\":2}"))).join();
+        assertThat(updates.poll(5, TimeUnit.SECONDS)).isEqualTo("updated");
+    }
+
+    @Test
+    void migrateInvokesPostMigrationCallback() {
+        final Repository fileRepo = gitRepositoryManager.create(REPO_NAME, 0, Author.SYSTEM, false);
+        final BlockingQueue<String> callbackResults = new LinkedBlockingQueue<>();
+        gitRepositoryManager.setPostMigrationCallback((repoName, newRepo) -> {
+            callbackResults.add(repoName + ":" + newRepo.isEncrypted());
+        });
+
+        storeWdekAndMigrate(REPO_NAME);
+        assertThat(callbackResults.poll()).isEqualTo(REPO_NAME + ":true");
+    }
+
+    @Test
+    void fallbackInvokesPostMigrationCallback() {
+        gitRepositoryManager.create(REPO_NAME, 0, Author.SYSTEM, false);
+        storeWdekAndMigrate(REPO_NAME);
+
+        final BlockingQueue<String> callbackResults = new LinkedBlockingQueue<>();
+        gitRepositoryManager.setPostMigrationCallback((repoName, newRepo) -> {
+            callbackResults.add(repoName + ":" + newRepo.isEncrypted());
+        });
+
+        gitRepositoryManager.fallbackToFileRepository(REPO_NAME);
+        assertThat(callbackResults.poll()).isEqualTo(REPO_NAME + ":false");
     }
 
     private void storeWdekAndMigrate(String repoName) {

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/XdsResourceWatchingService.java
@@ -112,7 +112,7 @@ public abstract class XdsResourceWatchingService {
                                     groupName + path, t);
                     }
                 }
-                watchRepository(repository, normalizedRevision);
+                watchRepository(groupName, normalizedRevision);
                 return null;
             }, executor()));
         }
@@ -144,13 +144,21 @@ public abstract class XdsResourceWatchingService {
                         continue;
                     }
                     logger.info("Start watching {}.", groupName);
-                    watchRepository(repo, Revision.INIT);
+                    watchRepository(groupName, Revision.INIT);
                 }
             });
         }));
     }
 
-    private void watchRepository(Repository repository, Revision lastKnownRevision) {
+    private void watchRepository(String groupName, Revision lastKnownRevision) {
+        final Repository repository;
+        try {
+            repository = xdsProject.repos().get(groupName);
+        } catch (RepositoryNotFoundException e) {
+            watchingGroups.remove(groupName);
+            onGroupRemoved(groupName);
+            return;
+        }
         final CompletableFuture<Revision> watchFuture = repository.watch(lastKnownRevision, pathPattern());
         watchFuture.handleAsync((BiFunction<Revision, Throwable, Void>) (newRevision, cause) -> {
             if (isStopped()) {
@@ -159,8 +167,8 @@ public abstract class XdsResourceWatchingService {
             if (cause != null) {
                 if (cause instanceof RepositoryNotFoundException) {
                     // Repository is removed.
-                    watchingGroups.remove(repository.name());
-                    onGroupRemoved(repository.name());
+                    watchingGroups.remove(groupName);
+                    onGroupRemoved(groupName);
                     return null;
                 }
                 if (cause instanceof ShuttingDownException) {
@@ -169,30 +177,29 @@ public abstract class XdsResourceWatchingService {
                 }
 
                 logger.warn("Unexpected exception while watching {} at {}. Try watching after {} seconds.",
-                            repository.name(), lastKnownRevision, BACKOFF_SECONDS, cause);
-                executor().schedule(() -> watchRepository(repository, lastKnownRevision),
+                            groupName, lastKnownRevision, BACKOFF_SECONDS, cause);
+                executor().schedule(() -> watchRepository(groupName, lastKnownRevision),
                                     BACKOFF_SECONDS, TimeUnit.SECONDS);
                 return null;
             }
             final CompletableFuture<Map<String, Change<?>>> diffFuture =
                     repository.diff(lastKnownRevision, newRevision,
                                     pathPattern(), DiffResultType.PATCH_TO_UPSERT);
-            handleDiff(repository, newRevision, diffFuture, lastKnownRevision);
+            handleDiff(groupName, newRevision, diffFuture, lastKnownRevision);
             return null;
         }, executor());
     }
 
-    private void handleDiff(Repository repository, Revision newRevision,
+    private void handleDiff(String groupName, Revision newRevision,
                             CompletableFuture<Map<String, Change<?>>> diffFuture, Revision lastKnownRevision) {
         diffFuture.handleAsync((BiFunction<Map<String, Change<?>>, Throwable, Void>) (changes, cause) -> {
             if (isStopped()) {
                 return null;
             }
-            final String groupName = repository.name();
             if (cause != null) {
                 logger.warn("Unexpected exception while diffing {} from {} to {}. Watching again.",
                             groupName, lastKnownRevision, newRevision, cause);
-                watchRepository(repository, Revision.INIT);
+                watchRepository(groupName, Revision.INIT);
                 return null;
             }
 
@@ -225,7 +232,7 @@ public abstract class XdsResourceWatchingService {
                 }
             }
             onDiffHandled();
-            watchRepository(repository, newRevision);
+            watchRepository(groupName, newRevision);
             return null;
         }, executor());
     }


### PR DESCRIPTION
Motivation:
- When `migrateToEncryptedRepository()` or `fallbackToFileRepository()` replaces a `Repository` instance, code holding references to the old instance becomes stale. Three cases were identified:
  1. `RepositoryListener`s registered on the old `GitRepository` are not transferred to the new one, causing metadata and token change detection to stop working.
  2. `DefaultProject.metaRepo` keeps wrapping the old repository, so all `MetaRepository` operations fail after migration.
  3. `XdsResourceWatchingService.watchRepository()` captures a `Repository` in a recursive async loop, causing the watch to permanently fail after the repository is replaced.

Modifications:
- Transfer all `RepositoryListener`s from the old repository to the new one in both `migrateToEncryptedRepository()` and `fallbackToFileRepository()` before closing the old repository.
- Add `setPostMigrationCallback()` to the `RepositoryManager` interface and implement it in `GitRepositoryManager` and `RepositoryManagerWrapper`. The callback is invoked after a successful migration or fallback with the repository name and the new `Repository` instance.
- Register a post-migration callback in `DefaultProject` to replace `metaRepo` with a new `DefaultMetaRepository` wrapping the new repository when `REPO_DOGMA` is migrated.
- Change `XdsResourceWatchingService.watchRepository()` to accept a group name instead of a `Repository` instance, re-fetching the latest repository from `xdsProject.repos().get()` on each watch cycle.

Result:
- `RepositoryListener`s (including metadata and app-identity-registry listeners) continue to work after migration without re-registration.
- `DefaultProject.metaRepo` is refreshed to wrap the new repository.
- `XdsResourceWatchingService` watch loops automatically pick up the new repository instance after migration.