### PR TITLE
Support distinct endpoints and Pod/Node metadata mapping for xDS K8s endpoints

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/KubernetesEndpointConverter.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/KubernetesEndpointConverter.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.k8s.v1;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+import com.linecorp.armeria.client.Endpoint;
+import com.linecorp.armeria.client.kubernetes.endpoints.KubernetesResourceAccess;
+
+import io.envoyproxy.envoy.config.core.v3.Address;
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+import io.envoyproxy.envoy.config.core.v3.SocketAddress;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+
+/**
+ * Converts Kubernetes {@link Endpoint}s into Envoy {@link LbEndpoint}s, applying the
+ * {@link ServiceEndpointWatcher#getDistinctEndpoint() distinct_endpoint} and
+ * {@link ServiceEndpointWatcher#getMetadataMappingList() metadata_mapping} options.
+ */
+final class KubernetesEndpointConverter {
+
+    private static final String DEFAULT_METADATA_NAMESPACE = "envoy.lb";
+
+    /**
+     * Appends an {@link LbEndpoint} to the specified {@code builder} for each {@link Endpoint}, collapsing
+     * endpoints that share the same host and port when {@code distinct_endpoint} is enabled and copying the
+     * Pod/Node label/annotation values described by {@code metadata_mapping} into the endpoint metadata.
+     */
+    static void addLbEndpoints(LocalityLbEndpoints.Builder builder, Iterable<Endpoint> endpoints,
+                               ServiceEndpointWatcher watcher) {
+        final boolean distinct = watcher.getDistinctEndpoint();
+        final List<MetadataMapping> mappings = watcher.getMetadataMappingList();
+        final Set<String> seen = distinct ? new HashSet<>() : null;
+        for (Endpoint endpoint : endpoints) {
+            if (!endpoint.hasPort()) {
+                continue;
+            }
+            if (seen != null && !seen.add(endpoint.host() + ':' + endpoint.port())) {
+                continue;
+            }
+            final SocketAddress socketAddress = SocketAddress.newBuilder()
+                                                             .setAddress(endpoint.host())
+                                                             .setPortValue(endpoint.port())
+                                                             .build();
+            final LbEndpoint.Builder lbEndpointBuilder =
+                    LbEndpoint.newBuilder()
+                              .setEndpoint(io.envoyproxy.envoy.config.endpoint.v3.Endpoint.newBuilder()
+                                                    .setAddress(Address.newBuilder()
+                                                                       .setSocketAddress(socketAddress)
+                                                                       .build())
+                                                    .build());
+            final Metadata metadata = buildMetadata(endpoint, mappings);
+            if (metadata != null) {
+                lbEndpointBuilder.setMetadata(metadata);
+            }
+            builder.addLbEndpoints(lbEndpointBuilder.build());
+        }
+    }
+
+    @Nullable
+    private static Metadata buildMetadata(Endpoint endpoint, List<MetadataMapping> mappings) {
+        if (mappings.isEmpty()) {
+            return null;
+        }
+        final Map<String, Struct.Builder> structsByNamespace = new LinkedHashMap<>();
+        for (MetadataMapping mapping : mappings) {
+            final ObjectMeta objectMeta = objectMeta(endpoint, mapping.getResourceType());
+            if (objectMeta == null) {
+                continue;
+            }
+            final Map<String, String> source =
+                    mapping.getEntryType() == MetadataMapping.EntryType.ANNOTATION ? objectMeta.getAnnotations()
+                                                                                   : objectMeta.getLabels();
+            if (source == null || source.isEmpty()) {
+                continue;
+            }
+            final String namespace = mapping.getMetadataNamespace().isEmpty() ? DEFAULT_METADATA_NAMESPACE
+                                                                              : mapping.getMetadataNamespace();
+            switch (mapping.getSourceCase()) {
+                case SOURCE_KEY:
+                    // Exact match: the destination key is metadata_key or, if empty, the source key.
+                    final String value = source.get(mapping.getSourceKey());
+                    if (value != null) {
+                        final String key = mapping.getMetadataKey().isEmpty() ? mapping.getSourceKey()
+                                                                              : mapping.getMetadataKey();
+                        putField(structsByNamespace, namespace, key, value);
+                    }
+                    break;
+                case SOURCE_KEY_PREFIX:
+                    // Prefix match: copy every matching entry, preserving the original key.
+                    final String prefix = mapping.getSourceKeyPrefix();
+                    for (Map.Entry<String, String> entry : source.entrySet()) {
+                        if (entry.getKey().startsWith(prefix)) {
+                            putField(structsByNamespace, namespace, entry.getKey(), entry.getValue());
+                        }
+                    }
+                    break;
+                default:
+                    // SOURCE_NOT_SET is rejected by validation.
+                    break;
+            }
+        }
+        if (structsByNamespace.isEmpty()) {
+            return null;
+        }
+        final Metadata.Builder metadataBuilder = Metadata.newBuilder();
+        structsByNamespace.forEach((namespace, struct) ->
+                                           metadataBuilder.putFilterMetadata(namespace, struct.build()));
+        return metadataBuilder.build();
+    }
+
+    private static void putField(Map<String, Struct.Builder> structsByNamespace, String namespace,
+                                 String key, String value) {
+        structsByNamespace.computeIfAbsent(namespace, unused -> Struct.newBuilder())
+                          .putFields(key, Value.newBuilder().setStringValue(value).build());
+    }
+
+    @Nullable
+    private static ObjectMeta objectMeta(Endpoint endpoint, MetadataMapping.ResourceType resourceType) {
+        switch (resourceType) {
+            case POD:
+                final Pod pod = KubernetesResourceAccess.pod(endpoint);
+                return pod != null ? pod.getMetadata() : null;
+            case NODE:
+                final Node node = KubernetesResourceAccess.node(endpoint);
+                return node != null ? node.getMetadata() : null;
+            default:
+                return null;
+        }
+    }
+
+    private KubernetesEndpointConverter() {}
+}

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesEndpointFetchingService.java
@@ -61,11 +61,7 @@ import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.xds.internal.XdsResourceWatchingService;
 
