### PR TITLE
Add a Repository Status page and surface read-only status across the web UI

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/ProjectDto.java
+++ b/common/src/main/java/com/linecorp/centraldogma/internal/api/v1/ProjectDto.java
@@ -34,6 +34,7 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.ProjectRole;
+import com.linecorp.centraldogma.common.ReplicationStatus;
 
 @JsonInclude(Include.NON_NULL)
 public class ProjectDto {
@@ -52,6 +53,9 @@ public class ProjectDto {
     @Nullable
     private String createdAt;
 
+    @Nullable
+    private ReplicationStatus status;
+
     public ProjectDto(String name) {
         this.name = requireNonNull(name, "name");
     }
@@ -62,20 +66,24 @@ public class ProjectDto {
                       @JsonProperty("creator") @Nullable Author creator,
                       @JsonProperty("url") @Nullable String url,
                       @JsonProperty("userRole") @Nullable ProjectRole userRole,
-                      @JsonProperty("createdAt") @Nullable String createdAt) {
+                      @JsonProperty("createdAt") @Nullable String createdAt,
+                      @JsonProperty("status") @Nullable ReplicationStatus status) {
         this.name = requireNonNull(name, "name");
         this.creator = creator;
         this.url = url;
         this.userRole = userRole;
         this.createdAt = createdAt;
+        this.status = status;
     }
 
-    public ProjectDto(String name, Author creator, ProjectRole userRole, long creationTimeMillis) {
+    public ProjectDto(String name, Author creator, ProjectRole userRole, long creationTimeMillis,
+                      ReplicationStatus status) {
         this.name = requireNonNull(name, "name");
         this.creator = requireNonNull(creator, "creator");
         createdAt = ISO_INSTANT.format(Instant.ofEpochMilli(creationTimeMillis));
         url = PROJECTS_PREFIX + '/' + name;
         this.userRole = requireNonNull(userRole, "userRole");
+        this.status = requireNonNull(status, "status");
     }
 
     @JsonProperty("name")
@@ -105,6 +113,12 @@ public class ProjectDto {
     @JsonProperty("createdAt")
     public String createdAt() {
         return createdAt;
+    }
+
+    @Nullable
+    @JsonProperty("status")
+    public ReplicationStatus status() {
+        return status;
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -1021,7 +1021,7 @@ public class CentralDogma implements AutoCloseable {
         final ContextPathServicesBuilder apiV1ServiceBuilder = sb.contextPath(API_V1_PATH_PREFIX);
         apiV1ServiceBuilder
                 .annotatedService(new ServerStatusService(executor, statusManager, repoStatusManager))
-                .annotatedService(new ProjectServiceV1(projectApiManager, executor))
+                .annotatedService(new ProjectServiceV1(projectApiManager, executor, repoStatusManager))
                 .annotatedService(new RepositoryServiceV1(executor, mds, encryptionStorageManager,
                                                           repoStatusManager))
                 .annotatedService(new CredentialServiceV1(projectApiManager, executor))

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -623,7 +623,7 @@ public class CentralDogma implements AutoCloseable {
         }
 
         statusManager = new ServerStatusManager(cfg.dataDir());
-        repoStatusManager = new RepoStatusManager(statusManager, pm);
+        repoStatusManager = new RepoStatusManager(statusManager, pm, meterRegistry);
         logger.info("Startup mode: {}", statusManager.serverStatus());
         final CommandExecutor executor;
         final ReplicationMethod replicationMethod = cfg.replicationConfig().method();
@@ -1020,7 +1020,7 @@ public class CentralDogma implements AutoCloseable {
         assert statusManager != null && repoStatusManager != null;
         final ContextPathServicesBuilder apiV1ServiceBuilder = sb.contextPath(API_V1_PATH_PREFIX);
         apiV1ServiceBuilder
-                .annotatedService(new ServerStatusService(executor, statusManager))
+                .annotatedService(new ServerStatusService(executor, statusManager, repoStatusManager))
                 .annotatedService(new ProjectServiceV1(projectApiManager, executor))
                 .annotatedService(new RepositoryServiceV1(executor, mds, encryptionStorageManager,
                                                           repoStatusManager))

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -650,6 +650,11 @@ public class CentralDogma implements AutoCloseable {
 
         final ServerStatus initialServerStatus = statusManager.serverStatus();
         executor.setWritable(initialServerStatus.writable());
+        if (executor instanceof ZooKeeperCommandExecutor) {
+            // setWritable() on the outer executor does not reach the inner delegate, so a restarted
+            // read-only replica would leave the delegate writable. Keep them in sync.
+            ((ZooKeeperCommandExecutor) executor).unwrap().setWritable(initialServerStatus.writable());
+        }
         if (!initialServerStatus.replicating()) {
             projectInitializer.initializeInReadOnlyMode();
             repoStatusManager.initialize();

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/AbstractCommandExecutor.java
@@ -134,10 +134,11 @@ public abstract class AbstractCommandExecutor implements CommandExecutor {
         if (!isStarted()) {
             throw new ReadOnlyException("running in read-only mode. command: " + command);
         }
-        if (!writable && !(command instanceof SystemAdministrativeCommand)) {
+        if (!writable && !ctx.isReplay() && !(command instanceof SystemAdministrativeCommand)) {
             // Reject all commands except for AdministrativeCommand when the replica is in read-only mode.
             // AdministrativeCommand is allowed because it is used to change the read-only mode or migrate
             // metadata under maintenance mode.
+            // A replayed command is exempted; rejecting it would drop the log entry and diverge this replica.
             throw new ReadOnlyException("running in read-only mode. command: " + command);
         }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/command/ExecutionContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/command/ExecutionContext.java
@@ -33,6 +33,8 @@ public interface ExecutionContext {
 
     /**
      * Returns {@code true} if the command is being executed as part of a replay.
+     * A replayed command bypasses the read-only checks so that a read-only replica keeps applying
+     * the replication log.
      */
     boolean isReplay();
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/DtoConverter.java
@@ -45,9 +45,10 @@ import com.linecorp.centraldogma.server.storage.repository.Repository;
  */
 final class DtoConverter {
 
-    public static ProjectDto newProjectDto(Project project, ProjectRole userRole) {
+    public static ProjectDto newProjectDto(Project project, ProjectRole userRole, ReplicationStatus status) {
         requireNonNull(project, "project");
-        return new ProjectDto(project.name(), project.author(), userRole, project.creationTimeMillis());
+        return new ProjectDto(project.name(), project.author(), userRole, project.creationTimeMillis(),
+                              status);
     }
 
     public static RepositoryDto newRepositoryDto(Repository repository, ReplicationStatus status) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1.java
@@ -45,12 +45,14 @@ import com.linecorp.armeria.server.annotation.ResponseConverter;
 import com.linecorp.armeria.server.annotation.StatusCode;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.ProjectRole;
+import com.linecorp.centraldogma.common.ReplicationStatus;
 import com.linecorp.centraldogma.internal.api.v1.CreateProjectRequest;
 import com.linecorp.centraldogma.internal.api.v1.ProjectDto;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresProjectRole;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresSystemAdministrator;
 import com.linecorp.centraldogma.server.internal.api.converter.CreateApiResponseConverter;
+import com.linecorp.centraldogma.server.internal.management.RepoStatusManager;
 import com.linecorp.centraldogma.server.internal.storage.project.ProjectApiManager;
 import com.linecorp.centraldogma.server.metadata.AppIdentityRegistration;
 import com.linecorp.centraldogma.server.metadata.Member;
@@ -67,10 +69,21 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 public class ProjectServiceV1 extends AbstractService {
 
     private final ProjectApiManager projectApiManager;
+    private final RepoStatusManager repoStatusManager;
 
-    public ProjectServiceV1(ProjectApiManager projectApiManager, CommandExecutor executor) {
+    public ProjectServiceV1(ProjectApiManager projectApiManager, CommandExecutor executor,
+                            RepoStatusManager repoStatusManager) {
         super(executor);
         this.projectApiManager = requireNonNull(projectApiManager, "projectApiManager");
+        this.repoStatusManager = requireNonNull(repoStatusManager, "repoStatusManager");
+    }
+
+    /**
+     * Returns the replication status of the project itself, which is stored in the {@code dogma} repository
+     * of the project.
+     */
+    private ReplicationStatus projectStatus(String projectName) {
+        return repoStatusManager.getRepoStatus(projectName, Project.REPO_DOGMA).status();
     }
 
     /**
@@ -92,7 +105,8 @@ public class ProjectServiceV1 extends AbstractService {
 
         return CompletableFuture.supplyAsync(() -> {
             return projectApiManager.listProjects(user).values().stream()
-                                    .map(project -> newProjectDto(project, getUserRole(project, user)))
+                                    .map(project -> newProjectDto(project, getUserRole(project, user),
+                                                                  projectStatus(project.name())))
                                     .collect(toImmutableList());
         }, executor);
     }
@@ -140,7 +154,7 @@ public class ProjectServiceV1 extends AbstractService {
     public CompletableFuture<ProjectDto> createProject(CreateProjectRequest request, Author author, User user) {
         return projectApiManager.createProject(request.name(), author).handle(returnOrThrow(() -> {
             final Project project = projectApiManager.getProject(request.name(), user);
-            return newProjectDto(project, ProjectRole.OWNER);
+            return newProjectDto(project, ProjectRole.OWNER, projectStatus(project.name()));
         }));
     }
 
@@ -196,6 +210,7 @@ public class ProjectServiceV1 extends AbstractService {
         checkUnremoveArgument(node);
         return projectApiManager.unremoveProject(projectName, author)
                                 .handle(returnOrThrow(() -> newProjectDto(
-                                        projectApiManager.getProject(projectName, user), ProjectRole.OWNER)));
+                                        projectApiManager.getProject(projectName, user), ProjectRole.OWNER,
+                                        projectStatus(projectName))));
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/ServerStatusService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/ServerStatusService.java
@@ -16,6 +16,7 @@
 
 package com.linecorp.centraldogma.server.internal.api.sysadmin;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.linecorp.armeria.common.HttpStatus;
@@ -29,6 +30,8 @@ import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.AbstractService;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresSystemAdministrator;
 import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest.Scope;
+import com.linecorp.centraldogma.server.internal.management.RepoStatusManager;
+import com.linecorp.centraldogma.server.internal.management.RepositoryState;
 import com.linecorp.centraldogma.server.internal.management.ServerStatusManager;
 import com.linecorp.centraldogma.server.internal.replication.ZooKeeperCommandExecutor;
 import com.linecorp.centraldogma.server.management.ServerStatus;
@@ -38,10 +41,13 @@ import com.linecorp.centraldogma.server.management.ServerStatus;
 public final class ServerStatusService extends AbstractService {
 
     private final ServerStatusManager serverStatusManager;
+    private final RepoStatusManager repoStatusManager;
 
-    public ServerStatusService(CommandExecutor executor, ServerStatusManager serverStatusManager) {
+    public ServerStatusService(CommandExecutor executor, ServerStatusManager serverStatusManager,
+                               RepoStatusManager repoStatusManager) {
         super(executor);
         this.serverStatusManager = serverStatusManager;
+        this.repoStatusManager = repoStatusManager;
     }
 
     /**
@@ -52,6 +58,17 @@ public final class ServerStatusService extends AbstractService {
     @Get("/status")
     public ServerStatus status() {
         return ServerStatus.of(executor().isWritable(), executor().isStarted());
+    }
+
+    /**
+     * GET /status/repos/read-only
+     *
+     * <p>Returns the projects and repositories that are currently read-only. A project-scoped entry uses
+     * {@code dogma} as its repository name.
+     */
+    @Get("/status/repos/read-only")
+    public List<RepositoryState> readOnlyRepositories() {
+        return repoStatusManager.readOnlyStatuses();
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
@@ -224,14 +224,9 @@ public final class RepoStatusManager {
                 statusMap.values().stream()
                          .<MultiGauge.Row<?>>map(state -> MultiGauge.Row.of(
                                  Tags.of("project", state.projectName(),
-                                         "repo", state.repoName(),
-                                         "scope", scopeOf(state)),
+                                         "repo", state.repoName()),
                                  1))
                          .collect(toImmutableList()),
                 true);
-    }
-
-    private static String scopeOf(RepositoryState state) {
-        return state.repoName().equals(Project.REPO_DOGMA) ? "project" : "repository";
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
@@ -225,10 +225,13 @@ public final class RepoStatusManager {
                          .<MultiGauge.Row<?>>map(state -> MultiGauge.Row.of(
                                  Tags.of("project", state.projectName(),
                                          "repo", state.repoName(),
-                                         "scope", state.repoName().equals(Project.REPO_DOGMA)
-                                                  ? "project" : "repository"),
+                                         "scope", scopeOf(state)),
                                  1))
                          .collect(toImmutableList()),
                 true);
+    }
+
+    private static String scopeOf(RepositoryState state) {
+        return state.repoName().equals(Project.REPO_DOGMA) ? "project" : "repository";
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManager.java
@@ -16,7 +16,10 @@
 
 package com.linecorp.centraldogma.server.internal.management;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.common.collect.ImmutableList;
 
 import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.centraldogma.common.Author;
@@ -43,6 +47,11 @@ import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.Repository;
 import com.linecorp.centraldogma.server.storage.repository.RepositoryListener;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
 
 /**
  * Manages the replication status of repositories and projects. The replication status is stored in a special
@@ -65,11 +74,17 @@ public final class RepoStatusManager {
     @Nullable
     private final StandaloneCrudOperation<RepositoryState> crudRepository;
     private final ServerStatusManager statusManager;
+    private final MultiGauge readOnlyScopeGauge;
 
-    public RepoStatusManager(ServerStatusManager statusManager, ProjectManager pm) {
+    public RepoStatusManager(ServerStatusManager statusManager, ProjectManager pm,
+                             MeterRegistry meterRegistry) {
         this.pm = pm;
         this.statusManager = statusManager;
         crudRepository = new StandaloneCrudOperation<>(RepositoryState.class, pm);
+
+        // read-only scope metrics
+        Gauge.builder("repository.read.only.count", statusMap, Map::size).register(meterRegistry);
+        readOnlyScopeGauge = MultiGauge.builder("repository.read.only").register(meterRegistry);
     }
 
     public void initialize() {
@@ -92,6 +107,7 @@ public final class RepoStatusManager {
                     statusMap.put(getKey(repoState.projectName(), repoState.repoName()), repoState);
                 }
             }
+            updateReadOnlyScopeMetrics();
         }));
     }
 
@@ -131,6 +147,15 @@ public final class RepoStatusManager {
             return repoStatus;
         }
         return new RepositoryState(projectName, repoName, ReplicationStatus.WRITABLE, null);
+    }
+
+    /**
+     * Returns the {@link RepositoryState}s of all projects and repositories that are currently not
+     * {@link ReplicationStatus#WRITABLE}. A project-scoped read-only entry uses {@link Project#REPO_DOGMA}
+     * as its repository name.
+     */
+    public List<RepositoryState> readOnlyStatuses() {
+        return ImmutableList.copyOf(statusMap.values());
     }
 
     @Nullable
@@ -192,5 +217,18 @@ public final class RepoStatusManager {
         final String targetPath = PATH_PREFIX + projectName + '/';
         return new CrudContext(InternalProjectInitializer.INTERNAL_PROJECT_DOGMA,
                                Project.REPO_DOGMA, targetPath);
+    }
+
+    private void updateReadOnlyScopeMetrics() {
+        readOnlyScopeGauge.register(
+                statusMap.values().stream()
+                         .<MultiGauge.Row<?>>map(state -> MultiGauge.Row.of(
+                                 Tags.of("project", state.projectName(),
+                                         "repo", state.repoName(),
+                                         "scope", state.repoName().equals(Project.REPO_DOGMA)
+                                                  ? "project" : "repository"),
+                                 1))
+                         .collect(toImmutableList()),
+                true);
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepositoryState.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/management/RepositoryState.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -39,6 +40,8 @@ public final class RepositoryState {
     private final String projectName;
     private final String repoName;
     private final ReplicationStatus status;
+    // Serialize as an ISO-8601 string to match the rest of the API (e.g. RepositoryDto.createdAt).
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
     @Nullable
     private final Instant updatedAt;
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/management/ServerStatus.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/management/ServerStatus.java
@@ -19,12 +19,24 @@ package com.linecorp.centraldogma.server.management;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * The status of the server.
+ * The status of the server, expressed as a combination of the {@code writable} and {@code replicating}
+ * properties.
  */
 public enum ServerStatus {
 
+    /**
+     * The server rejects writes and stops replaying the replication log. The replica no longer follows the
+     * cluster, so it must be re-synced manually before it can safely rejoin.
+     */
     READ_ONLY(false, false),
+    /**
+     * The server rejects client writes but keeps replaying the replication log, so the replica stays in
+     * sync with the cluster while serving reads.
+     */
     REPLICATION_ONLY(false, true),
+    /**
+     * The server accepts writes and replays the replication log. This is the normal operating status.
+     */
     WRITABLE(true, true);
 
     private final boolean writable;

--- a/server/src/test/java/com/linecorp/centraldogma/server/ReplicationOnlyRestartTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/ReplicationOnlyRestartTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
+import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest;
+import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest.Scope;
+import com.linecorp.centraldogma.server.internal.replication.ZooKeeperCommandExecutor;
+import com.linecorp.centraldogma.server.management.ServerStatus;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
+
+class ReplicationOnlyRestartTest {
+
+    @RegisterExtension
+    final CentralDogmaReplicationExtension cluster = new CentralDogmaReplicationExtension(3) {
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    @Test
+    void restartInReplicationOnlyKeepsDelegateReadOnly() throws Exception {
+        final BlockingWebClient client = cluster.servers().get(0).blockingHttpClient();
+        final ResponseEntity<ServerStatus> response =
+                client.prepare()
+                      .put("/api/v1/status")
+                      .contentJson(new UpdateServerStatusRequest(ServerStatus.REPLICATION_ONLY, Scope.ALL))
+                      .asJson(ServerStatus.class)
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+
+        // Wait until every replica has applied (and therefore persisted) REPLICATION_ONLY, so the restart
+        // below reliably reads it back from server-status.properties on all replicas.
+        await().untilAsserted(() -> {
+            for (CentralDogmaRuleDelegate server : cluster.servers()) {
+                assertThat(getServerStatus(server.blockingHttpClient()))
+                        .isEqualTo(ServerStatus.REPLICATION_ONLY);
+            }
+        });
+
+        cluster.stop();
+        cluster.start();
+
+        // The persisted REPLICATION_ONLY must reach the inner delegate at startup, not only the outer
+        // ZooKeeperCommandExecutor; otherwise the delegate would come back writable.
+        for (CentralDogmaRuleDelegate server : cluster.servers()) {
+            final CommandExecutor executor = requireNonNull(server.dogma().executor());
+            assertThat(executor).isInstanceOf(ZooKeeperCommandExecutor.class);
+            assertThat(executor.isWritable()).isFalse();
+            final CommandExecutor delegate = ((ZooKeeperCommandExecutor) executor).unwrap();
+            assertThat(delegate.isWritable()).isFalse();
+        }
+    }
+
+    private static ServerStatus getServerStatus(BlockingWebClient client) {
+        return client.prepare()
+                     .get("/api/v1/status")
+                     .asJson(ServerStatus.class)
+                     .execute()
+                     .content();
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/command/StandaloneCommandExecutorTest.java
@@ -37,6 +37,7 @@ import com.linecorp.centraldogma.common.EntryType;
 import com.linecorp.centraldogma.common.Markup;
 import com.linecorp.centraldogma.common.ReadOnlyException;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.server.internal.command.DefaultExecutionContext;
 import com.linecorp.centraldogma.server.management.ServerStatus;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
@@ -132,6 +133,29 @@ class StandaloneCommandExecutorTest {
                                                       .contentAsJson();
         assertThat(json.get("a").asText()).isEqualTo("b");
         executor.execute(Command.updateServerStatus(ServerStatus.WRITABLE)).join();
+        assertThat(executor.isWritable()).isTrue();
+    }
+
+    @Test
+    void shouldApplyReplayedCommandWithReadOnly() {
+        final StandaloneCommandExecutor executor = (StandaloneCommandExecutor) extension.executor();
+        executor.execute(Command.updateServerStatus(ServerStatus.REPLICATION_ONLY)).join();
+        assertThat(executor.isWritable()).isFalse();
+
+        try {
+            final Change<JsonNode> change = Change.ofJsonUpsert("/replayed.json", "{\"a\": \"b\"}");
+            final Command<Revision> push = Command.push(
+                    Author.SYSTEM, TEST_PRJ, TEST_REPO, Revision.HEAD, "", "", Markup.PLAINTEXT, change);
+            // A client push is rejected while the executor is not writable.
+            assertThatThrownBy(() -> executor.execute(push))
+                    .isInstanceOf(ReadOnlyException.class)
+                    .hasMessageContaining("running in read-only mode.");
+            // The same push must still be applied when replayed from the replication log.
+            final Revision revision = executor.execute(new DefaultExecutionContext(true), push).join();
+            assertThat(revision).isEqualTo(new Revision(2));
+        } finally {
+            executor.execute(Command.updateServerStatus(ServerStatus.WRITABLE)).join();
+        }
         assertThat(executor.isWritable()).isTrue();
     }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1ListProjectTest.java
@@ -128,6 +128,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"OWNER\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/hyangtack\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -138,6 +139,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "        \"userRole\":\"OWNER\"," +
+                "        \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/minwoox\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -148,6 +150,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"OWNER\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/trustin\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -158,6 +161,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"GUEST\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/jrhee17\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }" +
@@ -179,6 +183,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"system@localhost.localdomain\"" +
                 "        }," +
                 "        \"userRole\":\"OWNER\"," +
+                "        \"status\":\"WRITABLE\"," +
                 "        \"url\": \"/api/v1/projects/@foo\"," +
                 "        \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -189,6 +194,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"system@localhost.localdomain\"" +
                 "        }," +
                 "        \"userRole\":\"OWNER\"," +
+                "        \"status\":\"WRITABLE\"," +
                 "        \"url\": \"/api/v1/projects/dogma\"," +
                 "        \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -199,6 +205,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"OWNER\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/hyangtack\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -209,6 +216,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "        \"userRole\":\"OWNER\"," +
+                "        \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/minwoox\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -219,6 +227,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"OWNER\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/trustin\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }," +
@@ -229,6 +238,7 @@ class ProjectServiceV1ListProjectTest {
                 "           \"email\": \"" + TestAuthMessageUtil.USERNAME + "@localhost.localdomain\"" +
                 "       }," +
                 "       \"userRole\":\"OWNER\"," +
+                "       \"status\":\"WRITABLE\"," +
                 "       \"url\": \"/api/v1/projects/jrhee17\"," +
                 "       \"createdAt\": \"${json-unit.ignore}\"" +
                 "   }" +

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ProjectServiceV1Test.java
@@ -236,6 +236,7 @@ class ProjectServiceV1Test {
                 "       \"email\": \"" + TestAuthMessageUtil.USERNAME2 + "@localhost.localdomain\"" +
                 "   }," +
                 "   \"userRole\":\"OWNER\"," +
+                "   \"status\":\"WRITABLE\"," +
                 "   \"url\": \"/api/v1/projects/bar\"," +
                 "   \"createdAt\": \"${json-unit.ignore}\"" +
                 '}';

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ServerStatusServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/ServerStatusServiceTest.java
@@ -20,6 +20,7 @@ import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,6 +33,7 @@ import com.linecorp.armeria.client.logging.LoggingClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.centraldogma.common.ReplicationStatus;
 import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest;
 import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest.Scope;
 import com.linecorp.centraldogma.server.management.ServerStatus;
@@ -60,6 +62,37 @@ class ServerStatusServiceTest {
         final AggregatedHttpResponse res = client.get(API_V1_PATH_PREFIX + "status").aggregate().join();
         assertThat(res.status()).isEqualTo(HttpStatus.OK);
         assertThat(res.contentUtf8()).isEqualTo("\"WRITABLE\"");
+    }
+
+    @Test
+    void readOnlyRepositories() {
+        final BlockingWebClient client = dogma.httpClient().blocking();
+
+        // No read-only repository initially (an empty result is returned as 204 No Content).
+        assertThat(client.get(API_V1_PATH_PREFIX + "status/repos/read-only").status())
+                .isEqualTo(HttpStatus.NO_CONTENT);
+
+        // Set a repository read-only.
+        dogma.client().createProject("foo").join();
+        dogma.client().createRepository("foo", "bar").join();
+        final AggregatedHttpResponse updateRes =
+                client.prepare()
+                      .put(API_V1_PATH_PREFIX + "projects/foo/repos/bar/status")
+                      .contentJson(new UpdateRepositoryStatusRequest(ReplicationStatus.READ_ONLY))
+                      .execute();
+        assertThat(updateRes.status()).isEqualTo(HttpStatus.OK);
+
+        // The read-only repository should be listed.
+        await().untilAsserted(() -> {
+            final AggregatedHttpResponse res = client.get(API_V1_PATH_PREFIX + "status/repos/read-only");
+            assertThat(res.status()).isEqualTo(HttpStatus.OK);
+            assertThatJson(res.contentUtf8()).isArray().ofLength(1);
+            assertThatJson(res.contentUtf8()).node("[0].projectName").isEqualTo("foo");
+            assertThatJson(res.contentUtf8()).node("[0].repoName").isEqualTo("bar");
+            assertThatJson(res.contentUtf8()).node("[0].status").isEqualTo("READ_ONLY");
+            // updatedAt must serialize as an ISO-8601 string, not an epoch number (regression guard).
+            assertThatJson(res.contentUtf8()).node("[0].updatedAt").isString();
+        });
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresRoleTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/auth/RequiresRoleTest.java
@@ -92,7 +92,8 @@ class RequiresRoleTest {
                     NoopEncryptionStorageManager.INSTANCE,
                     com.google.common.collect.ImmutableMap.of());
             final ServerStatusManager statusManager = new ServerStatusManager(dataDir);
-            final RepoStatusManager repoStatusManager = new RepoStatusManager(statusManager, pm);
+            final RepoStatusManager repoStatusManager =
+                    new RepoStatusManager(statusManager, pm, NoopMeterRegistry.get());
             final CommandExecutor executor = new StandaloneCommandExecutor(
                     pm, ForkJoinPool.commonPool(), statusManager, repoStatusManager, null,
                     NoopEncryptionStorageManager.INSTANCE,

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
@@ -28,7 +28,9 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.ReplicationStatus;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 class RepoStatusManagerTest {
@@ -98,10 +100,11 @@ class RepoStatusManagerTest {
                         tuple("test_prj2", "dogma", ReplicationStatus.READ_ONLY)));
 
         assertThat(readOnlyCount()).isEqualTo(2);
-        assertThat(scopeGauge("test_prj", "test_repo", "repository")).isOne();
-        assertThat(scopeGauge("test_prj2", "dogma", "project")).isOne();
+        // A project-scoped entry is the one whose repository is "dogma".
+        assertThat(readOnlyGauge("test_prj", "test_repo")).isOne();
+        assertThat(readOnlyGauge("test_prj2", "dogma")).isOne();
 
-        // Reverting to WRITABLE removes the scope from the list and the metrics.
+        // Reverting to WRITABLE removes the entry from the list and the metrics.
         statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.WRITABLE)
                      .join();
         statusManager.updateProjectStatus("test_prj2", Author.DEFAULT, ReplicationStatus.WRITABLE).join();
@@ -123,9 +126,15 @@ class RepoStatusManagerTest {
         return meterRegistry.get("repository.read.only.count").gauge().value();
     }
 
-    private double scopeGauge(String projectName, String repoName, String scope) {
-        return meterRegistry.get("repository.read.only")
-                            .tags("project", projectName, "repo", repoName, "scope", scope)
-                            .gauge().value();
+    /**
+     * The repository name tells the scope apart, so the gauge carries no other tag.
+     */
+    private double readOnlyGauge(String projectName, String repoName) {
+        final Gauge gauge = meterRegistry.get("repository.read.only")
+                                         .tags("project", projectName, "repo", repoName)
+                                         .gauge();
+        assertThat(gauge.getId().getTags())
+                .containsExactlyInAnyOrder(Tag.of("project", projectName), Tag.of("repo", repoName));
+        return gauge.value();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
@@ -17,6 +17,7 @@
 package com.linecorp.centraldogma.server.internal.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,16 +27,22 @@ import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.ReplicationStatus;
 import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+
 class RepoStatusManagerTest {
 
     @RegisterExtension
     static ProjectManagerExtension pmExtension = new ProjectManagerExtension();
 
     private RepoStatusManager statusManager;
+    private MeterRegistry meterRegistry;
 
     @BeforeEach
     void setUp() {
-        statusManager = new RepoStatusManager(pmExtension.serverStatusManager(), pmExtension.projectManager());
+        meterRegistry = new SimpleMeterRegistry();
+        statusManager = new RepoStatusManager(pmExtension.serverStatusManager(), pmExtension.projectManager(),
+                                              meterRegistry);
         statusManager.initialize();
     }
 
@@ -74,5 +81,42 @@ class RepoStatusManagerTest {
         entity = statusManager.getRepoStatus("test_prj", "dogma");
         assertThat(entity).isEqualTo(
                 new RepositoryState("test_prj", "dogma", ReplicationStatus.WRITABLE, null));
+    }
+
+    @Test
+    void readOnlyStatuses_and_metrics() {
+        assertThat(statusManager.readOnlyStatuses()).isEmpty();
+        assertThat(readOnlyCount()).isZero();
+
+        statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.READ_ONLY)
+                     .join();
+        statusManager.updateProjectStatus("test_prj2", Author.DEFAULT, ReplicationStatus.READ_ONLY).join();
+
+        assertThat(statusManager.readOnlyStatuses())
+                .extracting(RepositoryState::projectName, RepositoryState::repoName, RepositoryState::status)
+                .containsExactlyInAnyOrder(
+                        tuple("test_prj", "test_repo", ReplicationStatus.READ_ONLY),
+                        tuple("test_prj2", "dogma", ReplicationStatus.READ_ONLY));
+
+        assertThat(readOnlyCount()).isEqualTo(2);
+        assertThat(scopeGauge("test_prj", "test_repo", "repository")).isOne();
+        assertThat(scopeGauge("test_prj2", "dogma", "project")).isOne();
+
+        // Reverting to WRITABLE removes the scope from the list and the metrics.
+        statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.WRITABLE)
+                     .join();
+        statusManager.updateProjectStatus("test_prj2", Author.DEFAULT, ReplicationStatus.WRITABLE).join();
+        assertThat(statusManager.readOnlyStatuses()).isEmpty();
+        assertThat(readOnlyCount()).isZero();
+    }
+
+    private double readOnlyCount() {
+        return meterRegistry.get("repository.read.only.count").gauge().value();
+    }
+
+    private double scopeGauge(String projectName, String repoName, String scope) {
+        return meterRegistry.get("repository.read.only")
+                            .tags("project", projectName, "repo", repoName, "scope", scope)
+                            .gauge().value();
     }
 }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/management/RepoStatusManagerTest.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.management;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.awaitility.Awaitility.await;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,36 +51,34 @@ class RepoStatusManagerTest {
     void repoStatus_cruTest() {
         statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.READ_ONLY)
                      .join();
-        RepositoryState entity = statusManager.getRepoStatus("test_prj", "test_repo");
-        assertThat(entity.status()).isEqualTo(ReplicationStatus.READ_ONLY);
+        awaitStatus("test_prj", "test_repo", ReplicationStatus.READ_ONLY);
 
         // Silently ignore the update if the status is the same as the current one.
         statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.READ_ONLY)
                      .join();
-        entity = statusManager.getRepoStatus("test_prj", "test_repo");
-        assertThat(entity.status()).isEqualTo(ReplicationStatus.READ_ONLY);
+        assertThat(statusManager.getRepoStatus("test_prj", "test_repo").status())
+                .isEqualTo(ReplicationStatus.READ_ONLY);
 
         statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.WRITABLE)
                      .join();
-        entity = statusManager.getRepoStatus("test_prj", "test_repo");
-        assertThat(entity).isEqualTo(
+        awaitStatus("test_prj", "test_repo", ReplicationStatus.WRITABLE);
+        assertThat(statusManager.getRepoStatus("test_prj", "test_repo")).isEqualTo(
                 new RepositoryState("test_prj", "test_repo", ReplicationStatus.WRITABLE, null));
     }
 
     @Test
     void projectStatus_cruTest() {
         statusManager.updateProjectStatus("test_prj", Author.DEFAULT, ReplicationStatus.READ_ONLY).join();
-        RepositoryState entity = statusManager.getRepoStatus("test_prj", "dogma");
-        assertThat(entity.status()).isEqualTo(ReplicationStatus.READ_ONLY);
+        awaitStatus("test_prj", "dogma", ReplicationStatus.READ_ONLY);
 
         // Silently ignore the update if the status is the same as the current one.
         statusManager.updateProjectStatus("test_prj", Author.DEFAULT, ReplicationStatus.READ_ONLY).join();
-        entity = statusManager.getRepoStatus("test_prj", "dogma");
-        assertThat(entity.status()).isEqualTo(ReplicationStatus.READ_ONLY);
+        assertThat(statusManager.getRepoStatus("test_prj", "dogma").status())
+                .isEqualTo(ReplicationStatus.READ_ONLY);
 
         statusManager.updateProjectStatus("test_prj", Author.DEFAULT, ReplicationStatus.WRITABLE).join();
-        entity = statusManager.getRepoStatus("test_prj", "dogma");
-        assertThat(entity).isEqualTo(
+        awaitStatus("test_prj", "dogma", ReplicationStatus.WRITABLE);
+        assertThat(statusManager.getRepoStatus("test_prj", "dogma")).isEqualTo(
                 new RepositoryState("test_prj", "dogma", ReplicationStatus.WRITABLE, null));
     }
 
@@ -92,11 +91,11 @@ class RepoStatusManagerTest {
                      .join();
         statusManager.updateProjectStatus("test_prj2", Author.DEFAULT, ReplicationStatus.READ_ONLY).join();
 
-        assertThat(statusManager.readOnlyStatuses())
+        await().untilAsserted(() -> assertThat(statusManager.readOnlyStatuses())
                 .extracting(RepositoryState::projectName, RepositoryState::repoName, RepositoryState::status)
                 .containsExactlyInAnyOrder(
                         tuple("test_prj", "test_repo", ReplicationStatus.READ_ONLY),
-                        tuple("test_prj2", "dogma", ReplicationStatus.READ_ONLY));
+                        tuple("test_prj2", "dogma", ReplicationStatus.READ_ONLY)));
 
         assertThat(readOnlyCount()).isEqualTo(2);
         assertThat(scopeGauge("test_prj", "test_repo", "repository")).isOne();
@@ -106,8 +105,18 @@ class RepoStatusManagerTest {
         statusManager.updateRepoStatus("test_prj", "test_repo", Author.DEFAULT, ReplicationStatus.WRITABLE)
                      .join();
         statusManager.updateProjectStatus("test_prj2", Author.DEFAULT, ReplicationStatus.WRITABLE).join();
-        assertThat(statusManager.readOnlyStatuses()).isEmpty();
+        await().untilAsserted(() -> assertThat(statusManager.readOnlyStatuses()).isEmpty());
         assertThat(readOnlyCount()).isZero();
+    }
+
+    /**
+     * A commit notifies the status listener inline, but {@link RepoStatusManager#initialize()} registers that
+     * listener asynchronously on the repository worker. An update committed before the registration lands is
+     * only picked up by the listener's initial snapshot, so wait for the cache to catch up.
+     */
+    private void awaitStatus(String projectName, String repoName, ReplicationStatus expected) {
+        await().untilAsserted(() -> assertThat(statusManager.getRepoStatus(projectName, repoName).status())
+                .isEqualTo(expected));
     }
 
     private double readOnlyCount() {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
@@ -66,6 +66,7 @@ import com.linecorp.centraldogma.server.plugin.PluginTarget;
 import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
+import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
 
 class ZooKeeperScopedReadonlyIntegrationTest {
 
@@ -413,6 +414,44 @@ class ZooKeeperScopedReadonlyIntegrationTest {
     }
 
     @Test
+    void replicationOnlyReplicaReplaysWhileSiblingRepoReadonly() {
+        // serverId == 2 in configureEach() is the fault-injected replica.
+        final CentralDogmaRuleDelegate faultReplica = replica.serverById(2);
+        final BlockingWebClient faultReplicaAdmin = faultReplica.blockingHttpClient();
+
+        // Drive TEST_REPO1 into cluster-wide repo-scope READ_ONLY, then also put the fault-injected replica
+        // into LOCAL REPLICATION_ONLY, so both read-only gates are active on it at once.
+        driveRepoIntoReadOnly(testProject1, TEST_REPO1);
+        enterReplicationOnly(faultReplicaAdmin);
+
+        // The origin pushes to the still-writable sibling repo.
+        final PushResult pushed = client0.forRepo(testProject1, TEST_REPO2)
+                                         .commit("push-to-writable-sibling",
+                                                 Change.ofJsonUpsert("/sibling.json", "{ \"b\": 1 }"))
+                                         .push()
+                                         .join();
+
+        // The replica must replay it despite the server-level REPLICATION_ONLY gate and the sibling
+        // READ_ONLY repo — neither exemption may drop the log entry.
+        final CentralDogmaRepository repo2OnReplica = faultReplica.client().forRepo(testProject1, TEST_REPO2);
+        await().ignoreExceptions().untilAsserted(() -> {
+            final Revision localHead = repo2OnReplica.normalize(Revision.HEAD).join();
+            assertThat(localHead.major()).isGreaterThanOrEqualTo(pushed.revision().major());
+        });
+        final Entry<JsonNode> entry = repo2OnReplica.file(Query.ofJson("/sibling.json")).get().join();
+        assertThat(entry.content().get("b").asInt()).isEqualTo(1);
+
+        // Neither gate flipped. Repo scopes are asserted on a writable replica, because a locally
+        // read-only replica composes its server status into every per-repo status.
+        final BlockingWebClient webClient0 = replica.servers().get(0).blockingHttpClient();
+        assertThat(getRepoStatus(webClient0, testProject1, TEST_REPO1).status())
+                .isEqualTo(ReplicationStatus.READ_ONLY);
+        assertThat(getRepoStatus(webClient0, testProject1, TEST_REPO2).status())
+                .isEqualTo(ReplicationStatus.WRITABLE);
+        assertThat(getServerStatus(faultReplicaAdmin)).isEqualTo(ServerStatus.REPLICATION_ONLY);
+    }
+
+    @Test
     void serverReadonlySupersedesRepositoryReadonly() {
         final CentralDogmaRepository victimRepo = client0.forRepo(testProject1, TEST_REPO1);
         victimRepo.commit("seed-victim", Change.ofJsonUpsert("/v.json", "{ \"v\": 1 }"))
@@ -679,6 +718,38 @@ class ZooKeeperScopedReadonlyIntegrationTest {
         // Server status is unchanged — force-push didn't undo the REPLICATION_ONLY.
         final BlockingWebClient client1 = replica.servers().get(1).blockingHttpClient();
         assertThat(getServerStatus(client1)).isEqualTo(ServerStatus.REPLICATION_ONLY);
+    }
+
+    private static void enterReplicationOnly(BlockingWebClient admin) {
+        final ResponseEntity<ServerStatus> statusResponse =
+                admin.prepare()
+                     .put("/api/v1/status")
+                     .contentJson(new UpdateServerStatusRequest(ServerStatus.REPLICATION_ONLY, Scope.LOCAL))
+                     .asJson(ServerStatus.class)
+                     .execute();
+        assertThat(statusResponse.status()).isEqualTo(HttpStatus.OK);
+        await().untilAsserted(
+                () -> assertThat(getServerStatus(admin)).isEqualTo(ServerStatus.REPLICATION_ONLY));
+    }
+
+    private static void driveRepoIntoReadOnly(String projectName, String repoName) {
+        final CentralDogmaRepository repo = client0.forRepo(projectName, repoName);
+        repo.commit("seed", Change.ofJsonUpsert("/a.json", "{ \"a\": 1 }")).push().join();
+        faultInjector.injectFault(Command.push(
+                Author.DEFAULT, projectName, repoName, Revision.HEAD,
+                "inject fault", "", Markup.PLAINTEXT,
+                ImmutableList.of(Change.ofJsonUpsert("/a.json", "{ \"a\": 3 }"))));
+        repo.commit("divergence",
+                    Change.ofJsonPatch("/a.json",
+                                       JsonPatchOperation.safeReplace("/a", new IntNode(1), new IntNode(2))))
+            .push()
+            .join();
+        // Confirm the repo-scope escalation on a writable replica; a locally read-only replica would
+        // compose its server status into every per-repo status.
+        final BlockingWebClient writableReplica = replica.servers().get(0).blockingHttpClient();
+        await().untilAsserted(() -> assertThat(
+                getRepoStatus(writableReplica, projectName, repoName).status())
+                .isEqualTo(ReplicationStatus.READ_ONLY));
     }
 
     private static RepositoryDto getRepoStatus(BlockingWebClient client, String projectName, String repoName) {

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
@@ -20,10 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
+import java.time.Duration;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -40,7 +42,10 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.Markup;
+import com.linecorp.centraldogma.common.PushResult;
+import com.linecorp.centraldogma.common.Query;
 import com.linecorp.centraldogma.common.ReadOnlyException;
 import com.linecorp.centraldogma.common.ReplicationStatus;
 import com.linecorp.centraldogma.common.Revision;
@@ -50,6 +55,7 @@ import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.command.RepositoryCommand;
 import com.linecorp.centraldogma.server.command.StandaloneCommandExecutor;
 import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest;
 import com.linecorp.centraldogma.server.internal.api.sysadmin.UpdateServerStatusRequest.Scope;
@@ -114,6 +120,26 @@ class ZooKeeperScopedReadonlyIntegrationTest {
         client0.createProject(testProject2).join();
         client0.createRepository(testProject2, TEST_REPO1).join();
         client0.createRepository(testProject2, TEST_REPO2).join();
+    }
+
+    @AfterEach
+    void afterEach() {
+        // All replicas must re-converge on the same dogma/dogma revision after every test.
+        await().atMost(Duration.ofSeconds(30)).ignoreExceptions().untilAsserted(() -> {
+            final long head0 = dogmaRepoHeadRevision(0);
+            final long head1 = dogmaRepoHeadRevision(1);
+            final long head2 = dogmaRepoHeadRevision(2);
+            assertThat(head1).isEqualTo(head0);
+            assertThat(head2).isEqualTo(head0);
+        });
+    }
+
+    private static long dogmaRepoHeadRevision(int serverIndex) {
+        return replica.servers().get(serverIndex).client()
+                      .forRepo(InternalProjectInitializer.INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA)
+                      .normalize(Revision.HEAD)
+                      .join()
+                      .major();
     }
 
     @Test
@@ -320,6 +346,73 @@ class ZooKeeperScopedReadonlyIntegrationTest {
     }
 
     @Test
+    void replicationOnlyReplicaKeepsReplaying() {
+        // Put replica 1 alone into REPLICATION_ONLY; the rest of the cluster stays writable.
+        final BlockingWebClient webClient1 = replica.servers().get(1).blockingHttpClient();
+        final ResponseEntity<ServerStatus> statusResponse =
+                webClient1.prepare()
+                          .put("/api/v1/status")
+                          .contentJson(new UpdateServerStatusRequest(ServerStatus.REPLICATION_ONLY,
+                                                                     Scope.LOCAL))
+                          .asJson(ServerStatus.class)
+                          .execute();
+        assertThat(statusResponse.status()).isEqualTo(HttpStatus.OK);
+        assertThat(getServerStatus(webClient1)).isEqualTo(ServerStatus.REPLICATION_ONLY);
+
+        // The origin still accepts writes while replica 1 is read-only.
+        final PushResult pushed = client0.forRepo(testProject1, TEST_REPO1)
+                                         .commit("push-while-replica-readonly",
+                                                 Change.ofJsonUpsert("/replicated.json", "{ \"a\": 1 }"))
+                                         .push()
+                                         .join();
+
+        // The read-only replica must keep applying replayed commands instead of dropping them.
+        final CentralDogmaRepository repo1OnReplica1 =
+                replica.servers().get(1).client().forRepo(testProject1, TEST_REPO1);
+        // ignoreExceptions: replica 1 may not have replayed the project creation yet.
+        await().ignoreExceptions().untilAsserted(() -> {
+            final Revision localHead = repo1OnReplica1.normalize(Revision.HEAD).join();
+            assertThat(localHead.major()).isGreaterThanOrEqualTo(pushed.revision().major());
+        });
+        final Entry<JsonNode> entry = repo1OnReplica1.file(Query.ofJson("/replicated.json")).get().join();
+        assertThat(entry.content().get("a").asInt()).isEqualTo(1);
+
+        // No read-only escalation was replicated for the repo — the replay succeeded cleanly.
+        final BlockingWebClient webClient0 = replica.servers().get(0).blockingHttpClient();
+        assertThat(getRepoStatus(webClient0, testProject1, TEST_REPO1).status())
+                .isEqualTo(ReplicationStatus.WRITABLE);
+
+        // Replaying must not flip the replica back to writable.
+        assertThat(getServerStatus(webClient1)).isEqualTo(ServerStatus.REPLICATION_ONLY);
+    }
+
+    @Test
+    void replicationOnlyReplicaReplaysProjectCreation() {
+        final BlockingWebClient webClient1 = replica.servers().get(1).blockingHttpClient();
+        final ResponseEntity<ServerStatus> statusResponse =
+                webClient1.prepare()
+                          .put("/api/v1/status")
+                          .contentJson(new UpdateServerStatusRequest(ServerStatus.REPLICATION_ONLY,
+                                                                     Scope.LOCAL))
+                          .asJson(ServerStatus.class)
+                          .execute();
+        assertThat(statusResponse.status()).isEqualTo(HttpStatus.OK);
+
+        // A project creation is not a SystemAdministrativeCommand; it must still replay on the replica.
+        final String lateProject = testProject1 + "-late";
+        client0.createProject(lateProject).join();
+        client0.createRepository(lateProject, TEST_REPO1).join();
+
+        final CentralDogmaRepository lateRepoOnReplica1 =
+                replica.servers().get(1).client().forRepo(lateProject, TEST_REPO1);
+        await().ignoreExceptions().untilAsserted(() -> {
+            final Revision localHead = lateRepoOnReplica1.normalize(Revision.HEAD).join();
+            assertThat(localHead.major()).isGreaterThanOrEqualTo(Revision.INIT.major());
+        });
+        assertThat(getServerStatus(webClient1)).isEqualTo(ServerStatus.REPLICATION_ONLY);
+    }
+
+    @Test
     void serverReadonlySupersedesRepositoryReadonly() {
         final CentralDogmaRepository victimRepo = client0.forRepo(testProject1, TEST_REPO1);
         victimRepo.commit("seed-victim", Change.ofJsonUpsert("/v.json", "{ \"v\": 1 }"))
@@ -339,18 +432,20 @@ class ZooKeeperScopedReadonlyIntegrationTest {
                   .push()
                   .join();
 
-        final BlockingWebClient client1 = replica.servers().get(1).blockingHttpClient();
+        final BlockingWebClient webClient1 = replica.servers().get(1).blockingHttpClient();
         await().untilAsserted(() -> assertThat(
-                getRepoStatus(client1, testProject1, TEST_REPO1).status())
+                getRepoStatus(webClient1, testProject1, TEST_REPO1).status())
                 .isEqualTo(ReplicationStatus.READ_ONLY));
 
         // The server itself and sibling repos are still writable.
-        assertThat(getServerStatus(client1)).isEqualTo(ServerStatus.WRITABLE);
-        assertThat(getRepoStatus(client1, testProject1, TEST_REPO2).status())
+        assertThat(getServerStatus(webClient1)).isEqualTo(ServerStatus.WRITABLE);
+        assertThat(getRepoStatus(webClient1, testProject1, TEST_REPO2).status())
                 .isEqualTo(ReplicationStatus.WRITABLE);
-        assertThat(getRepoStatus(client1, testProject2, TEST_REPO1).status())
+        assertThat(getRepoStatus(webClient1, testProject2, TEST_REPO1).status())
                 .isEqualTo(ReplicationStatus.WRITABLE);
 
+        final BlockingWebClient webClient0 = replica.servers().get(0).blockingHttpClient();
+        assertThat(getServerStatus(webClient0)).isEqualTo(ServerStatus.WRITABLE);
         // Escalate by triggering a server-scope failure on dogma/dogma.
         final String dogmaPath = "/repos/dummy/mirrors/server-readonly-2.json";
         final CentralDogmaRepository internalDogmaRepo =
@@ -383,11 +478,11 @@ class ZooKeeperScopedReadonlyIntegrationTest {
         });
 
         // Server scope wins: previously-writable siblings now report READ_ONLY too.
-        assertThat(getRepoStatus(client1, testProject1, TEST_REPO2).status())
+        assertThat(getRepoStatus(webClient1, testProject1, TEST_REPO2).status())
                 .isEqualTo(ReplicationStatus.READ_ONLY);
-        assertThat(getRepoStatus(client1, testProject2, TEST_REPO1).status())
+        assertThat(getRepoStatus(webClient1, testProject2, TEST_REPO1).status())
                 .isEqualTo(ReplicationStatus.READ_ONLY);
-        assertThat(getRepoStatus(client1, testProject1, TEST_REPO1).status())
+        assertThat(getRepoStatus(webClient1, testProject1, TEST_REPO1).status())
                 .isEqualTo(ReplicationStatus.READ_ONLY);
     }
 
@@ -615,6 +710,18 @@ class ZooKeeperScopedReadonlyIntegrationTest {
         private CommandExecutor zkCommandExecutor;
 
         void injectFault(Command<?> command) {
+            final RepositoryCommand<?> repositoryCommand = (RepositoryCommand<?>) command;
+            final String projectName = repositoryCommand.projectName();
+            final String repoName = repositoryCommand.repositoryName();
+            // Wait for the seed commit to be replayed; otherwise the fault fires one log entry too early.
+            final Revision originHead =
+                    client0.forRepo(projectName, repoName).normalize(Revision.HEAD).join();
+            final CentralDogma injectorClient = replica.servers().get(1).client();
+            await().untilAsserted(() -> {
+                final Revision localHead =
+                        injectorClient.forRepo(projectName, repoName).normalize(Revision.HEAD).join();
+                assertThat(localHead.major()).isGreaterThanOrEqualTo(originHead.major());
+            });
             commandExecutor.execute(command).join();
         }
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/replication/ZooKeeperScopedReadonlyIntegrationTest.java
@@ -88,13 +88,18 @@ class ZooKeeperScopedReadonlyIntegrationTest {
         client0 = replica.servers().get(0).client();
 
         // Restore the server status to WRITABLE so that a previous test that escalated to
-        // REPLICATION_ONLY does not block project/repository creation below.
+        // REPLICATION_ONLY does not block project/repository creation below. The reset is replicated
+        // (Scope.ALL) rather than local, because a replica that has not replayed the previous
+        // REPLICATION_ONLY log entry yet would otherwise apply it after a local reset and turn read-only
+        // in the middle of this test. A replicated reset is appended after that entry, so every replica
+        // ends up WRITABLE.
+        replica.servers().get(0).blockingHttpClient()
+               .prepare()
+               .put("/api/v1/status")
+               .contentJson(new UpdateServerStatusRequest(ServerStatus.WRITABLE, Scope.ALL))
+               .execute();
         for (int i = 0; i < 3; i++) {
             final BlockingWebClient adminClient = replica.servers().get(i).blockingHttpClient();
-            adminClient.prepare()
-                       .put("/api/v1/status")
-                       .contentJson(new UpdateServerStatusRequest(ServerStatus.WRITABLE, Scope.LOCAL))
-                       .execute();
             await().untilAsserted(() -> {
                 assertThat(getServerStatus(adminClient)).isEqualTo(ServerStatus.WRITABLE);
             });

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/CentralDogmaReplicationExtension.java
@@ -86,6 +86,20 @@ public class CentralDogmaReplicationExtension extends AbstractAllOrEachExtension
         return dogmaCluster;
     }
 
+    /**
+     * Returns the server with the specified 1-based {@code serverId}, matching the {@code serverId} passed to
+     * {@link #configureEach(int, CentralDogmaBuilder)}. Note that {@link #servers()} is 0-based, so
+     * {@code serverById(2)} is {@code servers().get(1)}.
+     */
+    public CentralDogmaRuleDelegate serverById(int serverId) {
+        final List<CentralDogmaRuleDelegate> servers = servers();
+        if (serverId < 1 || serverId > servers.size()) {
+            throw new IllegalArgumentException(
+                    "serverId: " + serverId + " (expected: 1.." + servers.size() + ')');
+        }
+        return servers.get(serverId - 1);
+    }
+
     private List<CentralDogmaRuleDelegate> newDogmaCluster(int numReplicas) throws IOException {
         final ImmutableMap.Builder<Integer, ZooKeeperServerConfig> builder =
                 ImmutableMap.builderWithExpectedSize(numReplicas);

--- a/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerExtension.java
+++ b/testing-internal/src/main/java/com/linecorp/centraldogma/testing/internal/ProjectManagerExtension.java
@@ -172,8 +172,10 @@ public class ProjectManagerExtension extends AbstractAllOrEachExtension {
      * Override this method to customize a {@link CommandExecutor}.
      */
     protected CommandExecutor newCommandExecutor(ProjectManager projectManager, Executor worker, File dataDir) {
+        final RepoStatusManager repoStatusManager =
+                new RepoStatusManager(serverStatusManager, projectManager, NoopMeterRegistry.get());
         return new StandaloneCommandExecutor(projectManager, worker, serverStatusManager,
-                                             new RepoStatusManager(serverStatusManager, projectManager), null,
+                                             repoStatusManager, null,
                                              NoopEncryptionStorageManager.INSTANCE, null, null, null,
                                              null);
     }

--- a/webapp/e2e/repo-status.spec.ts
+++ b/webapp/e2e/repo-status.spec.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect, type APIRequestContext, type Page } from '@playwright/test';
+
+// The Shiro test backend authorizes `foo` as a system administrator.
+const BACKEND = 'http://127.0.0.1:36462';
+const READ_ONLY_REPOS_API = '/api/v1/status/repos/read-only';
+
+// A project marked read-only via the API (project scope) drives the list/API assertions.
+const SEED_PROJECT = 'repo-status-e2e';
+// A dedicated writable repository that the UI form flips to read-only.
+const FORM_PROJECT = 'repo-status-form-e2e';
+const FORM_REPO = 'target';
+
+type RepositoryStatus = {
+  projectName: string;
+  repoName: string;
+  status: 'WRITABLE' | 'READ_ONLY';
+  updatedAt?: string;
+};
+
+let api: APIRequestContext;
+let csrfToken: string;
+
+async function readOnlyList(): Promise<RepositoryStatus[]> {
+  const res = await api.get(READ_ONLY_REPOS_API);
+  // An empty result is returned as 204 No Content.
+  if (res.status() === 204) {
+    return [];
+  }
+  expect(res.ok()).toBeTruthy();
+  return res.json();
+}
+
+async function setRepoStatus(project: string, repo: string, status: 'READ_ONLY' | 'WRITABLE') {
+  const res = await api.put(`/api/v1/projects/${project}/repos/${repo}/status`, {
+    headers: { 'X-CSRF-Token': csrfToken },
+    data: { status },
+  });
+  // A redundant change (already in that status) is accepted too.
+  expect(res.status(), `set ${status}: ${res.status()}`).toBeLessThan(400);
+}
+
+async function ensureProject(name: string) {
+  const res = await api.post('/api/v1/projects', { headers: { 'X-CSRF-Token': csrfToken }, data: { name } });
+  // 200/201 when created, 409 when it already exists from a previous run.
+  expect([200, 201, 409]).toContain(res.status());
+}
+
+async function ensureRepo(project: string, repo: string) {
+  const res = await api.post(`/api/v1/projects/${project}/repos`, {
+    headers: { 'X-CSRF-Token': csrfToken },
+    data: { name: repo },
+  });
+  expect([200, 201, 409]).toContain(res.status());
+}
+
+async function loginUi(page: Page) {
+  await page.goto('/');
+  await expect(page.getByText(/Login/)).toBeVisible({ timeout: 10000 });
+  await page.getByPlaceholder('ID').fill('foo');
+  await page.getByPlaceholder('Password').fill('bar');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page.getByRole('heading', { name: 'Welcome to Central Dogma!' })).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+// chakra-react-select: click the control, type to filter, and pick the first match.
+async function pickOption(page: Page, containerId: string, text: string) {
+  await page.locator(`#${containerId}`).click();
+  await page.keyboard.type(text);
+  await page.waitForTimeout(500);
+  await page.keyboard.press('Enter');
+}
+
+test.describe.serial('Repository Status', () => {
+  test.beforeAll(async ({ playwright }) => {
+    api = await playwright.request.newContext({ baseURL: BACKEND });
+
+    const loginRes = await api.post('/api/v1/login', {
+      form: { grant_type: 'password', username: 'foo', password: 'bar' },
+    });
+    expect(loginRes.ok()).toBeTruthy();
+    csrfToken = (await loginRes.json()).csrf_token;
+
+    // Project-scoped read-only entry (stored on the project's internal "dogma" repository).
+    await ensureProject(SEED_PROJECT);
+    await setRepoStatus(SEED_PROJECT, 'dogma', 'READ_ONLY');
+
+    // A writable repository the form flow will flip to read-only.
+    await ensureProject(FORM_PROJECT);
+    await ensureRepo(FORM_PROJECT, FORM_REPO);
+    await setRepoStatus(FORM_PROJECT, FORM_REPO, 'WRITABLE');
+
+    // The status is applied asynchronously via a repository listener; wait until it is visible.
+    await expect
+      .poll(async () => (await readOnlyList()).some((e) => e.projectName === SEED_PROJECT), {
+        timeout: 10000,
+      })
+      .toBe(true);
+  });
+
+  test.afterAll(async () => {
+    // Revert to keep the shared backend clean for other specs.
+    if (csrfToken) {
+      await setRepoStatus(SEED_PROJECT, 'dogma', 'WRITABLE');
+      await setRepoStatus(FORM_PROJECT, FORM_REPO, 'WRITABLE');
+    }
+    await api?.dispose();
+  });
+
+  test('exposes read-only entries with an ISO-8601 updatedAt', async () => {
+    const entry = (await readOnlyList()).find((e) => e.projectName === SEED_PROJECT);
+    expect(entry).toBeTruthy();
+    expect(entry!.status).toBe('READ_ONLY');
+    // A project-scoped entry uses "dogma" as its repository name.
+    expect(entry!.repoName).toBe('dogma');
+    // updatedAt must be an ISO-8601 string, not an epoch number, so the UI renders the real date.
+    expect(typeof entry!.updatedAt).toBe('string');
+    expect(new Date(entry!.updatedAt!).getFullYear()).toBeGreaterThanOrEqual(2024);
+  });
+
+  test.describe('UI', () => {
+    test.beforeEach(async ({ page }) => {
+      await loginUi(page);
+    });
+
+    test('is reachable as a system-administrator settings tab', async ({ page }) => {
+      await page.goto('/app/settings/server-status');
+      const tab = page.getByRole('tab', { name: 'Repository Status' });
+      await expect(tab).toBeVisible();
+      await tab.click();
+      await expect(page).toHaveURL(/\/app\/settings\/repo-status/);
+    });
+
+    test('lists the read-only project with scope, status and a valid date', async ({ page }) => {
+      await page.goto('/app/settings/repo-status');
+
+      await expect(page.getByText('Current Server Status:')).toBeVisible();
+
+      const table = page.locator('table');
+      await expect(table).toBeVisible();
+
+      // Six columns: Project, Repository, Scope, Status, Updated At, Actions.
+      const headers = table.locator('th');
+      await expect(headers).toHaveCount(6);
+      await expect(headers.nth(0)).toContainText('Project');
+      await expect(headers.nth(1)).toContainText('Repository');
+      await expect(headers.nth(2)).toContainText('Scope');
+      await expect(headers.nth(3)).toContainText('Status');
+      await expect(headers.nth(4)).toContainText('Updated At');
+      await expect(headers.nth(5)).toContainText('Actions');
+
+      const row = table.locator('tr', { hasText: SEED_PROJECT });
+      await expect(row).toContainText('READ_ONLY');
+      await expect(row).toContainText('Project'); // project-scoped
+      // Regression guard: a numeric epoch updatedAt would render as 1970.
+      await expect(row).not.toContainText('1970');
+    });
+
+    test('makes a repository read-only through the confirm form', async ({ page }) => {
+      // Start from a known-writable state.
+      await setRepoStatus(FORM_PROJECT, FORM_REPO, 'WRITABLE');
+
+      await page.goto('/app/settings/repo-status');
+      await expect(page.getByText('Make a repository read-only')).toBeVisible();
+
+      await pickOption(page, 'readonly-project-select', FORM_PROJECT);
+      await page.waitForTimeout(800); // repositories load after the project is chosen
+      await pickOption(page, 'readonly-repo-select', FORM_REPO);
+
+      // Open the confirmation modal.
+      await page.getByRole('button', { name: 'Make read-only' }).click();
+      const modal = page.locator('.chakra-modal__content');
+      await expect(modal).toBeVisible();
+
+      // The confirm button stays disabled until the exact project/repo is retyped.
+      const confirm = modal.getByRole('button', { name: 'Make read-only' });
+      await expect(confirm).toBeDisabled();
+      await page.getByPlaceholder(`${FORM_PROJECT}/${FORM_REPO}`).fill(`${FORM_PROJECT}/${FORM_REPO}`);
+      await expect(confirm).toBeEnabled();
+      await confirm.click();
+
+      // The repository now appears in the read-only list.
+      const row = page.locator('table').locator('tr', { hasText: FORM_REPO });
+      await expect(row).toContainText('READ_ONLY', { timeout: 10000 });
+      await expect(row).toContainText('Repository');
+    });
+
+    test('reverts a read-only repository to writable from the list', async ({ page }) => {
+      // Ensure the repository is read-only, then revert it through the list action.
+      await setRepoStatus(FORM_PROJECT, FORM_REPO, 'READ_ONLY');
+      await expect
+        .poll(
+          async () =>
+            (await readOnlyList()).some((e) => e.projectName === FORM_PROJECT && e.repoName === FORM_REPO),
+          { timeout: 10000 },
+        )
+        .toBe(true);
+
+      await page.goto('/app/settings/repo-status');
+      const table = page.locator('table');
+      const row = table.locator('tr', { hasText: FORM_REPO });
+      await expect(row).toContainText('READ_ONLY');
+
+      await row.getByRole('button', { name: 'Make writable' }).click();
+      const modal = page.locator('.chakra-modal__content');
+      await expect(modal).toBeVisible();
+
+      // The confirm button stays disabled until the exact project/repo is retyped.
+      const confirm = modal.getByRole('button', { name: 'Make writable' });
+      await expect(confirm).toBeDisabled();
+      await page.getByPlaceholder(`${FORM_PROJECT}/${FORM_REPO}`).fill(`${FORM_PROJECT}/${FORM_REPO}`);
+      await expect(confirm).toBeEnabled();
+      await confirm.click();
+
+      // The repository leaves the read-only list.
+      await expect(table.locator('tr', { hasText: FORM_REPO })).toHaveCount(0, { timeout: 10000 });
+    });
+  });
+});

--- a/webapp/e2e/repo-status.spec.ts
+++ b/webapp/e2e/repo-status.spec.ts
@@ -148,7 +148,7 @@ test.describe.serial('Repository Status', () => {
       await expect(page).toHaveURL(/\/app\/settings\/repo-status/);
     });
 
-    test('lists the read-only project with scope, status and a valid date', async ({ page }) => {
+    test('lists the read-only project with status and a valid date', async ({ page }) => {
       await page.goto('/app/settings/repo-status');
 
       await expect(page.getByText('Current Server Status:')).toBeVisible();
@@ -156,19 +156,19 @@ test.describe.serial('Repository Status', () => {
       const table = page.locator('table');
       await expect(table).toBeVisible();
 
-      // Six columns: Project, Repository, Scope, Status, Updated At, Actions.
+      // Five columns: Project, Repository, Status, Updated At, Actions.
       const headers = table.locator('th');
-      await expect(headers).toHaveCount(6);
+      await expect(headers).toHaveCount(5);
       await expect(headers.nth(0)).toContainText('Project');
       await expect(headers.nth(1)).toContainText('Repository');
-      await expect(headers.nth(2)).toContainText('Scope');
-      await expect(headers.nth(3)).toContainText('Status');
-      await expect(headers.nth(4)).toContainText('Updated At');
-      await expect(headers.nth(5)).toContainText('Actions');
+      await expect(headers.nth(2)).toContainText('Status');
+      await expect(headers.nth(3)).toContainText('Updated At');
+      await expect(headers.nth(4)).toContainText('Actions');
 
       const row = table.locator('tr', { hasText: SEED_PROJECT });
       await expect(row).toContainText('READ_ONLY');
-      await expect(row).toContainText('Project'); // project-scoped
+      // A project-scoped entry names the internal "dogma" repository.
+      await expect(row).toContainText('dogma');
       // Regression guard: a numeric epoch updatedAt would render as 1970.
       await expect(row).not.toContainText('1970');
     });

--- a/webapp/e2e/repo-status.spec.ts
+++ b/webapp/e2e/repo-status.spec.ts
@@ -196,10 +196,10 @@ test.describe.serial('Repository Status', () => {
       await expect(confirm).toBeEnabled();
       await confirm.click();
 
-      // The repository now appears in the read-only list.
+      // The repository now appears in the read-only list, named by its project and repository.
       const row = page.locator('table').locator('tr', { hasText: FORM_REPO });
       await expect(row).toContainText('READ_ONLY', { timeout: 10000 });
-      await expect(row).toContainText('Repository');
+      await expect(row).toContainText(FORM_PROJECT);
     });
 
     test('reverts a read-only repository to writable from the list', async ({ page }) => {

--- a/webapp/src/dogma/common/components/MetadataButton.tsx
+++ b/webapp/src/dogma/common/components/MetadataButton.tsx
@@ -2,9 +2,27 @@ import { Button, ButtonProps } from '@chakra-ui/react';
 import Link from 'next/link';
 import { FcSettings } from 'react-icons/fc';
 
-export const MetadataButton = ({ href, text, props }: { href: string; text?: string; props?: ButtonProps }) => {
+export const MetadataButton = ({
+  href,
+  text,
+  props,
+  isDisabled,
+}: {
+  href: string;
+  text?: string;
+  props?: ButtonProps;
+  isDisabled?: boolean;
+}) => {
   return (
-    <Button as={Link} href={href} colorScheme="teal" variant="outline" rightIcon={<FcSettings />} {...props}>
+    <Button
+      // A disabled anchor is still clickable, so the link is dropped when disabled.
+      {...(isDisabled ? {} : { as: Link, href })}
+      isDisabled={isDisabled}
+      colorScheme="teal"
+      variant="outline"
+      rightIcon={<FcSettings />}
+      {...props}
+    >
       {text ?? 'Metadata'}
     </Button>
   );

--- a/webapp/src/dogma/common/components/NotificationWrapper.tsx
+++ b/webapp/src/dogma/common/components/NotificationWrapper.tsx
@@ -1,5 +1,5 @@
 import { ReactNode, useEffect } from 'react';
-import { useToast } from '@chakra-ui/react';
+import { Box, useToast } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 import { Notification } from 'dogma/features/notification/notificationSlice';
 
@@ -14,7 +14,12 @@ export const NotificationWrapper = (props: { children: ReactNode }) => {
     if (timestamp) {
       toast({
         title,
-        description,
+        // A long error message would otherwise grow the toast past the viewport, hiding the close button.
+        description: description ? (
+          <Box maxHeight="40vh" overflowY="auto" overflowWrap="anywhere" whiteSpace="pre-wrap">
+            {description}
+          </Box>
+        ) : null,
         status: type,
         duration: 10000,
         isClosable: true,

--- a/webapp/src/dogma/common/components/ProjectSettingsButton.tsx
+++ b/webapp/src/dogma/common/components/ProjectSettingsButton.tsx
@@ -1,18 +1,26 @@
+import { Box, Tooltip } from '@chakra-ui/react';
 import { MetadataButton } from 'dogma/common/components/MetadataButton';
 import { WithProjectRole } from 'dogma/features/auth/ProjectRole';
+import { PROJECT_READ_ONLY_HINT, useProjectReadOnly } from 'dogma/features/repo/useReadOnly';
 
 export const ProjectSettingsButton = ({ projectName }: { projectName: string }) => {
+  const projectReadOnly = useProjectReadOnly(projectName);
   if (projectName === 'dogma') {
     return null;
   }
   return (
     <WithProjectRole projectName={projectName} roles={['OWNER', 'MEMBER']}>
       {() => (
-        <MetadataButton
-          href={`/app/projects/${projectName}/settings`}
-          props={{ size: 'sm' }}
-          text={'Project Settings'}
-        />
+        <Tooltip label={PROJECT_READ_ONLY_HINT} isDisabled={!projectReadOnly}>
+          <Box>
+            <MetadataButton
+              href={`/app/projects/${projectName}/settings`}
+              props={{ size: 'sm' }}
+              text={'Project Settings'}
+              isDisabled={projectReadOnly}
+            />
+          </Box>
+        </Tooltip>
       )}
     </WithProjectRole>
   );

--- a/webapp/src/dogma/common/components/editor/FileEditor.tsx
+++ b/webapp/src/dogma/common/components/editor/FileEditor.tsx
@@ -10,6 +10,7 @@ import {
   TabPanel,
   TabPanels,
   Tabs,
+  Tooltip,
   useColorMode,
   useDisclosure,
 } from '@chakra-ui/react';
@@ -32,6 +33,7 @@ import { useLocalMonaco } from 'dogma/features/file/MonacoLoader';
 import { Loading } from 'dogma/common/components/Loading';
 import { useGetFileContentQuery } from 'dogma/features/api/apiSlice';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
+import { useReadOnly } from 'dogma/features/repo/useReadOnly';
 
 export type FileEditorProps = {
   projectName: string;
@@ -73,6 +75,7 @@ const FileEditor = ({
   revision,
 }: FileEditorProps) => {
   const language = extensionToLanguageMap[extension] || extension;
+  const [repoReadOnly, readOnlyHint] = useReadOnly(projectName, repoName);
   const [tabIndex, setTabIndex] = useState(0);
   const handleTabChange = (index: number) => {
     setTabIndex(index);
@@ -166,26 +169,30 @@ const FileEditor = ({
           History
         </Button>
         {projectName !== 'dogma' && repoName !== 'dogma' && (
-          <>
-            <Button
-              onClick={switchMode}
-              leftIcon={readOnly ? <FcEditImage /> : <FcCancel />}
-              colorScheme={readOnly ? 'teal' : 'blue'}
-              variant="outline"
-              size="sm"
-            >
-              {readOnly ? 'Edit' : 'Cancel changes'}
-            </Button>
-            <Button
-              onClick={onDeleteModalOpen}
-              leftIcon={<AiOutlineDelete />}
-              colorScheme="red"
-              display={readOnly ? 'visible' : 'none'}
-              size="sm"
-            >
-              Delete
-            </Button>
-          </>
+          <Tooltip label={readOnlyHint} isDisabled={!repoReadOnly}>
+            <Flex gap={4}>
+              <Button
+                onClick={switchMode}
+                isDisabled={repoReadOnly}
+                leftIcon={readOnly ? <FcEditImage /> : <FcCancel />}
+                colorScheme={readOnly ? 'teal' : 'blue'}
+                variant="outline"
+                size="sm"
+              >
+                {readOnly ? 'Edit' : 'Cancel changes'}
+              </Button>
+              <Button
+                onClick={onDeleteModalOpen}
+                isDisabled={repoReadOnly}
+                leftIcon={<AiOutlineDelete />}
+                colorScheme="red"
+                display={readOnly ? 'visible' : 'none'}
+                size="sm"
+              >
+                Delete
+              </Button>
+            </Flex>
+          </Tooltip>
         )}
       </Flex>
       <Tabs

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -45,6 +45,7 @@ import {
   ServerStatusType,
   UpdateServerStatusRequest,
 } from 'dogma/features/settings/server-status/ServerStatusDto';
+import { ReplicationStatus, RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
 import Router from 'next/router';
 import { VariableDto } from 'dogma/features/project/settings/variables/VariableDto';
 import { XdsApp, XdsClientStatus, XdsSnapshot } from 'dogma/features/xds/ControlPlaneStatusDto';
@@ -122,7 +123,7 @@ export const apiSlice = createApi({
   baseQuery: baseQueryWithReauth(() => {
     Router.push(createLoginUrl());
   }),
-  tagTypes: ['Project', 'Metadata', 'Repo', 'File', 'AppIdentity', 'Mirror', 'ServerStatus'],
+  tagTypes: ['Project', 'Metadata', 'Repo', 'File', 'AppIdentity', 'Mirror', 'ServerStatus', 'RepoStatus'],
   endpoints: (builder) => ({
     getProjects: builder.query<ProjectDto[], GetProjects>({
       async queryFn(arg, _queryApi, _extraOptions, fetchWithBQ) {
@@ -466,6 +467,21 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['ServerStatus'],
     }),
+    getReadOnlyRepos: builder.query<RepositoryStatus[], void>({
+      query: () => '/api/v1/status/repos/read-only',
+      providesTags: ['RepoStatus'],
+    }),
+    updateRepositoryStatus: builder.mutation<
+      void,
+      { projectName: string; repoName: string; status: ReplicationStatus }
+    >({
+      query: ({ projectName, repoName, status }) => ({
+        url: `/api/v1/projects/${projectName}/repos/${repoName}/status`,
+        method: 'PUT',
+        body: { status },
+      }),
+      invalidatesTags: ['RepoStatus'],
+    }),
     getProjectCredentials: builder.query<CredentialDto[], string>({
       query: (projectName) => `/api/v1/projects/${projectName}/credentials`,
       transformResponse: (response: CredentialDto[]) => addIdFromCredentialNames(response),
@@ -684,6 +700,9 @@ export const {
   // Server Status
   useGetServerStatusQuery,
   useUpdateServerStatusMutation,
+  // Repository Status
+  useGetReadOnlyReposQuery,
+  useUpdateRepositoryStatusMutation,
   // Credential
   useGetProjectCredentialsQuery,
   useGetCredentialQuery,

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -480,7 +480,8 @@ export const apiSlice = createApi({
         method: 'PUT',
         body: { status },
       }),
-      invalidatesTags: ['RepoStatus'],
+      // The project and repository lists carry the replication status, so they go stale as well.
+      invalidatesTags: ['RepoStatus', 'Project', 'Repo'],
     }),
     getProjectCredentials: builder.query<CredentialDto[], string>({
       query: (projectName) => `/api/v1/projects/${projectName}/credentials`,

--- a/webapp/src/dogma/features/file/FileList.tsx
+++ b/webapp/src/dogma/features/file/FileList.tsx
@@ -9,6 +9,7 @@ import {
   MenuButton,
   MenuItem,
   MenuList,
+  Tooltip,
   useDisclosure,
 } from '@chakra-ui/react';
 import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
@@ -20,6 +21,7 @@ import { CopySupport } from 'dogma/features/file/CopySupport';
 import React, { useCallback, useMemo, useState } from 'react';
 import { MdDelete } from 'react-icons/md';
 import { DeleteFileModal } from 'dogma/common/components/editor/DeleteFileModal';
+import { useReadOnly } from 'dogma/features/repo/useReadOnly';
 
 export type FileListProps<Data extends object> = {
   data: Data[];
@@ -42,6 +44,7 @@ const FileList = <Data extends object>({
 }: FileListProps<Data>) => {
   const columnHelper = createColumnHelper<FileDto>();
   const slug = `/app/projects/${projectName}/repos/${repoName}/files/${revision}${path}`;
+  const [readOnly, readOnlyHint] = useReadOnly(projectName, repoName);
 
   const { isOpen: isDeleteModalOpen, onOpen: onDeleteModalOpen, onClose: onDeleteModalClose } = useDisclosure();
   const [deletePath, setDeletePath] = useState('');
@@ -112,21 +115,36 @@ const FileList = <Data extends object>({
                 </Menu>
               </WrapItem>
             </Wrap>
-            <Button
-              onClick={() => onClickDelete(info.row.original.path)}
-              leftIcon={<MdDelete />}
-              colorScheme="red"
-              size="sm"
-            >
-              Delete
-            </Button>
+            <Tooltip label={readOnlyHint} isDisabled={!readOnly}>
+              <Box>
+                <Button
+                  onClick={() => onClickDelete(info.row.original.path)}
+                  isDisabled={readOnly}
+                  leftIcon={<MdDelete />}
+                  colorScheme="red"
+                  size="sm"
+                >
+                  Delete
+                </Button>
+              </Box>
+            </Tooltip>
           </HStack>
         ),
         header: 'Actions',
         enableSorting: false,
       }),
     ],
-    [columnHelper, copySupport, directoryPath, projectName, repoName, slug, onClickDelete],
+    [
+      columnHelper,
+      copySupport,
+      directoryPath,
+      projectName,
+      repoName,
+      slug,
+      onClickDelete,
+      readOnly,
+      readOnlyHint,
+    ],
   );
   return (
     <Box>

--- a/webapp/src/dogma/features/history/HistoryList.tsx
+++ b/webapp/src/dogma/features/history/HistoryList.tsx
@@ -1,6 +1,6 @@
 import { createColumnHelper, PaginationState } from '@tanstack/react-table';
 import { HistoryDto } from 'dogma/features/history/HistoryDto';
-import { Badge, Box, Button, HStack, Icon, useDisclosure } from '@chakra-ui/react';
+import { Badge, Box, Button, HStack, Icon, Tooltip, useDisclosure } from '@chakra-ui/react';
 import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { ReactElement, useMemo, useState } from 'react';
@@ -11,6 +11,7 @@ import { VscGitCommit } from 'react-icons/vsc';
 import CompareButton from 'dogma/common/components/CompareButton';
 import { RevertCommitModal } from 'dogma/features/history/RevertCommitModal';
 import { WithRepositoryRole } from 'dogma/features/auth/RepositoryRole';
+import { useReadOnly } from 'dogma/features/repo/useReadOnly';
 
 export type HistoryListProps = {
   projectName: string;
@@ -39,6 +40,7 @@ const HistoryList = ({
 }: HistoryListProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [targetRevision, setTargetRevision] = useState<number>(headRevision);
+  const [readOnly, readOnlyHint] = useReadOnly(projectName, repoName);
   const columnHelper = createColumnHelper<HistoryDto>();
   const columns = useMemo(
     () => [
@@ -82,18 +84,22 @@ const HistoryList = ({
             {!filePath && (
               <WithRepositoryRole projectName={projectName} repoName={repoName} roles={['WRITE', 'ADMIN']}>
                 {() => (
-                  <Button
-                    size={'sm'}
-                    colorScheme={'red'}
-                    variant={'outline'}
-                    isDisabled={info.row.original.revision === headRevision}
-                    onClick={() => {
-                      setTargetRevision(info.row.original.revision);
-                      onOpen();
-                    }}
-                  >
-                    Revert
-                  </Button>
+                  <Tooltip label={readOnlyHint} isDisabled={!readOnly}>
+                    <Box>
+                      <Button
+                        size={'sm'}
+                        colorScheme={'red'}
+                        variant={'outline'}
+                        isDisabled={readOnly || info.row.original.revision === headRevision}
+                        onClick={() => {
+                          setTargetRevision(info.row.original.revision);
+                          onOpen();
+                        }}
+                      >
+                        Revert
+                      </Button>
+                    </Box>
+                  </Tooltip>
                 )}
               </WithRepositoryRole>
             )}
@@ -110,7 +116,7 @@ const HistoryList = ({
         header: 'Timestamp',
       }),
     ],
-    [columnHelper, projectName, repoName, filePath, isDirectory, headRevision, onOpen],
+    [columnHelper, projectName, repoName, filePath, isDirectory, headRevision, onOpen, readOnly, readOnlyHint],
   );
 
   return (

--- a/webapp/src/dogma/features/project/ProjectDto.ts
+++ b/webapp/src/dogma/features/project/ProjectDto.ts
@@ -15,7 +15,7 @@
  */
 
 import { ProjectRole } from 'dogma/features/auth/ProjectRole';
-import { CreatorDto } from 'dogma/features/repo/RepoDto';
+import { CreatorDto, ReplicationStatus } from 'dogma/features/repo/RepoDto';
 
 export interface ProjectDto {
   name: string;
@@ -23,4 +23,5 @@ export interface ProjectDto {
   creator?: CreatorDto;
   createdAt?: string;
   userRole?: ProjectRole;
+  status?: ReplicationStatus;
 }

--- a/webapp/src/dogma/features/project/Projects.tsx
+++ b/webapp/src/dogma/features/project/Projects.tsx
@@ -48,6 +48,8 @@ import { FaFilter, FaTrashAlt } from 'react-icons/fa';
 import { ChevronDownIcon } from '@chakra-ui/icons';
 import { ProjectFilterType, setProjectFilter } from 'dogma/features/filter/filterSlice';
 import { ProjectOwnersModal } from 'dogma/features/project/ProjectOwnersModal';
+import { RepoStatusTag } from 'dogma/features/repo/RepoStatusTag';
+import { PROJECT_READ_ONLY_HINT } from 'dogma/features/repo/useReadOnly';
 import { UserDto } from '../auth/UserDto';
 import { UserRole } from '../../common/components/UserRole';
 
@@ -119,6 +121,11 @@ export const Projects = () => {
           ),
         header: 'Name',
       }),
+      columnHelper.accessor((row: ProjectDto) => row.status, {
+        id: 'status',
+        cell: (info) => <RepoStatusTag status={info.getValue()} />,
+        header: 'Status',
+      }),
       columnHelper.accessor((row: ProjectDto) => row.creator?.name, {
         id: 'creator',
         cell: (info) =>
@@ -176,6 +183,22 @@ export const Projects = () => {
           if (info.row.original.createdAt) {
             const userRole = info.row.original.userRole;
             if (userRole === 'OWNER') {
+              if (info.row.original.status === 'READ_ONLY') {
+                // A disabled anchor is still clickable, so the link is dropped when disabled.
+                return (
+                  <Tooltip label={PROJECT_READ_ONLY_HINT} fontSize="md">
+                    <Box display="inline-block">
+                      <IconButton
+                        icon={<FcServices />}
+                        variant="ghost"
+                        colorScheme="teal"
+                        aria-label="Project Settings"
+                        isDisabled
+                      />
+                    </Box>
+                  </Tooltip>
+                );
+              }
               return (
                 <ChakraLink href={`/app/projects/${info.getValue()}/settings`}>
                   <Tooltip label="Project settings" fontSize="md">

--- a/webapp/src/dogma/features/repo/DeleteRepo.tsx
+++ b/webapp/src/dogma/features/repo/DeleteRepo.tsx
@@ -15,6 +15,8 @@ import { newNotification } from 'dogma/features/notification/notificationSlice';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import { useAppDispatch } from 'dogma/hooks';
 import { MdDelete } from 'react-icons/md';
+import { useReadOnly } from 'dogma/features/repo/useReadOnly';
+import { Box, Tooltip } from '@chakra-ui/react';
 
 export const DeleteRepo = ({
   projectName,
@@ -32,6 +34,7 @@ export const DeleteRepo = ({
   const { isOpen, onToggle, onClose } = useDisclosure();
   const dispatch = useAppDispatch();
   const [deleteRepo, { isLoading }] = useDeleteRepoMutation();
+  const [readOnly, readOnlyHint] = useReadOnly(projectName, repoName);
   const handleDelete = async () => {
     try {
       await deleteRepo({ projectName, repoName }).unwrap();
@@ -43,16 +46,20 @@ export const DeleteRepo = ({
   };
   return (
     <>
-      <Button
-        leftIcon={<MdDelete />}
-        colorScheme="red"
-        variant={buttonVariant}
-        size={buttonSize}
-        onClick={onToggle}
-        hidden={hidden}
-      >
-        Delete
-      </Button>
+      <Tooltip label={readOnlyHint} isDisabled={!readOnly}>
+        <Box hidden={hidden}>
+          <Button
+            leftIcon={<MdDelete />}
+            colorScheme="red"
+            variant={buttonVariant}
+            size={buttonSize}
+            onClick={onToggle}
+            isDisabled={readOnly}
+          >
+            Delete
+          </Button>
+        </Box>
+      </Tooltip>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>

--- a/webapp/src/dogma/features/repo/NewRepo.tsx
+++ b/webapp/src/dogma/features/repo/NewRepo.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   FormControl,
   FormErrorMessage,
@@ -13,6 +14,7 @@ import {
   PopoverHeader,
   PopoverTrigger,
   Spacer,
+  Tooltip,
   useDisclosure,
 } from '@chakra-ui/react';
 import { useAddNewRepoMutation } from 'dogma/features/api/apiSlice';
@@ -25,6 +27,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import { WithProjectRole } from 'dogma/features/auth/ProjectRole';
+import { PROJECT_READ_ONLY_HINT, useProjectReadOnly } from 'dogma/features/repo/useReadOnly';
 
 const ENTITY_NAME_PATTERN = /^[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$/;
 
@@ -34,6 +37,7 @@ type FormData = {
 
 export const NewRepo = ({ projectName }: { projectName: string }) => {
   const [addNewRepo, { isLoading }] = useAddNewRepoMutation();
+  const projectReadOnly = useProjectReadOnly(projectName);
   const {
     register,
     handleSubmit,
@@ -61,6 +65,24 @@ export const NewRepo = ({ projectName }: { projectName: string }) => {
       dispatch(newNotification('Failed to create a new repository', ErrorMessageParser.parse(error), 'error'));
     }
   };
+
+  // A disabled button swallows pointer events, so the hint has to sit on a wrapper. The button also
+  // cannot stay a PopoverTrigger child, which would anchor the popover to that wrapper instead.
+  if (projectReadOnly) {
+    return (
+      <WithProjectRole projectName={projectName} roles={['OWNER', 'MEMBER']}>
+        {() => (
+          <Tooltip label={PROJECT_READ_ONLY_HINT}>
+            <Box>
+              <Button colorScheme="teal" size="sm" isDisabled rightIcon={<IoMdArrowDropdown />}>
+                New Repository
+              </Button>
+            </Box>
+          </Tooltip>
+        )}
+      </WithProjectRole>
+    );
+  }
 
   return (
     <WithProjectRole projectName={projectName} roles={['OWNER', 'MEMBER']}>

--- a/webapp/src/dogma/features/repo/RepoDto.ts
+++ b/webapp/src/dogma/features/repo/RepoDto.ts
@@ -3,10 +3,13 @@ export interface CreatorDto {
   email: string;
 }
 
+export type ReplicationStatus = 'WRITABLE' | 'READ_ONLY';
+
 export interface RepoDto {
   name: string;
   creator: CreatorDto;
   headRevision: number;
   url: string;
   createdAt: string;
+  status: ReplicationStatus;
 }

--- a/webapp/src/dogma/features/repo/RepoList.tsx
+++ b/webapp/src/dogma/features/repo/RepoList.tsx
@@ -2,6 +2,7 @@ import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { DataTableClientPagination } from 'dogma/common/components/table/DataTableClientPagination';
 import { RepoDto } from 'dogma/features/repo/RepoDto';
+import { RepoStatusTag } from 'dogma/features/repo/RepoStatusTag';
 import { useMemo } from 'react';
 import { Author } from 'dogma/common/components/Author';
 import { RepoIcon } from 'dogma/common/components/RepoIcon';
@@ -18,6 +19,10 @@ const RepoList = <Data extends object>({ data, projectName }: RepoListProps<Data
       columnHelper.accessor((row: RepoDto) => row.name, {
         cell: (info) => <RepoIcon projectName={projectName} repoName={info.getValue()} isActive={true} />,
         header: 'Name',
+      }),
+      columnHelper.accessor((row: RepoDto) => row.status, {
+        cell: (info) => <RepoStatusTag status={info.getValue()} />,
+        header: 'Status',
       }),
       columnHelper.accessor((row: RepoDto) => row.creator.name, {
         cell: (info) => <Author name={info.getValue()} />,

--- a/webapp/src/dogma/features/repo/RepoStatusTag.tsx
+++ b/webapp/src/dogma/features/repo/RepoStatusTag.tsx
@@ -14,13 +14,23 @@
  * under the License.
  */
 
+import { Tag, TagLabel, TagLeftIcon } from '@chakra-ui/react';
 import { ReplicationStatus } from 'dogma/features/repo/RepoDto';
+import { GoLock, GoPencil } from 'react-icons/go';
 
-export type { ReplicationStatus };
+export type RepoStatusTagProps = {
+  status?: ReplicationStatus;
+};
 
-export type RepositoryStatus = {
-  projectName: string;
-  repoName: string;
-  status: ReplicationStatus;
-  updatedAt?: string;
+export const RepoStatusTag = ({ status }: RepoStatusTagProps) => {
+  if (!status) {
+    return null;
+  }
+  const readOnly = status === 'READ_ONLY';
+  return (
+    <Tag borderRadius="full" colorScheme={readOnly ? 'red' : 'green'} variant="subtle" size="sm">
+      <TagLeftIcon as={readOnly ? GoLock : GoPencil} />
+      <TagLabel>{readOnly ? 'Read-only' : 'Writable'}</TagLabel>
+    </Tag>
+  );
 };

--- a/webapp/src/dogma/features/repo/useReadOnly.ts
+++ b/webapp/src/dogma/features/repo/useReadOnly.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { useGetProjectsQuery, useGetReposQuery } from 'dogma/features/api/apiSlice';
+import { isInternalProject } from 'dogma/util/repo-util';
+
+export const PROJECT_READ_ONLY_HINT = 'This project is read-only.';
+export const REPO_READ_ONLY_HINT = 'This repository is read-only.';
+
+/**
+ * Returns whether the project is read-only. The status is unknown while the projects are being fetched, in
+ * which case {@code false} is returned so that a write action is never disabled by a transient loading error.
+ */
+export const useProjectReadOnly = (projectName: string): boolean => {
+  // An internal project is not writable by the web UI anyway.
+  const skip = !projectName || isInternalProject(projectName);
+  const { data: projects } = useGetProjectsQuery({ systemAdmin: false }, { skip });
+  if (skip) {
+    return false;
+  }
+  return projects?.find((project) => project.name === projectName)?.status === 'READ_ONLY';
+};
+
+/**
+ * Returns whether the repository is read-only. A repository is read-only when the server, the project or the
+ * repository itself is in read-only mode, because the server returns the effective status of the repository.
+ */
+export const useRepoReadOnly = (projectName: string, repoName: string): boolean => {
+  // The repositories of an internal project are only visible to a system administrator.
+  const skip = !projectName || !repoName || isInternalProject(projectName);
+  const { data: repos } = useGetReposQuery(projectName, { skip });
+  if (skip) {
+    return false;
+  }
+  return repos?.find((repo) => repo.name === repoName)?.status === 'READ_ONLY';
+};
+
+/**
+ * Returns whether the repository is read-only, along with the reason to show when it is. The project is
+ * checked first so that a project-scoped read-only is not reported as a repository-scoped one.
+ */
+export const useReadOnly = (projectName: string, repoName: string): [boolean, string] => {
+  const projectReadOnly = useProjectReadOnly(projectName);
+  const repoReadOnly = useRepoReadOnly(projectName, repoName);
+  return [projectReadOnly || repoReadOnly, projectReadOnly ? PROJECT_READ_ONLY_HINT : REPO_READ_ONLY_HINT];
+};

--- a/webapp/src/dogma/features/settings/SettingView.tsx
+++ b/webapp/src/dogma/features/settings/SettingView.tsx
@@ -27,7 +27,7 @@ interface SettingsViewProps {
   children: ReactNode;
 }
 
-type TabName = 'Mirror Access Control' | 'Application Identities' | 'Server Status';
+type TabName = 'Mirror Access Control' | 'Application Identities' | 'Server Status' | 'Repository Status';
 
 export interface TapInfo {
   name: TabName;
@@ -39,6 +39,7 @@ const TABS: TapInfo[] = [
   { name: 'Application Identities', path: 'app-identities', admin: false },
   { name: 'Mirror Access Control', path: 'mirror-access', admin: true },
   { name: 'Server Status', path: 'server-status', admin: true },
+  { name: 'Repository Status', path: 'repo-status', admin: true },
 ];
 
 const SettingView = ({ currentTab, children }: SettingsViewProps) => {

--- a/webapp/src/dogma/features/settings/repo-status/MakeReadOnlyForm.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/MakeReadOnlyForm.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  Heading,
+  useColorMode,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { OptionBase, Select } from 'chakra-react-select';
+import { useState } from 'react';
+import {
+  useGetProjectsQuery,
+  useGetReposQuery,
+  useUpdateRepositoryStatusMutation,
+} from 'dogma/features/api/apiSlice';
+import { ProjectDto } from 'dogma/features/project/ProjectDto';
+import { RepoDto } from 'dogma/features/repo/RepoDto';
+import { RepoStatusConfirmModal } from 'dogma/features/settings/repo-status/RepoStatusConfirmModal';
+import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
+import { newNotification } from 'dogma/features/notification/notificationSlice';
+import { useAppDispatch } from 'dogma/hooks';
+
+interface Option extends OptionBase {
+  value: string;
+  label: string;
+}
+
+const MakeReadOnlyForm = () => {
+  const { colorMode } = useColorMode();
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const dispatch = useAppDispatch();
+
+  const [project, setProject] = useState<Option | null>(null);
+  const [repo, setRepo] = useState<Option | null>(null);
+
+  const { data: projects = [], isLoading: projectsLoading } = useGetProjectsQuery({ systemAdmin: false });
+  const { data: repos = [], isFetching: reposFetching } = useGetReposQuery(project?.value ?? '', {
+    skip: !project,
+  });
+  const [updateRepositoryStatus, { isLoading: submitting }] = useUpdateRepositoryStatusMutation();
+
+  const projectOptions: Option[] = projects.map((p: ProjectDto) => ({ value: p.name, label: p.name }));
+  const repoOptions: Option[] = repos.map((r: RepoDto) => ({ value: r.name, label: r.name }));
+
+  const handleConfirm = async () => {
+    if (!project || !repo) {
+      return;
+    }
+    try {
+      await updateRepositoryStatus({
+        projectName: project.value,
+        repoName: repo.value,
+        status: 'READ_ONLY',
+      }).unwrap();
+      dispatch(
+        newNotification(
+          'Repository is now read-only',
+          `${project.value}/${repo.value} is now read-only`,
+          'success',
+        ),
+      );
+      onClose();
+      setRepo(null);
+    } catch (error) {
+      dispatch(
+        newNotification(
+          `Failed to make ${project.value}/${repo.value} read-only`,
+          ErrorMessageParser.parse(error),
+          'error',
+        ),
+      );
+    }
+  };
+
+  const controlStyles = {
+    control: (baseStyles: Record<string, unknown>) => ({
+      ...baseStyles,
+      backgroundColor: colorMode === 'light' ? 'white' : 'whiteAlpha.50',
+    }),
+  };
+
+  return (
+    <Box borderWidth="1px" borderRadius="md" p="4" mb="8">
+      <Heading size="md" mb="4">
+        Make a repository read-only
+      </Heading>
+      <Flex gap={4} align="flex-end" wrap="wrap">
+        <FormControl maxW="xs">
+          <FormLabel>Project</FormLabel>
+          <Select<Option>
+            id="readonly-project-select"
+            name="readonly-project"
+            options={projectOptions}
+            value={project}
+            onChange={(option: Option | null) => {
+              setProject(option);
+              setRepo(null);
+            }}
+            isLoading={projectsLoading}
+            isClearable
+            isSearchable
+            placeholder="Select project..."
+            chakraStyles={controlStyles}
+          />
+        </FormControl>
+        <FormControl maxW="xs">
+          <FormLabel>Repository</FormLabel>
+          <Select<Option>
+            id="readonly-repo-select"
+            name="readonly-repo"
+            options={repoOptions}
+            value={repo}
+            onChange={(option: Option | null) => setRepo(option)}
+            isLoading={reposFetching}
+            isDisabled={!project}
+            isClearable
+            isSearchable
+            placeholder="Select repository..."
+            chakraStyles={controlStyles}
+          />
+        </FormControl>
+        <Button colorScheme="red" onClick={onOpen} isDisabled={!project || !repo}>
+          Make read-only
+        </Button>
+      </Flex>
+      {project && repo && (
+        <RepoStatusConfirmModal
+          isOpen={isOpen}
+          onClose={onClose}
+          projectName={project.value}
+          repoName={repo.value}
+          targetStatus="READ_ONLY"
+          onConfirm={handleConfirm}
+          isLoading={submitting}
+        />
+      )}
+    </Box>
+  );
+};
+
+export default MakeReadOnlyForm;

--- a/webapp/src/dogma/features/settings/repo-status/MakeWritable.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/MakeWritable.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Button, useDisclosure } from '@chakra-ui/react';
+import { MdLockOpen } from 'react-icons/md';
+import { useUpdateRepositoryStatusMutation } from 'dogma/features/api/apiSlice';
+import { newNotification } from 'dogma/features/notification/notificationSlice';
+import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
+import { useAppDispatch } from 'dogma/hooks';
+import { RepoStatusConfirmModal } from 'dogma/features/settings/repo-status/RepoStatusConfirmModal';
+
+interface MakeWritableProps {
+  projectName: string;
+  repoName: string;
+}
+
+export const MakeWritable = ({ projectName, repoName }: MakeWritableProps): JSX.Element => {
+  const { isOpen, onToggle, onClose } = useDisclosure();
+  const dispatch = useAppDispatch();
+  const [updateRepositoryStatus, { isLoading }] = useUpdateRepositoryStatusMutation();
+
+  const handleConfirm = async () => {
+    try {
+      await updateRepositoryStatus({ projectName, repoName, status: 'WRITABLE' }).unwrap();
+      dispatch(
+        newNotification('Repository is now writable', `${projectName}/${repoName} is now writable`, 'success'),
+      );
+      onClose();
+    } catch (error) {
+      dispatch(
+        newNotification(
+          `Failed to make ${projectName}/${repoName} writable`,
+          ErrorMessageParser.parse(error),
+          'error',
+        ),
+      );
+    }
+  };
+
+  return (
+    <>
+      <Button leftIcon={<MdLockOpen />} colorScheme="green" variant="outline" size="sm" onClick={onToggle}>
+        Make writable
+      </Button>
+      <RepoStatusConfirmModal
+        isOpen={isOpen}
+        onClose={onClose}
+        projectName={projectName}
+        repoName={repoName}
+        targetStatus="WRITABLE"
+        onConfirm={handleConfirm}
+        isLoading={isLoading}
+      />
+    </>
+  );
+};

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusConfirmModal.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusConfirmModal.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  Button,
+  Code,
+  FormControl,
+  HStack,
+  Input,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+import { ReplicationStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
+
+interface RepoStatusConfirmModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  projectName: string;
+  repoName: string;
+  targetStatus: ReplicationStatus;
+  onConfirm: () => void;
+  isLoading: boolean;
+}
+
+export const RepoStatusConfirmModal = ({
+  isOpen,
+  onClose,
+  projectName,
+  repoName,
+  targetStatus,
+  onConfirm,
+  isLoading,
+}: RepoStatusConfirmModalProps): JSX.Element => {
+  const target = `${projectName}/${repoName}`;
+  const readOnly = targetStatus === 'READ_ONLY';
+  const actionLabel = readOnly ? 'Make read-only' : 'Make writable';
+  const colorScheme = readOnly ? 'red' : 'green';
+
+  const [typed, setTyped] = useState('');
+  const matched = typed === target;
+
+  // Start from an empty input every time the modal opens. This also covers the
+  // same component instance being reused for a different row (the list re-renders
+  // and reflows after a status change) and the success path that closes without
+  // going through handleClose.
+  useEffect(() => {
+    if (isOpen) {
+      setTyped('');
+    }
+  }, [isOpen, target]);
+
+  // Reset the typed confirmation whenever the modal is dismissed.
+  const handleClose = () => {
+    setTyped('');
+    onClose();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={handleClose} closeOnOverlayClick={!isLoading} closeOnEsc={!isLoading}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>{readOnly ? 'Make repository read-only' : 'Make repository writable'}</ModalHeader>
+        <ModalCloseButton isDisabled={isLoading} />
+        <ModalBody>
+          <VStack align="stretch" spacing={3}>
+            <Text>
+              This {readOnly ? 'blocks all writes to' : 'restores writes to'}{' '}
+              <Code fontWeight="bold" colorScheme={colorScheme}>
+                {target}
+              </Code>
+              . To confirm, type the full <Code>project/repository</Code> name below.
+            </Text>
+            <FormControl>
+              <Input
+                value={typed}
+                onChange={(e) => setTyped(e.target.value)}
+                placeholder={target}
+                autoFocus
+                autoComplete="off"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && matched && !isLoading) {
+                    onConfirm();
+                  }
+                }}
+              />
+            </FormControl>
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <HStack spacing={3}>
+            <Button variant="outline" onClick={handleClose} isDisabled={isLoading}>
+              Cancel
+            </Button>
+            <Button
+              colorScheme={colorScheme}
+              onClick={onConfirm}
+              isDisabled={!matched}
+              isLoading={isLoading}
+              loadingText="Applying"
+            >
+              {actionLabel}
+            </Button>
+          </HStack>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusConfirmModal.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusConfirmModal.tsx
@@ -15,6 +15,8 @@
  */
 
 import {
+  Alert,
+  AlertIcon,
   Button,
   Code,
   FormControl,
@@ -32,6 +34,9 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { ReplicationStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
+
+// A project-scoped read-only entry uses the internal "dogma" repository.
+const PROJECT_SCOPE_REPO = 'dogma';
 
 interface RepoStatusConfirmModalProps {
   isOpen: boolean;
@@ -56,6 +61,8 @@ export const RepoStatusConfirmModal = ({
   const readOnly = targetStatus === 'READ_ONLY';
   const actionLabel = readOnly ? 'Make read-only' : 'Make writable';
   const colorScheme = readOnly ? 'red' : 'green';
+  const projectScope = repoName === PROJECT_SCOPE_REPO;
+  const scopeLabel = projectScope ? 'project' : 'repository';
 
   const [typed, setTyped] = useState('');
   const matched = typed === target;
@@ -80,7 +87,7 @@ export const RepoStatusConfirmModal = ({
     <Modal isOpen={isOpen} onClose={handleClose} closeOnOverlayClick={!isLoading} closeOnEsc={!isLoading}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader>{readOnly ? 'Make repository read-only' : 'Make repository writable'}</ModalHeader>
+        <ModalHeader>{`Make ${scopeLabel} ${readOnly ? 'read-only' : 'writable'}`}</ModalHeader>
         <ModalCloseButton isDisabled={isLoading} />
         <ModalBody>
           <VStack align="stretch" spacing={3}>
@@ -91,6 +98,23 @@ export const RepoStatusConfirmModal = ({
               </Code>
               . To confirm, type the full <Code>project/repository</Code> name below.
             </Text>
+            {projectScope && (
+              <Alert status={readOnly ? 'warning' : 'info'} borderRadius="md" fontSize="sm">
+                <AlertIcon />
+                {readOnly ? (
+                  <Text>
+                    <Code>{PROJECT_SCOPE_REPO}</Code> is the internal repository of project{' '}
+                    <Code>{projectName}</Code>, so making it read-only blocks all writes to every repository in
+                    project <Code>{projectName}</Code>.
+                  </Text>
+                ) : (
+                  <Text>
+                    This clears the project-wide read-only status of <Code>{projectName}</Code>. Repositories
+                    that were made read-only individually stay read-only.
+                  </Text>
+                )}
+              </Alert>
+            )}
             <FormControl>
               <Input
                 value={typed}

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusDto.ts
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusDto.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+export type ReplicationStatus = 'WRITABLE' | 'READ_ONLY';
+
+export type RepositoryStatus = {
+  projectName: string;
+  repoName: string;
+  status: ReplicationStatus;
+  updatedAt?: string;
+};

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
@@ -17,6 +17,8 @@
 import { createColumnHelper } from '@tanstack/react-table';
 import { useMemo } from 'react';
 import { Badge, Text } from '@chakra-ui/react';
+import { ChakraLink } from 'dogma/common/components/ChakraLink';
+import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { DataTableClientPagination } from 'dogma/common/components/table/DataTableClientPagination';
 import { RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
 import { MakeWritable } from 'dogma/features/settings/repo-status/MakeWritable';
@@ -33,12 +35,26 @@ const RepoStatusList = ({ data }: RepoStatusListProps) => {
   const columns = useMemo(
     () => [
       columnHelper.accessor((row) => row.projectName, {
-        cell: (info) => <Text>{info.getValue()}</Text>,
+        cell: (info) => (
+          <ChakraLink href={`/app/projects/${info.getValue()}`} fontWeight="semibold">
+            {info.getValue()}
+          </ChakraLink>
+        ),
         header: 'Project',
         id: 'projectName',
       }),
       columnHelper.accessor((row) => (row.repoName === DOGMA_REPO ? '-' : row.repoName), {
-        cell: (info) => <Text>{info.getValue()}</Text>,
+        cell: (info) => {
+          const { projectName, repoName } = info.row.original;
+          if (repoName === DOGMA_REPO) {
+            return <Text>-</Text>;
+          }
+          return (
+            <ChakraLink href={`/app/projects/${projectName}/repos/${repoName}/tree/head`} fontWeight="semibold">
+              {repoName}
+            </ChakraLink>
+          );
+        },
         header: 'Repository',
         id: 'repoName',
       }),
@@ -55,7 +71,7 @@ const RepoStatusList = ({ data }: RepoStatusListProps) => {
       columnHelper.accessor((row) => row.updatedAt, {
         cell: (info) => {
           const value = info.getValue();
-          return <Text>{value ? new Date(value).toLocaleString() : '-'}</Text>;
+          return value ? <DateWithTooltip date={value} /> : <Text>-</Text>;
         },
         header: 'Updated At',
         id: 'updatedAt',

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
@@ -23,9 +23,6 @@ import { DataTableClientPagination } from 'dogma/common/components/table/DataTab
 import { RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
 import { MakeWritable } from 'dogma/features/settings/repo-status/MakeWritable';
 
-// A project-scoped read-only entry uses "dogma" as its repository name.
-const DOGMA_REPO = 'dogma';
-
 export type RepoStatusListProps = {
   data: RepositoryStatus[];
 };
@@ -43,12 +40,9 @@ const RepoStatusList = ({ data }: RepoStatusListProps) => {
         header: 'Project',
         id: 'projectName',
       }),
-      columnHelper.accessor((row) => (row.repoName === DOGMA_REPO ? '-' : row.repoName), {
+      columnHelper.accessor((row) => row.repoName, {
         cell: (info) => {
           const { projectName, repoName } = info.row.original;
-          if (repoName === DOGMA_REPO) {
-            return <Text>-</Text>;
-          }
           return (
             <ChakraLink href={`/app/projects/${projectName}/repos/${repoName}/tree/head`} fontWeight="semibold">
               {repoName}
@@ -57,11 +51,6 @@ const RepoStatusList = ({ data }: RepoStatusListProps) => {
         },
         header: 'Repository',
         id: 'repoName',
-      }),
-      columnHelper.accessor((row) => (row.repoName === DOGMA_REPO ? 'Project' : 'Repository'), {
-        cell: (info) => <Badge colorScheme="purple">{info.getValue()}</Badge>,
-        header: 'Scope',
-        id: 'scope',
       }),
       columnHelper.accessor((row) => row.status, {
         cell: (info) => <Badge colorScheme="red">{info.getValue()}</Badge>,

--- a/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
+++ b/webapp/src/dogma/features/settings/repo-status/RepoStatusList.tsx
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { createColumnHelper } from '@tanstack/react-table';
+import { useMemo } from 'react';
+import { Badge, Text } from '@chakra-ui/react';
+import { DataTableClientPagination } from 'dogma/common/components/table/DataTableClientPagination';
+import { RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
+import { MakeWritable } from 'dogma/features/settings/repo-status/MakeWritable';
+
+// A project-scoped read-only entry uses "dogma" as its repository name.
+const DOGMA_REPO = 'dogma';
+
+export type RepoStatusListProps = {
+  data: RepositoryStatus[];
+};
+
+const RepoStatusList = ({ data }: RepoStatusListProps) => {
+  const columnHelper = createColumnHelper<RepositoryStatus>();
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor((row) => row.projectName, {
+        cell: (info) => <Text>{info.getValue()}</Text>,
+        header: 'Project',
+        id: 'projectName',
+      }),
+      columnHelper.accessor((row) => (row.repoName === DOGMA_REPO ? '-' : row.repoName), {
+        cell: (info) => <Text>{info.getValue()}</Text>,
+        header: 'Repository',
+        id: 'repoName',
+      }),
+      columnHelper.accessor((row) => (row.repoName === DOGMA_REPO ? 'Project' : 'Repository'), {
+        cell: (info) => <Badge colorScheme="purple">{info.getValue()}</Badge>,
+        header: 'Scope',
+        id: 'scope',
+      }),
+      columnHelper.accessor((row) => row.status, {
+        cell: (info) => <Badge colorScheme="red">{info.getValue()}</Badge>,
+        header: 'Status',
+        id: 'status',
+      }),
+      columnHelper.accessor((row) => row.updatedAt, {
+        cell: (info) => {
+          const value = info.getValue();
+          return <Text>{value ? new Date(value).toLocaleString() : '-'}</Text>;
+        },
+        header: 'Updated At',
+        id: 'updatedAt',
+      }),
+      columnHelper.accessor((row) => row.repoName, {
+        cell: (info) => (
+          <MakeWritable projectName={info.row.original.projectName} repoName={info.row.original.repoName} />
+        ),
+        header: 'Actions',
+        id: 'actions',
+        enableSorting: false,
+      }),
+    ],
+    [columnHelper],
+  );
+
+  return <DataTableClientPagination columns={columns} data={data} />;
+};
+
+export default RepoStatusList;

--- a/webapp/src/pages/api/v1/projects/[projectName]/repos/index.ts
+++ b/webapp/src/pages/api/v1/projects/[projectName]/repos/index.ts
@@ -13,16 +13,18 @@ const newRepo = (id: number): RepoDto => {
     headRevision: parseInt(faker.random.numeric()),
     url: faker.internet.url(),
     createdAt: faker.datatype.datetime().toISOString(),
+    status: 'WRITABLE',
   };
 };
 
-const mockRepos = [
+const mockRepos: RepoDto[] = [
   {
     name: 'meta',
     creator: { name: 'System', email: 'system@localhost.localdomain' },
     headRevision: 1,
     url: '/api/v1/projects/abcd/repos/meta',
     createdAt: '2022-11-23T03:13:49.581Z',
+    status: 'WRITABLE',
   },
   {
     name: 'repo1',
@@ -30,6 +32,7 @@ const mockRepos = [
     headRevision: 6,
     url: '/api/v1/projects/abcd/repos/repo1',
     createdAt: '2022-11-23T03:16:17.880Z',
+    status: 'WRITABLE',
   },
 ];
 

--- a/webapp/src/pages/api/v1/projects/index.ts
+++ b/webapp/src/pages/api/v1/projects/index.ts
@@ -13,6 +13,7 @@ const newProject = (id: number): ProjectDto => {
     url: faker.internet.url(),
     userRole: faker.helpers.arrayElement(['OWNER', 'MEMBER', 'GUEST']),
     createdAt: faker.datatype.datetime().toString(),
+    status: 'WRITABLE',
   };
 };
 
@@ -23,13 +24,15 @@ const projects: ProjectDto[] = [
     url: '/api/v1/projects/abcd',
     userRole: 'OWNER',
     createdAt: '2022-11-02T04:16:12.444Z',
+    status: 'WRITABLE',
   },
   {
     name: 'xyz',
     creator: { name: 'System', email: 'system@localhost.localdomain' },
     url: '/api/v1/projects/xyz',
-    userRole: 'MEMBER',
+    userRole: 'OWNER',
     createdAt: '2022-11-02T04:16:03.175Z',
+    status: 'READ_ONLY',
   },
   {
     name: 'dogma',
@@ -37,6 +40,7 @@ const projects: ProjectDto[] = [
     url: '/api/v1/projects/dogma',
     userRole: 'GUEST',
     createdAt: '2022-11-02T04:16:03.175Z',
+    status: 'WRITABLE',
   },
   {
     name: 'project-removed',
@@ -69,6 +73,7 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
         },
         url: faker.internet.url(),
         createdAt: faker.datatype.datetime().toString(),
+        status: 'WRITABLE',
       });
       res.status(200).json(projects);
       break;

--- a/webapp/src/pages/app/projects/[projectName]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/index.tsx
@@ -7,10 +7,13 @@ import RepoList from 'dogma/features/repo/RepoList';
 import { useRouter } from 'next/router';
 import { FiBox } from 'react-icons/fi';
 import { ProjectSettingsButton } from 'dogma/common/components/ProjectSettingsButton';
+import { RepoStatusTag } from 'dogma/features/repo/RepoStatusTag';
+import { useProjectReadOnly } from 'dogma/features/repo/useReadOnly';
 
 const ProjectDetailPage = () => {
   const router = useRouter();
   const projectName = router.query.projectName as string;
+  const projectReadOnly = useProjectReadOnly(projectName);
   const {
     data: repoData,
     isLoading,
@@ -32,6 +35,7 @@ const ProjectDetailPage = () => {
                 <Box>{projectName}</Box>
               </HStack>
             </Heading>
+            {projectReadOnly && <RepoStatusTag status="READ_ONLY" />}
           </Flex>
           <Tabs variant="enclosed-colored" size="lg">
             <TabList>

--- a/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
+++ b/webapp/src/pages/app/projects/[projectName]/repos/[repoName]/tree/[revision]/[[...path]]/index.tsx
@@ -19,6 +19,8 @@ import { ChakraLink } from 'dogma/common/components/ChakraLink';
 import { FaHistory } from 'react-icons/fa';
 import { makeTraversalFileLinks, toFilePath } from 'dogma/util/path-util';
 import { WithRepositoryRole } from 'dogma/features/auth/RepositoryRole';
+import { useReadOnly } from 'dogma/features/repo/useReadOnly';
+import { RepoStatusTag } from 'dogma/features/repo/RepoStatusTag';
 
 const RepositoryDetailPage = () => {
   const router = useRouter();
@@ -28,6 +30,7 @@ const RepositoryDetailPage = () => {
   const filePath = router.query.path ? toFilePath(router.query.path) : '';
   const directoryPath = router.asPath;
   const dispatch = useAppDispatch();
+  const [readOnly, readOnlyHint] = useReadOnly(projectName, repoName);
 
   const copyToClipboard = async (text: string) => {
     try {
@@ -128,6 +131,7 @@ cat ${project}/${repo}${path}`;
                   Revision {revision} <InfoIcon ml={2} />
                 </Tag>
               </Tooltip>
+              {readOnly && <RepoStatusTag status="READ_ONLY" />}
               <Spacer />
             </Flex>
             <Flex gap={2}>
@@ -145,24 +149,38 @@ cat ${project}/${repo}${path}`;
               {projectName === 'dogma' ? null : (
                 <WithRepositoryRole projectName={projectName} repoName={repoName} roles={['ADMIN']}>
                   {() => (
-                    <MetadataButton
-                      href={`/app/projects/${projectName}/repos/${repoName}/settings`}
-                      props={{ size: 'sm' }}
-                      text={'Repository Settings'}
-                    />
+                    <Tooltip label={readOnlyHint} isDisabled={!readOnly}>
+                      <Box>
+                        <MetadataButton
+                          href={`/app/projects/${projectName}/repos/${repoName}/settings`}
+                          props={{ size: 'sm' }}
+                          text={'Repository Settings'}
+                          isDisabled={readOnly}
+                        />
+                      </Box>
+                    </Tooltip>
                   )}
                 </WithRepositoryRole>
               )}
               {projectName === 'dogma' || repoName === 'dogma' ? null : (
-                <Button
-                  as={Link}
-                  href={`/app/projects/${projectName}/repos/${repoName}/files/new${filePath}`}
-                  size="sm"
-                  rightIcon={<AiOutlinePlus />}
-                  colorScheme="teal"
-                >
-                  New File
-                </Button>
+                <Tooltip label={readOnlyHint} isDisabled={!readOnly}>
+                  <Box>
+                    <Button
+                      {...(readOnly
+                        ? {}
+                        : {
+                            as: Link,
+                            href: `/app/projects/${projectName}/repos/${repoName}/files/new${filePath}`,
+                          })}
+                      isDisabled={readOnly}
+                      size="sm"
+                      rightIcon={<AiOutlinePlus />}
+                      colorScheme="teal"
+                    >
+                      New File
+                    </Button>
+                  </Box>
+                </Tooltip>
               )}
             </Flex>
             <FileList

--- a/webapp/src/pages/app/settings/repo-status/index.tsx
+++ b/webapp/src/pages/app/settings/repo-status/index.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Badge, Box, Flex, Text } from '@chakra-ui/react';
+import SettingView from 'dogma/features/settings/SettingView';
+import { Deferred } from 'dogma/common/components/Deferred';
+import { useGetReadOnlyReposQuery, useGetServerStatusQuery } from 'dogma/features/api/apiSlice';
+import { ServerStatusType } from 'dogma/features/settings/server-status/ServerStatusDto';
+import RepoStatusList from 'dogma/features/settings/repo-status/RepoStatusList';
+import MakeReadOnlyForm from 'dogma/features/settings/repo-status/MakeReadOnlyForm';
+
+const getServerStatusColorScheme = (status: ServerStatusType) => {
+  switch (status) {
+    case 'WRITABLE':
+      return 'green';
+    case 'REPLICATION_ONLY':
+      return 'yellow';
+    case 'READ_ONLY':
+      return 'red';
+  }
+};
+
+const RepoStatusPage = () => {
+  const { data: serverStatus } = useGetServerStatusQuery();
+  const { data: readOnlyRepos, error, isLoading } = useGetReadOnlyReposQuery();
+
+  return (
+    <SettingView currentTab="Repository Status">
+      <Deferred isLoading={isLoading} error={error}>
+        {() => (
+          <Box p="4">
+            <Flex mb="6" alignItems="center">
+              <Text fontSize="lg" fontWeight="bold">
+                Current Server Status:
+              </Text>
+              {serverStatus ? (
+                <Badge
+                  ml="4"
+                  px="3"
+                  py="1"
+                  fontSize="md"
+                  colorScheme={getServerStatusColorScheme(serverStatus)}
+                  borderRadius="md"
+                >
+                  {serverStatus}
+                </Badge>
+              ) : (
+                <Text ml="4">Not available</Text>
+              )}
+            </Flex>
+
+            <MakeReadOnlyForm />
+
+            <Text fontSize="lg" fontWeight="bold" mb="3">
+              Read-only Projects &amp; Repositories:
+            </Text>
+            {readOnlyRepos && readOnlyRepos.length > 0 ? (
+              <RepoStatusList data={readOnlyRepos} />
+            ) : serverStatus && serverStatus !== 'WRITABLE' ? (
+              <Text color="orange.500">
+                The entire server is currently in {serverStatus} mode, so all repositories are read-only.
+              </Text>
+            ) : (
+              <Text color="gray.500">All projects and repositories are writable.</Text>
+            )}
+          </Box>
+        )}
+      </Deferred>
+    </SettingView>
+  );
+};
+
+export default RepoStatusPage;

--- a/webapp/tests/dogma/feature/api/repoStatusInvalidation.test.ts
+++ b/webapp/tests/dogma/feature/api/repoStatusInvalidation.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { waitFor } from '@testing-library/react';
+import { apiSlice } from 'dogma/features/api/apiSlice';
+import { setupStore } from 'dogma/store';
+
+const json = (body: unknown) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+  );
+
+const requestedUrls: string[] = [];
+
+const fetchMock = jest.fn((input: RequestInfo | URL) => {
+  const request = input as Request;
+  const url = typeof input === 'string' ? input : request.url;
+  requestedUrls.push(url);
+  if (request.method === 'PUT') {
+    return json({});
+  }
+  if (url.endsWith('/repos')) {
+    return json([
+      {
+        name: 'bar',
+        creator: { name: 'System', email: 'system@localhost.localdomain' },
+        headRevision: 1,
+        url: '/api/v1/projects/foo/repos/bar',
+        createdAt: '2026-01-01T00:00:00Z',
+        status: 'WRITABLE',
+      },
+    ]);
+  }
+  return json([{ name: 'foo', url: '/api/v1/projects/foo', status: 'WRITABLE' }]);
+});
+
+const countOf = (suffix: string) => requestedUrls.filter((url) => url.endsWith(suffix)).length;
+
+// The project and repository lists carry the replication status, so a status change has to refetch them.
+// Otherwise the read-only badge and the disabled write buttons keep showing the previous status until the
+// cache entry is dropped.
+describe('updateRepositoryStatus cache invalidation', () => {
+  beforeEach(() => {
+    requestedUrls.length = 0;
+    fetchMock.mockClear();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('refetches the project and repository lists after a status change', async () => {
+    const store = setupStore();
+
+    // Both lists stay subscribed, as they are while the pages are mounted.
+    store.dispatch(apiSlice.endpoints.getProjects.initiate({ systemAdmin: false }));
+    store.dispatch(apiSlice.endpoints.getRepos.initiate('foo'));
+    await waitFor(() => {
+      expect(countOf('/api/v1/projects')).toBe(1);
+      expect(countOf('/repos')).toBe(1);
+    });
+
+    await store.dispatch(
+      apiSlice.endpoints.updateRepositoryStatus.initiate({
+        projectName: 'foo',
+        repoName: 'bar',
+        status: 'READ_ONLY',
+      }),
+    );
+
+    await waitFor(() => {
+      expect(countOf('/api/v1/projects')).toBe(2);
+      expect(countOf('/repos')).toBe(2);
+    });
+  });
+
+  it('refetches the read-only repository list after a status change', async () => {
+    const store = setupStore();
+
+    store.dispatch(apiSlice.endpoints.getReadOnlyRepos.initiate());
+    await waitFor(() => expect(countOf('/api/v1/status/repos/read-only')).toBe(1));
+
+    await store.dispatch(
+      apiSlice.endpoints.updateRepositoryStatus.initiate({
+        projectName: 'foo',
+        repoName: 'bar',
+        status: 'READ_ONLY',
+      }),
+    );
+
+    await waitFor(() => expect(countOf('/api/v1/status/repos/read-only')).toBe(2));
+  });
+});

--- a/webapp/tests/dogma/feature/file/FileListReadOnly.test.tsx
+++ b/webapp/tests/dogma/feature/file/FileListReadOnly.test.tsx
@@ -1,0 +1,81 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import FileList from 'dogma/features/file/FileList';
+import { CopySupport } from 'dogma/features/file/CopySupport';
+import { PROJECT_READ_ONLY_HINT, REPO_READ_ONLY_HINT } from 'dogma/features/repo/useReadOnly';
+import { useGetProjectsQuery, useGetReposQuery } from 'dogma/features/api/apiSlice';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useGetProjectsQuery: jest.fn(),
+  useGetReposQuery: jest.fn(),
+}));
+
+const copySupport: CopySupport = {
+  handleApiUrl: jest.fn(),
+  handleWebUrl: jest.fn(),
+  handleAsCliCommand: jest.fn(),
+  handleAsCurlCommand: jest.fn(),
+};
+
+const data = [
+  { revision: 6, path: '/hello.txt', type: 'TEXT', url: '/api/v1/projects/foo/repos/bar/contents/hello.txt' },
+];
+
+const renderFileList = (projectStatus: string, repoStatus: string) => {
+  (useGetProjectsQuery as jest.Mock).mockReturnValue({ data: [{ name: 'foo', status: projectStatus }] });
+  (useGetReposQuery as jest.Mock).mockReturnValue({ data: [{ name: 'bar', status: repoStatus }] });
+  return renderWithProviders(
+    <FileList
+      data={data}
+      projectName="foo"
+      repoName="bar"
+      path=""
+      directoryPath="/app/projects/foo/repos/bar/tree/head"
+      revision="head"
+      copySupport={copySupport}
+    />,
+  );
+};
+
+const deleteButton = () => screen.getByRole('button', { name: 'Delete' });
+
+describe('FileList delete action', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('offers Delete on a writable repository', () => {
+    renderFileList('WRITABLE', 'WRITABLE');
+    expect(deleteButton()).toBeEnabled();
+  });
+
+  it('disables Delete when the repository is read-only', async () => {
+    renderFileList('WRITABLE', 'READ_ONLY');
+    expect(deleteButton()).toBeDisabled();
+
+    await userEvent.hover(deleteButton().parentElement);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(REPO_READ_ONLY_HINT);
+  });
+
+  it('disables Delete when the whole project is read-only', async () => {
+    renderFileList('READ_ONLY', 'READ_ONLY');
+    expect(deleteButton()).toBeDisabled();
+
+    await userEvent.hover(deleteButton().parentElement);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(PROJECT_READ_ONLY_HINT);
+  });
+
+  it('does not open the delete confirmation while read-only', async () => {
+    renderFileList('WRITABLE', 'READ_ONLY');
+
+    await userEvent.click(deleteButton());
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('keeps the copy actions available while read-only', () => {
+    renderFileList('WRITABLE', 'READ_ONLY');
+    const row = screen.getByText('hello.txt').closest('tr');
+    expect(within(row).getByRole('button', { name: /Copy/ })).toBeEnabled();
+  });
+});

--- a/webapp/tests/dogma/feature/project/Projects.test.tsx
+++ b/webapp/tests/dogma/feature/project/Projects.test.tsx
@@ -1,0 +1,124 @@
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { Projects } from 'dogma/features/project/Projects';
+import { ProjectDto } from 'dogma/features/project/ProjectDto';
+import { PROJECT_READ_ONLY_HINT } from 'dogma/features/repo/useReadOnly';
+import {
+  useGetMetadataByProjectNameQuery,
+  useGetProjectsQuery,
+  useRestoreProjectMutation,
+} from 'dogma/features/api/apiSlice';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useGetProjectsQuery: jest.fn(),
+  useGetMetadataByProjectNameQuery: jest.fn(),
+  useRestoreProjectMutation: jest.fn(),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: {},
+    pathname: '/app/projects',
+    asPath: '/app/projects',
+    push: jest.fn(),
+  }),
+}));
+
+const creator = { name: 'System', email: 'system@localhost.localdomain' };
+
+const mockProjects: ProjectDto[] = [
+  {
+    name: 'locked-project',
+    creator,
+    url: '/api/v1/projects/locked-project',
+    userRole: 'OWNER',
+    createdAt: '2026-01-01T00:00:00Z',
+    status: 'READ_ONLY',
+  },
+  {
+    name: 'open-project',
+    creator,
+    url: '/api/v1/projects/open-project',
+    userRole: 'OWNER',
+    createdAt: '2026-01-02T00:00:00Z',
+    status: 'WRITABLE',
+  },
+];
+
+const preloadedState = {
+  auth: {
+    isInAnonymousMode: false,
+    csrfToken: null,
+    isLoading: false,
+    user: {
+      login: 'admin',
+      name: 'Admin User',
+      email: 'admin@example.com',
+      roles: [],
+      systemAdmin: false,
+    },
+  },
+  filter: { projectFilter: 'ALL' as const, isInitialProjectFilter: false },
+};
+
+const rowOf = (projectName: string) => screen.getByText(projectName).closest('tr');
+
+describe('Projects', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useGetMetadataByProjectNameQuery as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    (useRestoreProjectMutation as jest.Mock).mockReturnValue([jest.fn(), { isLoading: false }]);
+    (useGetProjectsQuery as jest.Mock).mockReturnValue({
+      data: mockProjects,
+      error: undefined,
+      isLoading: false,
+    });
+  });
+
+  const renderProjects = () => renderWithProviders(<Projects />, { preloadedState });
+
+  it('tags a read-only project', () => {
+    renderProjects();
+    expect(within(rowOf('locked-project')).getByText('Read-only')).toBeInTheDocument();
+  });
+
+  it('tags a writable project', () => {
+    renderProjects();
+    expect(within(rowOf('open-project')).getByText('Writable')).toBeInTheDocument();
+  });
+
+  // A disabled anchor is still clickable, so the link has to be dropped rather than disabled.
+  it('disables the project settings button of a read-only project and drops its link', () => {
+    renderProjects();
+    const button = within(rowOf('locked-project')).getByRole('button', { name: 'Project Settings' });
+    expect(button).toBeDisabled();
+    expect(button.closest('a')).toBeNull();
+  });
+
+  it('explains why the project settings button is disabled on hover', async () => {
+    renderProjects();
+    const button = within(rowOf('locked-project')).getByRole('button', { name: 'Project Settings' });
+
+    await userEvent.hover(button.parentElement);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(PROJECT_READ_ONLY_HINT);
+  });
+
+  it('keeps the project settings button of a writable project linked', () => {
+    renderProjects();
+    const button = within(rowOf('open-project')).getByRole('button', { name: 'Project Settings' });
+    expect(button).toBeEnabled();
+    expect(button.closest('a')).toHaveAttribute('href', '/app/projects/open-project/settings');
+  });
+
+  it('keeps a read-only project browsable', () => {
+    renderProjects();
+    expect(within(rowOf('locked-project')).getByRole('link', { name: 'locked-project' })).toHaveAttribute(
+      'href',
+      '/app/projects/locked-project',
+    );
+  });
+});

--- a/webapp/tests/dogma/feature/repo/NewRepo.test.tsx
+++ b/webapp/tests/dogma/feature/repo/NewRepo.test.tsx
@@ -1,0 +1,81 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { NewRepo } from 'dogma/features/repo/NewRepo';
+import { PROJECT_READ_ONLY_HINT } from 'dogma/features/repo/useReadOnly';
+import {
+  useAddNewRepoMutation,
+  useGetMetadataByProjectNameQuery,
+  useGetProjectsQuery,
+} from 'dogma/features/api/apiSlice';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useAddNewRepoMutation: jest.fn(),
+  useGetMetadataByProjectNameQuery: jest.fn(),
+  useGetProjectsQuery: jest.fn(),
+}));
+
+jest.mock('next/router', () => ({
+  __esModule: true,
+  default: { push: jest.fn() },
+}));
+
+const authState = {
+  isInAnonymousMode: false,
+  csrfToken: null,
+  isLoading: false,
+  user: {
+    login: 'admin',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    roles: [],
+    systemAdmin: true,
+  },
+};
+
+const renderNewRepo = (projectStatus: 'WRITABLE' | 'READ_ONLY') => {
+  (useGetProjectsQuery as jest.Mock).mockReturnValue({ data: [{ name: 'foo', status: projectStatus }] });
+  return renderWithProviders(<NewRepo projectName="foo" />, { preloadedState: { auth: authState } });
+};
+
+describe('NewRepo', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAddNewRepoMutation as jest.Mock).mockReturnValue([jest.fn(), { isLoading: false }]);
+    // A system administrator is an OWNER of every project, but only once the metadata has arrived.
+    (useGetMetadataByProjectNameQuery as jest.Mock).mockReturnValue({ data: { members: {} } });
+  });
+
+  it('opens the create form when the project is writable', async () => {
+    renderNewRepo('WRITABLE');
+    const button = screen.getByRole('button', { name: 'New Repository' });
+    expect(button).toBeEnabled();
+
+    await userEvent.click(button);
+    expect(await screen.findByPlaceholderText('my-repo-name')).toBeInTheDocument();
+  });
+
+  it('disables the button when the project is read-only', () => {
+    renderNewRepo('READ_ONLY');
+    expect(screen.getByRole('button', { name: 'New Repository' })).toBeDisabled();
+  });
+
+  // A disabled button swallows pointer events, so the hint has to live on a wrapper around it.
+  it('explains why the button is disabled on hover', async () => {
+    renderNewRepo('READ_ONLY');
+    const button = screen.getByRole('button', { name: 'New Repository' });
+
+    await userEvent.hover(button.parentElement);
+
+    expect(await screen.findByRole('tooltip')).toHaveTextContent(PROJECT_READ_ONLY_HINT);
+  });
+
+  it('does not open the create form when the project is read-only', async () => {
+    renderNewRepo('READ_ONLY');
+
+    await userEvent.click(screen.getByRole('button', { name: 'New Repository' }));
+
+    expect(screen.queryByPlaceholderText('my-repo-name')).not.toBeInTheDocument();
+  });
+});

--- a/webapp/tests/dogma/feature/repo/useReadOnly.test.tsx
+++ b/webapp/tests/dogma/feature/repo/useReadOnly.test.tsx
@@ -1,0 +1,112 @@
+import { renderHook } from '@testing-library/react';
+import { useGetProjectsQuery, useGetReposQuery } from 'dogma/features/api/apiSlice';
+import {
+  PROJECT_READ_ONLY_HINT,
+  REPO_READ_ONLY_HINT,
+  useProjectReadOnly,
+  useReadOnly,
+  useRepoReadOnly,
+} from 'dogma/features/repo/useReadOnly';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  useGetProjectsQuery: jest.fn(),
+  useGetReposQuery: jest.fn(),
+}));
+
+const givenProjects = (data: unknown) => (useGetProjectsQuery as jest.Mock).mockReturnValue({ data });
+const givenRepos = (data: unknown) => (useGetReposQuery as jest.Mock).mockReturnValue({ data });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  givenProjects(undefined);
+  givenRepos(undefined);
+});
+
+describe('useProjectReadOnly', () => {
+  it('reports a read-only project', () => {
+    givenProjects([{ name: 'foo', status: 'READ_ONLY' }]);
+    const { result } = renderHook(() => useProjectReadOnly('foo'));
+    expect(result.current).toBe(true);
+  });
+
+  it('reports a writable project', () => {
+    givenProjects([{ name: 'foo', status: 'WRITABLE' }]);
+    const { result } = renderHook(() => useProjectReadOnly('foo'));
+    expect(result.current).toBe(false);
+  });
+
+  // A write action must never be disabled just because the status has not arrived yet.
+  it('is not read-only while the projects are still being fetched', () => {
+    givenProjects(undefined);
+    const { result } = renderHook(() => useProjectReadOnly('foo'));
+    expect(result.current).toBe(false);
+  });
+
+  it('is not read-only when the project is missing from the response', () => {
+    givenProjects([{ name: 'other', status: 'READ_ONLY' }]);
+    const { result } = renderHook(() => useProjectReadOnly('foo'));
+    expect(result.current).toBe(false);
+  });
+
+  it.each(['dogma', '@internal'])('skips the query for the internal project %s', (projectName) => {
+    const { result } = renderHook(() => useProjectReadOnly(projectName));
+    expect(result.current).toBe(false);
+    expect(useGetProjectsQuery).toHaveBeenCalledWith({ systemAdmin: false }, { skip: true });
+  });
+
+  it('skips the query until the project name is known', () => {
+    const { result } = renderHook(() => useProjectReadOnly(''));
+    expect(result.current).toBe(false);
+    expect(useGetProjectsQuery).toHaveBeenCalledWith({ systemAdmin: false }, { skip: true });
+  });
+});
+
+describe('useRepoReadOnly', () => {
+  it('reports a read-only repository', () => {
+    givenRepos([{ name: 'bar', status: 'READ_ONLY' }]);
+    const { result } = renderHook(() => useRepoReadOnly('foo', 'bar'));
+    expect(result.current).toBe(true);
+  });
+
+  it('reports a writable repository', () => {
+    givenRepos([{ name: 'bar', status: 'WRITABLE' }]);
+    const { result } = renderHook(() => useRepoReadOnly('foo', 'bar'));
+    expect(result.current).toBe(false);
+  });
+
+  it('is not read-only while the repositories are still being fetched', () => {
+    givenRepos(undefined);
+    const { result } = renderHook(() => useRepoReadOnly('foo', 'bar'));
+    expect(result.current).toBe(false);
+  });
+
+  it('skips the query for a repository of an internal project', () => {
+    const { result } = renderHook(() => useRepoReadOnly('dogma', 'bar'));
+    expect(result.current).toBe(false);
+    expect(useGetReposQuery).toHaveBeenCalledWith('dogma', { skip: true });
+  });
+});
+
+describe('useReadOnly', () => {
+  it('prefers the project hint when the whole project is read-only', () => {
+    givenProjects([{ name: 'foo', status: 'READ_ONLY' }]);
+    // The server returns the effective status, so a repository of a read-only project is read-only too.
+    givenRepos([{ name: 'bar', status: 'READ_ONLY' }]);
+    const { result } = renderHook(() => useReadOnly('foo', 'bar'));
+    expect(result.current).toEqual([true, PROJECT_READ_ONLY_HINT]);
+  });
+
+  it('uses the repository hint when only the repository is read-only', () => {
+    givenProjects([{ name: 'foo', status: 'WRITABLE' }]);
+    givenRepos([{ name: 'bar', status: 'READ_ONLY' }]);
+    const { result } = renderHook(() => useReadOnly('foo', 'bar'));
+    expect(result.current).toEqual([true, REPO_READ_ONLY_HINT]);
+  });
+
+  it('is not read-only when both the project and the repository are writable', () => {
+    givenProjects([{ name: 'foo', status: 'WRITABLE' }]);
+    givenRepos([{ name: 'bar', status: 'WRITABLE' }]);
+    const { result } = renderHook(() => useReadOnly('foo', 'bar'));
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/webapp/tests/dogma/feature/settings/repo-status/RepoStatusConfirmModal.test.tsx
+++ b/webapp/tests/dogma/feature/settings/repo-status/RepoStatusConfirmModal.test.tsx
@@ -1,0 +1,82 @@
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { RepoStatusConfirmModal } from 'dogma/features/settings/repo-status/RepoStatusConfirmModal';
+import { ReplicationStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
+
+const setup = (targetStatus: ReplicationStatus, onConfirm: jest.Mock = jest.fn()) => {
+  renderWithProviders(
+    <RepoStatusConfirmModal
+      isOpen
+      onClose={jest.fn()}
+      projectName="foo"
+      repoName="bar"
+      targetStatus={targetStatus}
+      onConfirm={onConfirm}
+      isLoading={false}
+    />,
+  );
+  return onConfirm;
+};
+
+const labelOf = (status: ReplicationStatus) => (status === 'READ_ONLY' ? 'Make read-only' : 'Make writable');
+
+describe('RepoStatusConfirmModal', () => {
+  it.each(['READ_ONLY', 'WRITABLE'] as const)(
+    'keeps the %s confirm button disabled until the exact project/repo is typed',
+    (status) => {
+      setup(status);
+      const confirmButton = screen.getByRole('button', { name: labelOf(status) });
+      expect(confirmButton).toBeDisabled();
+
+      // A partial/wrong name keeps it disabled.
+      fireEvent.change(screen.getByPlaceholderText('foo/bar'), { target: { value: 'foo/ba' } });
+      expect(confirmButton).toBeDisabled();
+
+      // The exact name enables it.
+      fireEvent.change(screen.getByPlaceholderText('foo/bar'), { target: { value: 'foo/bar' } });
+      expect(confirmButton).toBeEnabled();
+    },
+  );
+
+  it('calls onConfirm only after the exact name is typed', () => {
+    const onConfirm = setup('WRITABLE');
+
+    // Clicking while disabled does nothing.
+    fireEvent.click(screen.getByRole('button', { name: 'Make writable' }));
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByPlaceholderText('foo/bar'), { target: { value: 'foo/bar' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Make writable' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the typed confirmation when reused for a different target', () => {
+    const { rerender } = renderWithProviders(
+      <RepoStatusConfirmModal
+        isOpen
+        onClose={jest.fn()}
+        projectName="foo"
+        repoName="bar"
+        targetStatus="WRITABLE"
+        onConfirm={jest.fn()}
+        isLoading={false}
+      />,
+    );
+    fireEvent.change(screen.getByPlaceholderText('foo/bar'), { target: { value: 'foo/bar' } });
+    expect(screen.getByPlaceholderText('foo/bar')).toHaveValue('foo/bar');
+
+    // The list re-renders after a status change and the modal instance is reused for another row.
+    rerender(
+      <RepoStatusConfirmModal
+        isOpen
+        onClose={jest.fn()}
+        projectName="baz"
+        repoName="qux"
+        targetStatus="WRITABLE"
+        onConfirm={jest.fn()}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByPlaceholderText('baz/qux')).toHaveValue('');
+  });
+});

--- a/webapp/tests/dogma/feature/settings/repo-status/RepoStatusConfirmModal.test.tsx
+++ b/webapp/tests/dogma/feature/settings/repo-status/RepoStatusConfirmModal.test.tsx
@@ -3,13 +3,13 @@ import { renderWithProviders } from 'dogma/util/test-utils';
 import { RepoStatusConfirmModal } from 'dogma/features/settings/repo-status/RepoStatusConfirmModal';
 import { ReplicationStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
 
-const setup = (targetStatus: ReplicationStatus, onConfirm: jest.Mock = jest.fn()) => {
+const setup = (targetStatus: ReplicationStatus, onConfirm: jest.Mock = jest.fn(), repoName = 'bar') => {
   renderWithProviders(
     <RepoStatusConfirmModal
       isOpen
       onClose={jest.fn()}
       projectName="foo"
-      repoName="bar"
+      repoName={repoName}
       targetStatus={targetStatus}
       onConfirm={onConfirm}
       isLoading={false}
@@ -48,6 +48,47 @@ describe('RepoStatusConfirmModal', () => {
     fireEvent.change(screen.getByPlaceholderText('foo/bar'), { target: { value: 'foo/bar' } });
     fireEvent.click(screen.getByRole('button', { name: 'Make writable' }));
     expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  // Making the internal `dogma` repository read-only locks the whole project, which is not obvious
+  // from the `foo/dogma` target alone.
+  describe('the internal dogma repository', () => {
+    it('warns that a read-only dogma repository locks every repository in the project', () => {
+      setup('READ_ONLY', jest.fn(), 'dogma');
+
+      expect(screen.getByText('Make project read-only')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'blocks all writes to every repository in project foo',
+      );
+    });
+
+    it('warns that a writable dogma repository leaves individually read-only repositories locked', () => {
+      setup('WRITABLE', jest.fn(), 'dogma');
+
+      expect(screen.getByText('Make project writable')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Repositories that were made read-only individually stay read-only',
+      );
+    });
+
+    it('does not warn about the project scope for a regular repository', () => {
+      setup('READ_ONLY');
+
+      expect(screen.getByText('Make repository read-only')).toBeInTheDocument();
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('still requires the full project/repository name to confirm', () => {
+      setup('READ_ONLY', jest.fn(), 'dogma');
+      const confirmButton = screen.getByRole('button', { name: 'Make read-only' });
+      expect(confirmButton).toBeDisabled();
+
+      fireEvent.change(screen.getByPlaceholderText('foo/dogma'), { target: { value: 'foo' } });
+      expect(confirmButton).toBeDisabled();
+
+      fireEvent.change(screen.getByPlaceholderText('foo/dogma'), { target: { value: 'foo/dogma' } });
+      expect(confirmButton).toBeEnabled();
+    });
   });
 
   it('clears the typed confirmation when reused for a different target', () => {

--- a/webapp/tests/pages/app/settings/repo-status/index.test.tsx
+++ b/webapp/tests/pages/app/settings/repo-status/index.test.tsx
@@ -1,0 +1,141 @@
+import { renderWithProviders } from 'dogma/util/test-utils';
+import RepoStatusPage from 'pages/app/settings/repo-status';
+import { RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
+import {
+  useGetProjectsQuery,
+  useGetReadOnlyReposQuery,
+  useGetReposQuery,
+  useGetServerStatusQuery,
+  useUpdateRepositoryStatusMutation,
+} from 'dogma/features/api/apiSlice';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useGetReadOnlyReposQuery: jest.fn(),
+  useGetServerStatusQuery: jest.fn(),
+  useGetProjectsQuery: jest.fn(),
+  useGetReposQuery: jest.fn(),
+  useUpdateRepositoryStatusMutation: jest.fn(),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: '/app/settings/repo-status',
+    pathname: '/app/settings/repo-status',
+    isReady: true,
+    query: {},
+    push: jest.fn(),
+  }),
+}));
+
+// Mock chakra-react-select which doesn't work in JSDOM.
+jest.mock('chakra-react-select', () => ({
+  Select: ({ id, options, onChange, value, placeholder }: any) => (
+    <select
+      id={id}
+      data-testid={id}
+      value={value?.value || ''}
+      onChange={(e) => onChange(options?.find((o: any) => o.value === e.target.value) || null)}
+    >
+      <option value="">{placeholder || 'Select...'}</option>
+      {options?.map((o: any) => (
+        <option key={o.value} value={o.value}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+const mockReadOnlyRepos: RepositoryStatus[] = [
+  { projectName: 'foo', repoName: 'bar', status: 'READ_ONLY', updatedAt: '2026-01-01T00:00:00Z' },
+  { projectName: 'baz', repoName: 'dogma', status: 'READ_ONLY', updatedAt: '2026-01-02T00:00:00Z' },
+];
+
+const baseAuthState = {
+  isInAnonymousMode: false,
+  csrfToken: null,
+  isLoading: false,
+  user: {
+    login: 'admin',
+    name: 'Admin User',
+    email: 'admin@example.com',
+    roles: [],
+    systemAdmin: true,
+  },
+};
+
+describe('RepoStatusPage', () => {
+  beforeEach(() => {
+    (useGetServerStatusQuery as jest.Mock).mockReturnValue({
+      data: 'WRITABLE',
+      error: undefined,
+      isLoading: false,
+    });
+    (useGetProjectsQuery as jest.Mock).mockReturnValue({ data: [], isLoading: false });
+    (useGetReposQuery as jest.Mock).mockReturnValue({ data: [], isFetching: false });
+    (useUpdateRepositoryStatusMutation as jest.Mock).mockReturnValue([jest.fn(), { isLoading: false }]);
+  });
+
+  it('lists read-only projects and repositories', () => {
+    (useGetReadOnlyReposQuery as jest.Mock).mockReturnValue({
+      data: mockReadOnlyRepos,
+      error: undefined,
+      isLoading: false,
+    });
+
+    const { getByText, getAllByText } = renderWithProviders(<RepoStatusPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    expect(getByText('foo')).toBeInTheDocument();
+    expect(getByText('bar')).toBeInTheDocument();
+    expect(getByText('baz')).toBeInTheDocument();
+    expect(getAllByText('READ_ONLY')).toHaveLength(2);
+    // Each read-only entry offers a per-row action to revert it to writable.
+    expect(getAllByText('Make writable')).toHaveLength(2);
+  });
+
+  it('shows a writable message when there are no read-only repositories', () => {
+    (useGetReadOnlyReposQuery as jest.Mock).mockReturnValue({
+      data: [],
+      error: undefined,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithProviders(<RepoStatusPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    expect(getByText('All projects and repositories are writable.')).toBeInTheDocument();
+  });
+
+  it('shows the current server status', () => {
+    (useGetReadOnlyReposQuery as jest.Mock).mockReturnValue({
+      data: [],
+      error: undefined,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithProviders(<RepoStatusPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    expect(getByText('WRITABLE')).toBeInTheDocument();
+  });
+
+  it('renders the make-read-only form', () => {
+    (useGetReadOnlyReposQuery as jest.Mock).mockReturnValue({
+      data: [],
+      error: undefined,
+      isLoading: false,
+    });
+
+    const { getByText } = renderWithProviders(<RepoStatusPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    expect(getByText('Make a repository read-only')).toBeInTheDocument();
+    expect(getByText('Make read-only')).toBeInTheDocument();
+  });
+});

--- a/webapp/tests/pages/app/settings/repo-status/index.test.tsx
+++ b/webapp/tests/pages/app/settings/repo-status/index.test.tsx
@@ -1,3 +1,4 @@
+import { within } from '@testing-library/react';
 import { renderWithProviders } from 'dogma/util/test-utils';
 import RepoStatusPage from 'pages/app/settings/repo-status';
 import { RepositoryStatus } from 'dogma/features/settings/repo-status/RepoStatusDto';
@@ -94,6 +95,25 @@ describe('RepoStatusPage', () => {
     expect(getAllByText('READ_ONLY')).toHaveLength(2);
     // Each read-only entry offers a per-row action to revert it to writable.
     expect(getAllByText('Make writable')).toHaveLength(2);
+  });
+
+  it('names the internal dogma repository of a project-scoped entry', () => {
+    (useGetReadOnlyReposQuery as jest.Mock).mockReturnValue({
+      data: mockReadOnlyRepos,
+      error: undefined,
+      isLoading: false,
+    });
+
+    const { getByText, queryByRole } = renderWithProviders(<RepoStatusPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    const projectScopedRow = getByText('baz').closest('tr');
+    expect(within(projectScopedRow).getByText('dogma')).toBeInTheDocument();
+    expect(within(projectScopedRow).queryByText('-')).not.toBeInTheDocument();
+
+    // The repository name tells the scope apart, so there is no Scope column.
+    expect(queryByRole('columnheader', { name: /Scope/ })).not.toBeInTheDocument();
   });
 
   it('shows a writable message when there are no read-only repositories', () => {


### PR DESCRIPTION
Motivation:

Central Dogma can put an individual repository or a whole project into read-only mode (#1305), but the web UI neither showed that status nor acted on it. Every write button stayed enabled, so a user discovered the read-only state only by having the server reject the write, and there was no way to see or change the status from the UI.

Modifications:

- Add `status` to `ProjectDto` so that `GET /api/v1/projects` reports whether a project is read-only.
- Show a `Read-only` / `Writable` tag on the project list, the project detail page, the repository list and the repository tree page.
- Disable the write actions of a read-only project or repository, each with a tooltip that explains why: New Repository, New File, Edit, Delete (both a file and a repository), Revert, Project Settings and Repository Settings. A read-only project stays browsable.
- Add a "Repository Status" settings tab (system administrator only) that lists the read-only projects and repositories and lets an administrator make one read-only or writable, guarded by re-typing the full `project/repository` name. Selecting the internal `dogma` repository changes the whole project, and the confirmation now says so.
- Add `GET /api/v1/status/repos/read-only`, serialize `RepositoryState.updatedAt` as an ISO-8601 string, and expose `repository.read.only.count` and `repository.read.only` metrics.
- Invalidate the project and repository caches on a status change, so the lists do not keep showing the previous status.

Result:

- A user can see whether a project or a repository is read-only, and the write actions that would fail are disabled with an explanation of why.
- A system administrator can view every read-only project and repository and toggle the status from the web UI, with a type-to-confirm safeguard and an explicit warning when the change is project-wide.
