### PR TITLE
Persist pagination state in URL query parameters

### DIFF
--- a/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
+++ b/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
@@ -12,9 +12,21 @@ import {
 } from '@tanstack/react-table';
 import { DataTable } from 'dogma/common/components/table/DataTable';
 import { Filter } from 'dogma/common/components/table/Filter';
-import { PaginationBar } from 'dogma/common/components/table/PaginationBar';
+import { PAGE_SIZES, PaginationBar } from 'dogma/common/components/table/PaginationBar';
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
+
+const VALID_PAGE_SIZES: Set<number> = new Set(PAGE_SIZES);
+
+function parsePageIndex(value: string | string[] | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n - 1 : 0;
+}
+
+function parsePageSize(value: string | string[] | undefined): number {
+  const n = Number(value);
+  return VALID_PAGE_SIZES.has(n) ? n : 10;
+}
 
 export type DataTableClientPaginationProps<Data extends object> = {
   data: Data[];
@@ -58,11 +70,9 @@ export const DataTableClientPagination = <Data extends object>({
     if (!router.isReady) {
       return;
     }
-    const page = Number(router.query?.page);
-    const pageSize = Number(router.query?.pageSize);
     setPaginationState({
-      pageIndex: page > 0 ? page - 1 : 0,
-      pageSize: pageSize > 0 ? pageSize : 10,
+      pageIndex: parsePageIndex(router.query?.page),
+      pageSize: parsePageSize(router.query?.pageSize),
     });
   }, [router.isReady, router.query?.page, router.query?.pageSize]);
 

--- a/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
+++ b/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
@@ -6,13 +6,15 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
+  PaginationState,
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { DataTable } from 'dogma/common/components/table/DataTable';
 import { Filter } from 'dogma/common/components/table/Filter';
 import { PaginationBar } from 'dogma/common/components/table/PaginationBar';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 
 export type DataTableClientPaginationProps<Data extends object> = {
   data: Data[];
@@ -23,8 +25,50 @@ export const DataTableClientPagination = <Data extends object>({
   data,
   columns,
 }: DataTableClientPaginationProps<Data>) => {
+  const router = useRouter();
+  const queryPage = Number(router.query?.page);
+  const queryPageSize = Number(router.query?.pageSize);
+  const initialPageIndex = queryPage > 0 ? queryPage - 1 : 0;
+  const initialPageSize = queryPageSize > 0 ? queryPageSize : 10;
+
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: initialPageIndex,
+    pageSize: initialPageSize,
+  });
+
+  const setPagination = useCallback(
+    (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
+      setPaginationState((old) => {
+        const newState = typeof updater === 'function' ? updater(old) : updater;
+        const query = { ...router.query };
+        if (newState.pageIndex === 0) {
+          delete query.page;
+        } else {
+          query.page = String(newState.pageIndex + 1);
+        }
+        if (newState.pageSize === 10) {
+          delete query.pageSize;
+        } else {
+          query.pageSize = String(newState.pageSize);
+        }
+        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+        return newState;
+      });
+    },
+    [router],
+  );
+
+  useEffect(() => {
+    const page = Number(router.query?.page);
+    const pageSize = Number(router.query?.pageSize);
+    setPaginationState({
+      pageIndex: page > 0 ? page - 1 : 0,
+      pageSize: pageSize > 0 ? pageSize : 10,
+    });
+  }, [router.query?.page, router.query?.pageSize]);
+
   const table = useReactTable({
     columns: columns || [],
     data: data || [],
@@ -34,11 +78,13 @@ export const DataTableClientPagination = <Data extends object>({
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
+    onPaginationChange: setPagination,
     manualPagination: false,
     autoResetPageIndex: false,
     state: {
       sorting,
       columnFilters,
+      pagination,
     },
   });
 

--- a/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
+++ b/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
@@ -26,48 +26,45 @@ export const DataTableClientPagination = <Data extends object>({
   columns,
 }: DataTableClientPaginationProps<Data>) => {
   const router = useRouter();
-  const queryPage = Number(router.query?.page);
-  const queryPageSize = Number(router.query?.pageSize);
-  const initialPageIndex = queryPage > 0 ? queryPage - 1 : 0;
-  const initialPageSize = queryPageSize > 0 ? queryPageSize : 10;
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
   const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: initialPageIndex,
-    pageSize: initialPageSize,
+    pageIndex: 0,
+    pageSize: 10,
   });
 
   const setPagination = useCallback(
     (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
-      setPaginationState((old) => {
-        const newState = typeof updater === 'function' ? updater(old) : updater;
-        const query = { ...router.query };
-        if (newState.pageIndex === 0) {
-          delete query.page;
-        } else {
-          query.page = String(newState.pageIndex + 1);
-        }
-        if (newState.pageSize === 10) {
-          delete query.pageSize;
-        } else {
-          query.pageSize = String(newState.pageSize);
-        }
-        router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
-        return newState;
-      });
+      const newState = typeof updater === 'function' ? updater(pagination) : updater;
+      setPaginationState(newState);
+      const query = { ...router.query };
+      if (newState.pageIndex === 0) {
+        delete query.page;
+      } else {
+        query.page = String(newState.pageIndex + 1);
+      }
+      if (newState.pageSize === 10) {
+        delete query.pageSize;
+      } else {
+        query.pageSize = String(newState.pageSize);
+      }
+      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
     },
-    [router],
+    [pagination, router],
   );
 
   useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
     const page = Number(router.query?.page);
     const pageSize = Number(router.query?.pageSize);
     setPaginationState({
       pageIndex: page > 0 ? page - 1 : 0,
       pageSize: pageSize > 0 ? pageSize : 10,
     });
-  }, [router.query?.page, router.query?.pageSize]);
+  }, [router.isReady, router.query?.page, router.query?.pageSize]);
 
   const table = useReactTable({
     columns: columns || [],
@@ -87,6 +84,10 @@ export const DataTableClientPagination = <Data extends object>({
       pagination,
     },
   });
+
+  if (!router.isReady) {
+    return null;
+  }
 
   return (
     <>

--- a/webapp/src/dogma/common/components/table/PaginationBar.tsx
+++ b/webapp/src/dogma/common/components/table/PaginationBar.tsx
@@ -2,6 +2,8 @@ import { Flex, IconButton, Input, Select, Spacer, Text } from '@chakra-ui/react'
 import { Table as ReactTable } from '@tanstack/react-table';
 import { MdNavigateBefore, MdNavigateNext, MdSkipNext, MdSkipPrevious } from 'react-icons/md';
 
+export const PAGE_SIZES = [10, 20, 30, 40, 50, 100, 200, 400] as const;
+
 type PaginationBarProps<Data extends object> = {
   table: ReactTable<Data>;
   disableGotoButton?: boolean;
@@ -59,7 +61,7 @@ export const PaginationBar = <Data extends object>({ table, disableGotoButton }:
             }}
             width="auto"
           >
-            {[10, 20, 30, 40, 50, 100, 200, 400].map((pageSize) => (
+            {PAGE_SIZES.map((pageSize) => (
               <option key={pageSize} value={pageSize}>
                 Show {pageSize}
               </option>

--- a/webapp/tests/dogma/feature/repo/RepoList.test.tsx
+++ b/webapp/tests/dogma/feature/repo/RepoList.test.tsx
@@ -2,6 +2,14 @@ import { render } from '@testing-library/react';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
 import RepoList, { RepoListProps } from 'dogma/features/repo/RepoList';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    pathname: '/app/projects/[projectName]',
+    push: jest.fn(),
+  }),
+}));
+
 describe('RepoList', () => {
   let expectedProps: JSX.IntrinsicAttributes & RepoListProps<object>;
 

--- a/webapp/tests/dogma/feature/repo/RepoList.test.tsx
+++ b/webapp/tests/dogma/feature/repo/RepoList.test.tsx
@@ -4,6 +4,7 @@ import RepoList, { RepoListProps } from 'dogma/features/repo/RepoList';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
+    isReady: true,
     query: {},
     pathname: '/app/projects/[projectName]',
     push: jest.fn(),

--- a/webapp/tests/dogma/feature/repo/RepoPermissionList.test.tsx
+++ b/webapp/tests/dogma/feature/repo/RepoPermissionList.test.tsx
@@ -6,6 +6,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('next/router', () => ({
   useRouter: () => ({
+    isReady: true,
     query: {},
     pathname: '/app/projects/[projectName]/settings',
     push: jest.fn(),

--- a/webapp/tests/dogma/feature/repo/RepoPermissionList.test.tsx
+++ b/webapp/tests/dogma/feature/repo/RepoPermissionList.test.tsx
@@ -4,6 +4,14 @@ import RepoRoleList, { RepoRoleListProps } from 'dogma/features/repo/RepoRoleLis
 import { RepositoryMetadataDto } from 'dogma/features/repo/RepositoriesMetadataDto';
 import '@testing-library/jest-dom';
 
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    query: {},
+    pathname: '/app/projects/[projectName]/settings',
+    push: jest.fn(),
+  }),
+}));
+
 describe('RepoRoleList', () => {
   let expectedProps: JSX.IntrinsicAttributes & RepoRoleListProps<object>;
 

--- a/webapp/tests/pages/app/settings/app-identities/index.test.tsx
+++ b/webapp/tests/pages/app/settings/app-identities/index.test.tsx
@@ -10,7 +10,7 @@ jest.mock('dogma/features/api/apiSlice', () => ({
 }));
 
 jest.mock('next/router', () => ({
-  useRouter: () => ({ asPath: '/app/settings/app-identities' }),
+  useRouter: () => ({ asPath: '/app/settings/app-identities', isReady: true, query: {} }),
 }));
 
 const mockIdentities: AppIdentityDto[] = [


### PR DESCRIPTION
Motivation:
When navigating to a repository from a paginated list and pressing the browser back button, the pagination state (page number and page size) was lost and reset to page 1 with the default page size of 10.

Modifications:
- Sync pagination state (page index and page size) with URL query parameters.
  - Default values (page=1, pageSize=10) are omitted from the URL to keep it clean.

Result:
- Browser back/forward navigation now restores the correct pagination state across all pages that use DataTableClientPagination.