### PR TITLE
Validate file content compatibility on rename across entry types

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DefaultChangesApplier.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/DefaultChangesApplier.java
@@ -44,6 +44,7 @@ import com.google.common.base.MoreObjects;
 
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.ChangeConflictException;
+import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.common.TextPatchConflictException;
 import com.linecorp.centraldogma.common.jsonpatch.JsonPatchConflictException;
@@ -172,6 +173,11 @@ final class DefaultChangesApplier extends AbstractChangesApplier {
                             break;
                         }
 
+                        // Validate that the old content is compatible with the new path's entry type.
+                        if (oldContent != null) {
+                            validateRenameContent(changePath, newPath, oldContent);
+                        }
+
                         final DirCacheEditor editor = dirCache.editor();
                         editor.add(new DeletePath(changePath));
                         editor.add(new CopyOldEntry(newPath, oldEntry));
@@ -276,6 +282,24 @@ final class DefaultChangesApplier extends AbstractChangesApplier {
             }
         }
         return numEdits;
+    }
+
+    private static void validateRenameContent(String oldPath, String newPath, byte[] content) {
+        final EntryType oldEntryType = EntryType.guessFromPath(oldPath);
+        final EntryType newEntryType = EntryType.guessFromPath(newPath);
+        if (oldEntryType == newEntryType) {
+            return;
+        }
+
+        if (newEntryType == EntryType.JSON || newEntryType == EntryType.YAML) {
+            try {
+                Jackson.readTree(newPath, content);
+            } catch (JsonProcessingException e) {
+                throw new ChangeConflictException(
+                        "rename would produce an invalid " + newEntryType + " file: /" + oldPath +
+                        " -> /" + newPath, e);
+            }
+        }
     }
 
     private static JsonNode toJsonNode(String path, byte @Nullable [] content) throws JsonProcessingException {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/storage/repository/git/GitRepositoryTest.java
@@ -388,6 +388,26 @@ class GitRepositoryTest {
     }
 
     @Test
+    void testRenameTextFileToJsonFile() {
+        testRenameTextFileToJsonFile(fileRepo);
+        testRenameTextFileToJsonFile(encryptedRepo);
+    }
+
+    private void testRenameTextFileToJsonFile(GitRepository repo) {
+        // Create a text file with content that is not valid JSON.
+        final String textPath = prefix + "file.txt";
+        final String jsonPath = prefix + "file.json";
+        repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                    Change.ofTextUpsert(textPath, "not a valid JSON")).join();
+
+        // Rename the text file to a JSON file.
+        assertThatThrownBy(() -> repo.commit(HEAD, 0L, Author.UNKNOWN, SUMMARY,
+                                             Change.ofRename(textPath, jsonPath)).join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(ChangeConflictException.class);
+    }
+
+    @Test
     void testRecursiveRename() {
         testRecursiveRename(fileRepo);
         testRecursiveRename(encryptedRepo);


### PR DESCRIPTION
Motivation:
- When renaming a text file to a JSON/YAML path (e.g., `/a.txt` to `/a.json`) via `Change.ofRename()`, the rename succeeded without validating that the file content was valid for the target entry type.

Modifications:
- Added `validateRenameContent()` in `DefaultChangesApplier` to check that the existing file content is parseable as the target entry type when a rename changes the file extension from text to JSON/YAML.

Result:
- Renaming a file to a structured file path (JSON/YAML) now fails fast if the content is not valid for the target format.