### PR TITLE
Fix pretty print not being applied to single-line JSON files

### DIFF
--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -78,7 +78,7 @@ const FileEditor = ({
     setTabIndex(index);
   };
   let displayContent = originalContent;
-  if (path.endsWith('.json') && originalContent.indexOf('\n') === -1) {
+  if (path.endsWith('.json') && originalContent.trim().indexOf('\n') === -1) {
     // Pretty print JSON content if it's a single line which is hard to read.
     // If the file is not created from a raw JSON, the server will normalize it and write a compact JSON.
     displayContent = JSON.stringify(JSON.parse(originalContent), null, 2);


### PR DESCRIPTION
Motivation:
- When the server stores JSON content, it appends a trailing newline (`\n`). The existing single-line check `originalContent.indexOf('\n') === -1` fails because of this trailing newline, so compact JSON files are displayed as a single unformatted line.

Modifications:
- Trim the content before checking for newlines so that a trailing newline does not prevent the pretty print logic from being applied.

Result:
- Single-line JSON files are now correctly pretty-printed in the file viewer.