### PR TITLE
Fix UDP socket leak in CentralDogma-to-CentralDogma mirroring

### DIFF
--- a/client/java-armeria/src/main/java/com/linecorp/centraldogma/internal/client/armeria/ArmeriaCentralDogma.java
+++ b/client/java-armeria/src/main/java/com/linecorp/centraldogma/internal/client/armeria/ArmeriaCentralDogma.java
@@ -77,6 +77,7 @@ import com.linecorp.armeria.common.util.Exceptions;
 import com.linecorp.armeria.common.util.SafeCloseable;
 import com.linecorp.armeria.common.util.TimeoutMode;
 import com.linecorp.centraldogma.client.AbstractCentralDogma;
+import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.RepositoryInfo;
 import com.linecorp.centraldogma.common.ApiRequestTimeoutException;
@@ -174,6 +175,14 @@ public final class ArmeriaCentralDogma extends AbstractCentralDogma {
         authorization = "Bearer " + requireNonNull(accessToken, "accessToken");
         this.safeCloseable = safeCloseable;
         this.whenReady = whenReady;
+    }
+
+    @Override
+    public CentralDogma withAccessToken(String accessToken) {
+        requireNonNull(accessToken, "accessToken");
+        // Pass a no-op SafeCloseable: the base client owns the connection resources.
+        return new ArmeriaCentralDogma(executor(), client, accessToken,
+                                       () -> {}, meterRegistry(), null);
     }
 
     @Override

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/AbstractCentralDogma.java
@@ -74,6 +74,14 @@ public abstract class AbstractCentralDogma implements CentralDogma {
         return blockingTaskExecutor;
     }
 
