### PR TITLE
Fix mirror loading failure when a mirror has an invalid credential

### DIFF
--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -184,6 +184,25 @@ class ZoneAwareMirrorTest {
         final CentralDogmaRepository repo = client.forRepo(FOO_PROJ, Project.REPO_DOGMA);
         final String mirrorId = TEST_MIRROR_ID + "-unknown-zone";
         final String unknownZone = "unknown-zone";
+
+        // Create a valid SSH credential so that the mirror can be loaded and reach the zone validation.
+        // Otherwise, the git+ssh mirror fails to be constructed and is skipped before the zone is checked.
+        final BlockingWebClient webClient = WebClient.builder("http://127.0.0.1:" + serverPort)
+                                                     .auth(AuthToken.ofOAuth2(accessToken))
+                                                     .build()
+                                                     .blocking();
+        final CreateCredentialRequest credential =
+                getCreateCredentialRequest(FOO_PROJ, "bar-unknown-zone");
+        final ResponseEntity<PushResultDto> credentialResponse =
+                webClient.prepare()
+                         .post("/api/v1/projects/{proj}/repos/{repo}/credentials")
+                         .pathParam("proj", FOO_PROJ)
+                         .pathParam("repo", "bar-unknown-zone")
+                         .contentJson(credential)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(credentialResponse.status()).isEqualTo(HttpStatus.CREATED);
+
         final MirrorConfig mirrorConfig =
                 new MirrorConfig(mirrorId,
                                  true,
@@ -194,7 +213,7 @@ class ZoneAwareMirrorTest {
                                  URI.create("git+ssh://github.com/line/centraldogma-authtest.git/#main"),
                                  null,
                                  null,
-                                 credentialName("foo", "bar-unknown-zone", "credential-id"),
+                                 credentialName(FOO_PROJ, "bar-unknown-zone", PRIVATE_KEY_FILE),
                                  unknownZone);
         final Change<JsonNode> change = Change.ofJsonUpsert(
                 "/repos/bar-unknown-zone/mirrors/" + mirrorId + ".json",

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -29,6 +29,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.cronutils.model.Cron;
 import com.cronutils.model.field.CronField;
@@ -60,6 +62,8 @@ import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 
 public final class DefaultMetaRepository extends RepositoryWrapper implements MetaRepository {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultMetaRepository.class);
 
     private static final Pattern MIRROR_PATH_PATTERN = Pattern.compile("/repos/[^/]+/mirrors/[^/]+\\.json");
 
@@ -177,8 +181,19 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
         return future.thenApply(credentials -> {
             final List<MirrorConfig> mirrorConfigs = toMirrorConfigs(entries);
             return mirrorConfigs.stream()
-                                .map(mirrorConfig -> MirrorConverter.convertToMirror(
-                                        mirrorConfig, parent(), credentials, trustedHostKeys))
+                                .map(mirrorConfig -> {
+                                    try {
+                                        return MirrorConverter.convertToMirror(
+                                                mirrorConfig, parent(), credentials, trustedHostKeys);
+                                    } catch (Exception e) {
+                                        // Skip a malformed mirror so that a single bad mirror does not
+                                        // prevent the rest of the mirrors from being loaded.
+                                        logger.debug("Failed to convert a mirror configuration to a mirror. " +
+                                                     "project: {}, mirror: {}", parent().name(), mirrorConfig,
+                                                     e);
+                                        return null;
+                                    }
+                                })
                                 .filter(Objects::nonNull)
                                 .collect(toImmutableList());
         });


### PR DESCRIPTION
Motivation:
- The SSH host key verification change made SshGitMirror's constructor throw a MirrorException whenever the credential is not an SshKeyCredential (e.g. a missing credential that resolves to Credential.NONE).

Modifications:
- Wrap the per-mirror MirrorConverter.convertToMirror call in handleAllMirrors with a try/catch that logs a warning and skips the bad mirror (returns null) instead of failing the whole list.

Result:
- A mirror with an invalid or missing credential no longer prevents the rest of the project's mirrors from being loaded and scheduled; only the bad mirror is skipped with a warning.