-import io.envoyproxy.envoy.config.core.v3.Address;
-import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
-import io.envoyproxy.envoy.config.endpoint.v3.Endpoint;
-import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
@@ -362,20 +358,9 @@ final class XdsKubernetesEndpointFetchingService extends XdsResourceWatchingServ
                         kubernetesLocalityLbEndpoints.getLoadBalancingWeight());
             }
             localityLbEndpointsBuilder.setPriority(kubernetesLocalityLbEndpoints.getPriority());
-            for (com.linecorp.armeria.client.Endpoint endpoint : kubernetesEndpointGroup.endpoints()) {
-                assert endpoint.hasPort();
-                final SocketAddress socketAddress = SocketAddress.newBuilder()
-                                                                 .setAddress(endpoint.host())
-                                                                 .setPortValue(endpoint.port())
-                                                                 .build();
-                localityLbEndpointsBuilder.addLbEndpoints(
-                        LbEndpoint.newBuilder()
-                                  .setEndpoint(Endpoint.newBuilder()
-                                                       .setAddress(Address.newBuilder()
-                                                                          .setSocketAddress(socketAddress)
-                                                                          .build()).build())
-                                  .build());
-            }
+            KubernetesEndpointConverter.addLbEndpoints(localityLbEndpointsBuilder,
+                                                       kubernetesEndpointGroup.endpoints(),
+                                                       kubernetesLocalityLbEndpoints.getWatcher());
             clusterLoadAssignmentBuilder.addEndpoints(localityLbEndpointsBuilder.build());
         }
 

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesService.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/k8s/v1/XdsKubernetesService.java
@@ -55,10 +55,7 @@ import com.linecorp.centraldogma.server.storage.repository.MetaRepository;
 import com.linecorp.centraldogma.xds.internal.XdsResourceManager;
 import com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceGrpc.XdsKubernetesServiceImplBase;
 
-import io.envoyproxy.envoy.config.core.v3.Address;
-import io.envoyproxy.envoy.config.core.v3.SocketAddress;
 import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
-import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
 import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
