### PR TITLE
Add Central Dogma to Central Dogma mirroring UI support

### DIFF
--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/CentralDogmaMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/CentralDogmaMirrorTest.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.util.Map;
 import java.util.concurrent.CompletionException;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -281,11 +282,66 @@ class CentralDogmaMirrorTest {
                 .hasMessageContaining("file");
     }
 
+    @Test
+    void localToRemote_gitignore() throws Exception {
+        pushMirrorSettings("/", "/", MirrorDirection.LOCAL_TO_REMOTE, "*.log\n/build/");
+
+        // Add files - some match gitignore patterns.
+        localClient.forRepo(projName, REPO_FOO)
+                   .commit("Add files",
+                           Change.ofTextUpsert("/app.txt", "app content"),
+                           Change.ofTextUpsert("/error.log", "log content"),
+                           Change.ofTextUpsert("/build/output.txt", "build output"),
+                           Change.ofJsonUpsert("/config.json", "{\"key\":\"value\"}"))
+                   .push().join();
+
+        mirroringService.mirror().join();
+
+        final Map<String, Entry<?>> remoteEntries =
+                remoteClient.getFiles(projName, REPO_FOO, Revision.HEAD, PathPattern.all()).join();
+        // Non-ignored files should be mirrored.
+        assertThat(remoteEntries).containsKey("/app.txt");
+        assertThat(remoteEntries).containsKey("/config.json");
+        // Ignored files should NOT be mirrored.
+        assertThat(remoteEntries).doesNotContainKey("/error.log");
+        assertThat(remoteEntries).doesNotContainKey("/build/output.txt");
+    }
+
+    @Test
+    void remoteToLocal_gitignore() throws Exception {
+        pushMirrorSettings("/", "/", MirrorDirection.REMOTE_TO_LOCAL, "*.log\n/build/");
+
+        // Add files to remote - some match gitignore patterns.
+        remoteClient.forRepo(projName, REPO_FOO)
+                    .commit("Add files",
+                            Change.ofTextUpsert("/app.txt", "app content"),
+                            Change.ofTextUpsert("/error.log", "log content"),
+                            Change.ofTextUpsert("/build/output.txt", "build output"),
+                            Change.ofJsonUpsert("/config.json", "{\"key\":\"value\"}"))
+                    .push().join();
+
+        mirroringService.mirror().join();
+
+        final Map<String, Entry<?>> localEntries =
+                localClient.getFiles(projName, REPO_FOO, Revision.HEAD, PathPattern.all()).join();
+        // Non-ignored files should be mirrored.
+        assertThat(localEntries).containsKey("/app.txt");
+        assertThat(localEntries).containsKey("/config.json");
+        // Ignored files should NOT be mirrored.
+        assertThat(localEntries).doesNotContainKey("/error.log");
+        assertThat(localEntries).doesNotContainKey("/build/output.txt");
+    }
+
     private void pushMirrorSettings(String localPath, String remotePath) {
-        pushMirrorSettings(localPath, remotePath, MirrorDirection.LOCAL_TO_REMOTE);
+        pushMirrorSettings(localPath, remotePath, MirrorDirection.LOCAL_TO_REMOTE, null);
     }
 
     private void pushMirrorSettings(String localPath, String remotePath, MirrorDirection direction) {
+        pushMirrorSettings(localPath, remotePath, direction, null);
+    }
+
+    private void pushMirrorSettings(String localPath, String remotePath,
+                                    MirrorDirection direction, @Nullable String gitignore) {
         final InetSocketAddress remoteAddr = remoteDogma.serverAddress();
         final String remoteUri = "dogma://" + remoteAddr.getHostString() + ':' + remoteAddr.getPort() +
                                  '/' + projName + '/' + REPO_FOO + ".dogma" + remotePath;
@@ -306,20 +362,26 @@ class CentralDogmaMirrorTest {
             }
         }
 
