### PR TITLE
Override a Maven repository using mavenCentralMirror

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,12 @@ plugins {
 
 allprojects {
     repositories {
-        mavenCentral()
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
     }
 }
 

--- a/dist/build.gradle
+++ b/dist/build.gradle
@@ -1,6 +1,11 @@
 buildscript {
     repositories {
-        mavenCentral()
+        def mavenCentralMirror = providers.gradleProperty('mavenCentralMirror').getOrNull()
+        if (mavenCentralMirror) {
+            maven { url = mavenCentralMirror }
+        } else {
+            mavenCentral()
+        }
         gradlePluginPortal()
     }
     dependencies {


### PR DESCRIPTION
Motivation:

`mavenCentralMirror` was introduced in gradle-scripts to override the Maven repository, but Central Dogma does not apply this change to its own build.gradle files.

Modifications:

- Respect `mavenCentralMirror` to override `mavenCentral()` in build.gradle

Result:

We can use `mavenCentralMirror` to change the Maven repository URL when building Central Dogma.