### PR TITLE
Make it possible to permit empty endpoints in CD endpoint groups

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -104,21 +104,6 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
      * Query<T> query = ... // The query to the entry that contains the list of endpoints.
      * Watcher watcher = centralDogma.fileWatcher(projectName, repositoryName, query);
      * }</pre>
-     */
-    public static <T> CentralDogmaEndpointGroupBuilder<T> builder(Watcher<T> watcher,
-                                                                  EndpointListDecoder<T> endpointListDecoder) {
-        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder, false);
-    }
-
-    /**
-     * Returns a new {@link CentralDogmaEndpointGroupBuilder} with the {@link Watcher}
-     * and {@link EndpointListDecoder}. You can create a {@link Watcher} using {@link CentralDogma}:
-     *
-     * <pre>{@code
-     * CentralDogma centralDogma = ...
-     * Query<T> query = ... // The query to the entry that contains the list of endpoints.
-     * Watcher watcher = centralDogma.fileWatcher(projectName, repositoryName, query);
-     * }</pre>
      *
      * @param allowEmptyEndpoints if true, allow the group to start up with no endpoints instead of erroring,
      *                            and allow the list of endpoints to become empty instead of always retaining

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -140,7 +140,7 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
         instanceListWatcher.watch((revision, instances) -> {
             try {
                 final List<Endpoint> newEndpoints = endpointListDecoder.decode(instances);
-                if (newEndpoints.isEmpty()) {
+                if (newEndpoints.isEmpty() && !allowsEmptyEndpoints()) {
                     logger.info("Not refreshing the endpoint list of {} because it's empty. {}",
                                 instanceListWatcher, revision);
                     return;

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -73,7 +73,7 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
     public static <T> CentralDogmaEndpointGroup<T> ofWatcher(Watcher<T> watcher,
                                                              EndpointListDecoder<T> endpointListDecoder) {
         return new CentralDogmaEndpointGroup<>(EndpointSelectionStrategy.weightedRoundRobin(),
-                                               watcher, endpointListDecoder);
+                                               watcher, endpointListDecoder, false);
     }
 
     /**
@@ -107,13 +107,30 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
      */
     public static <T> CentralDogmaEndpointGroupBuilder<T> builder(Watcher<T> watcher,
                                                                   EndpointListDecoder<T> endpointListDecoder) {
-        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder);
+        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder, false);
+    }
+
+    /**
+     * Returns a new {@link CentralDogmaEndpointGroupBuilder} with the {@link Watcher}
+     * and {@link EndpointListDecoder}. You can create a {@link Watcher} using {@link CentralDogma}:
+     *
+     * <pre>{@code
+     * CentralDogma centralDogma = ...
+     * Query<T> query = ... // The query to the entry that contains the list of endpoints.
+     * Watcher watcher = centralDogma.fileWatcher(projectName, repositoryName, query);
+     * }</pre>
+     */
+    public static <T> CentralDogmaEndpointGroupBuilder<T> builder(Watcher<T> watcher,
+                                                                  EndpointListDecoder<T> endpointListDecoder,
+                                                                  boolean allowEmptyEndpoints) {
+        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder, allowEmptyEndpoints);
     }
 
     CentralDogmaEndpointGroup(EndpointSelectionStrategy strategy,
                               Watcher<T> instanceListWatcher,
-                              EndpointListDecoder<T> endpointListDecoder) {
-        super(strategy);
+                              EndpointListDecoder<T> endpointListDecoder,
+                              boolean allowEmptyEndpoints) {
+        super(strategy, allowEmptyEndpoints);
         this.instanceListWatcher = requireNonNull(instanceListWatcher, "instanceListWatcher");
         this.endpointListDecoder = requireNonNull(endpointListDecoder, "endpointListDecoder");
         registerWatcher();

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -104,15 +104,10 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
      * Query<T> query = ... // The query to the entry that contains the list of endpoints.
      * Watcher watcher = centralDogma.fileWatcher(projectName, repositoryName, query);
      * }</pre>
