### PR TITLE
Fix an exception thrown when an SSH mirror has an invalid credential type

### DIFF
--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
@@ -25,12 +25,18 @@ import static java.util.Objects.requireNonNull;
 
 import java.net.URI;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linecorp.centraldogma.server.internal.credential.SshKeyCredential;
 import com.linecorp.centraldogma.server.mirror.Mirror;
 import com.linecorp.centraldogma.server.mirror.MirrorContext;
 import com.linecorp.centraldogma.server.mirror.MirrorProvider;
 import com.linecorp.centraldogma.server.mirror.RepositoryUri;
 
 public final class GitMirrorProvider implements MirrorProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(GitMirrorProvider.class);
 
     @Override
     public Mirror newMirror(MirrorContext context) {
@@ -44,6 +50,11 @@ public final class GitMirrorProvider implements MirrorProvider {
 
         switch (scheme) {
             case SCHEME_GIT_SSH: {
+                if (!(context.credential() instanceof SshKeyCredential)) {
+                    logger.warn("Failed to load the mirror '{}': SSH mirror requires an SSH_KEY credential, " +
+                                "but got: {}", context.id(), context.credential().type());
+                    return null;
+                }
                 final RepositoryUri repositoryUri = RepositoryUri.parse(remoteUri, "git");
                 return new SshGitMirror(context.id(), context.enabled(), context.schedule(),
                                         context.direction(), context.credential(),

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/GitMirrorProvider.java
@@ -51,9 +51,8 @@ public final class GitMirrorProvider implements MirrorProvider {
         switch (scheme) {
             case SCHEME_GIT_SSH: {
                 if (!(context.credential() instanceof SshKeyCredential)) {
-                    logger.warn("Failed to load the mirror '{}': SSH mirror requires an SSH_KEY credential, " +
+                    logger.debug("'{}': SSH mirror requires an SSH_KEY credential, " +
                                 "but got: {}", context.id(), context.credential().type());
-                    return null;
                 }
                 final RepositoryUri repositoryUri = RepositoryUri.parse(remoteUri, "git");
                 return new SshGitMirror(context.id(), context.enabled(), context.schedule(),

--- a/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
+++ b/server-mirror-git/src/main/java/com/linecorp/centraldogma/server/internal/mirror/SshGitMirror.java
@@ -101,10 +101,6 @@ final class SshGitMirror extends AbstractGitMirror {
         super(id, enabled, schedule, direction, credential, localRepo, localPath,
               remoteUri, gitignore, zone);
         this.trustedHostKeys = requireNonNull(trustedHostKeys, "trustedHostKeys");
-        if (!(credential instanceof SshKeyCredential)) {
-            throw new MirrorException(
-                    "SSH mirror requires an SSH_KEY credential, but got: " + credential.type());
-        }
     }
 
     @Override

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/DefaultMetaRepository.java
@@ -189,9 +189,9 @@ public final class DefaultMetaRepository extends RepositoryWrapper implements Me
                                     } catch (Exception e) {
                                         // Skip a malformed mirror so that a single bad mirror does not
                                         // prevent the rest of the mirrors from being loaded.
-                                        logger.debug("Failed to convert a mirror configuration to a mirror. " +
-                                                     "project: {}, mirror: {}", parent().name(), mirrorConfig,
-                                                     e);
+                                        logger.warn("Failed to convert a mirror configuration to a mirror. " +
+                                                    "project: {}, mirror: {}", parent().name(), mirrorConfig,
+                                                    e);
                                         return null;
                                     }
                                 })


### PR DESCRIPTION
…type

Motivation:
When an SSH mirror was configured with a non-SSH_KEY credential (e.g. ACCESS_TOKEN), `SshGitMirror` threw a `MirrorException` during mirror conversion. Although the exception was caught by `handleAllMirrors()` and the bad mirror was skipped, the mirror was invisible in the UI as a result, making it impossible to update or delete the mirror.

Modifications:

- Move the credential type validation from `SshGitMirror` constructor to `GitMirrorProvider.newMirror()`. When the credential type is wrong, log a warning and return `null` instead of throwing `MirrorException`.

Result:

- A mirror with an invalid credential type is loaded correctly and shown in the UI, allowing users to update or delete it.