### PR TITLE
Remove the method filter in CentralDogmaBeanFactory and deprecate bidirectional

### DIFF
--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBean.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBean.java
@@ -70,6 +70,10 @@ public @interface CentralDogmaBean {
     /**
      * If {@code true}, the change of each bean property will be pushed to Central Dogma.
      * Use this property with caution because it can result in unnecessarily large number of commits.
+     *
+     * @deprecated This property is no longer used. All methods are now intercepted by the proxy
+     *             regardless of this setting.
      */
+    @Deprecated
     boolean bidirectional() default false;
 }

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/updater/CentralDogmaBeanFactory.java
@@ -336,14 +336,6 @@ public class CentralDogmaBeanFactory {
 
         final ProxyFactory factory = new ProxyFactory();
         factory.setSuperclass(beanType);
-        factory.setFilter(method -> {
-            // Allow all non-parameter methods (getter/closeWatcher..)
-            if (method.getParameterCount() == 0) {
-                return true;
-            }
-            // Allow methods have bidirectional property and looks like setter
-            return centralDogmaBean.bidirectional() && method.getParameterCount() == 1;
-        });
 
         try {
             return (T) factory.create(EMPTY_TYPES, EMPTY_ARGS,

--- a/it/server/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
+++ b/it/server/src/test/java/com/linecorp/centraldogma/it/updater/CentralDogmaBeanTest.java
@@ -217,6 +217,31 @@ class CentralDogmaBeanTest {
         assertThat(property.getRevision()).isNotNull();
     }
 
+    @Test
+    void methodWithParameterShouldBeIntercepted() {
+        final CentralDogma client = dogma.client();
+        final TestProperty property = factory.get(new TestProperty(), TestProperty.class);
+
+        client.forRepo("a", "b")
+              .commit("Add c.json",
+                      Change.ofJsonUpsert("/c.json",
+                                          '{' +
+                                          "  \"foo\": 30," +
+                                          "  \"bar\": \"UPDATED\"," +
+                                          "  \"qux\": [\"a\", \"b\"]" +
+                                          '}'))
+              .push().join();
+
+        // Verify that a method with parameters is also intercepted and uses the latest watched value.
+        await().atMost(5, TimeUnit.SECONDS)
+               .until(() -> "prefix-UPDATED".equals(property.getBarWithPrefix("prefix-")));
+
+        // Non-arg methods
+        assertThat(property.getFoo()).isEqualTo(30);
+        assertThat(property.getBar()).isEqualTo("UPDATED");
+        assertThat(property.getQux()).containsExactly("a", "b");
+    }
+
     @CentralDogmaBean(project = "a", repository = "b", path = "/c.json")
     static class TestProperty {
         int foo = 10;
@@ -238,6 +263,10 @@ class CentralDogmaBeanTest {
 
         public List<String> getQux() {
             return qux;
+        }
+
+        public String getBarWithPrefix(String prefix) {
+            return prefix + bar;
         }
 
         public void closeWatcher() {}


### PR DESCRIPTION
## Motivation
- The `MethodFilter` set on the Javassist `ProxyFactory` in `CentralDogmaBeanFactory` only intercepted methods with zero parameters(when `bidirectional = false`, the default).
- Any method with parameters was not intercepted and would read the default field value directly from the proxy instance, ignoring updates from the Central Dogma watcher.

## Modifications
 - Remove `ProxyFactory.setFilter()` call in `CentralDogmaBeanFactory`so that all methods are intercepted by the proxy
 - Deprecate `@CentralDogmaBean.bidirectional`, which is no longer referenced
 - Add `methodWithParameterShouldBeIntercepted` integration test to verify that methods with parameters return values from the latest watched value

## Result
All methods on a `@CentralDogmaBean` proxy are now intercepted and delegated to the latest watched value, regardless of their parameter count.