### PR TITLE
Fix replication replay failure after copying data directory from another replica

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -135,6 +134,7 @@ public final class ZooKeeperCommandExecutor
 
     private final ZooKeeperReplicationConfig cfg;
     private final File revisionFile;
+    private final File localRevisionFile;
     private final File zkConfFile;
     private final File zkDataDir;
     private final File zkLogDir;
@@ -347,7 +347,10 @@ public final class ZooKeeperCommandExecutor
     }
 
     private static final class ListenerInfo {
+        // Highest ZK revision processed by the replay loop.
         long lastReplayedRevision;
+        // Highest ZK revision applied to local data by storeLog.
+        long localLastAppliedRevision;
         @Nullable
         final Runnable onTakeLeadership;
         @Nullable
@@ -357,10 +360,11 @@ public final class ZooKeeperCommandExecutor
         @Nullable
         final Runnable onReleaseZoneLeadership;
 
-        ListenerInfo(long lastReplayedRevision,
+        ListenerInfo(long lastReplayedRevision, long localLastAppliedRevision,
                      @Nullable Runnable onTakeLeadership, @Nullable Runnable onReleaseLeadership,
                      @Nullable Runnable onTakeZoneLeadership, @Nullable Runnable onReleaseZoneLeadership) {
             this.lastReplayedRevision = lastReplayedRevision;
+            this.localLastAppliedRevision = localLastAppliedRevision;
             this.onReleaseLeadership = onReleaseLeadership;
             this.onTakeLeadership = onTakeLeadership;
             this.onTakeZoneLeadership = onTakeZoneLeadership;
@@ -383,6 +387,8 @@ public final class ZooKeeperCommandExecutor
         this.cfg = requireNonNull(cfg, "cfg");
         requireNonNull(dataDir, "dataDir");
         revisionFile = new File(dataDir.getAbsolutePath() + File.separatorChar + "last_revision");
+        localRevisionFile = new File(dataDir.getAbsolutePath() + File.separatorChar +
+                                     "local_last_revision");
         zkConfFile = new File(dataDir.getAbsolutePath() + File.separatorChar +
                               "_zookeeper" + File.separatorChar + "config.properties");
         zkDataDir = new File(dataDir.getAbsolutePath() + File.separatorChar +
@@ -426,6 +432,15 @@ public final class ZooKeeperCommandExecutor
                           return info.lastReplayedRevision;
                       })
              .register(meterRegistry);
+        Gauge.builder("replica.last.local.applied.revision", this,
+                      self -> {
+                          final ListenerInfo info = self.listenerInfo;
+                          if (info == null) {
+                              return 0;
+                          }
+                          return info.localLastAppliedRevision;
+                      })
+             .register(meterRegistry);
     }
 
     @Override
@@ -441,13 +456,22 @@ public final class ZooKeeperCommandExecutor
         try {
             // Get the last replayed revision.
             final long lastReplayedRevision;
+            long localLastAppliedRevision;
             try {
                 lastReplayedRevision = getLastReplayedRevision();
-                listenerInfo = new ListenerInfo(lastReplayedRevision, onTakeLeadership, onReleaseLeadership,
-                                                onTakeZoneLeadership, onReleaseZoneLeadership);
+                localLastAppliedRevision = getLocalLastAppliedRevision();
             } catch (Exception e) {
-                throw new ReplicationException("failed to read " + revisionFile, e);
+                throw new ReplicationException("failed to read " + revisionFile + " or " +
+                                               localRevisionFile, e);
             }
+            if (localLastAppliedRevision == -1 && lastReplayedRevision != -1) {
+                logger.info("local_last_revision missing; falling back to last_revision: {}",
+                            lastReplayedRevision);
+                localLastAppliedRevision = lastReplayedRevision;
+            }
+            listenerInfo = new ListenerInfo(lastReplayedRevision, localLastAppliedRevision,
+                                            onTakeLeadership, onReleaseLeadership,
+                                            onTakeZoneLeadership, onReleaseZoneLeadership);
 
             // Start the embedded ZooKeeper.
             quorumPeer = startZooKeeper();
@@ -782,9 +806,20 @@ public final class ZooKeeperCommandExecutor
     }
 
     private long getLastReplayedRevision() throws Exception {
+        return readRevisionFile(revisionFile);
+    }
+
+    private long getLocalLastAppliedRevision() throws Exception {
+        return readRevisionFile(localRevisionFile);
+    }
+
+    /**
+     * Returns -1 if the file does not exist or is empty.
+     **/
+    private static long readRevisionFile(File file) throws Exception {
         final FileInputStream fis;
         try {
-            fis = new FileInputStream(revisionFile);
+            fis = new FileInputStream(file);
         } catch (FileNotFoundException ignored) {
             return -1;
         }
@@ -798,16 +833,24 @@ public final class ZooKeeperCommandExecutor
         }
     }
 