@@ -154,6 +151,9 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
             StreamObserver<KubernetesEndpointAggregator> responseObserver,
             List<KubernetesLocalityLbEndpoints> kubernetesLocalityLbEndpointsList,
             String group, String fileName, Runnable onSuccess) {
+        for (KubernetesLocalityLbEndpoints kubernetesLocalityLbEndpoints : kubernetesLocalityLbEndpointsList) {
+            validateMetadataMappings(kubernetesLocalityLbEndpoints.getWatcher());
+        }
         // Create a KubernetesEndpointGroup to check if the watcher is valid.
         // We use KubernetesEndpointGroup for simplicity, but we will implement a custom implementation
         // for better debugging and error handling in the future.
@@ -226,6 +226,41 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
             }
             return null;
         });
+    }
+
+    private static void validateMetadataMappings(ServiceEndpointWatcher watcher) {
+        for (MetadataMapping mapping : watcher.getMetadataMappingList()) {
+            if (mapping.getResourceType() == MetadataMapping.ResourceType.RESOURCE_TYPE_UNSPECIFIED) {
+                throw Status.INVALID_ARGUMENT.withDescription(
+                        "resource_type must be specified in metadata_mapping: " + mapping)
+                                             .asRuntimeException();
+            }
+            if (mapping.getEntryType() == MetadataMapping.EntryType.ENTRY_TYPE_UNSPECIFIED) {
+                throw Status.INVALID_ARGUMENT.withDescription(
+                        "entry_type must be specified in metadata_mapping: " + mapping)
+                                             .asRuntimeException();
+            }
+            switch (mapping.getSourceCase()) {
+                case SOURCE_KEY:
+                    if (mapping.getSourceKey().isEmpty()) {
+                        throw Status.INVALID_ARGUMENT.withDescription(
+                                "source_key must not be empty in metadata_mapping: " + mapping)
+                                                     .asRuntimeException();
+                    }
+                    break;
+                case SOURCE_KEY_PREFIX:
+                    if (mapping.getSourceKeyPrefix().isEmpty()) {
+                        throw Status.INVALID_ARGUMENT.withDescription(
+                                "source_key_prefix must not be empty in metadata_mapping: " + mapping)
+                                                     .asRuntimeException();
+                    }
+                    break;
+                default:
+                    throw Status.INVALID_ARGUMENT.withDescription(
+                            "either source_key or source_key_prefix must be set in metadata_mapping: " +
+                            mapping).asRuntimeException();
+            }
+        }
     }
 
     /**
@@ -472,24 +507,8 @@ public final class XdsKubernetesService extends XdsKubernetesServiceImplBase {
             builder.setLoadBalancingWeight(localityLbEndpoints.getLoadBalancingWeight());
         }
         builder.setPriority(localityLbEndpoints.getPriority());
-        for (Endpoint endpoint : endpointGroup.endpoints()) {
-            if (!endpoint.hasPort()) {
-                continue;
-            }
-            final SocketAddress socketAddress = SocketAddress.newBuilder()
-                                                             .setAddress(endpoint.host())
-                                                             .setPortValue(endpoint.port())
-                                                             .build();
-            builder.addLbEndpoints(
-                    LbEndpoint.newBuilder()
-                              .setEndpoint(
-                                      io.envoyproxy.envoy.config.endpoint.v3.Endpoint.newBuilder()
-                                                .setAddress(Address.newBuilder()
-                                                                   .setSocketAddress(socketAddress)
-                                                                   .build())
-                                                .build())
-                              .build());
-        }
+        KubernetesEndpointConverter.addLbEndpoints(builder, endpointGroup.endpoints(),
+                                                   localityLbEndpoints.getWatcher());
         return builder.build();
     }
 }

--- a/xds/src/main/proto/centraldogma/xds/k8s/v1/xds_kubernetes.proto
+++ b/xds/src/main/proto/centraldogma/xds/k8s/v1/xds_kubernetes.proto
@@ -92,6 +92,51 @@ message ServiceEndpointWatcher {
   string port_name = 2 [(google.api.field_behavior) = OPTIONAL];
   Kubeconfig kubeconfig = 3 [(google.api.field_behavior) = REQUIRED];
   map<string, string> additional_properties = 4 [(google.api.field_behavior) = OPTIONAL];
+  // When true, endpoints that share the same host and port are collapsed into a
+  // single LbEndpoint. This is useful in NODE_PORT mode where multiple Pods on
+  // the same node resolve to the same nodeIP:nodePort. The first occurrence
+  // supplies the endpoint metadata.
+  bool distinct_endpoint = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Rules that copy Kubernetes Pod or Node label/annotation values into the
+  // metadata of the generated LbEndpoint.
+  repeated MetadataMapping metadata_mapping = 6 [(google.api.field_behavior) = OPTIONAL];
+}
+
+// A rule that copies a Kubernetes Pod or Node label/annotation value into the
+// metadata of the generated LbEndpoint.
+message MetadataMapping {
+  // The Kubernetes resource to read the value from.
+  ResourceType resource_type = 1 [(google.api.field_behavior) = REQUIRED];
+  // Whether the value is read from a label or an annotation.
+  EntryType entry_type = 2 [(google.api.field_behavior) = REQUIRED];
+  // Exactly one selector must be set.
+  oneof source {
+    // Copies the value of this single label/annotation key,
+    // e.g. "topology.kubernetes.io/zone".
+    string source_key = 3;
+    // Copies the value of every label/annotation key that starts with this
+    // prefix, e.g. "topology.kubernetes.io/". The original keys are preserved
+    // as the metadata keys.
+    string source_key_prefix = 4;
+  }
+  // The Envoy filter_metadata namespace to store the value under. Defaults to
+  // "envoy.lb" when empty.
+  string metadata_namespace = 5 [(google.api.field_behavior) = OPTIONAL];
+  // The metadata key to store the value under. Defaults to source_key when
+  // empty. Ignored in source_key_prefix mode where the original keys are kept.
+  string metadata_key = 6 [(google.api.field_behavior) = OPTIONAL];
+
+  enum ResourceType {
+    RESOURCE_TYPE_UNSPECIFIED = 0;
+    POD = 1;
+    NODE = 2;
+  }
+
+  enum EntryType {
+    ENTRY_TYPE_UNSPECIFIED = 0;
+    LABEL = 1;
+    ANNOTATION = 2;
+  }
 }
 
 message Kubeconfig {

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/KubernetesEndpointMetadataTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/k8s/v1/KubernetesEndpointMetadataTest.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.xds.k8s.v1;
+
+import static com.linecorp.centraldogma.xds.endpoint.v1.XdsEndpointServiceTest.checkEndpointsViaDiscoveryRequest;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.createGroup;
+import static com.linecorp.centraldogma.xds.internal.XdsTestUtil.endpoint;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.assertOk;
+import static com.linecorp.centraldogma.xds.k8s.v1.XdsKubernetesServiceTest.createAggregator;
+import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+
+import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
+import io.envoyproxy.envoy.config.core.v3.Metadata;
+import io.envoyproxy.envoy.config.endpoint.v3.ClusterLoadAssignment;
+import io.envoyproxy.envoy.config.endpoint.v3.LbEndpoint;
+import io.envoyproxy.envoy.config.endpoint.v3.LocalityLbEndpoints;
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
+
+@EnableKubernetesMockClient(crud = true)
+class KubernetesEndpointMetadataTest {
+
+    private static final String ZONE_KEY = "topology.kubernetes.io/zone";
+    private static final String REGION_KEY = "topology.kubernetes.io/region";
+
+    @RegisterExtension
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension();
+
+    static KubernetesClient client;
+
+    @BeforeAll
+    static void setup() {
+        final AggregatedHttpResponse response = createGroup("foo", dogma.httpClient());
+        assertThat(response.status()).isSameAs(HttpStatus.OK);
+
+        // Two nodes, each with topology labels and a rack annotation.
+        client.nodes().resource(newNode("node-a", "1.1.1.1",
+                                        ImmutableMap.of(ZONE_KEY, "zone-a", REGION_KEY, "region-1",
+                                                        "kubernetes.io/arch", "amd64"),
+                                        ImmutableMap.of("rack", "rack-1"))).create();
+        client.nodes().resource(newNode("node-b", "2.2.2.2",
+                                        ImmutableMap.of(ZONE_KEY, "zone-b", REGION_KEY, "region-1",
+                                                        "kubernetes.io/arch", "amd64"),
+                                        ImmutableMap.of("rack", "rack-2"))).create();
+
+        // A NodePort service backed by one Pod per node.
+        client.services().resource(newService("meta-service", ImmutableMap.of("app", "meta"), 30000)).create();
+        client.pods().resource(newPod("meta-pod-a", "node-a",
+                                      ImmutableMap.of("app", "meta", "version", "v1"))).create();
+        client.pods().resource(newPod("meta-pod-b", "node-b",
+                                      ImmutableMap.of("app", "meta", "version", "v2"))).create();
+
+        // A NodePort service backed by two Pods on the same node, producing duplicate endpoints.
+        client.services().resource(newService("dup-service", ImmutableMap.of("app", "dup"), 31000)).create();
+        client.pods().resource(newPod("dup-pod-1", "node-a", ImmutableMap.of("app", "dup"))).create();
+        client.pods().resource(newPod("dup-pod-2", "node-a", ImmutableMap.of("app", "dup"))).create();
+    }
+
+    @Test
+    void copyNodeLabelWithExactKey() throws IOException {
+        final String aggregatorId = "meta-node-label";
+        final ServiceEndpointWatcher watcher =
+                watcher("meta-service")
+                        .addMetadataMapping(MetadataMapping.newBuilder()
+                                                           .setResourceType(MetadataMapping.ResourceType.NODE)
+                                                           .setEntryType(MetadataMapping.EntryType.LABEL)
+                                                           .setSourceKey(ZONE_KEY)
+                                                           .setMetadataKey("zone"))
+                        .build();
+        final String clusterName = createAndGetClusterName(aggregatorId, watcher);
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(clusterName,
+                                      lbEndpoint("1.1.1.1", 30000, "envoy.lb",
+                                                 ImmutableMap.of("zone", "zone-a")),
+                                      lbEndpoint("2.2.2.2", 30000, "envoy.lb",
+                                                 ImmutableMap.of("zone", "zone-b"))),
+                clusterName);
+    }
+
+    @Test
+    void copyNodeLabelsWithPrefix() throws IOException {
+        final String aggregatorId = "meta-node-prefix";
+        final ServiceEndpointWatcher watcher =
+                watcher("meta-service")
+                        .addMetadataMapping(MetadataMapping.newBuilder()
+                                                           .setResourceType(MetadataMapping.ResourceType.NODE)
+                                                           .setEntryType(MetadataMapping.EntryType.LABEL)
+                                                           .setSourceKeyPrefix("topology.kubernetes.io/"))
+                        .build();
+        final String clusterName = createAndGetClusterName(aggregatorId, watcher);
+        // Only the keys under the prefix are copied, and their original keys are preserved.
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(clusterName,
+                                      lbEndpoint("1.1.1.1", 30000, "envoy.lb",
+                                                 ImmutableMap.of(ZONE_KEY, "zone-a", REGION_KEY, "region-1")),
+                                      lbEndpoint("2.2.2.2", 30000, "envoy.lb",
+                                                 ImmutableMap.of(ZONE_KEY, "zone-b", REGION_KEY, "region-1"))),
+                clusterName);
+    }
+
+    @Test
+    void copyPodLabelWithCustomNamespace() throws IOException {
+        final String aggregatorId = "meta-pod-label";
+        final ServiceEndpointWatcher watcher =
+                watcher("meta-service")
+                        .addMetadataMapping(MetadataMapping.newBuilder()
+                                                           .setResourceType(MetadataMapping.ResourceType.POD)
+                                                           .setEntryType(MetadataMapping.EntryType.LABEL)
+                                                           .setSourceKey("version")
+                                                           .setMetadataNamespace("com.example.custom")
+                                                           .setMetadataKey("ver"))
+                        .build();
+        final String clusterName = createAndGetClusterName(aggregatorId, watcher);
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(clusterName,
+                                      lbEndpoint("1.1.1.1", 30000, "com.example.custom",
+                                                 ImmutableMap.of("ver", "v1")),
+                                      lbEndpoint("2.2.2.2", 30000, "com.example.custom",
+                                                 ImmutableMap.of("ver", "v2"))),
+                clusterName);
+    }
+
+    @Test
+    void copyNodeAnnotation() throws IOException {
+        final String aggregatorId = "meta-node-annotation";
+        final ServiceEndpointWatcher watcher =
+                watcher("meta-service")
+                        .addMetadataMapping(MetadataMapping.newBuilder()
+                                                           .setResourceType(MetadataMapping.ResourceType.NODE)
+                                                           .setEntryType(MetadataMapping.EntryType.ANNOTATION)
+                                                           .setSourceKey("rack")) // metadata_key defaults to it
+                        .build();
+        final String clusterName = createAndGetClusterName(aggregatorId, watcher);
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(clusterName,
+                                      lbEndpoint("1.1.1.1", 30000, "envoy.lb",
+                                                 ImmutableMap.of("rack", "rack-1")),
+                                      lbEndpoint("2.2.2.2", 30000, "envoy.lb",
+                                                 ImmutableMap.of("rack", "rack-2"))),
+                clusterName);
+    }
+
+    @Test
+    void distinctEndpointCollapsesDuplicates() throws IOException {
+        // Two Pods on the same node resolve to the same nodeIP:nodePort.
+        final String keepId = "dup-keep";
+        final String keepCluster = createAndGetClusterName(keepId, watcher("dup-service").build());
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(keepCluster, endpoint("1.1.1.1", 31000), endpoint("1.1.1.1", 31000)),
+                keepCluster);
+
+        final String distinctId = "dup-distinct";
+        final String distinctCluster =
+                createAndGetClusterName(distinctId, watcher("dup-service").setDistinctEndpoint(true).build());
+        checkEndpointsViaDiscoveryRequest(
+                dogma.httpClient().uri(),
+                clusterLoadAssignment(distinctCluster, endpoint("1.1.1.1", 31000)),
+                distinctCluster);
+    }
+
+    @Test
+    void rejectInvalidMetadataMapping() throws IOException {
+        // Missing resource_type.
+        assertInvalidArgument("invalid-resource",
+                              MetadataMapping.newBuilder()
+                                             .setEntryType(MetadataMapping.EntryType.LABEL)
+                                             .setSourceKey(ZONE_KEY));
+        // Neither source_key nor source_key_prefix set.
+        assertInvalidArgument("invalid-source",
+                              MetadataMapping.newBuilder()
+                                             .setResourceType(MetadataMapping.ResourceType.NODE)
+                                             .setEntryType(MetadataMapping.EntryType.LABEL));
+    }
+
+    private static void assertInvalidArgument(String aggregatorId, MetadataMapping.Builder mapping)
+            throws IOException {
+        final ServiceEndpointWatcher watcher = watcher("meta-service").addMetadataMapping(mapping).build();
+        final AggregatedHttpResponse response = createAggregator(aggregator(aggregatorId, watcher),
+                                                                 aggregatorId, dogma.httpClient());
+        assertThat(response.status()).isSameAs(HttpStatus.BAD_REQUEST);
+        assertThatJson(response.contentUtf8()).node("grpc-code").isEqualTo("INVALID_ARGUMENT");
+    }
+
+    private static String createAndGetClusterName(String aggregatorId, ServiceEndpointWatcher watcher)
+            throws IOException {
+        assertOk(createAggregator(aggregator(aggregatorId, watcher), aggregatorId, dogma.httpClient()));
+        return "groups/foo/k8s/clusters/" + aggregatorId;
+    }
+
+    private static ServiceEndpointWatcher.Builder watcher(String serviceName) {
+        final Kubeconfig kubeconfig = Kubeconfig.newBuilder()
+                                                .setControlPlaneUrl(client.getMasterUrl().toString())
+                                                .setNamespace(client.getNamespace())
+                                                .setTrustCerts(true)
+                                                .build();
+        return ServiceEndpointWatcher.newBuilder().setServiceName(serviceName).setKubeconfig(kubeconfig);
+    }
+
+    private static KubernetesEndpointAggregator aggregator(String aggregatorId,
+                                                           ServiceEndpointWatcher watcher) {
+        return KubernetesEndpointAggregator
+                .newBuilder()
+                .setName("groups/foo/k8s/endpointAggregators/" + aggregatorId)
+                .addLocalityLbEndpoints(KubernetesLocalityLbEndpoints.newBuilder().setWatcher(watcher).build())
+                .build();
+    }
+
+    private static ClusterLoadAssignment clusterLoadAssignment(String clusterName, LbEndpoint... lbEndpoints) {
+        final LocalityLbEndpoints.Builder locality = LocalityLbEndpoints.newBuilder();
+        for (LbEndpoint lbEndpoint : lbEndpoints) {
+            locality.addLbEndpoints(lbEndpoint);
+        }
+        return ClusterLoadAssignment.newBuilder()
+                                    .setClusterName(clusterName)
+                                    .addEndpoints(locality.build())
+                                    .build();
+    }
+
+    private static LbEndpoint lbEndpoint(String host, int port, String namespace, Map<String, String> fields) {
+        final Struct.Builder struct = Struct.newBuilder();
+        fields.forEach((key, value) -> struct.putFields(key, Value.newBuilder().setStringValue(value).build()));
+        final Metadata metadata = Metadata.newBuilder().putFilterMetadata(namespace, struct.build()).build();
+        return endpoint(host, port).toBuilder().setMetadata(metadata).build();
+    }
+
+    private static Node newNode(String name, String ip, Map<String, String> labels,
+                               Map<String, String> annotations) {
+        return new NodeBuilder()
+                .withNewMetadata().withName(name).withLabels(labels).withAnnotations(annotations).endMetadata()
+                .withNewStatus()
+                .addNewAddress().withType("InternalIP").withAddress(ip).endAddress()
+                .endStatus()
+                .build();
+    }
+
+    private static Service newService(String name, Map<String, String> selector, int nodePort) {
+        return new ServiceBuilder()
+                .withNewMetadata().withName(name).endMetadata()
+                .withNewSpec()
+                .withType("NodePort")
+                .withSelector(selector)
+                .addNewPort().withPort(80).withNodePort(nodePort).endPort()
+                .endSpec()
+                .build();
+    }
+
+    private static Pod newPod(String name, String nodeName, Map<String, String> labels) {
+        return new PodBuilder()
+                .withNewMetadata().withName(name).withLabels(labels).endMetadata()
+                .withNewSpec()
+                .withNodeName(nodeName)
+                .addNewContainer().withName("app").withImage("nginx:1.14.2").endContainer()
+                .endSpec()
+                .build();
+    }
+}


### PR DESCRIPTION
Motivation:

The xDS control plane converts Kubernetes service endpoints into Envoy ClusterLoadAssignment resources, but had two gaps: in NODE_PORT mode multiple Pods on the same node produce duplicate LbEndpoints, and LbEndpoint.metadata was never populated, so users could not drive Envoy subset load balancing from Kubernetes Pod/Node labels or annotations.

Modifications:

- Add `distinct_endpoint` to `ServiceEndpointWatcher`; when true, endpoints that share the same host:port are collapsed into a single LbEndpoint.
- Add `metadata_mapping` (repeated `MetadataMapping`) to `ServiceEndpointWatcher`. Each rule copies a Pod/Node label or annotation into `LbEndpoint.metadata`, selecting an exact `source_key` or a `source_key_prefix` (original keys kept), under a configurable `metadata_namespace` (default `envoy.lb`) and `metadata_key`.
- Add `KubernetesEndpointConverter` centralizing endpoint-to-LbEndpoint conversion (dedup + metadata) via Armeria `KubernetesResourceAccess`.
- Route both build sites (background fetching service and preview) through the converter, removing duplicated conversion code.
- Validate metadata mappings on create/update, rejecting malformed rules with INVALID_ARGUMENT.
- Add tests for exact/prefix metadata copy, custom namespace, annotations, endpoint dedup, and validation errors.

Result:

Users can deduplicate Kubernetes endpoints and carry Pod/Node labels and annotations as Envoy endpoint metadata by configuring the watcher. Both fields are optional; existing configurations are unaffected.