+        final StringBuilder config = new StringBuilder();
+        config.append('{')
+              .append("  \"id\": \"foo\",")
+              .append("  \"enabled\": true,")
+              .append("  \"direction\": \"").append(direction).append("\",")
+              .append("  \"localRepo\": \"").append(REPO_FOO).append("\",")
+              .append("  \"localPath\": \"").append(localPath).append("\",")
+              .append("  \"remoteUri\": \"").append(remoteUri).append("\",")
+              .append("  \"schedule\": \"0 0 0 1 1 ? 2099\",")
+              .append("  \"credentialName\": \"").append(credName).append('"');
+        if (gitignore != null) {
+            config.append(",  \"gitignore\": \"").append(gitignore.replace("\n", "\\n")).append('"');
+        }
+        config.append('}');
+
         localClient.forRepo(projName, Project.REPO_DOGMA)
                    .commit("Add mirror config",
                            Change.ofJsonUpsert(
                                    "/repos/" + REPO_FOO + "/mirrors/foo.json",
-                                   '{' +
-                                   "  \"id\": \"foo\"," +
-                                   "  \"enabled\": true," +
-                                   "  \"direction\": \"" + direction + "\"," +
-                                   "  \"localRepo\": \"" + REPO_FOO + "\"," +
-                                   "  \"localPath\": \"" + localPath + "\"," +
-                                   "  \"remoteUri\": \"" + remoteUri + "\"," +
-                                   "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
-                                   "  \"credentialName\": \"" + credName + '"' +
-                                   '}'))
+                                   config.toString()))
                    .push().join();
     }
 }

--- a/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -140,9 +140,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
                 return newMirrorResult(MirrorStatus.UP_TO_DATE, description, triggeredTime);
             }
 
-            // Read local files under localPath.
-            final Map<String, Entry<?>> localEntries =
-                    localRepo().find(localHead, localPath() + "**", FIND_ALL_WITH_CONTENT).join();
+            // Read local files under localPath and apply gitignore filter.
+            final Map<String, Entry<?>> localEntries = filterByGitignore(
+                    localRepo().find(localHead, localPath() + "**", FIND_ALL_WITH_CONTENT).join(),
+                    localPath());
 
             // Fetch remote files for comparison/removal detection.
             final Map<String, Entry<?>> remoteEntries =
@@ -279,9 +280,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
                 return newMirrorResult(MirrorStatus.UP_TO_DATE, description, triggeredTime);
             }
 
-            // Fetch all remote files under remotePath.
-            final Map<String, Entry<?>> remoteEntries =
-                    repo.file(PathPattern.of(remotePath() + "**")).viewRaw(true).get(remoteHead).join();
+            // Fetch all remote files under remotePath and apply gitignore filter.
+            final Map<String, Entry<?>> remoteEntries = filterByGitignore(
+                    repo.file(PathPattern.of(remotePath() + "**")).viewRaw(true).get(remoteHead).join(),
+                    remotePath());
 
             // Build Change objects.
             final Map<String, Change<?>> changes = new HashMap<>();

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractGitMirror.java
@@ -21,20 +21,16 @@ import static com.linecorp.centraldogma.server.storage.repository.FindOptions.FI
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jgit.lib.Constants.OBJECT_ID_ABBREV_STRING_LENGTH;
 
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.eclipse.jgit.api.RemoteSetUrlCommand;
 import org.eclipse.jgit.api.RemoteSetUrlCommand.UriType;
@@ -46,7 +42,6 @@ import org.eclipse.jgit.dircache.DirCacheEditor;
 import org.eclipse.jgit.dircache.DirCacheEditor.DeletePath;
 import org.eclipse.jgit.dircache.DirCacheEditor.PathEdit;
 import org.eclipse.jgit.dircache.DirCacheEntry;
-import org.eclipse.jgit.ignore.IgnoreNode;
 import org.eclipse.jgit.ignore.IgnoreNode.MatchResult;
 import org.eclipse.jgit.lib.CommitBuilder;
 import org.eclipse.jgit.lib.Constants;