-    private void updateLastReplayedRevision(long lastReplayedRevision) throws Exception {
+    private void updateLastReplayedRevision(long rev) throws Exception {
+        writeRevisionFile(revisionFile, rev, "lastReplayedRevision");
+    }
+
+    private void updateLocalLastAppliedRevision(long rev) throws Exception {
+        writeRevisionFile(localRevisionFile, rev, "localLastAppliedRevision");
+    }
+
+    private static void writeRevisionFile(File file, long rev, String name) throws Exception {
         boolean success = false;
-        try (FileOutputStream fos = new FileOutputStream(revisionFile)) {
-            fos.write(String.valueOf(lastReplayedRevision).getBytes(StandardCharsets.UTF_8));
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(String.valueOf(rev).getBytes(StandardCharsets.UTF_8));
             success = true;
         } finally {
             if (success) {
-                logger.info("Updated lastReplayedRevision to: {}", lastReplayedRevision);
+                logger.info("Updated {} to: {}", name, rev);
             } else {
-                logger.error("Failed to update lastReplayedRevision to: {}", lastReplayedRevision);
+                logger.error("Failed to update {} to: {}", name, rev);
             }
         }
     }
@@ -829,11 +872,11 @@ public final class ZooKeeperCommandExecutor
             }
             ReplicationLog<?> l = null;
             try {
-                final Optional<ReplicationLog<?>> log = loadLog(nextRevision, true);
-                Command<?> command = null;
-                if (log.isPresent()) {
-                    l = log.get();
-                    command = l.command();
+                l = loadLog(nextRevision);
+                final Command<?> command = l.command();
+                // Skip when local data already has this revision's effect.
+                final boolean shouldExecute = nextRevision > info.localLastAppliedRevision;
+                if (shouldExecute) {
                     final Object expectedResult = l.result();
                     final Object actualResult = delegate.execute(REPLAY_CONTEXT, command).get();
 
@@ -844,12 +887,13 @@ public final class ZooKeeperCommandExecutor
                                 ", command: " + command + ')');
                     }
                 } else {
-                    // same replicaId. skip
+                    logger.debug("Skipping replay at revision {} (already applied locally): {}",
+                                 nextRevision, l);
                 }
 
                 updateLastReplayedRevision(nextRevision);
                 info.lastReplayedRevision = nextRevision;
-                if (command instanceof UpdateServerStatusCommand) {
+                if (shouldExecute && command instanceof UpdateServerStatusCommand) {
                     updateZkCommandStatusLater((UpdateServerStatusCommand) command);
                 }
                 if (nextRevision == targetRevision) {
@@ -1028,11 +1072,24 @@ public final class ZooKeeperCommandExecutor
                 logMeta.appendBlock(blockId);
             }
 
-            final String logPath =
-                    curator.create().withMode(CreateMode.PERSISTENT_SEQUENTIAL)
-                           .forPath(absolutePath(LOG_PATH) + '/', Jackson.writeValueAsBytes(logMeta));
+            final byte[] logMetaBytes = Jackson.writeValueAsBytes(logMeta);
+            final long revision;
+            // Hold replayLogs's monitor across the logMeta create and the state bump so a
+            // childEvent for this revision can't race in and re-execute it.
+            synchronized (this) {
+                final String logPath =
+                        curator.create().withMode(CreateMode.PERSISTENT_SEQUENTIAL)
+                               .forPath(absolutePath(LOG_PATH) + '/', logMetaBytes);
+                revision = revisionFromPath(logPath);
 
-            return revisionFromPath(logPath);
+                final ListenerInfo info = listenerInfo;
+                if (info != null && revision > info.localLastAppliedRevision) {
+                    updateLocalLastAppliedRevision(revision);
+                    info.localLastAppliedRevision = revision;
+                }
+            }
+
+            return revision;
         } catch (Exception e) {
             logger.error("Failed to store a log; entering read-only mode: {}", log, e);
             stopLater();
@@ -1041,17 +1098,13 @@ public final class ZooKeeperCommandExecutor
     }
 
     @VisibleForTesting
