### PR TITLE
Allow the dogma project's dogma repository to be migrated to an encrypted repository

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -468,7 +468,7 @@ public class RepositoryServiceV1 extends AbstractService {
 
         final Revision normalizeNow = repository.normalizeNow(Revision.HEAD);
         if (normalizeNow.major() > 2000) {
-            // Prohibit migration to an encrypted repository if the repository has more than 1000 revisions.
+            // Prohibit migration to an encrypted repository if the repository has more than 2000 revisions.
             // After we implement the repository history rollover feature,
             // the repository can be migrated to an encrypted repository.
             throw new IllegalArgumentException(

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -333,17 +333,28 @@ public class RepositoryServiceV1 extends AbstractService {
         validateFallbackPrerequisites(ctx, project, repository);
         ctx.setRequestTimeoutMillis(Long.MAX_VALUE); // Disable the request timeout for migration.
 
+        final boolean isDogmaProject =
+                InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name());
+        if (isDogmaProject) {
+            return fallback(author, project, repository, true).toCompletableFuture();
+        }
+
+        final RepositoryStatus currentStatus = repositoryStatus(repository);
+        if (currentStatus == RepositoryStatus.READ_ONLY) {
+            // Already read-only, skip the redundant status change.
+            return fallback(author, project, repository, false).toCompletableFuture();
+        }
         return setRepositoryStatus(author, project, repository.name(), RepositoryStatus.READ_ONLY)
-                .thenCompose(unused -> fallback(author, project, repository));
+                .thenCompose(unused -> fallback(author, project, repository, false));
     }
 
     private static void validateFallbackPrerequisites(ServiceRequestContext ctx, Project project,
                                                       Repository repository) {
-        if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) ||
-            project.name().startsWith("@") || Project.REPO_DOGMA.equals(repository.name())) {
+        if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) &&
+            !Project.REPO_DOGMA.equals(repository.name())) {
             throw new IllegalArgumentException(
-                    "Cannot fallback the internal project or repository to a file-based repository. project: " +
-                    project.name() + ", repository: " + repository.name());
+                    "Only the dogma repository can be fallen back in the dogma project." +
+                    " repository: " + repository.name());
         }
 
         if (!repository.isEncrypted()) {
@@ -352,17 +363,12 @@ public class RepositoryServiceV1 extends AbstractService {
                     " project: " + project.name() + ", repository: " + repository.name());
         }
 