@@ -109,22 +104,10 @@ abstract class AbstractGitMirror extends AbstractMirror {
 
     private static final String HEAD_REF_MASTER = Constants.R_HEADS + Constants.MASTER;
 
-    @Nullable
-    private IgnoreNode ignoreNode;
-
     AbstractGitMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
                       Credential credential, Repository localRepo, String localPath,
                       RepositoryUri remoteUri, @Nullable String gitignore, @Nullable String zone) {
         super(id, enabled, schedule, direction, credential, localRepo, localPath, remoteUri, gitignore, zone);
-
-        if (gitignore != null) {
-            ignoreNode = new IgnoreNode();
-            try {
-                ignoreNode.parse(new ByteArrayInputStream(gitignore.getBytes()));
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to read gitignore: " + gitignore, e);
-            }
-        }
     }
 
     GitWithAuth openGit(File workDir,
@@ -388,10 +371,9 @@ abstract class AbstractGitMirror extends AbstractMirror {
                 final FileMode fileMode = treeWalk.getFileMode();
                 final String path = '/' + treeWalk.getPathString();
 
-                if (ignoreNode != null && path.startsWith(remotePath())) {
-                    assert ignoreNode != null;
-                    if (ignoreNode.isIgnored('/' + path.substring(remotePath().length()),
-                                             fileMode == FileMode.TREE) == MatchResult.IGNORED) {
+                if (ignoreNode() != null && path.startsWith(remotePath())) {
+                    if (ignoreNode().isIgnored('/' + path.substring(remotePath().length()),
+                                               fileMode == FileMode.TREE) == MatchResult.IGNORED) {
                         continue;
                     }
                 }
@@ -656,42 +638,7 @@ abstract class AbstractGitMirror extends AbstractMirror {
     private Map<String, Entry<?>> localHeadEntries(Revision localHead) {
         final Map<String, Entry<?>> localRawHeadEntries = localRepo().find(localHead, localPath() + "**")
                                                                      .join();
-
-        final Stream<Map.Entry<String, Entry<?>>> entryStream =
-                localRawHeadEntries.entrySet()
-                                   .stream();
-        if (ignoreNode == null) {
-            // Use HashMap to manipulate it.
-            return entryStream.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
-
-        final Map<String, Entry<?>> sortedMap =
-                entryStream.collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
-                                                     (v1, v2) -> v1, LinkedHashMap::new));
-        // Use HashMap to manipulate it.
-        final HashMap<String, Entry<?>> result = new HashMap<>(sortedMap.size());
-        String lastIgnoredDirectory = null;
-        for (Map.Entry<String, ? extends Entry<?>> entry : sortedMap.entrySet()) {
-            final String path = entry.getKey();
-            final boolean isDirectory = entry.getValue().type() == EntryType.DIRECTORY;
-            assert ignoreNode != null;
-            final MatchResult ignoreResult = ignoreNode.isIgnored(
-                    path.substring(localPath().length()), isDirectory);
-            if (ignoreResult == MatchResult.IGNORED) {
-                if (isDirectory) {
-                    lastIgnoredDirectory = path;
-                }
-                continue;
-            }
-            if (ignoreResult == MatchResult.CHECK_PARENT) {
-                if (lastIgnoredDirectory != null && path.startsWith(lastIgnoredDirectory)) {
-                    continue;
-                }
-            }
-            result.put(path, entry.getValue());
-        }
-
-        return result;
+        return filterByGitignore(localRawHeadEntries, localPath());
     }
 
     private boolean addModifiedEntryToCache(Revision localHead, DirCache dirCache, ObjectReader reader,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -20,13 +20,19 @@ import static com.linecorp.centraldogma.server.mirror.MirrorUtil.normalizePath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.eclipse.jgit.ignore.IgnoreNode;
+import org.eclipse.jgit.ignore.IgnoreNode.MatchResult;
 import org.jspecify.annotations.Nullable;
 
 import com.cronutils.descriptor.CronDescriptor;
@@ -38,6 +44,8 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.hash.Hashing;
 
 import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.credential.Credential;
@@ -81,6 +89,9 @@ public abstract class AbstractMirror implements Mirror {
     private final long jitterMillis;
 
     @Nullable
+    private final IgnoreNode ignoreNode;
+
+    @Nullable
     private String hashString;
 
     protected AbstractMirror(String id, boolean enabled, @Nullable Cron schedule, MirrorDirection direction,
@@ -96,6 +107,17 @@ public abstract class AbstractMirror implements Mirror {
         this.remoteUri = remoteUri;
         this.gitignore = gitignore;
         this.zone = zone;
+
+        if (gitignore != null) {
+            ignoreNode = new IgnoreNode();
+            try {
+                ignoreNode.parse(new ByteArrayInputStream(gitignore.getBytes()));
+            } catch (IOException e) {
+                throw new IllegalArgumentException("Failed to read gitignore: " + gitignore, e);
+            }
+        } else {
+            ignoreNode = null;
+        }
 
         if (schedule != null) {
             this.schedule = requireNonNull(schedule, "schedule");
@@ -223,6 +245,42 @@ public abstract class AbstractMirror implements Mirror {
                                                  Instant triggeredTime) {
         return new MirrorResult(id, localRepo.parent().name(), localRepo.name(), mirrorStatus, description,
                                 triggeredTime, Instant.now(), zone);
+    }
+
+    @Nullable
+    protected final IgnoreNode ignoreNode() {
+        return ignoreNode;
+    }
+
+    /**
+     * Filters the entries using gitignore patterns. Returns the entries as-is if no gitignore is configured.
+     * The entries should be sorted by path so that directory entries come before their children.
+     */
+    protected final Map<String, Entry<?>> filterByGitignore(Map<String, Entry<?>> entries, String basePath) {
+        if (ignoreNode == null) {
+            return entries;
+        }
+        final Map<String, Entry<?>> result = new HashMap<>(entries.size());
+        String lastIgnoredDirectory = null;
+        for (Map.Entry<String, Entry<?>> entry : entries.entrySet()) {
+            final String path = entry.getKey();
+            final boolean isDirectory = entry.getValue().type() == EntryType.DIRECTORY;
+            final String relativePath = path.substring(basePath.length());
+            final MatchResult ignoreResult = ignoreNode.isIgnored(relativePath, isDirectory);
+            if (ignoreResult == MatchResult.IGNORED) {
+                if (isDirectory) {
+                    lastIgnoredDirectory = path;
+                }
+                continue;
+            }
+            if (ignoreResult == MatchResult.CHECK_PARENT) {
+                if (lastIgnoredDirectory != null && path.startsWith(lastIgnoredDirectory)) {
+                    continue;
+                }
+            }
+            result.put(path, entry.getValue());
+        }
+        return result;
     }
 
     String hashString() {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/AbstractMirror.java
@@ -111,7 +111,7 @@ public abstract class AbstractMirror implements Mirror {
         if (gitignore != null) {
             ignoreNode = new IgnoreNode();
             try {
-                ignoreNode.parse(new ByteArrayInputStream(gitignore.getBytes()));
+                ignoreNode.parse(new ByteArrayInputStream(gitignore.getBytes(UTF_8)));
             } catch (IOException e) {
                 throw new IllegalArgumentException("Failed to read gitignore: " + gitignore, e);
             }
@@ -269,7 +269,7 @@ public abstract class AbstractMirror implements Mirror {
             final MatchResult ignoreResult = ignoreNode.isIgnored(relativePath, isDirectory);
             if (ignoreResult == MatchResult.IGNORED) {
                 if (isDirectory) {
-                    lastIgnoredDirectory = path;
+                    lastIgnoredDirectory = path.endsWith("/") ? path : path + '/';
                 }
                 continue;
             }

--- a/site/src/sphinx/mirroring.rst
+++ b/site/src/sphinx/mirroring.rst
@@ -113,6 +113,53 @@ Here is the properties of the mirroring task:
 
   - whether the mirroring task is enabled.
 
+Central Dogma to Central Dogma mirroring
+=========================================
+In addition to Git-to-CD mirroring, Central Dogma supports mirroring between two Central Dogma servers.
+This is useful when you want to replicate configuration across multiple Central Dogma clusters, such as
+syncing configurations between different environments or regions.
+
+Setting up a CD-to-CD mirror
+-----------------------------
+The setup is similar to Git mirroring, with a few differences:
+
+- ``Remote``
+
+  - Supported schemes are:
+
+    - ``dogma`` - connects to a remote Central Dogma server via plain HTTP.
+    - ``dogma+https`` - connects to a remote Central Dogma server via HTTPS.
+
+  - ``repo``
+
+    - the URI of the remote Central Dogma repository.
+      The format is ``<host>[:<port>]/<project>/<repository>.dogma``.
+      e.g. ``my-cd.com:36462/myproject/myrepo.dogma``
+
+  - ``path``
+
+    - the path within the remote Central Dogma repository. If unspecified, the whole content of the remote
+      repository is mirrored.
+
+  - Unlike Git mirroring, the ``branch`` field is not used because Central Dogma has no notion of branches.
+
+- ``Credential``
+
+  - An access token credential must be used for authentication to the remote Central Dogma server.
+
+- ``Direction``
+
+  - ``REMOTE_TO_LOCAL``: Replicates files from a remote Central Dogma repository to the local repository.
+  - ``LOCAL_TO_REMOTE``: Pushes files from the local repository to a remote Central Dogma repository.
+
+- ``gitignore``
+
+  - gitignore patterns are also supported for CD-to-CD mirroring, allowing you to exclude specific files
+    from being mirrored.
+
+All other properties (``Mirror ID``, ``Schedule``, ``Local path``, ``Zone``, ``Enable mirror``) work the
+same way as in Git mirroring.
+
 Mirror limit settings
 ---------------------
 Central Dogma limits the number of files and the total size of the files in a mirror for its reliability.

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     // Dependencies to run test servers for testing the web application
     testImplementation(project(":server"))
     testImplementation(project(":server-mirror-git"))
+    testImplementation(project(":server-mirror-dogma"))
     testImplementation(project(":server-auth:saml"))
     testImplementation(project(":server-auth:shiro"))
     testImplementation(project(":xds"))

--- a/webapp/src/dogma/features/repo/settings/mirrors/MirrorForm.tsx
+++ b/webapp/src/dogma/features/repo/settings/mirrors/MirrorForm.tsx
@@ -73,10 +73,16 @@ interface OptionType {
   label: string;
 }
 
-const MIRROR_SCHEMES: OptionType[] = ['git+ssh', 'git+http', 'git+https'].map((scheme) => ({
-  value: scheme,
-  label: scheme,
-}));
+const MIRROR_SCHEMES: OptionType[] = ['git+ssh', 'git+http', 'git+https', 'dogma', 'dogma+https'].map(
+  (scheme) => ({
+    value: scheme,
+    label: scheme,
+  }),
+);
+
+function isDogmaScheme(scheme: string): boolean {
+  return scheme === 'dogma' || scheme === 'dogma+https';
+}
 
 function repoMirrorCredentialName(project: string, repo: string, id: string): string {
   return `projects/${project}/repos/${repo}/credentials/${id}`;
@@ -109,6 +115,8 @@ const MirrorForm = ({ projectName, repoName, defaultValue, onSubmit, isWaitingRe
 
   const [isScheduleEnabled, setScheduleEnabled] = useState<boolean>(defaultValue.schedule != null);
   const schedule = watch('schedule');
+  const remoteScheme = watch('remoteScheme');
+  const isDogma = isDogmaScheme(remoteScheme);
 
   const repoCredentialOptions: OptionType[] = (repoCredentials || [])
     .filter((credential: CredentialDto) => credential.id)
@@ -175,6 +183,9 @@ const MirrorForm = ({ projectName, repoName, defaultValue, onSubmit, isWaitingRe
   return (
     <form
       onSubmit={handleSubmit((mirror) => {
+        if (isDogmaScheme(mirror.remoteScheme)) {
+          mirror.remoteBranch = '';
+        }
         return onSubmit(mirror, () => {}, setError);
       })}
     >
@@ -353,27 +364,38 @@ const MirrorForm = ({ projectName, repoName, defaultValue, onSubmit, isWaitingRe
                 name="remoteUrl"
                 type="text"
                 defaultValue={defaultValue.remoteUrl}
-                placeholder="my.git.com/org/myrepo.git"
-                {...register('remoteUrl', { required: true, pattern: /^[\w.\-]+(:[0-9]+)?\/[\w.\-\/]+.git$/ })}
+                placeholder={isDogma ? 'my-cd.com/myproject/myrepo.dogma' : 'my.git.com/org/myrepo.git'}
+                {...register('remoteUrl', {
+                  required: true,
+                  pattern: isDogma
+                    ? /^[\w.\-]+(:[0-9]+)?\/[\w.\-\/]+\.dogma$/
+                    : /^[\w.\-]+(:[0-9]+)?\/[\w.\-\/]+\.git$/,
+                })}
               />
               <FieldErrorMessage
                 error={errors.remoteUrl}
                 fieldName="remote URL"
-                errorMessage="Invalid remote URL. (expected format: 'my.git.com/org/myrepo.git')"
+                errorMessage={
+                  isDogma
+                    ? "Invalid remote URL. (expected format: 'my-cd.com/myproject/myrepo.dogma')"
+                    : "Invalid remote URL. (expected format: 'my.git.com/org/myrepo.git')"
+                }
               />
             </FormControl>
-            <FormControl width="50%" isRequired isInvalid={errors.remoteBranch != null}>
-              <FormLabel>branch</FormLabel>
-              <Input
-                id="remoteBranch"
-                name="remoteBranch"
-                type="text"
-                defaultValue={defaultValue.remoteBranch}
-                placeholder="main"
-                {...register('remoteBranch', { required: true })}
-              />
-              <FieldErrorMessage error={errors.remoteBranch} fieldName="remote branch" />
-            </FormControl>
+            {!isDogma && (
+              <FormControl width="50%" isRequired isInvalid={errors.remoteBranch != null}>
+                <FormLabel>branch</FormLabel>
+                <Input
+                  id="remoteBranch"
+                  name="remoteBranch"
+                  type="text"
+                  defaultValue={defaultValue.remoteBranch}
+                  placeholder="main"
+                  {...register('remoteBranch', { required: !isDogma })}
+                />
+                <FieldErrorMessage error={errors.remoteBranch} fieldName="remote branch" />
+              </FormControl>
+            )}
             <FormControl width="50%" isRequired isInvalid={errors.remotePath != null}>
               <FormLabel>path</FormLabel>
               <Input

--- a/webapp/src/dogma/features/repo/settings/mirrors/MirrorView.tsx
+++ b/webapp/src/dogma/features/repo/settings/mirrors/MirrorView.tsx
@@ -126,7 +126,9 @@ const MirrorView = ({ projectName, repoName, mirror }: MirrorViewProps) => {
                   <Code fontSize="md" padding="2px 10px 2px 10px">
                     {mirror.remoteScheme}://{mirror.remoteUrl}
                     {mirror.remotePath}
-                    {mirror.remoteBranch ? `#${mirror.remoteBranch}` : ''}
+                    {!['dogma', 'dogma+https'].includes(mirror.remoteScheme) && mirror.remoteBranch
+                      ? `#${mirror.remoteBranch}`
+                      : ''}
                   </Code>
                 </Td>
               </Tr>

--- a/webapp/src/dogma/features/repo/settings/mirrors/MirrorView.tsx
+++ b/webapp/src/dogma/features/repo/settings/mirrors/MirrorView.tsx
@@ -125,7 +125,8 @@ const MirrorView = ({ projectName, repoName, mirror }: MirrorViewProps) => {
                 <Td>
                   <Code fontSize="md" padding="2px 10px 2px 10px">
                     {mirror.remoteScheme}://{mirror.remoteUrl}
-                    {mirror.remotePath}#{mirror.remoteBranch}
+                    {mirror.remotePath}
+                    {mirror.remoteBranch ? `#${mirror.remoteBranch}` : ''}
                   </Code>
                 </Td>
               </Tr>

--- a/webapp/tests/dogma/feature/repo/settings/mirrors/MirrorForm.test.tsx
+++ b/webapp/tests/dogma/feature/repo/settings/mirrors/MirrorForm.test.tsx
@@ -1,0 +1,153 @@
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import MirrorForm from 'dogma/features/repo/settings/mirrors/MirrorForm';
+import { MirrorRequest } from 'dogma/features/repo/settings/mirrors/MirrorRequest';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    pathname: '/',
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useGetProjectCredentialsQuery: jest.fn().mockReturnValue({
+    data: [{ id: 'test-credential', name: 'projects/myProject/credentials/test-credential' }],
+  }),
+  useGetRepoCredentialsQuery: jest.fn().mockReturnValue({
+    data: [],
+  }),
+  useGetMirrorConfigQuery: jest.fn().mockReturnValue({
+    data: { zonePinned: false },
+  }),
+}));
+
+// Mock chakra-react-select which doesn't work in JSDOM
+jest.mock('chakra-react-select', () => ({
+  Select: ({ id, name, options, onChange, value, placeholder, ...rest }: any) => (
+    <select
+      id={id}
+      data-testid={id}
+      name={name}
+      value={value?.value || ''}
+      onChange={(e) => {
+        const selected = options
+          ?.flatMap((opt: any) => (opt.options ? opt.options : [opt]))
+          .find((opt: any) => opt.value === e.target.value);
+        onChange(selected || null);
+      }}
+    >
+      <option value="">{placeholder || 'Select...'}</option>
+      {options?.flatMap((opt: any) =>
+        opt.options
+          ? opt.options.map((o: any) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))
+          : [
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>,
+            ],
+      )}
+    </select>
+  ),
+}));
+
+const emptyMirror: MirrorRequest = {
+  id: '',
+  direction: 'REMOTE_TO_LOCAL',
+  schedule: '0 * * * * ?',
+  projectName: 'myProject',
+  localRepo: '',
+  localPath: '/',
+  remoteScheme: '',
+  remoteUrl: '',
+  remoteBranch: 'main',
+  remotePath: '/',
+  credentialName: null,
+  gitignore: null,
+  enabled: false,
+};
+
+const mockOnSubmit = jest.fn().mockResolvedValue(undefined);
+
+function renderMirrorForm(defaultValue: MirrorRequest = emptyMirror) {
+  return renderWithProviders(
+    <MirrorForm
+      projectName="myProject"
+      repoName="myRepo"
+      defaultValue={defaultValue}
+      onSubmit={mockOnSubmit}
+      isWaitingResponse={false}
+    />,
+  );
+}
+
+describe('MirrorForm', () => {
+  beforeEach(() => {
+    mockOnSubmit.mockClear();
+  });
+
+  it('renders dogma and dogma+https in the scheme dropdown', () => {
+    const { container } = renderMirrorForm();
+    const schemeSelect = container.querySelector('#remoteScheme') as HTMLSelectElement;
+    const options = Array.from(schemeSelect.querySelectorAll('option')).map((opt) => opt.textContent);
+    expect(options).toContain('dogma');
+    expect(options).toContain('dogma+https');
+  });
+
+  it('renders git schemes in the scheme dropdown', () => {
+    const { container } = renderMirrorForm();
+    const schemeSelect = container.querySelector('#remoteScheme') as HTMLSelectElement;
+    const options = Array.from(schemeSelect.querySelectorAll('option')).map((opt) => opt.textContent);
+    expect(options).toContain('git+ssh');
+    expect(options).toContain('git+http');
+    expect(options).toContain('git+https');
+  });
+
+  it('shows the branch field by default', () => {
+    renderMirrorForm();
+    expect(screen.getByPlaceholderText('main')).toBeInTheDocument();
+  });
+
+  it('hides the branch field when dogma scheme is selected', () => {
+    const dogmaMirror: MirrorRequest = {
+      ...emptyMirror,
+      remoteScheme: 'dogma',
+    };
+    renderMirrorForm(dogmaMirror);
+    expect(screen.queryByPlaceholderText('main')).not.toBeInTheDocument();
+  });
+
+  it('hides the branch field when dogma+https scheme is selected', () => {
+    const dogmaHttpsMirror: MirrorRequest = {
+      ...emptyMirror,
+      remoteScheme: 'dogma+https',
+    };
+    renderMirrorForm(dogmaHttpsMirror);
+    expect(screen.queryByPlaceholderText('main')).not.toBeInTheDocument();
+  });
+
+  it('shows dogma URL placeholder when dogma scheme is selected', () => {
+    const dogmaMirror: MirrorRequest = {
+      ...emptyMirror,
+      remoteScheme: 'dogma',
+    };
+    renderMirrorForm(dogmaMirror);
+    expect(screen.getByPlaceholderText('my-cd.com/myproject/myrepo.dogma')).toBeInTheDocument();
+  });
+
+  it('shows git URL placeholder when git scheme is selected', () => {
+    const gitMirror: MirrorRequest = {
+      ...emptyMirror,
+      remoteScheme: 'git+ssh',
+    };
+    renderMirrorForm(gitMirror);
+    expect(screen.getByPlaceholderText('my.git.com/org/myrepo.git')).toBeInTheDocument();
+  });
+});

--- a/webapp/tests/dogma/feature/repo/settings/mirrors/MirrorView.test.tsx
+++ b/webapp/tests/dogma/feature/repo/settings/mirrors/MirrorView.test.tsx
@@ -1,0 +1,78 @@
+import { renderWithProviders } from 'dogma/util/test-utils';
+import MirrorView from 'dogma/features/repo/settings/mirrors/MirrorView';
+import { MirrorRequest } from 'dogma/features/repo/settings/mirrors/MirrorRequest';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    pathname: '/',
+    push: jest.fn(),
+  }),
+}));
+
+const baseMirror: MirrorRequest = {
+  id: 'test-mirror',
+  projectName: 'myProject',
+  schedule: '0 * * * * ?',
+  direction: 'REMOTE_TO_LOCAL',
+  localRepo: 'myRepo',
+  localPath: '/',
+  remoteScheme: 'git+ssh',
+  remoteUrl: 'github.com/org/repo.git',
+  remoteBranch: 'main',
+  remotePath: '/',
+  credentialName: 'projects/myProject/credentials/my-credential',
+  enabled: true,
+};
+
+describe('MirrorView', () => {
+  it('renders remote path with branch for git mirrors', () => {
+    const { getByText } = renderWithProviders(
+      <MirrorView projectName="myProject" repoName="myRepo" mirror={baseMirror} />,
+    );
+    expect(getByText(/git\+ssh:\/\/github\.com\/org\/repo\.git\/#main/)).toBeInTheDocument();
+  });
+
+  it('renders remote path without branch for dogma mirrors', () => {
+    const dogmaMirror: MirrorRequest = {
+      ...baseMirror,
+      id: 'dogma-mirror',
+      remoteScheme: 'dogma',
+      remoteUrl: 'my-cd.com/myproject/myrepo.dogma',
+      remoteBranch: '',
+      remotePath: '/',
+    };
+    const { container } = renderWithProviders(
+      <MirrorView projectName="myProject" repoName="myRepo" mirror={dogmaMirror} />,
+    );
+    // Find the remote path row's code element (not the local path row)
+    const remotePathCodes = Array.from(container.querySelectorAll('code')).filter((el) =>
+      el.textContent.includes('my-cd.com'),
+    );
+    expect(remotePathCodes.length).toBe(1);
+    expect(remotePathCodes[0].textContent).toContain('dogma://my-cd.com/myproject/myrepo.dogma');
+    expect(remotePathCodes[0].textContent).not.toContain('#');
+  });
+
+  it('renders remote path without branch for dogma+https mirrors', () => {
+    const dogmaHttpsMirror: MirrorRequest = {
+      ...baseMirror,
+      id: 'dogma-https-mirror',
+      remoteScheme: 'dogma+https',
+      remoteUrl: 'my-cd.com/myproject/myrepo.dogma',
+      remoteBranch: '',
+      remotePath: '/config/',
+    };
+    const { container } = renderWithProviders(
+      <MirrorView projectName="myProject" repoName="myRepo" mirror={dogmaHttpsMirror} />,
+    );
+    const remotePathCode = Array.from(container.querySelectorAll('code')).find((el) =>
+      el.textContent.includes('dogma+https://'),
+    );
+    expect(remotePathCode).toBeDefined();
+    expect(remotePathCode.textContent).toContain('dogma+https://my-cd.com/myproject/myrepo.dogma');
+    expect(remotePathCode.textContent).toContain('/config/');
+    expect(remotePathCode.textContent).not.toContain('#');
+  });
+});


### PR DESCRIPTION
Motivation:
- Central Dogma to Central Dogma mirroring was added in #1300, but the web UI did not support creating or viewing dogma mirrors.
- The gitignore filter was not implemented in CentralDogmaMirror, so gitignore patterns were silently ignored for CD-to-CD mirrors.

Modifications:
- Added `dogma` and `dogma+https` schemes to the mirror form dropdown.
- Conditionally hide the remote branch field when a dogma scheme is selected, since Central Dogma has no notion of branches.
- Implemented gitignore filtering in CentralDogmaMirror using JGit's IgnoreNode for both local-to-remote and remote-to-local directions.

Result:
- Users can now create and view Central Dogma to Central Dogma mirrors through the web UI.
- Gitignore patterns are properly applied to CD-to-CD mirrors.