+    /**
+     * Returns the {@link MeterRegistry}, or {@code null} if none was configured.
+     */
+    @Nullable
+    protected final MeterRegistry meterRegistry() {
+        return meterRegistry;
+    }
+
     @Override
     public CentralDogmaRepository forRepo(String projectName, String repositoryName) {
         requireNonNull(projectName, "projectName");

--- a/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/client/CentralDogma.java
@@ -54,6 +54,17 @@ import com.linecorp.centraldogma.common.RevisionNotFoundException;
 public interface CentralDogma extends AutoCloseable {
 
     /**
+     * Returns a derived {@link CentralDogma} that reuses the underlying connection pool of this client
+     * but authenticates with the given {@code accessToken}. Calling {@link #close()} on the derived client
+     * is a no-op; the connection pool is owned by this (base) client.
+     *
+     * @throws UnsupportedOperationException if this implementation does not support derived clients
+     */
+    default CentralDogma withAccessToken(String accessToken) {
+        throw new UnsupportedOperationException(getClass().getName() + " does not support withAccessToken");
+    }
+
+    /**
      * Returns a new {@link CentralDogmaRepository} that is used to send a request to the specified
      * {@code projectName} and {@code repositoryName}.
      */

--- a/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
+++ b/client/java/src/main/java/com/linecorp/centraldogma/internal/client/ReplicationLagTolerantCentralDogma.java
@@ -107,6 +107,14 @@ public final class ReplicationLagTolerantCentralDogma extends AbstractCentralDog
     }
 
     @Override
+    public CentralDogma withAccessToken(String accessToken) {
+        requireNonNull(accessToken, "accessToken");
+        return new ReplicationLagTolerantCentralDogma(
+                executor(), delegate.withAccessToken(accessToken),
+                maxRetries, retryIntervalMillis, currentReplicaHintSupplier, meterRegistry());
+    }
+
+    @Override
     public CompletableFuture<Void> createProject(String projectName) {
         return delegate.createProject(projectName);
     }

--- a/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
+++ b/it/mirror-listener/src/test/java/com/linecorp/centraldogma/it/mirror/listener/CustomMirrorListenerTest.java
@@ -127,8 +127,7 @@ class CustomMirrorListenerTest {
         final DefaultMirrorAccessController ac = new DefaultMirrorAccessController();
         ac.setRepository(repositoryExtension.crudRepository());
         final MirrorSchedulingService service = new MirrorSchedulingService(
-                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null, false,
-                ac);
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null, ac);
         final CommandExecutor executor = mock(CommandExecutor.class);
         service.start(executor);
 

--- a/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -78,9 +78,6 @@ public final class CentralDogmaMirror extends AbstractMirror {
     @Nullable
     private volatile ConcurrentHashMap<String, Object> baseClientPool;
 
-    @Nullable
-    private CentralDogma remoteClient;
-
     public CentralDogmaMirror(String id, boolean enabled, Cron schedule, MirrorDirection direction,
                               Credential credential, Repository localRepo, String localPath,
                               RepositoryUri remoteUri, String remoteProject, String remoteRepo,
@@ -113,43 +110,40 @@ public final class CentralDogmaMirror extends AbstractMirror {
     }
 
     // maxNumBytes comes from MirrorSchedulingService.maxNumBytesPerMirror, which is fixed at server startup.
-    private synchronized CentralDogma getOrCreateRemoteClient(long maxNumBytes) throws UnknownHostException {
-        if (remoteClient == null) {
-            final URI uri = remoteUri().uri();
-            final ConcurrentHashMap<String, Object> pool = baseClientPool;
+    private synchronized CentralDogma createRemoteClient(long maxNumBytes) throws UnknownHostException {
+        final URI uri = remoteUri().uri();
+        final ConcurrentHashMap<String, Object> pool = baseClientPool;
 
-            CentralDogma base;
-            if (pool != null) {
-                // Reuse or create a shared base client (MirrorSchedulingService owns the pool lifecycle).
-                final String key = baseClientPoolKey(uri);
-                final Object existing = pool.get(key);
-                if (existing instanceof CentralDogma) {
-                    base = (CentralDogma) existing;
-                } else {
-                    base = createBaseClient(uri, maxNumBytes);
-                    final Object prev = pool.putIfAbsent(key, base);
-                    if (prev instanceof CentralDogma) {
-                        // Lost the race; close ours and reuse the winner.
-                        try {
-                            base.close();
-                        } catch (Exception e) {
-                            logger.warn("Failed to close the redundant base CentralDogma client: {}", uri, e);
-                        }
-                        base = (CentralDogma) prev;
-                    }
-                }
+        CentralDogma base;
+        if (pool != null) {
+            // Reuse or create a shared base client (MirrorSchedulingService owns the pool lifecycle).
+            final String key = baseClientPoolKey(uri);
+            final Object existing = pool.get(key);
+            if (existing instanceof CentralDogma) {
+                base = (CentralDogma) existing;
             } else {
-                // No pool injected (tests or direct usage without the scheduler).
                 base = createBaseClient(uri, maxNumBytes);
+                final Object prev = pool.putIfAbsent(key, base);
+                if (prev instanceof CentralDogma) {
+                    // Lost the race; close ours and reuse the winner.
+                    try {
+                        base.close();
+                    } catch (Exception e) {
+                        logger.warn("Failed to close the redundant base CentralDogma client: {}", uri, e);
+                    }
+                    base = (CentralDogma) prev;
+                }
             }
-
-            final Credential cred = credential();
-            final String token = cred instanceof AccessTokenCredential ?
-                                 ((AccessTokenCredential) cred).accessToken() : CsrfToken.ANONYMOUS;
-            // TODO(minwoox) Support mTLS authentication as well.
-            remoteClient = base.withAccessToken(token);
+        } else {
+            // No pool injected (tests or direct usage without the scheduler).
+            base = createBaseClient(uri, maxNumBytes);
         }
-        return remoteClient;
+
+        final Credential cred = credential();
+        final String token = cred instanceof AccessTokenCredential ?
+                             ((AccessTokenCredential) cred).accessToken() : CsrfToken.ANONYMOUS;
+        // TODO(minwoox) Support mTLS authentication as well.
+        return base.withAccessToken(token);
     }
 
     private static CentralDogma createBaseClient(URI uri, long maxResponseLength) throws UnknownHostException {
@@ -169,27 +163,11 @@ public final class CentralDogmaMirror extends AbstractMirror {
     }
 
     @Override
-    public synchronized void close() {
-        final CentralDogma client = remoteClient;
-        if (client == null) {
-            return;
-        }
-        remoteClient = null;
-        try {
-            client.close();
-        } catch (Exception e) {
-            logger.warn("Failed to close the remote CentralDogma client: {}. {}/{}/{}",
-                        remoteUri(), localRepo().parent().name(), localRepo().name(), id(), e);
-        }
-    }
-
-    @Override
     protected MirrorResult mirrorLocalToRemote(File workDir, int maxNumFiles, long maxNumBytes,
                                                Instant triggeredTime) throws Exception {
         final Revision localHead = localRepo().normalizeNow(Revision.HEAD);
 
-        final CentralDogma remote = getOrCreateRemoteClient(maxNumBytes);
-        try {
+        try (CentralDogma remote = createRemoteClient(maxNumBytes)) {
             final CentralDogmaRepository repo = remote.forRepo(remoteProject, remoteRepo);
             // Get remote HEAD revision.
             final Revision remoteHead = repo.normalize(Revision.HEAD).join();
@@ -330,8 +308,7 @@ public final class CentralDogmaMirror extends AbstractMirror {
         final Revision localRev = localRepo().normalizeNow(Revision.HEAD);
         final String mirrorStatePath = localPath() + MIRROR_STATE_FILE_NAME;
 
-        final CentralDogma remote = getOrCreateRemoteClient(maxNumBytes);
-        try {
+        try (CentralDogma remote = createRemoteClient(maxNumBytes)) {
             final CentralDogmaRepository repo = remote.forRepo(remoteProject, remoteRepo);
             // Get remote HEAD revision.
             final Revision remoteHead = repo.normalize(Revision.HEAD).join();

--- a/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -72,6 +72,9 @@ public final class CentralDogmaMirror extends AbstractMirror {
     private final String remoteProject;
     private final String remoteRepo;
 
+    @Nullable
+    private CentralDogma remoteClient;
+
     public CentralDogmaMirror(String id, boolean enabled, Cron schedule, MirrorDirection direction,
                               Credential credential, Repository localRepo, String localPath,
                               RepositoryUri remoteUri, String remoteProject, String remoteRepo,
@@ -93,6 +96,14 @@ public final class CentralDogmaMirror extends AbstractMirror {
         return remoteRepo;
     }
 
+    // maxNumBytes comes from MirrorSchedulingService.maxNumBytesPerMirror, which is fixed at server startup.
+    private synchronized CentralDogma getOrCreateRemoteClient(long maxNumBytes) throws UnknownHostException {
+        if (remoteClient == null) {
+            remoteClient = createRemoteClient(maxNumBytes);
+        }
+        return remoteClient;
+    }
+
     private CentralDogma createRemoteClient(long maxNumBytes) throws UnknownHostException {
         final URI uri = remoteUri().uri();
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
@@ -112,7 +123,25 @@ public final class CentralDogmaMirror extends AbstractMirror {
         // TODO(minwoox) Support mTLS authentication as well.
 
         builder.clientConfigurator(cb -> cb.maxResponseLength(maxNumBytes));
+        // Mirrors run on a fixed schedule; a failed run simply retries on the next tick.
+        // Persistent health-check traffic is unnecessary and wasteful at scale.
+        builder.healthCheckIntervalMillis(0);
         return builder.build();
+    }
+
+    @Override
+    public synchronized void close() {
+        final CentralDogma client = remoteClient;
+        if (client == null) {
+            return;
+        }
+        remoteClient = null;
+        try {
+            client.close();
+        } catch (Exception e) {
+            logger.warn("Failed to close the remote CentralDogma client: {}. {}/{}/{}",
+                        remoteUri(), localRepo().parent().name(), localRepo().name(), id(), e);
+        }
     }
 
     @Override
@@ -120,7 +149,8 @@ public final class CentralDogmaMirror extends AbstractMirror {
                                                Instant triggeredTime) throws Exception {
         final Revision localHead = localRepo().normalizeNow(Revision.HEAD);
 
-        try (CentralDogma remote = createRemoteClient(maxNumBytes)) {
+        final CentralDogma remote = getOrCreateRemoteClient(maxNumBytes);
+        try {
             final CentralDogmaRepository repo = remote.forRepo(remoteProject, remoteRepo);
             // Get remote HEAD revision.
             final Revision remoteHead = repo.normalize(Revision.HEAD).join();
@@ -261,7 +291,8 @@ public final class CentralDogmaMirror extends AbstractMirror {
         final Revision localRev = localRepo().normalizeNow(Revision.HEAD);
         final String mirrorStatePath = localPath() + MIRROR_STATE_FILE_NAME;
 
-        try (CentralDogma remote = createRemoteClient(maxNumBytes)) {
+        final CentralDogma remote = getOrCreateRemoteClient(maxNumBytes);
+        try {
             final CentralDogmaRepository repo = remote.forRepo(remoteProject, remoteRepo);
             // Get remote HEAD revision.
             final Revision remoteHead = repo.normalize(Revision.HEAD).join();

--- a/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -114,6 +114,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
         final URI uri = remoteUri().uri();
         final ConcurrentHashMap<String, Object> pool = baseClientPool;
 
+        final Credential cred = credential();
+        final String token = cred instanceof AccessTokenCredential ?
+                             ((AccessTokenCredential) cred).accessToken() : CsrfToken.ANONYMOUS;
+
         CentralDogma base;
         if (pool != null) {
             // Reuse or create a shared base client (MirrorSchedulingService owns the pool lifecycle).
@@ -122,7 +126,7 @@ public final class CentralDogmaMirror extends AbstractMirror {
             if (existing instanceof CentralDogma) {
                 base = (CentralDogma) existing;
             } else {
-                base = createBaseClient(uri, maxNumBytes);
+                base = createClient(uri, maxNumBytes, null);
                 final Object prev = pool.putIfAbsent(key, base);
                 if (prev instanceof CentralDogma) {
                     // Lost the race; close ours and reuse the winner.
@@ -134,19 +138,16 @@ public final class CentralDogmaMirror extends AbstractMirror {
                     base = (CentralDogma) prev;
                 }
             }
-        } else {
-            // No pool injected (tests or direct usage without the scheduler).
-            base = createBaseClient(uri, maxNumBytes);
-        }
 
-        final Credential cred = credential();
-        final String token = cred instanceof AccessTokenCredential ?
-                             ((AccessTokenCredential) cred).accessToken() : CsrfToken.ANONYMOUS;
-        // TODO(minwoox) Support mTLS authentication as well.
-        return base.withAccessToken(token);
+            // TODO(minwoox) Support mTLS authentication as well.
+            return base.withAccessToken(token);
+        }
+        // No pool injected (tests or direct usage without the scheduler).
+        return createClient(uri, maxNumBytes, token);
     }
 
-    private static CentralDogma createBaseClient(URI uri, long maxResponseLength) throws UnknownHostException {
+    private static CentralDogma createClient(URI uri, long maxResponseLength, @Nullable String token)
+            throws UnknownHostException {
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
         if (uri.getPort() > 0) {
             builder.host(uri.getHost(), uri.getPort());
@@ -158,7 +159,9 @@ public final class CentralDogmaMirror extends AbstractMirror {
         // Mirrors run on a fixed schedule; a failed run simply retries on the next tick.
         // Persistent health-check traffic is unnecessary and wasteful at scale.
         builder.healthCheckIntervalMillis(0);
-        // No accessToken here — derived clients supply per-mirror tokens via withAccessToken().
+        if (token != null) {
+            builder.accessToken(token);
+        }
         return builder.build();
     }
 

--- a/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
+++ b/server-mirror-dogma/src/main/java/com/linecorp/centraldogma/server/internal/mirror/CentralDogmaMirror.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -52,6 +53,7 @@ import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
 import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.CsrfToken;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.Util;
 import com.linecorp.centraldogma.server.command.Command;
@@ -72,6 +74,10 @@ public final class CentralDogmaMirror extends AbstractMirror {
     private final String remoteProject;
     private final String remoteRepo;
 
+    // Injected by MirrorSchedulingService before each run; null only in tests / direct usage.
+    @Nullable
+    private volatile ConcurrentHashMap<String, Object> baseClientPool;
+
     @Nullable
     private CentralDogma remoteClient;
 
@@ -86,6 +92,11 @@ public final class CentralDogmaMirror extends AbstractMirror {
         this.remoteRepo = requireNonNull(remoteRepo, "remoteRepo");
     }
 
+    @Override
+    public void setBaseClientPool(ConcurrentHashMap<String, Object> pool) {
+        baseClientPool = pool;
+    }
+
     @VisibleForTesting
     String remoteProject() {
         return remoteProject;
@@ -96,36 +107,64 @@ public final class CentralDogmaMirror extends AbstractMirror {
         return remoteRepo;
     }
 
+    private static String baseClientPoolKey(URI uri) {
+        return uri.getHost() + ':' + uri.getPort() + ':' +
+               SCHEME_DOGMA_HTTPS.equals(uri.getScheme());
+    }
+
     // maxNumBytes comes from MirrorSchedulingService.maxNumBytesPerMirror, which is fixed at server startup.
     private synchronized CentralDogma getOrCreateRemoteClient(long maxNumBytes) throws UnknownHostException {
         if (remoteClient == null) {
-            remoteClient = createRemoteClient(maxNumBytes);
+            final URI uri = remoteUri().uri();
+            final ConcurrentHashMap<String, Object> pool = baseClientPool;
+
+            CentralDogma base;
+            if (pool != null) {
+                // Reuse or create a shared base client (MirrorSchedulingService owns the pool lifecycle).
+                final String key = baseClientPoolKey(uri);
+                final Object existing = pool.get(key);
+                if (existing instanceof CentralDogma) {
+                    base = (CentralDogma) existing;
+                } else {
+                    base = createBaseClient(uri, maxNumBytes);
+                    final Object prev = pool.putIfAbsent(key, base);
+                    if (prev instanceof CentralDogma) {
+                        // Lost the race; close ours and reuse the winner.
+                        try {
+                            base.close();
+                        } catch (Exception e) {
+                            logger.warn("Failed to close the redundant base CentralDogma client: {}", uri, e);
+                        }
+                        base = (CentralDogma) prev;
+                    }
+                }
+            } else {
+                // No pool injected (tests or direct usage without the scheduler).
+                base = createBaseClient(uri, maxNumBytes);
+            }
+
+            final Credential cred = credential();
+            final String token = cred instanceof AccessTokenCredential ?
+                                 ((AccessTokenCredential) cred).accessToken() : CsrfToken.ANONYMOUS;
+            // TODO(minwoox) Support mTLS authentication as well.
+            remoteClient = base.withAccessToken(token);
         }
         return remoteClient;
     }
 
-    private CentralDogma createRemoteClient(long maxNumBytes) throws UnknownHostException {
-        final URI uri = remoteUri().uri();
+    private static CentralDogma createBaseClient(URI uri, long maxResponseLength) throws UnknownHostException {
         final ArmeriaCentralDogmaBuilder builder = new ArmeriaCentralDogmaBuilder();
-        final int port = uri.getPort();
-        if (port > 0) {
-            builder.host(uri.getHost(), port);
+        if (uri.getPort() > 0) {
+            builder.host(uri.getHost(), uri.getPort());
         } else {
             builder.host(uri.getHost());
         }
-        if (SCHEME_DOGMA_HTTPS.equals(uri.getScheme())) {
-            builder.useTls(true);
-        }
-        final Credential cred = credential();
-        if (cred instanceof AccessTokenCredential) {
-            builder.accessToken(((AccessTokenCredential) cred).accessToken());
-        }
-        // TODO(minwoox) Support mTLS authentication as well.
-
-        builder.clientConfigurator(cb -> cb.maxResponseLength(maxNumBytes));
+        builder.useTls(SCHEME_DOGMA_HTTPS.equals(uri.getScheme()));
+        builder.clientConfigurator(cb -> cb.maxResponseLength(maxResponseLength));
         // Mirrors run on a fixed schedule; a failed run simply retries on the next tick.
         // Persistent health-check traffic is unnecessary and wasteful at scale.
         builder.healthCheckIntervalMillis(0);
+        // No accessToken here — derived clients supply per-mirror tokens via withAccessToken().
         return builder.build();
     }
 

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingServiceTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingServiceTest.java
@@ -102,7 +102,7 @@ class MirrorSchedulingServiceTest {
         when(mr.mirrors()).thenReturn(CompletableFuture.completedFuture(ImmutableList.of(mirror)));
 
         final MirrorSchedulingService service = new MirrorSchedulingService(
-                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null, false,
+                temporaryFolder, pm, new SimpleMeterRegistry(), 1, 1, 1, null,
                 AlwaysAllowedMirrorAccessController.INSTANCE);
         final CommandExecutor executor = mock(CommandExecutor.class);
         service.start(executor);

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMirroringServicePlugin.java
@@ -77,7 +77,6 @@ public final class DefaultMirroringServicePlugin implements Plugin {
             final int maxNumFilesPerMirror;
             final long maxNumBytesPerMirror;
             final ZoneConfig zoneConfig;
-            final boolean runMigration;
 
             if (mirroringServicePluginConfig != null) {
                 numThreads = mirroringServicePluginConfig.numMirroringThreads();
@@ -93,13 +92,11 @@ public final class DefaultMirroringServicePlugin implements Plugin {
                     logger.warn("No 'trustedHostKeys' configured in the mirroring service plugin config. " +
                                 "SSH mirror connections will accept any host key without verification.");
                 }
-                runMigration = mirroringServicePluginConfig.runMigration();
             } else {
                 numThreads = MirroringServicePluginConfig.INSTANCE.numMirroringThreads();
                 maxNumFilesPerMirror = MirroringServicePluginConfig.INSTANCE.maxNumFilesPerMirror();
                 maxNumBytesPerMirror = MirroringServicePluginConfig.INSTANCE.maxNumBytesPerMirror();
                 zoneConfig = null;
-                runMigration = true;
                 logger.warn("No 'trustedHostKeys' configured in the mirroring service plugin config. " +
                             "SSH mirror connections will accept any host key without verification.");
             }
@@ -108,7 +105,7 @@ public final class DefaultMirroringServicePlugin implements Plugin {
                                                            context.meterRegistry(),
                                                            numThreads,
                                                            maxNumFilesPerMirror,
-                                                           maxNumBytesPerMirror, zoneConfig, runMigration,
+                                                           maxNumBytesPerMirror, zoneConfig,
                                                            context.mirrorAccessController());
             this.mirroringService = mirroringService;
         }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
@@ -24,9 +24,12 @@ import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -110,21 +113,21 @@ public final class MirrorSchedulingService implements MirroringService {
     private volatile ListeningExecutorService worker;
     private volatile boolean closing;
 
+    private final ConcurrentHashMap<String, Mirror> activeMirrors = new ConcurrentHashMap<>();
+
+    @Nullable
     private ZonedDateTime lastExecutionTime;
     private final MeterRegistry meterRegistry;
-    // Used to disable in the tests.
-    private final boolean runMigration;
 
     @VisibleForTesting
     public MirrorSchedulingService(File workDir, ProjectManager projectManager, MeterRegistry meterRegistry,
                                    int numThreads, int maxNumFilesPerMirror, long maxNumBytesPerMirror,
-                                   @Nullable ZoneConfig zoneConfig, boolean runMigration,
+                                   @Nullable ZoneConfig zoneConfig,
                                    MirrorAccessController mirrorAccessController) {
 
         this.workDir = requireNonNull(workDir, "workDir");
         this.projectManager = requireNonNull(projectManager, "projectManager");
         this.meterRegistry = requireNonNull(meterRegistry, "meterRegistry");
-        this.runMigration = runMigration;
 
         checkArgument(numThreads > 0, "numThreads: %s (expected: > 0)", numThreads);
         checkArgument(maxNumFilesPerMirror > 0,
@@ -227,6 +230,8 @@ public final class MirrorSchedulingService implements MirroringService {
         } finally {
             this.scheduler = null;
             this.worker = null;
+            activeMirrors.values().forEach(Mirror::close);
+            activeMirrors.clear();
         }
     }
 
@@ -242,6 +247,9 @@ public final class MirrorSchedulingService implements MirroringService {
 
         final ZonedDateTime currentLastExecutionTime = lastExecutionTime;
         lastExecutionTime = now;
+
+        // Track all mirror keys seen in this tick to detect deleted mirrors.
+        final Set<String> currentMirrorKeys = new HashSet<>();
 
         projectManager.list()
                       .values()
@@ -265,10 +273,34 @@ public final class MirrorSchedulingService implements MirroringService {
                               logger.warn("Failed to load the mirror list from: {}", project.name(), e);
                               return;
                           }
-                          for (Mirror m : mirrors) {
-                              if (m.schedule() == null) {
+                          for (Mirror freshMirror : mirrors) {
+                              if (freshMirror.schedule() == null) {
                                   continue;
                               }
+
+                              final String key = mirrorCacheKey(freshMirror);
+                              currentMirrorKeys.add(key);
+
+                              // Reuse the cached instance if the config is unchanged so that resources
+                              // such as the remote CentralDogma client and its DNS resolver are kept
+                              // alive across runs. Close the old instance on config change.
+                              // Note: hashString() is based on toString() which intentionally omits the
+                              // actual credential secret (e.g. access token value), so we also compare
+                              // credential via equals() which does include the secret value.
+                              final Mirror m = activeMirrors.compute(key, (k, existing) -> {
+                                  if (existing instanceof AbstractMirror &&
+                                      freshMirror instanceof AbstractMirror &&
+                                      ((AbstractMirror) existing).hashString().equals(
+                                              ((AbstractMirror) freshMirror).hashString()) &&
+                                      existing.credential().equals(freshMirror.credential())) {
+                                      return existing;
+                                  }
+                                  if (existing != null) {
+                                      existing.close();
+                                  }
+                                  return freshMirror;
+                              });
+                              // TODO(minwoox): Cache SSH client as well.
 
                               if (closing) {
                                   return;
@@ -318,6 +350,19 @@ public final class MirrorSchedulingService implements MirroringService {
                               }
                           }
                       });
+
+        // Close mirrors that have been deleted from the meta repository.
+        activeMirrors.entrySet().removeIf(entry -> {
+            if (!currentMirrorKeys.contains(entry.getKey())) {
+                entry.getValue().close();
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private static String mirrorCacheKey(Mirror m) {
+        return m.localRepo().parent().name() + '/' + m.localRepo().name() + '/' + m.id();
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
@@ -277,8 +277,8 @@ public final class MirrorSchedulingService implements MirroringService {
                               logger.warn("Failed to load the mirror list from: {}", project.name(), e);
                               return;
                           }
-                          for (Mirror mirror : mirrors) {
-                              if (mirror.schedule() == null) {
+                          for (Mirror m : mirrors) {
+                              if (m.schedule() == null) {
                                   continue;
                               }
 
@@ -287,20 +287,20 @@ public final class MirrorSchedulingService implements MirroringService {
                               }
 
                               try {
-                                  final boolean allowed = mirrorAccessController.isAllowed(mirror)
+                                  final boolean allowed = mirrorAccessController.isAllowed(m)
                                                                                 .get(5, TimeUnit.SECONDS);
                                   if (!allowed) {
-                                      mirrorListener.onDisallowed(mirror);
+                                      mirrorListener.onDisallowed(m);
                                       continue;
                                   }
                               } catch (Exception e) {
                                   logger.warn("Failed to check the access control. mirror: {}",
-                                              mirror, e);
+                                              m, e);
                                   continue;
                               }
 
                               if (zoneConfig != null) {
-                                  String pinnedZone = mirror.zone();
+                                  String pinnedZone = m.zone();
                                   if (pinnedZone == null) {
                                       // Use the first zone if the mirror does not specify a zone.
                                       pinnedZone = zoneConfig.allZones().get(0);
@@ -310,7 +310,7 @@ public final class MirrorSchedulingService implements MirroringService {
                                       if (!zoneConfig.allZones().contains(pinnedZone)) {
                                           // The mirror is pinned to an invalid zone.
                                           final MirrorTask invalidMirror =
-                                                  new MirrorTask(mirror, User.SYSTEM, Instant.now(),
+                                                  new MirrorTask(m, User.SYSTEM, Instant.now(),
                                                                  pinnedZone, true);
                                           mirrorListener.onStart(invalidMirror);
                                           mirrorListener.onError(invalidMirror, new MirrorException(
@@ -321,13 +321,13 @@ public final class MirrorSchedulingService implements MirroringService {
                                   }
                               }
                               try {
-                                  if (mirror.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0) {
-                                      mirror.setBaseClientPool(baseClientPool);
-                                      runAsync(new MirrorTask(mirror, User.SYSTEM, Instant.now(),
+                                  if (m.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0) {
+                                      m.setBaseClientPool(baseClientPool);
+                                      runAsync(new MirrorTask(m, User.SYSTEM, Instant.now(),
                                                               currentZone, true));
                                   }
                               } catch (Exception e) {
-                                  logger.warn("Unexpected exception while mirroring: {}", mirror, e);
+                                  logger.warn("Unexpected exception while mirroring: {}", m, e);
                               }
                           }
                       });

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/mirror/MirrorSchedulingService.java
@@ -24,10 +24,8 @@ import java.io.File;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ServiceLoader;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -107,13 +105,14 @@ public final class MirrorSchedulingService implements MirroringService {
     private final String currentZone;
     private final MirrorAccessController mirrorAccessController;
     private final AtomicInteger numActiveMirrors = new AtomicInteger();
+    // Shared base-client pool for CentralDogmaMirror instances. Keyed by "host:port:tls:maxBytes".
+    // Owned here so stop() can close all entries; injected into each mirror before it runs.
+    private final ConcurrentHashMap<String, Object> baseClientPool = new ConcurrentHashMap<>();
 
     private volatile CommandExecutor commandExecutor;
     private volatile ListeningScheduledExecutorService scheduler;
     private volatile ListeningExecutorService worker;
     private volatile boolean closing;
-
-    private final ConcurrentHashMap<String, Mirror> activeMirrors = new ConcurrentHashMap<>();
 
     @Nullable
     private ZonedDateTime lastExecutionTime;
@@ -230,8 +229,16 @@ public final class MirrorSchedulingService implements MirroringService {
         } finally {
             this.scheduler = null;
             this.worker = null;
-            activeMirrors.values().forEach(Mirror::close);
-            activeMirrors.clear();
+            baseClientPool.forEach((key, client) -> {
+                if (client instanceof AutoCloseable) {
+                    try {
+                        ((AutoCloseable) client).close();
+                    } catch (Exception e) {
+                        logger.warn("Failed to close base CentralDogma client for key: {}", key, e);
+                    }
+                }
+            });
+            baseClientPool.clear();
         }
     }
 
@@ -247,9 +254,6 @@ public final class MirrorSchedulingService implements MirroringService {
 
         final ZonedDateTime currentLastExecutionTime = lastExecutionTime;
         lastExecutionTime = now;
-
-        // Track all mirror keys seen in this tick to detect deleted mirrors.
-        final Set<String> currentMirrorKeys = new HashSet<>();
 
         projectManager.list()
                       .values()
@@ -273,54 +277,30 @@ public final class MirrorSchedulingService implements MirroringService {
                               logger.warn("Failed to load the mirror list from: {}", project.name(), e);
                               return;
                           }
-                          for (Mirror freshMirror : mirrors) {
-                              if (freshMirror.schedule() == null) {
+                          for (Mirror mirror : mirrors) {
+                              if (mirror.schedule() == null) {
                                   continue;
                               }
-
-                              final String key = mirrorCacheKey(freshMirror);
-                              currentMirrorKeys.add(key);
-
-                              // Reuse the cached instance if the config is unchanged so that resources
-                              // such as the remote CentralDogma client and its DNS resolver are kept
-                              // alive across runs. Close the old instance on config change.
-                              // Note: hashString() is based on toString() which intentionally omits the
-                              // actual credential secret (e.g. access token value), so we also compare
-                              // credential via equals() which does include the secret value.
-                              final Mirror m = activeMirrors.compute(key, (k, existing) -> {
-                                  if (existing instanceof AbstractMirror &&
-                                      freshMirror instanceof AbstractMirror &&
-                                      ((AbstractMirror) existing).hashString().equals(
-                                              ((AbstractMirror) freshMirror).hashString()) &&
-                                      existing.credential().equals(freshMirror.credential())) {
-                                      return existing;
-                                  }
-                                  if (existing != null) {
-                                      existing.close();
-                                  }
-                                  return freshMirror;
-                              });
-                              // TODO(minwoox): Cache SSH client as well.
 
                               if (closing) {
                                   return;
                               }
 
                               try {
-                                  final boolean allowed = mirrorAccessController.isAllowed(m)
+                                  final boolean allowed = mirrorAccessController.isAllowed(mirror)
                                                                                 .get(5, TimeUnit.SECONDS);
                                   if (!allowed) {
-                                      mirrorListener.onDisallowed(m);
+                                      mirrorListener.onDisallowed(mirror);
                                       continue;
                                   }
                               } catch (Exception e) {
                                   logger.warn("Failed to check the access control. mirror: {}",
-                                              m, e);
+                                              mirror, e);
                                   continue;
                               }
 
                               if (zoneConfig != null) {
-                                  String pinnedZone = m.zone();
+                                  String pinnedZone = mirror.zone();
                                   if (pinnedZone == null) {
                                       // Use the first zone if the mirror does not specify a zone.
                                       pinnedZone = zoneConfig.allZones().get(0);
@@ -330,7 +310,7 @@ public final class MirrorSchedulingService implements MirroringService {
                                       if (!zoneConfig.allZones().contains(pinnedZone)) {
                                           // The mirror is pinned to an invalid zone.
                                           final MirrorTask invalidMirror =
-                                                  new MirrorTask(m, User.SYSTEM, Instant.now(),
+                                                  new MirrorTask(mirror, User.SYSTEM, Instant.now(),
                                                                  pinnedZone, true);
                                           mirrorListener.onStart(invalidMirror);
                                           mirrorListener.onError(invalidMirror, new MirrorException(
@@ -341,28 +321,16 @@ public final class MirrorSchedulingService implements MirroringService {
                                   }
                               }
                               try {
-                                  if (m.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0) {
-                                      runAsync(new MirrorTask(m, User.SYSTEM, Instant.now(),
+                                  if (mirror.nextExecutionTime(currentLastExecutionTime).compareTo(now) < 0) {
+                                      mirror.setBaseClientPool(baseClientPool);
+                                      runAsync(new MirrorTask(mirror, User.SYSTEM, Instant.now(),
                                                               currentZone, true));
                                   }
                               } catch (Exception e) {
-                                  logger.warn("Unexpected exception while mirroring: {}", m, e);
+                                  logger.warn("Unexpected exception while mirroring: {}", mirror, e);
                               }
                           }
                       });
-
-        // Close mirrors that have been deleted from the meta repository.
-        activeMirrors.entrySet().removeIf(entry -> {
-            if (!currentMirrorKeys.contains(entry.getKey())) {
-                entry.getValue().close();
-                return true;
-            }
-            return false;
-        });
-    }
-
-    private static String mirrorCacheKey(Mirror m) {
-        return m.localRepo().parent().name() + '/' + m.localRepo().name() + '/' + m.id();
     }
 
     @Override
@@ -379,7 +347,10 @@ public final class MirrorSchedulingService implements MirroringService {
                     }
                     try {
                         p.metaRepo().mirrors().get(5, TimeUnit.SECONDS)
-                         .forEach(m -> run(new MirrorTask(m, User.SYSTEM, Instant.now(), currentZone, false)));
+                         .forEach(m -> {
+                             m.setBaseClientPool(baseClientPool);
+                             run(new MirrorTask(m, User.SYSTEM, Instant.now(), currentZone, false));
+                         });
                     } catch (InterruptedException | TimeoutException | ExecutionException e) {
                         throw new IllegalStateException(
                                 "Failed to load mirror list with in 5 seconds. project: " + p.name(), e);

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -131,4 +131,10 @@ public interface Mirror {
      */
     MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes,
                         Instant triggeredTime);
+
+    /**
+     * Closes the resources held by this {@link Mirror}, such as cached connections to the remote.
+     * The default implementation is a no-op.
+     */
+    default void close() {}
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -139,10 +139,4 @@ public interface Mirror {
      * CentralDogma-type mirrors use this; the default implementation is a no-op.
      */
     default void setBaseClientPool(ConcurrentHashMap<String, Object> baseClientPool) {}
-
-    /**
-     * Closes the resources held by this {@link Mirror}, such as cached connections to the remote.
-     * The default implementation is a no-op.
-     */
-    default void close() {}
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/mirror/Mirror.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.net.URI;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.jspecify.annotations.Nullable;
 
@@ -131,6 +132,13 @@ public interface Mirror {
      */
     MirrorResult mirror(File workDir, CommandExecutor executor, int maxNumFiles, long maxNumBytes,
                         Instant triggeredTime);
+
+    /**
+     * Injects the shared base-client pool managed by the mirroring scheduler. The pool maps a string key
+     * (encoding host, port, TLS flag, and maxResponseLength) to a shared base client instance. Only
+     * CentralDogma-type mirrors use this; the default implementation is a no-op.
+     */
+    default void setBaseClientPool(ConcurrentHashMap<String, Object> baseClientPool) {}
 
     /**
      * Closes the resources held by this {@link Mirror}, such as cached connections to the remote.


### PR DESCRIPTION
Motivation:

CentralDogma-to-CentralDogma mirrors were creating a new
ArmeriaCentralDogmaClient on every scheduler tick, allocating a fresh
Armeria WebClient, connection pool, and UDP socket each time. These
sockets were not reclaimed promptly, leading to too many open
files.

Modifications:

- Add CentralDogma.withAccessToken(String) as a default interface method
  that returns a derived client sharing the same underlying WebClient.
  Calling close() on the derived client is a no-op; the base client owns
  the connection resources.
- Add Mirror.setBaseClientPool(ConcurrentHashMap<String, Object>) as a
  default no-op method so MirrorSchedulingService can inject the pool
  without coupling the server module to client types.

Result:

- Mirrors pointing at the same remote host share one Armeria WebClient,
  eliminating per-run DNS/TLS/connection overhead and stopping UDP socket
  accumulation.