-        final RepositoryStatus currentStatus = repositoryStatus(repository);
-        if (currentStatus == RepositoryStatus.READ_ONLY) {
-            HttpApiUtil.throwResponse(
-                    ctx, HttpStatus.CONFLICT,
-                    "Cannot fallback a read-only repository to a file-based repository. " +
-                    "Please change the status to ACTIVE first.");
-        }
+        // Allow fallback even when the repository is in read-only mode.
     }
 
     private CompletionStage<RepositoryDto> fallback(Author author, Project project,
-                                                    Repository repository) {
+                                                    Repository repository,
+                                                    boolean skipStatusChange) {
         final String projectName = project.name();
         final String repoName = repository.name();
         logger.info("Starting repository fallback to file-based: project={}, repository={}",
@@ -376,12 +382,24 @@ public class RepositoryServiceV1 extends AbstractService {
                              if (cause != null) {
                                  logger.warn("failed to fallback repository to a file-based repository: " +
                                              "project={}, repository={}", projectName, repoName, cause);
+                                 if (skipStatusChange) {
+                                     return CompletableFuture.<RepositoryDto>completedFuture(null)
+                                             .thenApply(unused1 ->
+                                                                Exceptions.<RepositoryDto>throwUnsafely(cause));
+                                 }
                                  return setRepositoryStatus(author, project, repository.name(),
                                                             RepositoryStatus.ACTIVE)
-                                         .thenApply(unused1 -> (RepositoryDto) Exceptions.throwUnsafely(cause));
+                                         .thenApply(unused1 ->
+                                                            Exceptions.<RepositoryDto>throwUnsafely(cause));
                              }
                              logger.info("Successfully fallback repository to a file-based repository: " +
                                          "project={}, repository={}", projectName, repoName);
+                             if (skipStatusChange) {
+                                 final Repository updatedRepository =
+                                         project.repos().get(repository.name());
+                                 return CompletableFuture.completedFuture(
+                                         newRepositoryDto(updatedRepository, RepositoryStatus.ACTIVE));
+                             }
                              return setRepositoryStatus(author, project, repository.name(),
                                                         RepositoryStatus.ACTIVE)
                                      .thenApply(unused1 -> {
@@ -449,7 +467,7 @@ public class RepositoryServiceV1 extends AbstractService {
         }
 
         final Revision normalizeNow = repository.normalizeNow(Revision.HEAD);
-        if (normalizeNow.major() > 1000) {
+        if (normalizeNow.major() > 2000) {
             // Prohibit migration to an encrypted repository if the repository has more than 1000 revisions.
             // After we implement the repository history rollover feature,
             // the repository can be migrated to an encrypted repository.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceV1.java
@@ -407,16 +407,25 @@ public class RepositoryServiceV1 extends AbstractService {
         validateMigrationPrerequisites(ctx, project, repository);
         ctx.setRequestTimeoutMillis(Long.MAX_VALUE); // Disable the request timeout for migration.
 
+        final boolean isDogmaProject =
+                InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name());
+
         return encryptionStorageManager
                 .generateWdek()
-                .thenCompose(wdek -> setRepositoryStatus(author, project, repository.name(),
-                                                         RepositoryStatus.READ_ONLY)
-                        .thenCompose(unused -> {
-                            final WrappedDekDetails wdekDetails = new WrappedDekDetails(
-                                    wdek, 1, encryptionStorageManager.kekId(),
-                                    project.name(), repository.name());
-                            return migrate(author, project, repository, wdekDetails);
-                        }));
+                .thenCompose(wdek -> {
+                    final WrappedDekDetails wdekDetails = new WrappedDekDetails(
+                            wdek, 1, encryptionStorageManager.kekId(),
+                            project.name(), repository.name());
+                    if (isDogmaProject) {
+                        // The dogma project does not have project metadata, so the repository
+                        // status cannot be changed. Migrate directly without changing the status.
+                        return migrate(author, project, repository, wdekDetails, true);
+                    }
+                    return setRepositoryStatus(author, project, repository.name(),
+                                               RepositoryStatus.READ_ONLY)
+                            .thenCompose(unused -> migrate(author, project, repository,
+                                                           wdekDetails, false));
+                });
     }
 
     private void validateMigrationPrerequisites(ServiceRequestContext ctx, Project project,
@@ -426,14 +435,13 @@ public class RepositoryServiceV1 extends AbstractService {
                     "Encryption is not enabled in the server. Cannot migrate to an encrypted repository.");
         }
 
-        // TODO(minwoox): Dogma project will be migrated one day later by a plugin.
-        if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name())) {
+        if (InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name()) &&
+            !Project.REPO_DOGMA.equals(repository.name())) {
             throw new IllegalArgumentException(
-                    "Cannot migrate the internal project to an encrypted repository. project: " +
-                    project.name());
+                    "Only the dogma repository can be migrated in the dogma project." +
+                    " repository: " + repository.name());
         }
 
-        final RepositoryStatus currentStatus = repositoryStatus(repository);
         if (repository.isEncrypted()) {
             throw new IllegalArgumentException(
                     "The repository is already encrypted. Cannot migrate to an encrypted repository again." +
@@ -449,11 +457,15 @@ public class RepositoryServiceV1 extends AbstractService {
                     "Cannot migrate a repository with more than 1000 revisions to an encrypted repository.");
         }
 
-        if (currentStatus == RepositoryStatus.READ_ONLY) {
-            HttpApiUtil.throwResponse(
-                    ctx, HttpStatus.CONFLICT,
-                    "Cannot migrate a read-only repository to an encrypted repository. " +
-                    "Please change the status to ACTIVE first.");
+        // The dogma project does not have project metadata, so skip the status check.
+        if (!InternalProjectInitializer.INTERNAL_PROJECT_DOGMA.equals(project.name())) {
+            final RepositoryStatus currentStatus = repositoryStatus(repository);
+            if (currentStatus == RepositoryStatus.READ_ONLY) {
+                HttpApiUtil.throwResponse(
+                        ctx, HttpStatus.CONFLICT,
+                        "Cannot migrate a read-only repository to an encrypted repository. " +
+                        "Please change the status to ACTIVE first.");
+            }
         }
     }
 
@@ -477,7 +489,9 @@ public class RepositoryServiceV1 extends AbstractService {
     }
 
     private CompletionStage<RepositoryDto> migrate(Author author, Project project,
-                                                   Repository repository, WrappedDekDetails wdekDetails) {
+                                                   Repository repository,
+                                                   WrappedDekDetails wdekDetails,
+                                                   boolean skipStatusChange) {
         final String projectName = project.name();
         final String repoName = repository.name();
         logger.info("Starting repository encryption migration: project={}, repository={}",
@@ -491,12 +505,24 @@ public class RepositoryServiceV1 extends AbstractService {
                              if (cause != null) {
                                  logger.warn("failed to migrate repository to an encrypted repository: " +
                                              "project={}, repository={}", projectName, repoName, cause);
+                                 if (skipStatusChange) {
+                                     return CompletableFuture.<RepositoryDto>completedFuture(null)
+                                             .thenApply(unused1 ->
+                                                                Exceptions.<RepositoryDto>throwUnsafely(cause));
+                                 }
                                  return setRepositoryStatus(author, project, repository.name(),
                                                             RepositoryStatus.ACTIVE)
-                                         .thenApply(unused1 -> (RepositoryDto) Exceptions.throwUnsafely(cause));
+                                         .thenApply(unused1 ->
+                                                            Exceptions.<RepositoryDto>throwUnsafely(cause));
                              }
                              logger.info("Successfully migrated repository to an encrypted repository: " +
                                          "project={}, repository={}", projectName, repoName);
+                             if (skipStatusChange) {
+                                 final Repository updatedRepository =
+                                         project.repos().get(repository.name());
+                                 return CompletableFuture.completedFuture(
+                                         newRepositoryDto(updatedRepository, RepositoryStatus.ACTIVE));
+                             }
                              return setRepositoryStatus(author, project, repository.name(),
                                                         RepositoryStatus.ACTIVE)
                                      .thenApply(unused1 -> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/storage/project/InternalProjectInitializer.java
@@ -167,7 +167,7 @@ public final class InternalProjectInitializer {
 
         // These repositories might be created when creating an internal project, but we try to create them
         // again here in order to make sure them exist because sometimes their names are changed.
-        initializeInternalRepos(projectName, Project.internalRepos(), creationTimeMillis);
+        initializeInternalRepos(projectName, ImmutableList.of(Project.REPO_DOGMA), creationTimeMillis);
     }
 
     private void initializeAppIdentityRegistry() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
@@ -75,7 +75,7 @@ class DogmaRepoMigrationTest {
         // Migrate the dogma/dogma repository via the API.
         // This should succeed without setting the repository to read-only.
         final AggregatedHttpResponse response = postApi(dogma.httpClient(),
-                                                         DOGMA_PROJECT, DOGMA_REPO, "/migrate/encrypted");
+                                                        DOGMA_PROJECT, DOGMA_REPO, "/migrate/encrypted");
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
         // Verify that the dogma repo is now encrypted.
@@ -86,7 +86,7 @@ class DogmaRepoMigrationTest {
 
     @Test
     @Order(2)
-    void fallbackDogmaRepoFromReadOnlyState() {
+    void fallbackDogmaRepo() {
         // After the migration test, the dogma repo is encrypted.
         assertThat(dogma.projectManager().get(DOGMA_PROJECT).repos().get(DOGMA_REPO).isEncrypted()).isTrue();
 
@@ -105,8 +105,8 @@ class DogmaRepoMigrationTest {
     void migrateNonDogmaRepoInDogmaProjectShouldFail() {
         // The meta repository is no longer created, so attempting to migrate it should return 404.
         final AggregatedHttpResponse response = postApi(dogma.httpClient(),
-                                                         DOGMA_PROJECT, Project.REPO_META,
-                                                         "/migrate/encrypted");
+                                                        DOGMA_PROJECT, Project.REPO_META,
+                                                        "/migrate/encrypted");
         assertThat(response.status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.EncryptionConfig;
+import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
+import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.server.storage.repository.Repository;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+class DogmaRepoMigrationTest {
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
+        @Override
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.encryption(new EncryptionConfig(true, false, "kekId"))
+                   .systemAdministrators(USERNAME)
+                   .authProviderFactory(new TestAuthProviderFactory());
+        }
+
+        @Override
+        protected String accessToken() {
+            return getAccessToken(WebClient.of("http://127.0.0.1:" + dogma.serverAddress().getPort()),
+                                  USERNAME, PASSWORD, "testAppId", true);
+        }
+    };
+
+    @Test
+    void migrateDogmaProjectDogmaRepository() {
+        final String projectName = InternalProjectInitializer.INTERNAL_PROJECT_DOGMA;
+        final String repoName = Project.REPO_DOGMA;
+
+        // The dogma repo should not be encrypted initially.
+        final Repository dogmaRepo =
+                dogma.projectManager().get(projectName).repos().get(repoName);
+        assertThat(dogmaRepo.isEncrypted()).isFalse();
+
+        // Migrate the dogma/dogma repository via the API.
+        // This should succeed without setting the repository to read-only.
+        final AggregatedHttpResponse response = migrateRepository(dogma.httpClient(),
+                                                                   projectName, repoName);
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        // Verify that the dogma repo is now encrypted.
+        final Repository encryptedDogmaRepo =
+                dogma.projectManager().get(projectName).repos().get(repoName);
+        assertThat(encryptedDogmaRepo.isEncrypted()).isTrue();
+    }
+
+    @Test
+    void migrateNonDogmaRepoInDogmaProjectShouldFail() {
+        final String projectName = InternalProjectInitializer.INTERNAL_PROJECT_DOGMA;
+
+        // The meta repository is no longer created, so attempting to migrate it should return 404.
+        final AggregatedHttpResponse response = migrateRepository(dogma.httpClient(),
+                                                                  projectName, Project.REPO_META);
+        assertThat(response.status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private static AggregatedHttpResponse migrateRepository(WebClient client,
+                                                             String projectName, String repoName) {
+        final RequestHeaders headers = RequestHeaders.of(
+                HttpMethod.POST,
+                "/api/v1/projects/" + projectName + "/repos/" + repoName + "/migrate/encrypted",
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        return client.execute(headers).aggregate().join();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/DogmaRepoMigrationTest.java
@@ -20,7 +20,10 @@ import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUti
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.linecorp.armeria.client.WebClient;
@@ -38,7 +41,11 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DogmaRepoMigrationTest {
+
+    private static final String DOGMA_PROJECT = InternalProjectInitializer.INTERNAL_PROJECT_DOGMA;
+    private static final String DOGMA_REPO = Project.REPO_DOGMA;
 
     @RegisterExtension
     static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
@@ -58,42 +65,56 @@ class DogmaRepoMigrationTest {
     };
 
     @Test
+    @Order(1)
     void migrateDogmaProjectDogmaRepository() {
-        final String projectName = InternalProjectInitializer.INTERNAL_PROJECT_DOGMA;
-        final String repoName = Project.REPO_DOGMA;
-
         // The dogma repo should not be encrypted initially.
         final Repository dogmaRepo =
-                dogma.projectManager().get(projectName).repos().get(repoName);
+                dogma.projectManager().get(DOGMA_PROJECT).repos().get(DOGMA_REPO);
         assertThat(dogmaRepo.isEncrypted()).isFalse();
 
         // Migrate the dogma/dogma repository via the API.
         // This should succeed without setting the repository to read-only.
-        final AggregatedHttpResponse response = migrateRepository(dogma.httpClient(),
-                                                                   projectName, repoName);
+        final AggregatedHttpResponse response = postApi(dogma.httpClient(),
+                                                         DOGMA_PROJECT, DOGMA_REPO, "/migrate/encrypted");
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
 
         // Verify that the dogma repo is now encrypted.
         final Repository encryptedDogmaRepo =
-                dogma.projectManager().get(projectName).repos().get(repoName);
+                dogma.projectManager().get(DOGMA_PROJECT).repos().get(DOGMA_REPO);
         assertThat(encryptedDogmaRepo.isEncrypted()).isTrue();
     }
 
     @Test
-    void migrateNonDogmaRepoInDogmaProjectShouldFail() {
-        final String projectName = InternalProjectInitializer.INTERNAL_PROJECT_DOGMA;
+    @Order(2)
+    void fallbackDogmaRepoFromReadOnlyState() {
+        // After the migration test, the dogma repo is encrypted.
+        assertThat(dogma.projectManager().get(DOGMA_PROJECT).repos().get(DOGMA_REPO).isEncrypted()).isTrue();
 
+        // Fallback should succeed without changing the status because
+        // the dogma project does not have project metadata.
+        final AggregatedHttpResponse response = postApi(dogma.httpClient(),
+                                                        DOGMA_PROJECT, DOGMA_REPO, "/migrate/file");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        final Repository fallbackRepo =
+                dogma.projectManager().get(DOGMA_PROJECT).repos().get(DOGMA_REPO);
+        assertThat(fallbackRepo.isEncrypted()).isFalse();
+    }
+
+    @Test
+    void migrateNonDogmaRepoInDogmaProjectShouldFail() {
         // The meta repository is no longer created, so attempting to migrate it should return 404.
-        final AggregatedHttpResponse response = migrateRepository(dogma.httpClient(),
-                                                                  projectName, Project.REPO_META);
+        final AggregatedHttpResponse response = postApi(dogma.httpClient(),
+                                                         DOGMA_PROJECT, Project.REPO_META,
+                                                         "/migrate/encrypted");
         assertThat(response.status()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
-    private static AggregatedHttpResponse migrateRepository(WebClient client,
-                                                             String projectName, String repoName) {
+    private static AggregatedHttpResponse postApi(WebClient client,
+                                                   String projectName, String repoName, String action) {
         final RequestHeaders headers = RequestHeaders.of(
                 HttpMethod.POST,
-                "/api/v1/projects/" + projectName + "/repos/" + repoName + "/migrate/encrypted",
+                "/api/v1/projects/" + projectName + "/repos/" + repoName + action,
                 HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
         return client.execute(headers).aggregate().join();
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/FallbackFromReadOnlyTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/FallbackFromReadOnlyTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpHeaderNames;
+import com.linecorp.armeria.common.HttpMethod;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.MediaType;
+import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.server.CentralDogma;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.EncryptionConfig;
+import com.linecorp.centraldogma.server.GracefulShutdownTimeout;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
+
+class FallbackFromReadOnlyTest {
+
+    private static final String PROJECT_NAME = "myProject";
+    private static final String REPO_NAME = "myRepo";
+
+    @TempDir
+    File dataDir;
+
+    @Test
+    void fallbackFromReadOnlyState() throws Exception {
+        // 1. Start the server WITHOUT encryption and create a project/repo.
+        CentralDogma dogma = new CentralDogmaBuilder(dataDir)
+                .port(0, com.linecorp.armeria.common.SessionProtocol.HTTP)
+                .webAppEnabled(false)
+                .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
+                .systemAdministrators(USERNAME)
+                .authProviderFactory(new TestAuthProviderFactory())
+                .build();
+        dogma.start().join();
+
+        InetSocketAddress addr = dogma.activePort().localAddress();
+        WebClient client = newClient(addr);
+
+        createProject(client, PROJECT_NAME);
+        createRepository(client, PROJECT_NAME, REPO_NAME);
+
+        assertThat(dogma.projectManager().get(PROJECT_NAME).repos().get(REPO_NAME).isEncrypted()).isFalse();
+        dogma.stop().join();
+
+        // 2. Restart the server WITH encryption enabled and migrate the repo.
+        dogma = new CentralDogmaBuilder(dataDir)
+                .port(0, com.linecorp.armeria.common.SessionProtocol.HTTP)
+                .webAppEnabled(false)
+                .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
+                .encryption(new EncryptionConfig(true, false, "kekId"))
+                .systemAdministrators(USERNAME)
+                .authProviderFactory(new TestAuthProviderFactory())
+                .build();
+        dogma.start().join();
+
+        addr = dogma.activePort().localAddress();
+        client = newClient(addr);
+
+        // Migrate the non-encrypted repo to an encrypted repo.
+        AggregatedHttpResponse response = postApi(client, PROJECT_NAME, REPO_NAME, "/migrate/encrypted");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(dogma.projectManager().get(PROJECT_NAME).repos().get(REPO_NAME).isEncrypted()).isTrue();
+
+        // Set the repository to read-only.
+        response = updateRepositoryStatus(client, PROJECT_NAME, REPO_NAME, "READ_ONLY");
+        assertThat(response.contentUtf8()).contains("READ_ONLY");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        // Fallback should succeed even in read-only state.
+        response = postApi(client, PROJECT_NAME, REPO_NAME, "/migrate/file");
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        assertThat(response.contentUtf8()).contains("\"status\":\"ACTIVE\"");
+
+        assertThat(dogma.projectManager().get(PROJECT_NAME).repos().get(REPO_NAME).isEncrypted()).isFalse();
+        dogma.stop().join();
+    }
+
+    private static int appIdCounter;
+
+    private static WebClient newClient(InetSocketAddress addr) {
+        final String appId = "testAppId" + appIdCounter++;
+        final String accessToken = getAccessToken(
+                WebClient.of("http://127.0.0.1:" + addr.getPort()),
+                USERNAME, PASSWORD, appId, true);
+        return WebClient.builder("h2c://127.0.0.1:" + addr.getPort())
+                        .auth(AuthToken.ofOAuth2(accessToken))
+                        .build();
+    }
+
+    private static void createProject(WebClient client, String projectName) {
+        final RequestHeaders headers = RequestHeaders.of(
+                HttpMethod.POST, "/api/v1/projects",
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final AggregatedHttpResponse response =
+                client.execute(headers, "{\"name\":\"" + projectName + "\"}").aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    private static void createRepository(WebClient client, String projectName, String repoName) {
+        final RequestHeaders headers = RequestHeaders.of(
+                HttpMethod.POST, "/api/v1/projects/" + projectName + "/repos",
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        final AggregatedHttpResponse response =
+                client.execute(headers, "{\"name\":\"" + repoName + "\"}").aggregate().join();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    private static AggregatedHttpResponse postApi(WebClient client,
+                                                   String projectName, String repoName, String action) {
+        final RequestHeaders headers = RequestHeaders.of(
+                HttpMethod.POST,
+                "/api/v1/projects/" + projectName + "/repos/" + repoName + action,
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        return client.execute(headers).aggregate().join();
+    }
+
+    private static AggregatedHttpResponse updateRepositoryStatus(WebClient client, String projectName,
+                                                                  String repoName, String status) {
+        final RequestHeaders headers = RequestHeaders.of(
+                HttpMethod.PUT,
+                "/api/v1/projects/" + projectName + "/repos/" + repoName + "/status",
+                HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        return client.execute(headers, "{\"status\":\"" + status + "\"}").aggregate().join();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/FallbackFromReadOnlyTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/FallbackFromReadOnlyTest.java
@@ -33,6 +33,7 @@ import com.linecorp.armeria.common.HttpMethod;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.SessionProtocol;
 import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.centraldogma.server.CentralDogma;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
@@ -52,7 +53,7 @@ class FallbackFromReadOnlyTest {
     void fallbackFromReadOnlyState() throws Exception {
         // 1. Start the server WITHOUT encryption and create a project/repo.
         CentralDogma dogma = new CentralDogmaBuilder(dataDir)
-                .port(0, com.linecorp.armeria.common.SessionProtocol.HTTP)
+                .port(0, SessionProtocol.HTTP)
                 .webAppEnabled(false)
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .systemAdministrators(USERNAME)
@@ -71,7 +72,7 @@ class FallbackFromReadOnlyTest {
 
         // 2. Restart the server WITH encryption enabled and migrate the repo.
         dogma = new CentralDogmaBuilder(dataDir)
-                .port(0, com.linecorp.armeria.common.SessionProtocol.HTTP)
+                .port(0, SessionProtocol.HTTP)
                 .webAppEnabled(false)
                 .gracefulShutdownTimeout(new GracefulShutdownTimeout(0, 0))
                 .encryption(new EncryptionConfig(true, false, "kekId"))


### PR DESCRIPTION
Motivation:
- Previously, the dogma project and its repositories were excluded from encryption migration. Modifications:
- Remove the restriction that blocks the dogma project from encryption migration in `RepositoryServiceV1.validateMigrationPrerequisites()`.
- Only the dogma repository is allowed to be migrated in the dogma project; other repositories in the dogma project are rejected with a bad request.
- Skip the read-only status transition for the dogma project because its project metadata is stored in the dogma repository itself, making it impossible to change the repository status.
- Stop creating the deprecated meta repository in `InternalProjectInitializer.initializeInternalRepos()`. The meta repository is no longer used, and `isInternalRepo("meta")` still returns `true` to prevent name collisions.

Result:
- The dogma project's dogma repository can now be migrated to an encrypted repository.
- The meta repository is no longer created on new server initialization.