-    Optional<ReplicationLog<?>> loadLog(long revision, boolean skipIfSameReplica) {
+    ReplicationLog<?> loadLog(long revision) {
         try {
             createParentNodes();
 
             final String logPath = absolutePath(LOG_PATH) + '/' + pathFromRevision(revision);
 
             final LogMeta logMeta = Jackson.readValue(curator.getData().forPath(logPath), LogMeta.class);
-
-            if (skipIfSameReplica && replicaId() == logMeta.replicaId()) {
-                return Optional.empty();
-            }
 
             byte[] bytes = new byte[logMeta.size()];
             int offset = 0;
@@ -1067,8 +1120,7 @@ public final class ZooKeeperCommandExecutor
             if (Boolean.TRUE.equals(compressed)) {
                 bytes = Zstd.decompress(bytes);
             }
-            final ReplicationLog<?> log = Jackson.readValue(bytes, ReplicationLog.class);
-            return Optional.of(log);
+            return Jackson.readValue(bytes, ReplicationLog.class);
         } catch (Exception e) {
             logger.error("Failed to load a log at revision {}; entering read-only mode", revision, e);
             stopLater();

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -666,7 +666,7 @@ public final class ZooKeeperCommandExecutor
             peer.start();
 
             // Wait until the ZooKeeper joins the cluster.
-            for (;;) {
+            for (; ; ) {
                 final ServerState state = peer.getPeerState();
                 if (state == ServerState.FOLLOWING || state == ServerState.LEADING) {
                     break;
@@ -866,17 +866,17 @@ public final class ZooKeeperCommandExecutor
         }
 
         long nextRevision = info.lastReplayedRevision + 1;
-        for (;;) {
+        for (; ; ) {
             if (!canReplicate) {
                 break;
             }
             ReplicationLog<?> l = null;
             try {
-                l = loadLog(nextRevision);
-                final Command<?> command = l.command();
                 // Skip when local data already has this revision's effect.
                 final boolean shouldExecute = nextRevision > info.localLastAppliedRevision;
                 if (shouldExecute) {
+                    l = loadLog(nextRevision);
+                    final Command<?> command = l.command();
                     final Object expectedResult = l.result();
                     final Object actualResult = delegate.execute(REPLAY_CONTEXT, command).get();
 
@@ -887,14 +887,14 @@ public final class ZooKeeperCommandExecutor
                                 ", command: " + command + ')');
                     }
                 } else {
-                    logger.debug("Skipping replay at revision {} (already applied locally): {}",
-                                 nextRevision, l);
+                    logger.debug("Skipping replay at revision {} (already applied locally)",
+                                 nextRevision);
                 }
 
                 updateLastReplayedRevision(nextRevision);
                 info.lastReplayedRevision = nextRevision;
-                if (shouldExecute && command instanceof UpdateServerStatusCommand) {
-                    updateZkCommandStatusLater((UpdateServerStatusCommand) command);
+                if (shouldExecute && l.command() instanceof UpdateServerStatusCommand) {
+                    updateZkCommandStatusLater((UpdateServerStatusCommand) l.command());
                 }
                 if (nextRevision == targetRevision) {
                     break;
@@ -970,7 +970,7 @@ public final class ZooKeeperCommandExecutor
             // Retry up to 1 minute, to minimize the chance of going read-only.
             long remainingTimeNanos = lockTimeoutNanos;
             final long deadlineNanos = startTime + remainingTimeNanos;
-            for (;;) {
+            for (; ; ) {
                 try {
                     if (mtx.acquire(remainingTimeNanos, TimeUnit.NANOSECONDS)) {
                         lockAcquired = true;

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java
@@ -26,6 +26,10 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -666,7 +670,7 @@ public final class ZooKeeperCommandExecutor
             peer.start();
 
             // Wait until the ZooKeeper joins the cluster.
-            for (; ; ) {
+            for (;;) {
                 final ServerState state = peer.getPeerState();
                 if (state == ServerState.FOLLOWING || state == ServerState.LEADING) {
                     break;
@@ -842,16 +846,25 @@ public final class ZooKeeperCommandExecutor
     }
 
     private static void writeRevisionFile(File file, long rev, String name) throws Exception {
-        boolean success = false;
-        try (FileOutputStream fos = new FileOutputStream(file)) {
-            fos.write(String.valueOf(rev).getBytes(StandardCharsets.UTF_8));
-            success = true;
-        } finally {
-            if (success) {
-                logger.info("Updated {} to: {}", name, rev);
-            } else {
-                logger.error("Failed to update {} to: {}", name, rev);
+        final Path target = file.toPath();
+        final Path tmp = target.resolveSibling(file.getName() + ".tmp");
+        try {
+            Files.write(tmp, String.valueOf(rev).getBytes(StandardCharsets.UTF_8));
+            try {
+                Files.move(tmp, target,
+                           StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);
             }
+            logger.info("Updated {} to: {}", name, rev);
+        } catch (Exception e) {
+            logger.error("Failed to update {} to: {}", name, rev, e);
+            try {
+                Files.deleteIfExists(tmp);
+            } catch (Exception ignored) {
+                // best effort
+            }
+            throw e;
         }
     }
 
@@ -866,7 +879,7 @@ public final class ZooKeeperCommandExecutor
         }
 
         long nextRevision = info.lastReplayedRevision + 1;
-        for (; ; ) {
+        for (;;) {
             if (!canReplicate) {
                 break;
             }
@@ -970,7 +983,7 @@ public final class ZooKeeperCommandExecutor
             // Retry up to 1 minute, to minimize the chance of going read-only.
             long remainingTimeNanos = lockTimeoutNanos;
             final long deadlineNanos = startTime + remainingTimeNanos;
-            for (; ; ) {
+            for (;;) {
                 try {
                     if (mtx.acquire(remainingTimeNanos, TimeUnit.NANOSECONDS)) {
                         lockAcquired = true;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/Replica.java
@@ -100,8 +100,21 @@ final class Replica {
         }, Objects::nonNull);
     }
 
+    long localLastAppliedRevision() {
+        return await().ignoreExceptions().until(() -> {
+            try (BufferedReader br = new BufferedReader(new InputStreamReader(
+                    new FileInputStream(new File(dataDir, "local_last_revision"))))) {
+                return Long.parseLong(br.readLine());
+            }
+        }, Objects::nonNull);
+    }
+
     boolean existsLocalRevision() {
         return Files.isReadable(new File(dataDir, "last_revision").toPath());
+    }
+
+    File dataDir() {
+        return dataDir;
     }
 
     ZooKeeperCommandExecutor commandExecutor() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationProgressFilesIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ReplicationProgressFilesIntegrationTest.java
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.replication;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.management.ServerStatus;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
+/**
+ * Integration tests for the two replication progress files {@code last_revision} (replay loop
+ * progress) and {@code local_last_revision} (highest revision applied via {@code storeLog}).
+ */
+class ReplicationProgressFilesIntegrationTest {
+
+    private final Map<Integer, SimpleMeterRegistry> meterRegistryMap = new ConcurrentHashMap<>();
+
+    @RegisterExtension
+    final CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+
+        @Override
+        protected void configureEach(int serverId, CentralDogmaBuilder builder) {
+            final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+            meterRegistryMap.put(serverId, registry);
+            builder.meterRegistry(registry);
+        }
+    };
+
+    /**
+     * A commit on the originator advances {@code last_revision} and {@code local_last_revision}
+     * on the originator, and {@code last_revision} (only) on the followers.
+     */
+    @Test
+    void commitAdvancesProgressFiles() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate follower = cluster.servers().get(1);
+
+        // Snapshot baselines — cluster startup may have already originated some internal commands
+        // (e.g., creating the system project), so we compare against pre-commit values rather
+        // than assert specific revisions or file (non-)existence.
+        final long originatorLastBefore = readLastReplayed(originator);
+        final long followerLastBefore = readLastReplayed(follower);
+        final long followerLocalLastBefore = readLocalLastAppliedOrMinusOne(follower);
+
+        originator.client().createProject("p_advance").join();
+
+        // last_revision advances on every replica.
+        await().untilAsserted(() -> {
+            assertThat(readLastReplayed(originator)).isGreaterThan(originatorLastBefore);
+            assertThat(readLastReplayed(follower)).isGreaterThan(followerLastBefore);
+        });
+
+        // The originator wrote local_last_revision via storeLog → equals last_revision once the
+        // childEvent for its own commit has processed.
+        await().untilAsserted(() -> {
+            assertThat(readLocalLastApplied(originator)).isEqualTo(readLastReplayed(originator));
+        });
+
+        // The follower only replayed — its local_last_revision is never written by replayLogs,
+        // so it stays at whatever value it had before the originator's commit.
+        assertThat(readLocalLastAppliedOrMinusOne(follower)).isEqualTo(followerLocalLastBefore);
+    }
+
+    /**
+     * The originator's own {@code childEvent} replay must take the skip path; otherwise replay
+     * would re-execute the just-applied command and throw {@code RedundantChangeException},
+     * flipping the server to read-only mode.
+     */
+    @Test
+    void originatorStaysWritableAfterRepeatedCommits() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+        final BlockingWebClient client = originator.httpClient().blocking();
+
+        for (int i = 0; i < 5; i++) {
+            originator.client().createProject("p_repeated_" + i).join();
+        }
+
+        // Wait for childEvent replay to run.
+        Thread.sleep(500);
+
+        final ServerStatus status = client.prepare()
+                                          .get("/api/v1/status")
+                                          .asJson(ServerStatus.class)
+                                          .execute()
+                                          .content();
+        assertThat(status.writable()).isTrue();
+        assertThat(status.replicating()).isTrue();
+    }
+
+    /**
+     * After a self-originated commit, the originator's {@code local_last_revision} file content
+     * matches its {@code last_revision}, and both equal the result revision of the latest
+     * replayed command.
+     */
+    @Test
+    void originatorLocalLastEqualsLastReplayedAfterReplicationSettles() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+
+        originator.client().createProject("p_eq").join();
+        originator.client().createRepository("p_eq", "r_eq").join();
+
+        await().atMost(Duration.ofSeconds(5)).untilAsserted(() -> {
+            final long localLast = readLocalLastApplied(originator);
+            final long lastReplayed = readLastReplayed(originator);
+            assertThat(localLast).isEqualTo(lastReplayed);
+            assertThat(localLast).isGreaterThan(0L);
+        });
+    }
+
+    /**
+     * Files survive a full cluster restart and remain at the same values when no commits happen
+     * between stop and start.
+     */
+    @Test
+    void filesPersistAcrossClusterRestart() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+
+        originator.client().createProject("p_persist").join();
+        await().untilAsserted(() -> assertThat(readLastReplayed(originator)).isGreaterThan(0L));
+
+        final long originatorLastBefore = readLastReplayed(originator);
+        final long originatorLocalLastBefore = readLocalLastApplied(originator);
+
+        cluster.stop();
+        cluster.start();
+
+        assertThat(readLastReplayed(originator)).isEqualTo(originatorLastBefore);
+        assertThat(readLocalLastApplied(originator)).isEqualTo(originatorLocalLastBefore);
+
+        // New commits should still work after restart.
+        originator.client().createProject("p_post_restart").join();
+        await().untilAsserted(
+                () -> assertThat(readLastReplayed(originator)).isGreaterThan(originatorLastBefore));
+    }
+
+    /**
+     * A follower that was offline during a commit catches up after individual restart — its
+     * {@code last_revision} converges to the originator's.
+     */
+    @Test
+    void followerCatchesUpAfterIndividualRestart() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate follower = cluster.servers().get(2);
+
+        // Establish baseline replication.
+        originator.client().createProject("p_pre_stop").join();
+        await().untilAsserted(() -> {
+            assertThat(readLastReplayed(follower)).isEqualTo(readLastReplayed(originator));
+        });
+
+        // Stop the follower while keeping quorum (2-of-3) alive.
+        follower.dogma().stop().join();
+
+        // Originate while the follower is down.
+        originator.client().createProject("p_during_stop").join();
+        originator.client().createRepository("p_during_stop", "r1").join();
+
+        await().untilAsserted(() -> assertThat(readLastReplayed(originator)).isGreaterThan(0L));
+        final long originatorLast = readLastReplayed(originator);
+
+        // Restart the follower.
+        follower.dogma().start().join();
+
+        // It catches up via replay.
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            assertThat(readLastReplayed(follower)).isGreaterThanOrEqualTo(originatorLast);
+        });
+    }
+
+    /**
+     * Each replica only writes its own {@code local_last_revision} (in {@code storeLog}), so the
+     * file lags behind {@code last_revision} on replicas that have other-originated revisions
+     * applied via replay.
+     */
+    @Test
+    void localLastRevisionTracksOnlyOwnSelfOriginations() throws Exception {
+        final CentralDogmaRuleDelegate replica0 = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate replica1 = cluster.servers().get(1);
+
+        // Step 1: replica0 originates → its file is updated and equals last_revision.
+        replica0.client().createProject("p_repl0").join();
+
+        await().untilAsserted(() -> {
+            assertThat(readLastReplayed(replica1)).isEqualTo(readLastReplayed(replica0));
+            assertThat(readLocalLastApplied(replica0)).isEqualTo(readLastReplayed(replica0));
+        });
+        final long replica0LocalLastAfterStep1 = readLocalLastApplied(replica0);
+        final long replica1LocalLastAfterStep1 = readLocalLastAppliedOrMinusOne(replica1);
+
+        // Step 2: replica1 originates. replica0's local_last_revision stays at its previous
+        // value (replica0 only replayed replica1's command, no storeLog ran on it).
+        replica1.client().createProject("p_repl1").join();
+
+        await().untilAsserted(() -> {
+            assertThat(readLastReplayed(replica0)).isEqualTo(readLastReplayed(replica1));
+            assertThat(readLastReplayed(replica0)).isGreaterThan(replica0LocalLastAfterStep1);
+        });
+
+        // replica1's local_last_revision advanced past its Step-1 value to its current
+        // last_revision.
+        assertThat(readLocalLastApplied(replica1)).isEqualTo(readLastReplayed(replica1));
+        assertThat(readLocalLastApplied(replica1)).isGreaterThan(replica1LocalLastAfterStep1);
+        // replica0's local_last_revision did not advance — its last_revision is now strictly
+        // higher than its local_last_revision.
+        assertThat(readLocalLastApplied(replica0)).isEqualTo(replica0LocalLastAfterStep1);
+        assertThat(readLocalLastApplied(replica0)).isLessThan(readLastReplayed(replica0));
+    }
+
+    /**
+     * Round-robin commits across all three replicas: after replication settles, every replica's
+     * {@code last_revision} converges to the same value, but each replica's
+     * {@code local_last_revision} records only its own self-origination history.
+     */
+    @Test
+    void roundRobinCommitsAdvanceEachReplicasOwnLocalLastRevision() throws Exception {
+        final CentralDogmaRuleDelegate replica0 = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate replica1 = cluster.servers().get(1);
+        final CentralDogmaRuleDelegate replica2 = cluster.servers().get(2);
+
+        replica0.client().createProject("p_rr_0").join();
+        await().untilAsserted(
+                () -> assertThat(readLocalLastApplied(replica0)).isEqualTo(readLastReplayed(replica0)));
+        final long replica0LocalLast = readLocalLastApplied(replica0);
+
+        replica1.client().createProject("p_rr_1").join();
+        await().untilAsserted(
+                () -> assertThat(readLocalLastApplied(replica1)).isEqualTo(readLastReplayed(replica1)));
+        final long replica1LocalLast = readLocalLastApplied(replica1);
+
+        replica2.client().createProject("p_rr_2").join();
+        await().untilAsserted(
+                () -> assertThat(readLocalLastApplied(replica2)).isEqualTo(readLastReplayed(replica2)));
+        final long replica2LocalLast = readLocalLastApplied(replica2);
+
+        // last_revision converges across all replicas.
+        await().untilAsserted(() -> {
+            final long last = readLastReplayed(replica2);
+            assertThat(readLastReplayed(replica0)).isEqualTo(last);
+            assertThat(readLastReplayed(replica1)).isEqualTo(last);
+        });
+
+        // Each replica's local_last_revision is captured at the time of its own commit;
+        // replica2's must be the largest because it originated last.
+        assertThat(replica0LocalLast).isLessThan(replica1LocalLast);
+        assertThat(replica1LocalLast).isLessThan(replica2LocalLast);
+
+        // Older originators' local_last_revision did not advance during subsequent replay of
+        // other replicas' commits — so their last_revision is now strictly larger than their
+        // local_last_revision.
+        assertThat(readLocalLastApplied(replica0)).isEqualTo(replica0LocalLast);
+        assertThat(readLocalLastApplied(replica0)).isLessThan(readLastReplayed(replica0));
+        assertThat(readLocalLastApplied(replica1)).isEqualTo(replica1LocalLast);
+        assertThat(readLocalLastApplied(replica1)).isLessThan(readLastReplayed(replica1));
+    }
+
+    /**
+     * Each replica's {@code local_last_revision} is a per-replica file: after the cluster is
+     * restarted, every replica reads back its OWN value, not another replica's.
+     */
+    @Test
+    void perReplicaLocalLastRevisionPreservedAcrossClusterRestart() throws Exception {
+        final CentralDogmaRuleDelegate replica0 = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate replica1 = cluster.servers().get(1);
+        final CentralDogmaRuleDelegate replica2 = cluster.servers().get(2);
+
+        replica0.client().createProject("p_pre_0").join();
+        replica1.client().createProject("p_pre_1").join();
+        replica2.client().createProject("p_pre_2").join();
+
+        await().untilAsserted(() -> {
+            assertThat(readLastReplayed(replica0)).isEqualTo(readLastReplayed(replica1));
+            assertThat(readLastReplayed(replica1)).isEqualTo(readLastReplayed(replica2));
+            assertThat(readLocalLastApplied(replica2)).isEqualTo(readLastReplayed(replica2));
+        });
+
+        final long replica0LocalLastBefore = readLocalLastApplied(replica0);
+        final long replica1LocalLastBefore = readLocalLastApplied(replica1);
+        final long replica2LocalLastBefore = readLocalLastApplied(replica2);
+        // Sanity: per-replica values must be distinct and ordered (since each replica originated
+        // exactly once in order 0 → 1 → 2).
+        assertThat(replica0LocalLastBefore).isLessThan(replica1LocalLastBefore);
+        assertThat(replica1LocalLastBefore).isLessThan(replica2LocalLastBefore);
+
+        cluster.stop();
+        cluster.start();
+
+        // Each replica reads back its own value, not another replica's.
+        assertThat(readLocalLastApplied(replica0)).isEqualTo(replica0LocalLastBefore);
+        assertThat(readLocalLastApplied(replica1)).isEqualTo(replica1LocalLastBefore);
+        assertThat(readLocalLastApplied(replica2)).isEqualTo(replica2LocalLastBefore);
+    }
+
+    /**
+     * While a follower catches up by replaying commands originated by other replicas, its own
+     * {@code local_last_revision} stays unchanged — only {@code last_revision} advances.
+     */
+    @Test
+    void followerLocalLastRevisionUnchangedDuringCatchUp() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate follower = cluster.servers().get(2);
+
+        // Pre-stop: follower originates once so its local_last_revision file exists with a
+        // known value we can compare against later.
+        follower.client().createProject("p_follower_pre").join();
+        await().untilAsserted(
+                () -> assertThat(readLocalLastApplied(follower)).isEqualTo(readLastReplayed(follower)));
+        final long followerLocalLastBefore = readLocalLastApplied(follower);
+
+        follower.dogma().stop().join();
+
+        // While follower is down, originator pushes several commits. Replication keeps quorum
+        // (2-of-3 still alive).
+        originator.client().createProject("p_during_outage_1").join();
+        originator.client().createRepository("p_during_outage_1", "r1").join();
+        originator.client().createProject("p_during_outage_2").join();
+
+        final long originatorLastAfterCommits = readLastReplayed(originator);
+        assertThat(originatorLastAfterCommits).isGreaterThan(followerLocalLastBefore);
+
+        follower.dogma().start().join();
+
+        // Follower catches up — its last_revision converges to the originator's.
+        await().atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+            assertThat(readLastReplayed(follower)).isGreaterThanOrEqualTo(originatorLastAfterCommits);
+        });
+
+        // But the follower's local_last_revision did NOT advance: replay does not write
+        // local_last_revision, only storeLog does, and the follower did not originate any of
+        // the catch-up commands.
+        assertThat(readLocalLastApplied(follower)).isEqualTo(followerLocalLastBefore);
+        assertThat(readLocalLastApplied(follower)).isLessThan(readLastReplayed(follower));
+    }
+
+    /**
+     * After a self-originated commit, both gauges on the originator reflect the corresponding
+     * file values.
+     */
+    @Test
+    void gaugesReflectFileContentsOnOriginatorAfterCommit() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+
+        originator.client().createProject("p_gauge").join();
+
+        await().untilAsserted(() -> {
+            final long localLast = readLocalLastApplied(originator);
+            final long lastReplayed = readLastReplayed(originator);
+            assertThat(readLongGauge(1, "replica.last.local.applied.revision")).isEqualTo(localLast);
+            assertThat(readLongGauge(1, "replica.last.replayed.revision")).isEqualTo(lastReplayed);
+        });
+    }
+
+    /**
+     * {@code replica.last.replayed.revision} advances on a follower replaying a command from
+     * another replica, but {@code replica.last.local.applied.revision} does not — only storeLog
+     * advances it.
+     */
+    @Test
+    void gaugesDivergeOnFollowerReplayingOtherReplicaCommit() throws Exception {
+        final CentralDogmaRuleDelegate originator = cluster.servers().get(0);
+        final CentralDogmaRuleDelegate follower = cluster.servers().get(1);
+
+        final long followerLocalLastBefore =
+                readLongGauge(2, "replica.last.local.applied.revision");
+        final long followerLastBefore = readLongGauge(2, "replica.last.replayed.revision");
+
+        originator.client().createProject("p_gauge_async").join();
+
+        // last_replayed gauge advances on the follower as it replays.
+        await().untilAsserted(() -> {
+            assertThat(readLongGauge(2, "replica.last.replayed.revision"))
+                    .isGreaterThan(followerLastBefore);
+        });
+
+        // But local_applied gauge stays put — the follower never ran storeLog for this command.
+        assertThat(readLongGauge(2, "replica.last.local.applied.revision"))
+                .isEqualTo(followerLocalLastBefore);
+    }
+
+    private long readLongGauge(int serverId, String name) {
+        return (long) meterRegistryMap.get(serverId).get(name).gauge().value();
+    }
+
+    private static File dataDir(CentralDogmaRuleDelegate dogma) {
+        return dogma.dogma().config().dataDir();
+    }
+
+    private static long readRev(File file) throws IOException {
+        try (BufferedReader br = new BufferedReader(
+                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))) {
+            return Long.parseLong(br.readLine().trim());
+        }
+    }
+
+    private static long readLastReplayed(CentralDogmaRuleDelegate dogma) throws IOException {
+        return readRev(new File(dataDir(dogma), "last_revision"));
+    }
+
+    private static long readLocalLastApplied(CentralDogmaRuleDelegate dogma) throws IOException {
+        return readRev(new File(dataDir(dogma), "local_last_revision"));
+    }
+
+    /** Returns the current value, or -1 when the file is absent (replica never originated). */
+    private static long readLocalLastAppliedOrMinusOne(CentralDogmaRuleDelegate dogma)
+            throws IOException {
+        final File file = new File(dataDir(dogma), "local_last_revision");
+        return file.exists() ? readRev(file) : -1L;
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutorTest.java
@@ -29,11 +29,11 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -103,10 +103,9 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final Optional<ReplicationLog<?>> commandResult2 = replica1.commandExecutor().loadLog(0, false);
-            assertThat(commandResult2).isPresent();
-            assertThat(commandResult2.get().command()).isEqualTo(command1);
-            assertThat(commandResult2.get().result()).isNull();
+            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(0);
+            assertThat(commandResult2.command()).isEqualTo(command1);
+            assertThat(commandResult2.result()).isNull();
 
             await().untilAsserted(() -> verify(replica1.delegate()).apply(eq(command1)));
             await().untilAsserted(() -> verify(replica2.delegate()).apply(eq(command1)));
@@ -228,7 +227,7 @@ class ZooKeeperCommandExecutorTest {
                 for (int i = 0; i < COMMANDS_PER_REPLICA * cluster.size(); i++) {
                     @SuppressWarnings("unchecked")
                     final ReplicationLog<Revision> log =
-                            (ReplicationLog<Revision>) r.commandExecutor().loadLog(i, false).get();
+                            (ReplicationLog<Revision>) r.commandExecutor().loadLog(i);
 
                     assertThat(log.result().major()).isEqualTo(i + 1);
                 }
@@ -270,10 +269,9 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final Optional<ReplicationLog<?>> commandResult2 = replica1.commandExecutor().loadLog(0, false);
-            assertThat(commandResult2).isPresent();
-            assertThat(commandResult2.get().command()).isEqualTo(command1);
-            assertThat(commandResult2.get().result()).isNull();
+            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(0);
+            assertThat(commandResult2.command()).isEqualTo(command1);
+            assertThat(commandResult2.result()).isNull();
 
             withReplica(cluster, replica -> {
                 await().untilAsserted(() -> verify(replica.delegate()).apply(eq(command1)));
@@ -305,7 +303,7 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0, false).get();
+            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0);
             assertThat(commandResult1.command()).isEqualTo(command1);
             assertThat(commandResult1.result()).isNull();
 
@@ -323,7 +321,7 @@ class ZooKeeperCommandExecutorTest {
             cluster.get(4).commandExecutor().stop().join();
 
             final PushAsIsCommand asIsCommand = executeCommand(replica1, normalizingPushCommand);
-            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(1, false).get();
+            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(1);
             assertThat(commandResult2.command()).isEqualTo(asIsCommand);
             assertThat(commandResult2.result()).isInstanceOf(Revision.class);
 
@@ -411,7 +409,7 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0, false).get();
+            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0);
             assertThat(commandResult1.command()).isEqualTo(command1);
             assertThat(commandResult1.result()).isNull();
 
@@ -433,7 +431,7 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0, false).get();
+            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0);
             assertThat(commandResult1.command()).isEqualTo(command1);
             assertThat(commandResult1.result()).isNull();
 
@@ -542,7 +540,7 @@ class ZooKeeperCommandExecutorTest {
             final Command<Void> command1 = Command.createRepository(Author.SYSTEM, "project", "repo1");
             replica1.commandExecutor().execute(command1).join();
 
-            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0, false).get();
+            final ReplicationLog<?> commandResult1 = replica1.commandExecutor().loadLog(0);
             assertThat(commandResult1.command()).isEqualTo(command1);
             assertThat(commandResult1.result()).isNull();
             awaitUntilReplicated(cluster, command1);
@@ -551,7 +549,7 @@ class ZooKeeperCommandExecutorTest {
                     Command.updateServerStatus(ServerStatus.REPLICATION_ONLY);
             replica1.commandExecutor().execute(readOnlyCommand).join();
             assertThat(replica1.commandExecutor().isWritable()).isFalse();
-            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(1, false).get();
+            final ReplicationLog<?> commandResult2 = replica1.commandExecutor().loadLog(1);
             assertThat(commandResult2.command()).isEqualTo(readOnlyCommand);
             awaitUntilReplicated(cluster, readOnlyCommand);
 
@@ -570,7 +568,7 @@ class ZooKeeperCommandExecutorTest {
             final Command<Revision> forceNormalizingPush = Command.forcePush(pushCommand);
             assertThat(replica1.commandExecutor().execute(forceNormalizingPush).join())
                     .isEqualTo(new Revision(2));
-            final ReplicationLog<?> commandResult3 = replica1.commandExecutor().loadLog(2, false).get();
+            final ReplicationLog<?> commandResult3 = replica1.commandExecutor().loadLog(2);
             // The content of force push is changed to PushAsIsCommand.
             final Command<Revision> forceAsIsCommand = Command.forcePush(asIsCommand);
             assertThat(commandResult3.command()).isEqualTo(forceAsIsCommand);
@@ -581,6 +579,128 @@ class ZooKeeperCommandExecutorTest {
                 final Replica replica = cluster.get(i);
                 await().untilAsserted(() -> verify(replica.delegate()).apply(eq(forceAsIsCommand)));
             }
+        }
+    }
+
+    /**
+     * Regression test for the case where one replica's data directory is restored from another
+     * replica's snapshot. Before this fix, replayLogs would skip self-originated entries via
+     * {@code skipIfSameReplica=true}, assuming local data already had those changes, which was
+     * not true after a cross-replica restore. The new design tracks {@code local_last_revision}
+     * separately so the skip is data-driven, not replicaId-driven.
+     */
+    @Test
+    void testReplayAfterDataRestoreFromAnotherReplica() throws Exception {
+        try (Cluster cluster = Cluster.of(ZooKeeperCommandExecutorTest::newMockDelegate)) {
+            final Replica self = cluster.get(0); // replicaId=1
+            final Replica other = cluster.get(1);
+
+            // 1. The replica we'll later "restore" originates a couple commands. These end up in
+            //    ZK with replicaId=1.
+            final Command<Void> selfOriginated1 =
+                    Command.createRepository(Author.SYSTEM, "p", "r-self-1");
+            self.commandExecutor().execute(selfOriginated1).join();
+            final Command<Void> selfOriginated2 =
+                    Command.createRepository(Author.SYSTEM, "p", "r-self-2");
+            self.commandExecutor().execute(selfOriginated2).join();
+
+            await().untilAsserted(() -> verify(self.delegate()).apply(eq(selfOriginated1)));
+            await().untilAsserted(() -> verify(self.delegate()).apply(eq(selfOriginated2)));
+
+            // last_revision and local_last_revision should both advance for the originator.
+            await().untilAsserted(() -> assertThat(self.localRevision()).isGreaterThanOrEqualTo(1L));
+            await().untilAsserted(
+                    () -> assertThat(self.localLastAppliedRevision()).isGreaterThanOrEqualTo(1L));
+
+            // 2. Stop the replica we're going to "restore", then simulate having received a stale
+            //    data dir: rewrite both last_revision and local_last_revision to -1 (i.e., the
+            //    other replica's idea of "I've replayed nothing yet"). The git/storage side-effects
+            //    of the prior pushes remain on disk — exactly the data-corruption shape that
+            //    triggered the original bug.
+            self.commandExecutor().stop().join();
+            java.nio.file.Files.writeString(new File(self.dataDir(), "last_revision").toPath(), "-1");
+            java.nio.file.Files.writeString(
+                    new File(self.dataDir(), "local_last_revision").toPath(), "-1");
+
+            // 3. Restart "self". Under the old logic it would silently skip its own historical
+            //    entries (replicaId match) and never re-apply them to local state. Under the new
+            //    logic it sees `localLastAppliedRevision = -1` and re-executes everything.
+            self.commandExecutor().start().join();
+
+            // Verify the prior self-originated commands were actually replayed against the
+            // delegate — i.e., we did NOT silently skip them.
+            await().untilAsserted(
+                    () -> verify(self.delegate(), times(2)).apply(eq(selfOriginated1)));
+            await().untilAsserted(
+                    () -> verify(self.delegate(), times(2)).apply(eq(selfOriginated2)));
+
+            // 4. Have another replica push a fresh command. Replica `self` must replay it
+            //    cleanly without entering read-only mode.
+            final Command<Void> followUp = Command.createRepository(Author.SYSTEM, "p", "r-followup");
+            other.commandExecutor().execute(followUp).join();
+            await().untilAsserted(() -> verify(self.delegate()).apply(eq(followUp)));
+            assertThat(self.commandExecutor().isWritable()).isTrue();
+        }
+    }
+
+    /**
+     * Tests upgrade compatibility: a data directory written by an older binary contains only
+     * {@code last_revision}, not {@code local_last_revision}. The new code must fall back to the
+     * {@code last_revision} value and proceed normally.
+     */
+    @Test
+    void testMissingLocalLastRevisionFileFallsBackToLastRevision() throws Exception {
+        try (Cluster cluster = Cluster.of(ZooKeeperCommandExecutorTest::newMockDelegate)) {
+            final Replica restarted = cluster.get(0);
+            final Replica writer = cluster.get(1);
+
+            // Originate from `restarted` so its local_last_revision file is created
+            // (only storeLog writes that file).
+            final Command<Void> cmd = Command.createRepository(Author.SYSTEM, "p", "r-upgrade");
+            restarted.commandExecutor().execute(cmd).join();
+            await().untilAsserted(() -> verify(restarted.delegate()).apply(eq(cmd)));
+            await().untilAsserted(
+                    () -> assertThat(restarted.localLastAppliedRevision()).isGreaterThanOrEqualTo(0L));
+
+            // Simulate an upgrade by deleting local_last_revision while leaving last_revision
+            // intact, then restarting.
+            restarted.commandExecutor().stop().join();
+            final File localFile = new File(restarted.dataDir(), "local_last_revision");
+            assertThat(localFile.delete()).isTrue();
+
+            restarted.commandExecutor().start().join();
+            assertThat(restarted.commandExecutor().isWritable()).isTrue();
+
+            // A subsequent command pushed by another replica should still be replayed normally;
+            // the missing local_last_revision file fell back to last_revision so nothing is
+            // silently skipped.
+            final Command<Void> cmd2 =
+                    Command.createRepository(Author.SYSTEM, "p", "r-upgrade-2");
+            writer.commandExecutor().execute(cmd2).join();
+            await().untilAsserted(() -> verify(restarted.delegate()).apply(eq(cmd2)));
+        }
+    }
+
+    /**
+     * Tests that a corrupted {@code local_last_revision} file (parse failure) fails startup
+     * rather than silently falling back to zero or some other guess.
+     */
+    @Test
+    void testLocalLastRevisionParseFailureFailsStartup() throws Exception {
+        try (Cluster cluster = Cluster.of(ZooKeeperCommandExecutorTest::newMockDelegate)) {
+            final Replica replica = cluster.get(0);
+
+            final Command<Void> cmd = Command.createRepository(Author.SYSTEM, "p", "r-parse");
+            replica.commandExecutor().execute(cmd).join();
+            await().untilAsserted(() -> verify(replica.delegate()).apply(eq(cmd)));
+
+            replica.commandExecutor().stop().join();
+            java.nio.file.Files.writeString(
+                    new File(replica.dataDir(), "local_last_revision").toPath(), "not-a-number");
+
+            // Start should fail with a parse-related cause.
+            assertThatThrownBy(() -> replica.commandExecutor().start().join())
+                    .hasCauseInstanceOf(ReplicationException.class);
         }
     }
 


### PR DESCRIPTION
Motivation:

When a replica's data directory was copied from another replica (e.g., for disaster recovery) and the replica was restarted, replication replay could silently skip self-originated commands and leave the local data inconsistent with the ZooKeeper log. A subsequent push from another replica then failed with `mismatching replay result` and the restored replica entered read-only mode.

The root cause was that `ZooKeeperCommandExecutor.replayLogs` skipped log entries whose originating replica id matched the running replica's id. https://github.com/line/centraldogma/blob/ab4a05a51c48df8e8905c270b61eeba69f534057/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java#L1044-L1054 https://github.com/line/centraldogma/blob/ab4a05a51c48df8e8905c270b61eeba69f534057/server/src/main/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperCommandExecutor.java#L832-L847

The skip assumed the local state already had those changes — true under normal operation because `blockingExecute` applies the command locally before storing the log to ZooKeeper, but no longer true after a cross-replica restore.

Modifications:

- Add a new per-replica progress file `<dataDir>/local_last_revision` that tracks the highest ZooKeeper revision whose effect is actually in the local data. It is updated only by `storeLog`, reflecting this replica's own self-origination history.
- Change the replay skip decision to be data-driven instead of based on the originating replica id, so a restored data directory replays every revision the local data is missing.
- On startup, fall back to `last_revision` when `local_last_revision` is absent so binaries upgraded from older versions keep working.
- Expose a `replica.last.local.applied.revision` gauge alongside the existing `replica.last.replayed.revision`.
- Add unit tests (data-restore regression, missing/corrupt `local_last_revision` handling) and integration tests covering commit, restart, follower catch-up, per-replica state, and gauge behavior.

Result:

Replicas that have been restored from another replica's data directory now replay any revisions missing from local data instead of silently skipping them, eliminating the read-only-mode incident triggered by `mismatching replay result`.