-     *
-     * @param allowEmptyEndpoints if true, allow the group to start up with no endpoints instead of erroring,
-     *                            and allow the list of endpoints to become empty instead of always retaining
-     *                            the last non-empty version
      */
     public static <T> CentralDogmaEndpointGroupBuilder<T> builder(Watcher<T> watcher,
-                                                                  EndpointListDecoder<T> endpointListDecoder,
-                                                                  boolean allowEmptyEndpoints) {
-        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder, allowEmptyEndpoints);
+                                                                  EndpointListDecoder<T> endpointListDecoder) {
+        return new CentralDogmaEndpointGroupBuilder<>(watcher, endpointListDecoder);
     }
 
     CentralDogmaEndpointGroup(EndpointSelectionStrategy strategy,

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroup.java
@@ -119,6 +119,10 @@ public final class CentralDogmaEndpointGroup<T> extends DynamicEndpointGroup {
      * Query<T> query = ... // The query to the entry that contains the list of endpoints.
      * Watcher watcher = centralDogma.fileWatcher(projectName, repositoryName, query);
      * }</pre>
+     *
+     * @param allowEmptyEndpoints if true, allow the group to start up with no endpoints instead of erroring,
+     *                            and allow the list of endpoints to become empty instead of always retaining
+     *                            the last non-empty version
      */
     public static <T> CentralDogmaEndpointGroupBuilder<T> builder(Watcher<T> watcher,
                                                                   EndpointListDecoder<T> endpointListDecoder,

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
@@ -35,7 +35,8 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
     private final boolean allowEmptyEndpoints;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
-    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder, boolean allowEmptyEndpoints) {
+    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder,
+                                     boolean allowEmptyEndpoints) {
         this.watcher = requireNonNull(watcher, "watcher");
         this.endpointListDecoder = requireNonNull(endpointListDecoder, "endpointListDecoder");
         this.allowEmptyEndpoints = allowEmptyEndpoints;
@@ -54,6 +55,7 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
      * from an entry in Central Dogma.
      */
     public CentralDogmaEndpointGroup<T> build() {
-        return new CentralDogmaEndpointGroup<>(selectionStrategy, watcher, endpointListDecoder, allowEmptyEndpoints);
+        return new CentralDogmaEndpointGroup<>(selectionStrategy, watcher, endpointListDecoder,
+                allowEmptyEndpoints);
     }
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
@@ -32,7 +32,7 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
 
     private final Watcher<T> watcher;
     private final EndpointListDecoder<T> endpointListDecoder;
-    private final boolean allowEmptyEndpoints;
+    private boolean allowEmptyEndpoints;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
     CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder,
@@ -57,5 +57,14 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
     public CentralDogmaEndpointGroup<T> build() {
         return new CentralDogmaEndpointGroup<>(selectionStrategy, watcher, endpointListDecoder,
                 allowEmptyEndpoints);
+    }
+
+    /**
+     * @param allowEmptyEndpoints if true, allow the group to start up with no endpoints instead of erroring,
+     *                            and allow the list of endpoints to become empty instead of always retaining
+     *                            the last non-empty version
+     */
+    public void setAllowEmptyEndpoints(boolean allowEmptyEndpoints) {
+        this.allowEmptyEndpoints = allowEmptyEndpoints;
     }
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
@@ -35,11 +35,9 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
     private boolean allowEmptyEndpoints;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
-    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder,
-                                     boolean allowEmptyEndpoints) {
+    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder) {
         this.watcher = requireNonNull(watcher, "watcher");
         this.endpointListDecoder = requireNonNull(endpointListDecoder, "endpointListDecoder");
-        this.allowEmptyEndpoints = allowEmptyEndpoints;
     }
 
     /**
@@ -64,7 +62,8 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
      * and allow the list of endpoints to become empty instead of always retaining
      * the last non-empty version.
      */
-    public void setAllowEmptyEndpoints(boolean allowEmptyEndpoints) {
+    public CentralDogmaEndpointGroupBuilder<T> setAllowEmptyEndpoints(boolean allowEmptyEndpoints) {
         this.allowEmptyEndpoints = allowEmptyEndpoints;
+        return this;
     }
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
@@ -32,11 +32,13 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
 
     private final Watcher<T> watcher;
     private final EndpointListDecoder<T> endpointListDecoder;
+    private final boolean allowEmptyEndpoints;
     private EndpointSelectionStrategy selectionStrategy = EndpointSelectionStrategy.weightedRoundRobin();
 
-    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder) {
+    CentralDogmaEndpointGroupBuilder(Watcher<T> watcher, EndpointListDecoder<T> endpointListDecoder, boolean allowEmptyEndpoints) {
         this.watcher = requireNonNull(watcher, "watcher");
         this.endpointListDecoder = requireNonNull(endpointListDecoder, "endpointListDecoder");
+        this.allowEmptyEndpoints = allowEmptyEndpoints;
     }
 
     /**
@@ -52,6 +54,6 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
      * from an entry in Central Dogma.
      */
     public CentralDogmaEndpointGroup<T> build() {
-        return new CentralDogmaEndpointGroup<>(selectionStrategy, watcher, endpointListDecoder);
+        return new CentralDogmaEndpointGroup<>(selectionStrategy, watcher, endpointListDecoder, allowEmptyEndpoints);
     }
 }

--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/client/armeria/CentralDogmaEndpointGroupBuilder.java
@@ -60,9 +60,9 @@ public final class CentralDogmaEndpointGroupBuilder<T> {
     }
 
     /**
-     * @param allowEmptyEndpoints if true, allow the group to start up with no endpoints instead of erroring,
-     *                            and allow the list of endpoints to become empty instead of always retaining
-     *                            the last non-empty version
+     * If set to true, allow the group to start up with no endpoints instead of erroring,
+     * and allow the list of endpoints to become empty instead of always retaining
+     * the last non-empty version.
      */
     public void setAllowEmptyEndpoints(boolean allowEmptyEndpoints) {
         this.allowEmptyEndpoints = allowEmptyEndpoints;


### PR DESCRIPTION
We have a use case where this is desirable for a testing-only endpoint group (which will be empty when there are no tests currently active, and will then be populated before testing starts - we'd like the server to start up successfully even if no tests are currently active).