### PR TITLE
Prevent open redirect in SamlAuthSsoHandler via RelayState normalization bypass

### DIFF
--- a/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
+++ b/server-auth/saml/src/main/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandler.java
@@ -40,6 +40,7 @@ import org.opensaml.saml.saml2.core.NameIDType;
 import org.opensaml.saml.saml2.core.Response;
 import org.owasp.encoder.Encode;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 import com.linecorp.armeria.common.AggregatedHttpRequest;
@@ -145,10 +146,10 @@ final class SamlAuthSsoHandler implements SamlSingleSignOnHandler {
         final String redirectionScript;
         if (!Strings.isNullOrEmpty(relayState)) {
             final String trimmed = relayState.trim();
-            if (!trimmed.startsWith("/") || trimmed.startsWith("//")) {
-                redirectionScript = "window.location.href='/'";
-            } else {
+            if (isSafeRelayState(trimmed)) {
                 redirectionScript = "window.location.href='" + Encode.forJavaScript(trimmed) + '\'';
+            } else {
+                redirectionScript = "window.location.href='/'";
             }
         } else {
             redirectionScript = "window.location.href='/'";
@@ -171,6 +172,30 @@ final class SamlAuthSsoHandler implements SamlSingleSignOnHandler {
             }
             return httpResponse(loginResult, redirectionScript);
         }));
+    }
+
+    /**
+     * Returns whether the specified {@code relayState} is safe to be used as a redirect target. Only a
+     * relative path that starts with exactly one {@code '/'} is allowed in order to prevent an open
+     * redirect. Note that validating the raw string is not enough: a browser normalizes a backslash to
+     * {@code '/'} and strips control characters such as TAB, CR and LF from a URL before navigating, so a
+     * value like {@code "/\evil.example"} or {@code "/\t/evil.example"} would otherwise be resolved to a
+     * protocol-relative URL pointing at an attacker host. Therefore backslashes and control characters are
+     * rejected as well.
+     */
+    @VisibleForTesting
+    static boolean isSafeRelayState(String relayState) {
+        if (!relayState.startsWith("/") || relayState.startsWith("//")) {
+            // Not a relative path, or a protocol-relative URL such as '//evil.example/'.
+            return false;
+        }
+        for (int i = 0; i < relayState.length(); i++) {
+            final char c = relayState.charAt(i);
+            if (c == '\\' || Character.isISOControl(c)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private HttpResponse httpResponse(LoginResult loginResult, String redirectionScript) {

--- a/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandlerTest.java
+++ b/server-auth/saml/src/test/java/com/linecorp/centraldogma/server/auth/saml/SamlAuthSsoHandlerTest.java
@@ -92,6 +92,39 @@ class SamlAuthSsoHandlerTest {
         assertCookie(tlsEnabled, aggregated.headers(), "3");
     }
 
+    @ValueSource(strings = {
+            // Absolute URLs and dangerous schemes.
+            "https://evil.example/phish",
+            "javascript:alert(document.domain)",
+            // Protocol-relative URL.
+            "//evil.example/",
+            // Backslash is normalized to '/' by browsers, so this resolves to '//evil.example'.
+            "/\\evil.example",
+            "/\\/evil.example",
+            // Control characters (TAB, CR, LF) are stripped by browsers, so this resolves to
+            // '//evil.example'.
+            "/\t/evil.example",
+            "/\r/evil.example",
+            "/\n/evil.example",
+            // Not a path at all.
+            "evil.example",
+    })
+    @ParameterizedTest
+    void unsafeRelayStateIsRejected(String relayState) {
+        assertThat(SamlAuthSsoHandler.isSafeRelayState(relayState)).isFalse();
+    }
+
+    @ValueSource(strings = {
+            "/",
+            "/dashboard",
+            "/dashboard?next=/home",
+            "/a/b/c",
+    })
+    @ParameterizedTest
+    void relativePathRelayStateIsAccepted(String relayState) {
+        assertThat(SamlAuthSsoHandler.isSafeRelayState(relayState)).isTrue();
+    }
+
     private static void assertCookie(boolean tlsEnabled, ResponseHeaders responseHeaders, String value) {
         final String setCookieValue = responseHeaders.get(HttpHeaderNames.SET_COOKIE);
         final Cookie setCookie = Cookie.fromSetCookieHeader(setCookieValue);


### PR DESCRIPTION
Motivation:
- `SamlAuthSsoHandler.loginSucceeded()` reflects the attacker-controlled `RelayState` into a `window.location.href='...'` redirect after a successful SAML login. The existing guard only checked that the value starts with a single `/` (`startsWith("/")` && `!startsWith("//")`), which validates the raw string but not the URL a browser actually navigates to.

Modifications:
- Extract the RelayState validation into `SamlAuthSsoHandler.isSafeRelayState()` and additionally reject backslashes and ISO control characters, so the validated string matches what the browser will navigate to. Unsafe values fall back to `/`.

Result:
- `RelayState` values that a browser would resolve off-origin are no longer used as a redirect target; the handler falls back to `/`.