### PR TITLE
Allow regenerating the secret of an application token

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
@@ -251,9 +251,10 @@ public final class AppIdentityRegistryService extends AbstractService {
     /**
      * POST /appIdentities/{appId}/secret
      *
-     * <p>Regenerates the secret of the token of the specified {@code appId} and returns the token with
-     * a newly-generated secret. The old secret is revoked in the same commit, but it may take a short
-     * time for the revocation to be propagated to the authorization cache.
+     * <p>Regenerates the secret of the deactivated token of the specified {@code appId} and returns the
+     * token with a newly-generated secret. The token must be deactivated first and the new secret does
+     * not authenticate until the token is activated, so that the new secret can be distributed to the
+     * clients before it takes effect.
      */
     @Post("/appIdentities/{appId}/secret")
     public CompletableFuture<Token> regenerateTokenSecret(ServiceRequestContext ctx,
@@ -265,9 +266,13 @@ public final class AppIdentityRegistryService extends AbstractService {
                         throw new IllegalArgumentException(
                                 "You can't regenerate the secret of the token scheduled for deletion.");
                     }
-                    // Pass the creation metadata of the authorized token so that a token recreated
-                    // with the same application ID in the meantime is not rotated.
-                    return mds.regenerateTokenSecret(author, appId, token.creation());
+                    if (token.isActive()) {
+                        throw new IllegalArgumentException(
+                                "You can't regenerate the secret of an active token. Deactivate it first.");
+                    }
+                    // Pass the authorized token so that the regeneration fails if the token is
+                    // recreated or regenerated concurrently in the meantime.
+                    return mds.regenerateTokenSecret(author, appId, token);
                 });
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
@@ -249,6 +249,28 @@ public final class AppIdentityRegistryService extends AbstractService {
     }
 
     /**
+     * POST /appIdentities/{appId}/secret
+     *
+     * <p>Regenerates the secret of the token of the specified {@code appId}. The old secret is revoked
+     * immediately and the token with a newly-generated secret is returned.
+     */
+    @Post("/appIdentities/{appId}/secret")
+    public CompletableFuture<Token> regenerateTokenSecret(ServiceRequestContext ctx,
+                                                          @Param String appId,
+                                                          Author author, User loginUser) {
+        return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
+                token -> {
+                    if (token.isDeleted()) {
+                        throw new IllegalArgumentException(
+                                "You can't regenerate the secret of the token scheduled for deletion.");
+                    }
+                    // Pass the creation metadata of the authorized token so that a token recreated
+                    // with the same application ID in the meantime is not rotated.
+                    return mds.regenerateTokenSecret(author, appId, token.creation());
+                });
+    }
+
+    /**
      * PATCH /appIdentities/{appId}/level
      *
      * <p>Updates a level of the app identity of the specified ID.

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
@@ -251,8 +251,9 @@ public final class AppIdentityRegistryService extends AbstractService {
     /**
      * POST /appIdentities/{appId}/secret
      *
-     * <p>Regenerates the secret of the token of the specified {@code appId}. The old secret is revoked
-     * immediately and the token with a newly-generated secret is returned.
+     * <p>Regenerates the secret of the token of the specified {@code appId} and returns the token with
+     * a newly-generated secret. The old secret is revoked in the same commit, but it may take a short
+     * time for the revocation to be propagated to the authorization cache.
      */
     @Post("/appIdentities/{appId}/secret")
     public CompletableFuture<Token> regenerateTokenSecret(ServiceRequestContext ctx,

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
@@ -260,6 +260,7 @@ public final class AppIdentityRegistryService extends AbstractService {
     public CompletableFuture<Token> regenerateTokenSecret(ServiceRequestContext ctx,
                                                           @Param String appId,
                                                           Author author, User loginUser) {
+        // Permission is checked at the HTTP layer; the metadata layer is caller-agnostic.
         return getTokenOrRespondForbidden(ctx, appId, loginUser).thenCompose(
                 token -> {
                     if (token.isDeleted()) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/sysadmin/AppIdentityRegistryService.java
@@ -270,9 +270,7 @@ public final class AppIdentityRegistryService extends AbstractService {
                         throw new IllegalArgumentException(
                                 "You can't regenerate the secret of an active token. Deactivate it first.");
                     }
-                    // Pass the authorized token so that the regeneration fails if the token is
-                    // recreated or regenerated concurrently in the meantime.
-                    return mds.regenerateTokenSecret(author, appId, token);
+                    return mds.regenerateTokenSecret(author, appId);
                 });
     }
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TransformingChangesApplier.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/git/TransformingChangesApplier.java
@@ -76,8 +76,8 @@ final class TransformingChangesApplier extends AbstractChangesApplier {
         } catch (CentralDogmaException e) {
             throw e;
         } catch (Exception e) {
-            throw new ChangeConflictException("failed to transform the content: " + oldJsonNode +
-                                              " transformer: " + transformer, e);
+            // Do not include the old content in the message; it may contain sensitive data such as secrets.
+            throw new ChangeConflictException("failed to transform the content with " + transformer, e);
         }
         return 0;
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -32,6 +32,9 @@ import static java.util.Objects.requireNonNull;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -166,6 +169,64 @@ final class AppIdentityService {
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer)
                                       .join();
+    }
+
+    CompletableFuture<Token> regenerateTokenSecret(Author author, String appId) {
+        return regenerateTokenSecret(author, appId, null);
+    }
+
+    CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
+                                                   @Nullable UserAndTimestamp expectedCreation) {
+        requireNonNull(author, "author");
+        requireNonNull(appId, "appId");
+
+        final String commitSummary = "Regenerate the secret of the token: " + appId;
+
+        // Capture the regenerated token so that the caller gets the secret this commit produced
+        // even if another commit lands right after this one.
+        final AtomicReference<Token> newTokenRef = new AtomicReference<>();
+        final AppIdentityRegistryTransformer transformer = new AppIdentityRegistryTransformer(
+                (headRevision, registry) -> {
+                    final AppIdentity appIdentity = registry.get(appId); // Raise an exception if not found.
+                    if (appIdentity.deletion() != null) {
+                        // Note that a ChangeConflictException is raised instead of an
+                        // IllegalArgumentException so that the storage layer does not wrap it with
+                        // another exception.
+                        throw new ChangeConflictException(
+                                "The app identity is already destroyed: " + appId);
+                    }
+                    throwIfInvalidType(appId, appIdentity, AppIdentityType.TOKEN);
+                    if (expectedCreation != null && !expectedCreation.equals(appIdentity.creation())) {
+                        // The token the caller was authorized for has been recreated in the meantime.
+                        throw new ChangeConflictException(
+                                "The app identity has been recreated concurrently: " + appId);
+                    }
+
+                    final Token token = (Token) appIdentity;
+                    final String oldSecret = token.secret();
+                    assert oldSecret != null;
+                    final String newSecret = SECRET_PREFIX + UUID.randomUUID();
+                    if (registry.secrets().containsKey(newSecret)) {
+                        throw new ChangeConflictException("Secret already exists");
+                    }
+
+                    final Token newToken = new Token(token.appId(), newSecret, token.isSystemAdmin(),
+                                                     token.allowGuestAccess(), token.creation(),
+                                                     token.deactivation(), null);
+                    newTokenRef.set(newToken);
+                    final Map<String, AppIdentity> newAppIds =
+                            updateMap(registry.appIds(), appId, newToken);
+                    final Map<String, String> secretsWithoutOld =
+                            removeFromMap(registry.secrets(), oldSecret);
+                    // A deactivated token has no entry in the secret map.
+                    final Map<String, String> newSecrets =
+                            token.isActive() ? addToMap(secretsWithoutOld, newSecret, appId)
+                                             : secretsWithoutOld;
+                    return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
+                });
+        return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
+                                            commitSummary, transformer)
+                                      .thenApply(unused -> newTokenRef.get());
     }
 
     CompletableFuture<Revision> activateToken(Author author, String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -30,6 +30,7 @@ import static com.linecorp.centraldogma.server.storage.project.InternalProjectIn
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -176,7 +177,7 @@ final class AppIdentityService {
     }
 
     CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
-                                                   @Nullable UserAndTimestamp expectedCreation) {
+                                                   @Nullable Token expectedToken) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
@@ -196,10 +197,24 @@ final class AppIdentityService {
                                 "The app identity is already destroyed: " + appId);
                     }
                     throwIfInvalidType(appId, appIdentity, AppIdentityType.TOKEN);
-                    if (expectedCreation != null && !expectedCreation.equals(appIdentity.creation())) {
+                    if (expectedToken != null &&
+                        !expectedToken.creation().equals(appIdentity.creation())) {
                         // The token the caller was authorized for has been recreated in the meantime.
                         throw new ChangeConflictException(
                                 "The app identity has been recreated concurrently: " + appId);
+                    }
+                    if (expectedToken != null &&
+                        !Objects.equals(expectedToken.secret(), ((Token) appIdentity).secret())) {
+                        // Another regeneration has been committed in the meantime; failing loudly
+                        // prevents the caller from distributing a secret that will never work.
+                        throw new ChangeConflictException(
+                                "The secret has been regenerated concurrently: " + appId);
+                    }
+                    if (appIdentity.deactivation() == null) {
+                        // Regenerating the secret of an active token would break its clients with no
+                        // way to prepare, so the token must be deactivated first.
+                        throw new ChangeConflictException(
+                                "The token must be deactivated before regenerating its secret: " + appId);
                     }
 
                     final Token token = (Token) appIdentity;
@@ -216,12 +231,11 @@ final class AppIdentityService {
                     newTokenRef.set(newToken);
                     final Map<String, AppIdentity> newAppIds =
                             updateMap(registry.appIds(), appId, newToken);
-                    final Map<String, String> secretsWithoutOld =
-                            removeFromMap(registry.secrets(), oldSecret);
-                    // A deactivated token has no entry in the secret map.
+                    // A deactivated token has no entry in the secret map, so the new secret is not
+                    // added; it is registered when the token is activated. The old secret is removed
+                    // defensively in case a stale entry is left over.
                     final Map<String, String> newSecrets =
-                            token.isActive() ? addToMap(secretsWithoutOld, newSecret, appId)
-                                             : secretsWithoutOld;
+                            removeFromMap(registry.secrets(), oldSecret);
                     return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
                 });
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.jspecify.annotations.Nullable;
 
@@ -183,9 +182,6 @@ final class AppIdentityService {
 
         final String commitSummary = "Regenerate the secret of the token: " + appId;
 
-        // Capture the regenerated token so that the caller gets the secret this commit produced
-        // even if another commit lands right after this one.
-        final AtomicReference<Token> newTokenRef = new AtomicReference<>();
         final AppIdentityRegistryTransformer transformer = new AppIdentityRegistryTransformer(
                 (headRevision, registry) -> {
                     final AppIdentity appIdentity = registry.get(appId); // Raise an exception if not found.
@@ -228,7 +224,6 @@ final class AppIdentityService {
                     final Token newToken = new Token(token.appId(), newSecret, token.isSystemAdmin(),
                                                      token.allowGuestAccess(), token.creation(),
                                                      token.deactivation(), null);
-                    newTokenRef.set(newToken);
                     final Map<String, AppIdentity> newAppIds =
                             updateMap(registry.appIds(), appId, newToken);
                     // A deactivated token has no entry in the secret map, so the new secret is not
@@ -238,9 +233,14 @@ final class AppIdentityService {
                             removeFromMap(registry.secrets(), oldSecret);
                     return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
                 });
+        // Read the registry back at the revision this commit produced so that the caller gets
+        // the secret of this commit even if another commit lands right after.
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer)
-                                      .thenApply(unused -> newTokenRef.get());
+                                      .thenCompose(revision -> appIdentityRegistryRepo.fetch(
+                                              INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON,
+                                              revision))
+                                      .thenApply(holder -> (Token) holder.object().get(appId));
     }
 
     CompletableFuture<Revision> activateToken(Author author, String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -30,11 +30,8 @@ import static com.linecorp.centraldogma.server.storage.project.InternalProjectIn
 import static java.util.Objects.requireNonNull;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import org.jspecify.annotations.Nullable;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -172,11 +169,6 @@ final class AppIdentityService {
     }
 
     CompletableFuture<Token> regenerateTokenSecret(Author author, String appId) {
-        return regenerateTokenSecret(author, appId, null);
-    }
-
-    CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
-                                                   @Nullable Token expectedToken) {
         requireNonNull(author, "author");
         requireNonNull(appId, "appId");
 
@@ -193,19 +185,6 @@ final class AppIdentityService {
                                 "The app identity is already destroyed: " + appId);
                     }
                     throwIfInvalidType(appId, appIdentity, AppIdentityType.TOKEN);
-                    if (expectedToken != null &&
-                        !expectedToken.creation().equals(appIdentity.creation())) {
-                        // The token the caller was authorized for has been recreated in the meantime.
-                        throw new ChangeConflictException(
-                                "The app identity has been recreated concurrently: " + appId);
-                    }
-                    if (expectedToken != null &&
-                        !Objects.equals(expectedToken.secret(), ((Token) appIdentity).secret())) {
-                        // Another regeneration has been committed in the meantime; failing loudly
-                        // prevents the caller from distributing a secret that will never work.
-                        throw new ChangeConflictException(
-                                "The secret has been regenerated concurrently: " + appId);
-                    }
                     if (appIdentity.deactivation() == null) {
                         // Regenerating the secret of an active token would break its clients with no
                         // way to prepare, so the token must be deactivated first.

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -165,7 +165,7 @@ final class AppIdentityService {
                     final Map<String, AppIdentity> newAppIds = removeFromMap(registry.appIds(), appId);
                     // The app identity is already removed from secrets and certificateIds when destroyed.
                     return new AppIdentityRegistry(newAppIds, registry.secrets(), registry.certificateIds());
-        });
+                });
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer)
                                       .join();
@@ -235,12 +235,13 @@ final class AppIdentityService {
                 });
         // Read the registry back at the revision this commit produced so that the caller gets
         // the secret of this commit even if another commit lands right after.
-        return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                                            commitSummary, transformer)
-                                      .thenCompose(revision -> appIdentityRegistryRepo.fetch(
-                                              INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON,
-                                              revision))
-                                      .thenApply(holder -> (Token) holder.object().get(appId));
+        return appIdentityRegistryRepo
+                .push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author, commitSummary, transformer)
+                .thenCompose(revision -> {
+                    return appIdentityRegistryRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA,
+                                                         TOKEN_JSON, revision);
+                })
+                .thenApply(holder -> (Token) holder.object().get(appId));
     }
 
     CompletableFuture<Revision> activateToken(Author author, String appId) {
@@ -275,18 +276,19 @@ final class AppIdentityService {
 
         final AppIdentityRegistryTransformer transformer = new AppIdentityRegistryTransformer(
                 (headRevision, registry) -> {
-            final AppIdentity appIdentity =
-                    getAppIdentityToDeactivate(headRevision, registry, appId, AppIdentityType.TOKEN);
-            final String secret = ((Token) appIdentity).secret();
-            assert secret != null;
-            final Token newToken = new Token(appIdentity.appId(), secret,
-                                             appIdentity.isSystemAdmin(), appIdentity.allowGuestAccess(),
-                                             appIdentity.creation(), userAndTimestamp, null);
-            final Map<String, AppIdentity> newAppIds = updateMap(registry.appIds(), appId, newToken);
-            final Map<String, String> newSecrets =
-                    removeFromMap(registry.secrets(), secret); // Note that the key is secret not appId.
-            return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
-        });
+                    final AppIdentity appIdentity =
+                            getAppIdentityToDeactivate(headRevision, registry, appId, AppIdentityType.TOKEN);
+                    final String secret = ((Token) appIdentity).secret();
+                    assert secret != null;
+                    final Token newToken = new Token(appIdentity.appId(), secret,
+                                                     appIdentity.isSystemAdmin(),
+                                                     appIdentity.allowGuestAccess(),
+                                                     appIdentity.creation(), userAndTimestamp, null);
+                    final Map<String, AppIdentity> newAppIds = updateMap(registry.appIds(), appId, newToken);
+                    final Map<String, String> newSecrets =
+                            removeFromMap(registry.secrets(), secret); // Note that the key is secret not appId.
+                    return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
+                });
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer);
     }
@@ -377,7 +379,7 @@ final class AppIdentityService {
                                                                       Jackson.valueToTree(
                                                                               certificate.appId()))));
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                              "Add a certificate: " + certificate.id(), change);
+                                            "Add a certificate: " + certificate.id(), change);
     }
 
     CompletableFuture<Revision> destroyCertificate(Author author, String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -193,8 +193,6 @@ final class AppIdentityService {
                     }
 
                     final Token token = (Token) appIdentity;
-                    final String oldSecret = token.secret();
-                    assert oldSecret != null;
                     final String newSecret = SECRET_PREFIX + UUID.randomUUID();
                     if (registry.secrets().containsKey(newSecret)) {
                         throw new ChangeConflictException("Secret already exists");
@@ -205,12 +203,7 @@ final class AppIdentityService {
                                                      token.deactivation(), null);
                     final Map<String, AppIdentity> newAppIds =
                             updateMap(registry.appIds(), appId, newToken);
-                    // A deactivated token has no entry in the secret map, so the new secret is not
-                    // added; it is registered when the token is activated. The old secret is removed
-                    // defensively in case a stale entry is left over.
-                    final Map<String, String> newSecrets =
-                            removeFromMap(registry.secrets(), oldSecret);
-                    return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
+                    return new AppIdentityRegistry(newAppIds, registry.secrets(), registry.certificateIds());
                 });
         // Read the registry back at the revision this commit produced so that the caller gets
         // the secret of this commit even if another commit lands right after.

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -162,7 +162,7 @@ final class AppIdentityService {
                     final Map<String, AppIdentity> newAppIds = removeFromMap(registry.appIds(), appId);
                     // The app identity is already removed from secrets and certificateIds when destroyed.
                     return new AppIdentityRegistry(newAppIds, registry.secrets(), registry.certificateIds());
-                });
+        });
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer)
                                       .join();
@@ -214,13 +214,12 @@ final class AppIdentityService {
                 });
         // Read the registry back at the revision this commit produced so that the caller gets
         // the secret of this commit even if another commit lands right after.
-        return appIdentityRegistryRepo
-                .push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author, commitSummary, transformer)
-                .thenCompose(revision -> {
-                    return appIdentityRegistryRepo.fetch(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA,
-                                                         TOKEN_JSON, revision);
-                })
-                .thenApply(holder -> (Token) holder.object().get(appId));
+        return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
+                                            commitSummary, transformer)
+                                      .thenCompose(revision -> appIdentityRegistryRepo.fetch(
+                                              INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, TOKEN_JSON,
+                                              revision))
+                                      .thenApply(holder -> (Token) holder.object().get(appId));
     }
 
     CompletableFuture<Revision> activateToken(Author author, String appId) {
@@ -255,19 +254,18 @@ final class AppIdentityService {
 
         final AppIdentityRegistryTransformer transformer = new AppIdentityRegistryTransformer(
                 (headRevision, registry) -> {
-                    final AppIdentity appIdentity =
-                            getAppIdentityToDeactivate(headRevision, registry, appId, AppIdentityType.TOKEN);
-                    final String secret = ((Token) appIdentity).secret();
-                    assert secret != null;
-                    final Token newToken = new Token(appIdentity.appId(), secret,
-                                                     appIdentity.isSystemAdmin(),
-                                                     appIdentity.allowGuestAccess(),
-                                                     appIdentity.creation(), userAndTimestamp, null);
-                    final Map<String, AppIdentity> newAppIds = updateMap(registry.appIds(), appId, newToken);
-                    final Map<String, String> newSecrets =
-                            removeFromMap(registry.secrets(), secret); // Note that the key is secret not appId.
-                    return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
-                });
+            final AppIdentity appIdentity =
+                    getAppIdentityToDeactivate(headRevision, registry, appId, AppIdentityType.TOKEN);
+            final String secret = ((Token) appIdentity).secret();
+            assert secret != null;
+            final Token newToken = new Token(appIdentity.appId(), secret,
+                                             appIdentity.isSystemAdmin(), appIdentity.allowGuestAccess(),
+                                             appIdentity.creation(), userAndTimestamp, null);
+            final Map<String, AppIdentity> newAppIds = updateMap(registry.appIds(), appId, newToken);
+            final Map<String, String> newSecrets =
+                    removeFromMap(registry.secrets(), secret); // Note that the key is secret not appId.
+            return new AppIdentityRegistry(newAppIds, newSecrets, registry.certificateIds());
+        });
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
                                             commitSummary, transformer);
     }
@@ -358,7 +356,7 @@ final class AppIdentityService {
                                                                       Jackson.valueToTree(
                                                                               certificate.appId()))));
         return appIdentityRegistryRepo.push(INTERNAL_PROJECT_DOGMA, Project.REPO_DOGMA, author,
-                                            "Add a certificate: " + certificate.id(), change);
+                              "Add a certificate: " + certificate.id(), change);
     }
 
     CompletableFuture<Revision> destroyCertificate(Author author, String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/AppIdentityService.java
@@ -203,7 +203,10 @@ final class AppIdentityService {
                                                      token.deactivation(), null);
                     final Map<String, AppIdentity> newAppIds =
                             updateMap(registry.appIds(), appId, newToken);
-                    return new AppIdentityRegistry(newAppIds, registry.secrets(), registry.certificateIds());
+                    // A deactivated token has no entry in the secret map; create a new map so that
+                    // the new registry does not share the mutable map with the old one.
+                    return new AppIdentityRegistry(newAppIds, ImmutableMap.copyOf(registry.secrets()),
+                                                   registry.certificateIds());
                 });
         // Read the registry back at the revision this commit produced so that the caller gets
         // the secret of this commit even if another commit lands right after.

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1166,6 +1166,27 @@ public class MetadataService {
     }
 
     /**
+     * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
+     * {@link Token} with the newly-generated secret. The old secret is revoked immediately.
+     */
+    public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId) {
+        return appIdentityService.regenerateTokenSecret(author, appId);
+    }
+
+    /**
+     * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
+     * {@link Token} with the newly-generated secret. The old secret is revoked immediately.
+     * The regeneration fails with a {@link ChangeConflictException} if the token's creation metadata
+     * does not match {@code expectedCreation}, which prevents rotating a token that was recreated
+     * with the same application ID after the caller was authorized.
+     */
+    public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
+                                                          UserAndTimestamp expectedCreation) {
+        requireNonNull(expectedCreation, "expectedCreation");
+        return appIdentityService.regenerateTokenSecret(author, appId, expectedCreation);
+    }
+
+    /**
      * Returns an {@link AppIdentity} which has the specified {@code appId}.
      */
     public AppIdentity findAppIdentity(String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1167,7 +1167,8 @@ public class MetadataService {
 
     /**
      * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
-     * {@link Token} with the newly-generated secret. The old secret is revoked immediately.
+     * {@link Token} with the newly-generated secret. The old secret is revoked in the same commit,
+     * but it may take a short time for the revocation to be propagated to the authorization cache.
      */
     public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId) {
         return appIdentityService.regenerateTokenSecret(author, appId);
@@ -1175,7 +1176,8 @@ public class MetadataService {
 
     /**
      * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
-     * {@link Token} with the newly-generated secret. The old secret is revoked immediately.
+     * {@link Token} with the newly-generated secret. The old secret is revoked in the same commit,
+     * but it may take a short time for the revocation to be propagated to the authorization cache.
      * The regeneration fails with a {@link ChangeConflictException} if the token's creation metadata
      * does not match {@code expectedCreation}, which prevents rotating a token that was recreated
      * with the same application ID after the caller was authorized.

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1166,26 +1166,27 @@ public class MetadataService {
     }
 
     /**
-     * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
-     * {@link Token} with the newly-generated secret. The old secret is revoked in the same commit,
-     * but it may take a short time for the revocation to be propagated to the authorization cache.
+     * Regenerates the secret of the deactivated {@link Token} of the specified {@code appId} and
+     * returns the {@link Token} with the newly-generated secret. The token must be deactivated first
+     * and the new secret does not authenticate until the token is activated. The regeneration fails
+     * with a {@link ChangeConflictException} if the token is still active.
      */
     public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId) {
         return appIdentityService.regenerateTokenSecret(author, appId);
     }
 
     /**
-     * Regenerates the secret of the {@link Token} of the specified {@code appId} and returns the
-     * {@link Token} with the newly-generated secret. The old secret is revoked in the same commit,
-     * but it may take a short time for the revocation to be propagated to the authorization cache.
-     * The regeneration fails with a {@link ChangeConflictException} if the token's creation metadata
-     * does not match {@code expectedCreation}, which prevents rotating a token that was recreated
-     * with the same application ID after the caller was authorized.
+     * Regenerates the secret of the deactivated {@link Token} of the specified {@code appId} and
+     * returns the {@link Token} with the newly-generated secret. The token must be deactivated first
+     * and the new secret does not authenticate until the token is activated. The regeneration fails
+     * with a {@link ChangeConflictException} if the token is still active, or if the token does not
+     * match {@code expectedToken} anymore because it was recreated or regenerated after the caller
+     * was authorized.
      */
     public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
-                                                          UserAndTimestamp expectedCreation) {
-        requireNonNull(expectedCreation, "expectedCreation");
-        return appIdentityService.regenerateTokenSecret(author, appId, expectedCreation);
+                                                          Token expectedToken) {
+        requireNonNull(expectedToken, "expectedToken");
+        return appIdentityService.regenerateTokenSecret(author, appId, expectedToken);
     }
 
     /**

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/MetadataService.java
@@ -1176,20 +1176,6 @@ public class MetadataService {
     }
 
     /**
-     * Regenerates the secret of the deactivated {@link Token} of the specified {@code appId} and
-     * returns the {@link Token} with the newly-generated secret. The token must be deactivated first
-     * and the new secret does not authenticate until the token is activated. The regeneration fails
-     * with a {@link ChangeConflictException} if the token is still active, or if the token does not
-     * match {@code expectedToken} anymore because it was recreated or regenerated after the caller
-     * was authorized.
-     */
-    public CompletableFuture<Token> regenerateTokenSecret(Author author, String appId,
-                                                          Token expectedToken) {
-        requireNonNull(expectedToken, "expectedToken");
-        return appIdentityService.regenerateTokenSecret(author, appId, expectedToken);
-    }
-
-    /**
      * Returns an {@link AppIdentity} which has the specified {@code appId}.
      */
     public AppIdentity findAppIdentity(String appId) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/metadata/RepositorySupport.java
@@ -66,6 +66,13 @@ final class RepositorySupport<T> {
         return fetch(projectManager().get(projectName).repos().get(repoName), path);
     }
 
+    CompletableFuture<HolderWithRevision<T>> fetch(String projectName, String repoName, String path,
+                                                   Revision revision) {
+        requireNonNull(projectName, "projectName");
+        requireNonNull(repoName, "repoName");
+        return fetch(projectManager().get(projectName).repos().get(repoName), path, revision);
+    }
+
     private CompletableFuture<HolderWithRevision<T>> fetch(Repository repository, String path) {
         requireNonNull(path, "path");
         final Revision revision = normalize(repository);

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
@@ -18,6 +18,7 @@ package com.linecorp.centraldogma.server.internal.api;
 import static com.linecorp.centraldogma.internal.api.v1.HttpApiV1Constants.API_V1_PATH_PREFIX;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
 
@@ -69,6 +70,166 @@ class AppIdentityRegistryServiceViaHttpTest {
                                                                              TestAuthMessageUtil.PASSWORD,
                                                                              true)))
                                      .build();
+    }
+
+    @Test
+    void regenerateTokenSecret() throws JsonProcessingException {
+        final AggregatedHttpResponse createResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                       QueryParams.of("appId", "forRegenerate", "type", "TOKEN",
+                                                      "isSystemAdmin", false),
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
+        final String oldSecret = Jackson.readTree(createResponse.contentUtf8()).get("secret").asText();
+
+        // The old secret authenticates requests.
+        assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                            .status()).isEqualTo(HttpStatus.OK);
+
+        final AggregatedHttpResponse regenerateResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forRegenerate/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(regenerateResponse.status()).isEqualTo(HttpStatus.OK);
+        final JsonNode regenerated = Jackson.readTree(regenerateResponse.contentUtf8());
+        assertThat(regenerated.get("appId").asText()).isEqualTo("forRegenerate");
+        final String newSecret = regenerated.get("secret").asText();
+        assertThat(newSecret).startsWith("appToken-")
+                             .isNotEqualTo(oldSecret);
+
+        // The old secret is revoked and the new secret authenticates requests.
+        // The registry used by the authorizer is updated asynchronously so await the changes.
+        await().untilAsserted(() -> {
+            assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+            assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.OK);
+        });
+    }
+
+    @Test
+    void ownerCanRegenerateOwnTokenSecret() throws JsonProcessingException {
+        // A non-admin user creates its own token and regenerates its secret.
+        final WebClient userClient =
+                WebClient.builder(dogma.httpClient().uri())
+                         .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
+                                                                 TestAuthMessageUtil.USERNAME2,
+                                                                 TestAuthMessageUtil.PASSWORD2,
+                                                                 "ownerAppId",
+                                                                 false)))
+                         .build();
+        assertThat(userClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                   QueryParams.of("appId", "ownedByUser2", "type", "TOKEN",
+                                                  "isSystemAdmin", false),
+                                   HttpData.empty())
+                             .aggregate()
+                             .join()
+                             .status()).isEqualTo(HttpStatus.CREATED);
+
+        final AggregatedHttpResponse response =
+                userClient.post(API_V1_PATH_PREFIX + "appIdentities/ownedByUser2/secret", HttpData.empty())
+                          .aggregate()
+                          .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void regenerateSecretOfDeactivatedTokenViaHttp() throws JsonProcessingException {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "forInactive", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+        final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH,
+                                                         API_V1_PATH_PREFIX + "appIdentities/forInactive",
+                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(systemAdminClient.execute(headers, "{\"status\":\"inactive\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+
+        final AggregatedHttpResponse response =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forInactive/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
+        final JsonNode regenerated = Jackson.readTree(response.contentUtf8());
+        final String newSecret = regenerated.get("secret").asText();
+        assertThat(newSecret).startsWith("appToken-");
+        // The token remains deactivated so the new secret does not authenticate until activation.
+        assertThat(regenerated.get("deactivation")).isNotNull();
+        await().untilAsserted(() -> {
+            assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        });
+    }
+
+    @Test
+    void cannotRegenerateSecretOfMissingToken() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/nonexistent/secret",
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void cannotRegenerateSecretWithoutPermission() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "ownedBySystemAdmin", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+
+        final WebClient userClient =
+                WebClient.builder(dogma.httpClient().uri())
+                         .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
+                                                                 TestAuthMessageUtil.USERNAME2,
+                                                                 TestAuthMessageUtil.PASSWORD2,
+                                                                 "appIdOfUser2",
+                                                                 false)))
+                         .build();
+        assertThat(userClient.post(API_V1_PATH_PREFIX + "appIdentities/ownedBySystemAdmin/secret",
+                                   HttpData.empty())
+                             .aggregate()
+                             .join()
+                             .status()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    void cannotRegenerateSecretOfDestroyedToken() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "forDestroyed", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+        // The DELETE method always responds with 204 No Content on success.
+        assertThat(systemAdminClient.delete(API_V1_PATH_PREFIX + "appIdentities/forDestroyed")
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        final AggregatedHttpResponse response =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forDestroyed/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.contentUtf8()).contains("scheduled for deletion");
+    }
+
+    private static WebClient newTokenClient(String secret) {
+        return WebClient.builder(dogma.httpClient().uri())
+                        .auth(AuthToken.ofOAuth2(secret))
+                        .build();
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
@@ -88,6 +88,18 @@ class AppIdentityRegistryServiceViaHttpTest {
         assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
                                             .status()).isEqualTo(HttpStatus.OK);
 
+        // Deactivate the token to revoke the old secret.
+        final RequestHeaders patchHeaders =
+                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forRegenerate",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+        // The registry used by the authorizer is updated asynchronously so await the changes.
+        await().untilAsserted(() -> {
+            assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        });
+
         final AggregatedHttpResponse regenerateResponse =
                 systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forRegenerate/secret",
                                        HttpData.empty())
@@ -99,20 +111,48 @@ class AppIdentityRegistryServiceViaHttpTest {
         final String newSecret = regenerated.get("secret").asText();
         assertThat(newSecret).startsWith("appToken-")
                              .isNotEqualTo(oldSecret);
-
-        // The old secret is revoked and the new secret authenticates requests.
-        // The registry used by the authorizer is updated asynchronously so await the changes.
+        // The token remains deactivated so neither secret authenticates yet.
+        assertThat(regenerated.get("deactivation")).isNotNull();
         await().untilAsserted(() -> {
+            assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
             assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
                                                 .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        });
+
+        // Activating the token makes the new secret usable while the old one stays revoked.
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+        await().untilAsserted(() -> {
             assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
                                                 .status()).isEqualTo(HttpStatus.OK);
+            assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
+                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
         });
     }
 
     @Test
+    void cannotRegenerateSecretOfActiveToken() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "forActive", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+
+        final AggregatedHttpResponse response =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forActive/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(response.status()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.contentUtf8()).contains("Deactivate it first");
+    }
+
+    @Test
     void ownerCanRegenerateOwnTokenSecret() throws JsonProcessingException {
-        // A non-admin user creates its own token and regenerates its secret.
+        // A non-admin user creates its own token, deactivates it and regenerates its secret.
         final WebClient userClient =
                 WebClient.builder(dogma.httpClient().uri())
                          .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
@@ -128,44 +168,17 @@ class AppIdentityRegistryServiceViaHttpTest {
                              .aggregate()
                              .join()
                              .status()).isEqualTo(HttpStatus.CREATED);
+        final RequestHeaders patchHeaders =
+                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/ownedByUser2",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(userClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
+                             .status()).isEqualTo(HttpStatus.OK);
 
         final AggregatedHttpResponse response =
                 userClient.post(API_V1_PATH_PREFIX + "appIdentities/ownedByUser2/secret", HttpData.empty())
                           .aggregate()
                           .join();
         assertThat(response.status()).isEqualTo(HttpStatus.OK);
-    }
-
-    @Test
-    void regenerateSecretOfDeactivatedTokenViaHttp() throws JsonProcessingException {
-        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
-                                          QueryParams.of("appId", "forInactive", "type", "TOKEN",
-                                                         "isSystemAdmin", false),
-                                          HttpData.empty())
-                                    .aggregate()
-                                    .join()
-                                    .status()).isEqualTo(HttpStatus.CREATED);
-        final RequestHeaders headers = RequestHeaders.of(HttpMethod.PATCH,
-                                                         API_V1_PATH_PREFIX + "appIdentities/forInactive",
-                                                         HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(systemAdminClient.execute(headers, "{\"status\":\"inactive\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
-
-        final AggregatedHttpResponse response =
-                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forInactive/secret",
-                                       HttpData.empty())
-                                 .aggregate()
-                                 .join();
-        assertThat(response.status()).isEqualTo(HttpStatus.OK);
-        final JsonNode regenerated = Jackson.readTree(response.contentUtf8());
-        final String newSecret = regenerated.get("secret").asText();
-        assertThat(newSecret).startsWith("appToken-");
-        // The token remains deactivated so the new secret does not authenticate until activation.
-        assertThat(regenerated.get("deactivation")).isNotNull();
-        await().untilAsserted(() -> {
-            assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
-                                                .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
-        });
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
@@ -47,8 +48,10 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.ProjectRole;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
+import com.linecorp.centraldogma.server.internal.api.MetadataApiService.IdAndProjectRole;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
@@ -98,11 +101,7 @@ class AppIdentityRegistryServiceViaHttpTest {
                                             .status()).isEqualTo(HttpStatus.OK);
 
         // Deactivate the token to revoke the old secret.
-        final RequestHeaders patchHeaders =
-                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forRegenerate",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forRegenerate", "inactive");
         // The registry used by the authorizer is updated asynchronously so await the changes.
         await().untilAsserted(() -> {
             assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
@@ -135,8 +134,7 @@ class AppIdentityRegistryServiceViaHttpTest {
         });
 
         // Activating the token makes the new secret usable while the old one stays revoked.
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forRegenerate", "active");
         await().untilAsserted(() -> {
             assertThat(newTokenClient(newSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
                                                 .status()).isEqualTo(HttpStatus.OK);
@@ -166,12 +164,11 @@ class AppIdentityRegistryServiceViaHttpTest {
                                  .join();
         assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
         final String oldSecret = Jackson.readTree(createResponse.contentUtf8()).get("secret").asText();
-        final RequestHeaders registerHeaders =
-                RequestHeaders.of(HttpMethod.POST,
-                                  API_V1_PATH_PREFIX + "metadata/rotationProj/appIdentities",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(systemAdminClient.execute(registerHeaders, "{\"id\":\"forRoles\",\"role\":\"MEMBER\"}")
-                                    .aggregate().join().status()).isEqualTo(HttpStatus.OK);
+        assertThat(systemAdminClient.blocking().prepare()
+                                    .post(API_V1_PATH_PREFIX + "metadata/rotationProj/appIdentities")
+                                    .contentJson(new IdAndProjectRole("forRoles", ProjectRole.MEMBER))
+                                    .execute()
+                                    .status()).isEqualTo(HttpStatus.OK);
 
         // The token can read the repository with the old secret.
         final CentralDogma oldSecretClient = newDogmaClient(oldSecret);
@@ -182,11 +179,7 @@ class AppIdentityRegistryServiceViaHttpTest {
         });
 
         // Rotate the secret: deactivate, regenerate and activate.
-        final RequestHeaders patchHeaders =
-                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forRoles",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forRoles", "inactive");
         final AggregatedHttpResponse regenerateResponse =
                 systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forRoles/secret",
                                        HttpData.empty())
@@ -194,8 +187,7 @@ class AppIdentityRegistryServiceViaHttpTest {
                                  .join();
         assertThat(regenerateResponse.status()).isEqualTo(HttpStatus.OK);
         final String newSecret = Jackson.readTree(regenerateResponse.contentUtf8()).get("secret").asText();
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forRoles", "active");
 
         // The token keeps its project role: the new secret can read the repository without
         // being registered again, while the old secret cannot authenticate anymore.
@@ -227,11 +219,7 @@ class AppIdentityRegistryServiceViaHttpTest {
                              .aggregate()
                              .join()
                              .status()).isEqualTo(HttpStatus.CREATED);
-        final RequestHeaders patchHeaders =
-                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/rotatedByAdmin",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(userClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
-                             .status()).isEqualTo(HttpStatus.OK);
+        setStatus(userClient, "rotatedByAdmin", "inactive");
 
         // A system administrator can regenerate the secret of a token it does not own.
         assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/rotatedByAdmin/secret",
@@ -251,11 +239,7 @@ class AppIdentityRegistryServiceViaHttpTest {
                                  .aggregate()
                                  .join();
         assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
-        final RequestHeaders patchHeaders =
-                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forTwice",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forTwice", "inactive");
 
         // Both regenerations succeed but only the last secret survives.
         final AggregatedHttpResponse firstResponse =
@@ -274,8 +258,7 @@ class AppIdentityRegistryServiceViaHttpTest {
         final String secondSecret = Jackson.readTree(secondResponse.contentUtf8()).get("secret").asText();
         assertThat(secondSecret).isNotEqualTo(firstSecret);
 
-        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
-                                    .status()).isEqualTo(HttpStatus.OK);
+        setStatus(systemAdminClient, "forTwice", "active");
         await().untilAsserted(() -> {
             assertThat(newTokenClient(secondSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate()
                                                    .join().status()).isEqualTo(HttpStatus.OK);
@@ -387,11 +370,7 @@ class AppIdentityRegistryServiceViaHttpTest {
                              .aggregate()
                              .join()
                              .status()).isEqualTo(HttpStatus.CREATED);
-        final RequestHeaders patchHeaders =
-                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/ownedByUser2",
-                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
-        assertThat(userClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
-                             .status()).isEqualTo(HttpStatus.OK);
+        setStatus(userClient, "ownedByUser2", "inactive");
 
         final AggregatedHttpResponse response =
                 userClient.post(API_V1_PATH_PREFIX + "appIdentities/ownedByUser2/secret", HttpData.empty())
@@ -462,6 +441,15 @@ class AppIdentityRegistryServiceViaHttpTest {
         return WebClient.builder(dogma.httpClient().uri())
                         .auth(AuthToken.ofOAuth2(secret))
                         .build();
+    }
+
+    private static void setStatus(WebClient client, String appId, String status) {
+        final AggregatedHttpResponse response =
+                client.blocking().prepare()
+                      .patch(API_V1_PATH_PREFIX + "appIdentities/" + appId)
+                      .contentJson(ImmutableMap.of("status", status))
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.OK);
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/AppIdentityRegistryServiceViaHttpTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.net.URI;
+import java.net.UnknownHostException;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 import com.linecorp.armeria.client.WebClient;
 import com.linecorp.armeria.common.AggregatedHttpResponse;
+import com.linecorp.armeria.common.Cookie;
 import com.linecorp.armeria.common.HttpData;
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpMethod;
@@ -41,6 +43,10 @@ import com.linecorp.armeria.common.MediaType;
 import com.linecorp.armeria.common.QueryParams;
 import com.linecorp.armeria.common.RequestHeaders;
 import com.linecorp.armeria.common.auth.AuthToken;
+import com.linecorp.centraldogma.client.CentralDogma;
+import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
@@ -59,16 +65,18 @@ class AppIdentityRegistryServiceViaHttpTest {
         }
     };
 
+    private static String systemAdminAccessToken;
     private static WebClient systemAdminClient;
 
     @BeforeAll
     static void setUp() throws JsonMappingException, JsonParseException {
         final URI uri = dogma.httpClient().uri();
+        systemAdminAccessToken = getAccessToken(dogma.httpClient(),
+                                                TestAuthMessageUtil.USERNAME,
+                                                TestAuthMessageUtil.PASSWORD,
+                                                true);
         systemAdminClient = WebClient.builder(uri)
-                                     .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
-                                                                             TestAuthMessageUtil.USERNAME,
-                                                                             TestAuthMessageUtil.PASSWORD,
-                                                                             true)))
+                                     .auth(AuthToken.ofOAuth2(systemAdminAccessToken))
                                      .build();
     }
 
@@ -82,7 +90,8 @@ class AppIdentityRegistryServiceViaHttpTest {
                                  .aggregate()
                                  .join();
         assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
-        final String oldSecret = Jackson.readTree(createResponse.contentUtf8()).get("secret").asText();
+        final JsonNode created = Jackson.readTree(createResponse.contentUtf8());
+        final String oldSecret = created.get("secret").asText();
 
         // The old secret authenticates requests.
         assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
@@ -111,6 +120,11 @@ class AppIdentityRegistryServiceViaHttpTest {
         final String newSecret = regenerated.get("secret").asText();
         assertThat(newSecret).startsWith("appToken-")
                              .isNotEqualTo(oldSecret);
+        // Everything except the secret is preserved.
+        assertThat(regenerated.get("creation")).isEqualTo(created.get("creation"));
+        assertThat(regenerated.get("systemAdmin").asBoolean()).isFalse();
+        assertThat(regenerated.get("allowGuestAccess").asBoolean())
+                .isEqualTo(created.get("allowGuestAccess").asBoolean());
         // The token remains deactivated so neither secret authenticates yet.
         assertThat(regenerated.get("deactivation")).isNotNull();
         await().untilAsserted(() -> {
@@ -129,6 +143,211 @@ class AppIdentityRegistryServiceViaHttpTest {
             assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate().join()
                                                 .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
         });
+    }
+
+    @Test
+    void rotatedTokenKeepsItsRolesAndPermissions() throws UnknownHostException, JsonProcessingException {
+        // Scaffold a project with a file, using the system administrator's token.
+        final CentralDogma adminDogmaClient = newDogmaClient(systemAdminAccessToken);
+        adminDogmaClient.createProject("rotationProj").join();
+        adminDogmaClient.createRepository("rotationProj", "rotationRepo").join();
+        adminDogmaClient.forRepo("rotationProj", "rotationRepo")
+                        .commit("Add a.txt", Change.ofTextUpsert("/a.txt", "foo"))
+                        .push()
+                        .join();
+
+        // Create a token and register it to the project as a member.
+        final AggregatedHttpResponse createResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                       QueryParams.of("appId", "forRoles", "type", "TOKEN",
+                                                      "isSystemAdmin", false),
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
+        final String oldSecret = Jackson.readTree(createResponse.contentUtf8()).get("secret").asText();
+        final RequestHeaders registerHeaders =
+                RequestHeaders.of(HttpMethod.POST,
+                                  API_V1_PATH_PREFIX + "metadata/rotationProj/appIdentities",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(systemAdminClient.execute(registerHeaders, "{\"id\":\"forRoles\",\"role\":\"MEMBER\"}")
+                                    .aggregate().join().status()).isEqualTo(HttpStatus.OK);
+
+        // The token can read the repository with the old secret.
+        final CentralDogma oldSecretClient = newDogmaClient(oldSecret);
+        await().untilAsserted(() -> {
+            final Entry<?> entry = oldSecretClient.forRepo("rotationProj", "rotationRepo")
+                                                  .file("/a.txt").get().join();
+            assertThat(entry.contentAsText().trim()).isEqualTo("foo");
+        });
+
+        // Rotate the secret: deactivate, regenerate and activate.
+        final RequestHeaders patchHeaders =
+                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forRoles",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+        final AggregatedHttpResponse regenerateResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forRoles/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(regenerateResponse.status()).isEqualTo(HttpStatus.OK);
+        final String newSecret = Jackson.readTree(regenerateResponse.contentUtf8()).get("secret").asText();
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+
+        // The token keeps its project role: the new secret can read the repository without
+        // being registered again, while the old secret cannot authenticate anymore.
+        final CentralDogma newSecretClient = newDogmaClient(newSecret);
+        await().untilAsserted(() -> {
+            final Entry<?> entry = newSecretClient.forRepo("rotationProj", "rotationRepo")
+                                                  .file("/a.txt").get().join();
+            assertThat(entry.contentAsText().trim()).isEqualTo("foo");
+            assertThat(newTokenClient(oldSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate()
+                                                .join().status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        });
+    }
+
+    @Test
+    void systemAdminCanRegenerateOthersTokenSecret() throws JsonProcessingException {
+        // A non-admin user creates and deactivates its own token.
+        final WebClient userClient =
+                WebClient.builder(dogma.httpClient().uri())
+                         .auth(AuthToken.ofOAuth2(getAccessToken(dogma.httpClient(),
+                                                                 TestAuthMessageUtil.USERNAME2,
+                                                                 TestAuthMessageUtil.PASSWORD2,
+                                                                 "adminBypassLogin",
+                                                                 false)))
+                         .build();
+        assertThat(userClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                   QueryParams.of("appId", "rotatedByAdmin", "type", "TOKEN",
+                                                  "isSystemAdmin", false),
+                                   HttpData.empty())
+                             .aggregate()
+                             .join()
+                             .status()).isEqualTo(HttpStatus.CREATED);
+        final RequestHeaders patchHeaders =
+                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/rotatedByAdmin",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(userClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
+                             .status()).isEqualTo(HttpStatus.OK);
+
+        // A system administrator can regenerate the secret of a token it does not own.
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/rotatedByAdmin/secret",
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void consecutiveRegenerationsKeepOnlyTheLastSecret() throws JsonProcessingException {
+        final AggregatedHttpResponse createResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                       QueryParams.of("appId", "forTwice", "type", "TOKEN",
+                                                      "isSystemAdmin", false),
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(createResponse.status()).isEqualTo(HttpStatus.CREATED);
+        final RequestHeaders patchHeaders =
+                RequestHeaders.of(HttpMethod.PATCH, API_V1_PATH_PREFIX + "appIdentities/forTwice",
+                                  HttpHeaderNames.CONTENT_TYPE, MediaType.JSON);
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"inactive\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+
+        // Both regenerations succeed but only the last secret survives.
+        final AggregatedHttpResponse firstResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forTwice/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(firstResponse.status()).isEqualTo(HttpStatus.OK);
+        final String firstSecret = Jackson.readTree(firstResponse.contentUtf8()).get("secret").asText();
+        final AggregatedHttpResponse secondResponse =
+                systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forTwice/secret",
+                                       HttpData.empty())
+                                 .aggregate()
+                                 .join();
+        assertThat(secondResponse.status()).isEqualTo(HttpStatus.OK);
+        final String secondSecret = Jackson.readTree(secondResponse.contentUtf8()).get("secret").asText();
+        assertThat(secondSecret).isNotEqualTo(firstSecret);
+
+        assertThat(systemAdminClient.execute(patchHeaders, "{\"status\":\"active\"}").aggregate().join()
+                                    .status()).isEqualTo(HttpStatus.OK);
+        await().untilAsserted(() -> {
+            assertThat(newTokenClient(secondSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate()
+                                                   .join().status()).isEqualTo(HttpStatus.OK);
+            assertThat(newTokenClient(firstSecret).get(API_V1_PATH_PREFIX + "appIdentities").aggregate()
+                                                  .join().status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        });
+    }
+
+    @Test
+    void cannotRegenerateSecretOfPurgedToken() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "forPurged", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+        assertThat(systemAdminClient.delete(API_V1_PATH_PREFIX + "appIdentities/forPurged")
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(systemAdminClient.delete(API_V1_PATH_PREFIX + "appIdentities/forPurged/removed")
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.NO_CONTENT);
+
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities/forPurged/secret",
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void cannotRegenerateSecretWithoutAuthentication() {
+        assertThat(WebClient.of(dogma.httpClient().uri())
+                            .post(API_V1_PATH_PREFIX + "appIdentities/nonexistent/secret", HttpData.empty())
+                            .aggregate()
+                            .join()
+                            .status()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    void cannotRegenerateSecretWithoutCsrfToken() {
+        assertThat(systemAdminClient.post(API_V1_PATH_PREFIX + "appIdentities",
+                                          QueryParams.of("appId", "forCsrf", "type", "TOKEN",
+                                                         "isSystemAdmin", false),
+                                          HttpData.empty())
+                                    .aggregate()
+                                    .join()
+                                    .status()).isEqualTo(HttpStatus.CREATED);
+
+        // A session-cookie request without the CSRF token header must be rejected.
+        final AggregatedHttpResponse loginResponse =
+                TestAuthMessageUtil.login(dogma.httpClient(),
+                                          TestAuthMessageUtil.USERNAME,
+                                          TestAuthMessageUtil.PASSWORD);
+        assertThat(loginResponse.status()).isEqualTo(HttpStatus.OK);
+        final Cookie sessionCookie = TestAuthMessageUtil.getSessionCookie(loginResponse);
+        final RequestHeaders headers =
+                RequestHeaders.builder(HttpMethod.POST, API_V1_PATH_PREFIX + "appIdentities/forCsrf/secret")
+                              .cookie(sessionCookie)
+                              .build();
+        assertThat(dogma.httpClient().execute(headers, HttpData.empty()).aggregate().join()
+                        .status()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    private static CentralDogma newDogmaClient(String accessToken) throws UnknownHostException {
+        return new ArmeriaCentralDogmaBuilder()
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
+                .accessToken(accessToken)
+                .build();
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -555,6 +555,114 @@ class MetadataServiceTest {
     }
 
     @Test
+    void regenerateTokenSecret() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().getOrDefault(app1, null))
+                .isNotNull());
+        final Token token = (Token) mds.getAppIdentityRegistry().get(app1);
+        final String oldSecret = token.secret();
+        assertThat(oldSecret).isNotNull();
+
+        final Token returned = mds.regenerateTokenSecret(author, app1).join();
+        final String newSecret = returned.secret();
+        assertThat(newSecret).isNotNull()
+                             .startsWith("appToken-")
+                             .isNotEqualTo(oldSecret);
+        assertThat(returned.creation()).isEqualTo(token.creation());
+        assertThat(returned.isActive()).isTrue();
+
+        // The registry has the token with the new secret.
+        await().untilAsserted(() -> assertThat(((Token) mds.getAppIdentityRegistry().get(app1)).secret())
+                .isEqualTo(newSecret));
+
+        // The new secret resolves to the token while the old one does not.
+        assertThat(mds.findTokenBySecret(newSecret).appId()).isEqualTo(app1);
+        assertThatThrownBy(() -> mds.findTokenBySecret(oldSecret))
+                .isInstanceOf(AppIdentityNotFoundException.class);
+    }
+
+    @Test
+    void regenerateSecretOfDeactivatedToken() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+        mds.deactivateToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive()).isFalse());
+        final String oldSecret = ((Token) mds.getAppIdentityRegistry().get(app1)).secret();
+
+        final Token returned = mds.regenerateTokenSecret(author, app1).join();
+        final String newSecret = returned.secret();
+        assertThat(newSecret).isNotEqualTo(oldSecret);
+        await().untilAsserted(() -> assertThat(((Token) mds.getAppIdentityRegistry().get(app1)).secret())
+                .isEqualTo(newSecret));
+
+        // The token remains deactivated so neither secret resolves to it.
+        assertThat(returned.isActive()).isFalse();
+        assertThatThrownBy(() -> mds.findTokenBySecret(newSecret))
+                .isInstanceOf(AppIdentityNotFoundException.class);
+        assertThatThrownBy(() -> mds.findTokenBySecret(oldSecret))
+                .isInstanceOf(AppIdentityNotFoundException.class);
+
+        // Activating the token makes the new secret usable.
+        mds.activateToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive()).isTrue());
+        assertThat(mds.findTokenBySecret(newSecret).appId()).isEqualTo(app1);
+    }
+
+    @Test
+    void cannotRegenerateSecretOfDestroyedToken() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+        mds.destroyToken(author, app1).join();
+
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1).join())
+                .hasCauseInstanceOf(ChangeConflictException.class)
+                .hasStackTraceContaining("already destroyed");
+    }
+
+    @Test
+    void cannotRegenerateSecretOfRecreatedToken() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().getOrDefault(app1, null))
+                .isNotNull());
+        final UserAndTimestamp oldCreation = mds.getAppIdentityRegistry().get(app1).creation();
+
+        // Destroy, purge and recreate a token with the same application ID.
+        mds.destroyToken(author, app1).join();
+        mds.purgeAppIdentity(author, app1);
+        mds.createToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).creation())
+                .isNotEqualTo(oldCreation));
+        final UserAndTimestamp newCreation = mds.getAppIdentityRegistry().get(app1).creation();
+
+        // A regeneration authorized against the old token must not rotate the recreated one.
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, oldCreation).join())
+                .hasCauseInstanceOf(ChangeConflictException.class)
+                .hasStackTraceContaining("recreated concurrently");
+
+        // A regeneration with the matching creation metadata succeeds.
+        final Token returned = mds.regenerateTokenSecret(author, app1, newCreation).join();
+        assertThat(returned.secret()).startsWith("appToken-");
+    }
+
+    @Test
+    void cannotRegenerateSecretOfCertificate() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createCertificate(author, cert1, certificateId1, false).join();
+
+        // An IllegalArgumentException raised in a transformer is wrapped with a ChangeConflictException.
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, cert1).join())
+                .hasRootCauseInstanceOf(IllegalArgumentException.class)
+                .hasStackTraceContaining("not a TOKEN");
+    }
+
+    @Test
     void certificateActivationAndDeactivation() {
         final MetadataService mds = newMetadataService(manager);
 

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -565,50 +565,44 @@ class MetadataServiceTest {
         final String oldSecret = token.secret();
         assertThat(oldSecret).isNotNull();
 
+        mds.deactivateToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive()).isFalse());
+
         final Token returned = mds.regenerateTokenSecret(author, app1).join();
         final String newSecret = returned.secret();
         assertThat(newSecret).isNotNull()
                              .startsWith("appToken-")
                              .isNotEqualTo(oldSecret);
         assertThat(returned.creation()).isEqualTo(token.creation());
-        assertThat(returned.isActive()).isTrue();
 
         // The registry has the token with the new secret.
         await().untilAsserted(() -> assertThat(((Token) mds.getAppIdentityRegistry().get(app1)).secret())
                 .isEqualTo(newSecret));
 
-        // The new secret resolves to the token while the old one does not.
-        assertThat(mds.findTokenBySecret(newSecret).appId()).isEqualTo(app1);
-        assertThatThrownBy(() -> mds.findTokenBySecret(oldSecret))
-                .isInstanceOf(AppIdentityNotFoundException.class);
-    }
-
-    @Test
-    void regenerateSecretOfDeactivatedToken() {
-        final MetadataService mds = newMetadataService(manager);
-
-        mds.createToken(author, app1).join();
-        mds.deactivateToken(author, app1).join();
-        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive()).isFalse());
-        final String oldSecret = ((Token) mds.getAppIdentityRegistry().get(app1)).secret();
-
-        final Token returned = mds.regenerateTokenSecret(author, app1).join();
-        final String newSecret = returned.secret();
-        assertThat(newSecret).isNotEqualTo(oldSecret);
-        await().untilAsserted(() -> assertThat(((Token) mds.getAppIdentityRegistry().get(app1)).secret())
-                .isEqualTo(newSecret));
-
-        // The token remains deactivated so neither secret resolves to it.
+        // The token remains deactivated so neither secret resolves to it yet.
         assertThat(returned.isActive()).isFalse();
         assertThatThrownBy(() -> mds.findTokenBySecret(newSecret))
                 .isInstanceOf(AppIdentityNotFoundException.class);
         assertThatThrownBy(() -> mds.findTokenBySecret(oldSecret))
                 .isInstanceOf(AppIdentityNotFoundException.class);
 
-        // Activating the token makes the new secret usable.
+        // Activating the token makes the new secret usable while the old one stays revoked.
         mds.activateToken(author, app1).join();
         await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive()).isTrue());
         assertThat(mds.findTokenBySecret(newSecret).appId()).isEqualTo(app1);
+        assertThatThrownBy(() -> mds.findTokenBySecret(oldSecret))
+                .isInstanceOf(AppIdentityNotFoundException.class);
+    }
+
+    @Test
+    void cannotRegenerateSecretOfActiveToken() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1).join())
+                .hasCauseInstanceOf(ChangeConflictException.class)
+                .hasStackTraceContaining("must be deactivated");
     }
 
     @Test
@@ -630,24 +624,47 @@ class MetadataServiceTest {
         mds.createToken(author, app1).join();
         await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().getOrDefault(app1, null))
                 .isNotNull());
-        final UserAndTimestamp oldCreation = mds.getAppIdentityRegistry().get(app1).creation();
+        final Token oldToken = (Token) mds.getAppIdentityRegistry().get(app1);
 
         // Destroy, purge and recreate a token with the same application ID.
         mds.destroyToken(author, app1).join();
         mds.purgeAppIdentity(author, app1);
         mds.createToken(author, app1).join();
         await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).creation())
-                .isNotEqualTo(oldCreation));
-        final UserAndTimestamp newCreation = mds.getAppIdentityRegistry().get(app1).creation();
+                .isNotEqualTo(oldToken.creation()));
 
-        // A regeneration authorized against the old token must not rotate the recreated one.
-        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, oldCreation).join())
+        // A regeneration authorized against the old token must not rotate the recreated one,
+        // even before the recreated token is deactivated.
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, oldToken).join())
                 .hasCauseInstanceOf(ChangeConflictException.class)
                 .hasStackTraceContaining("recreated concurrently");
 
-        // A regeneration with the matching creation metadata succeeds.
-        final Token returned = mds.regenerateTokenSecret(author, app1, newCreation).join();
+        // A regeneration with the matching token succeeds once it is deactivated.
+        mds.deactivateToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive())
+                .isFalse());
+        final Token newToken = (Token) mds.getAppIdentityRegistry().get(app1);
+        final Token returned = mds.regenerateTokenSecret(author, app1, newToken).join();
         assertThat(returned.secret()).startsWith("appToken-");
+    }
+
+    @Test
+    void cannotRegenerateSecretConcurrently() {
+        final MetadataService mds = newMetadataService(manager);
+
+        mds.createToken(author, app1).join();
+        mds.deactivateToken(author, app1).join();
+        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive())
+                .isFalse());
+        final Token snapshot = (Token) mds.getAppIdentityRegistry().get(app1);
+
+        // Another regeneration is committed after the caller was authorized against the snapshot.
+        mds.regenerateTokenSecret(author, app1).join();
+
+        // The stale caller fails loudly instead of receiving a secret that will never work.
+        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, snapshot).join())
+                .hasCauseInstanceOf(ChangeConflictException.class)
+                .hasStackTraceContaining("regenerated concurrently");
     }
 
     @Test

--- a/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/metadata/MetadataServiceTest.java
@@ -618,56 +618,6 @@ class MetadataServiceTest {
     }
 
     @Test
-    void cannotRegenerateSecretOfRecreatedToken() {
-        final MetadataService mds = newMetadataService(manager);
-
-        mds.createToken(author, app1).join();
-        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().getOrDefault(app1, null))
-                .isNotNull());
-        final Token oldToken = (Token) mds.getAppIdentityRegistry().get(app1);
-
-        // Destroy, purge and recreate a token with the same application ID.
-        mds.destroyToken(author, app1).join();
-        mds.purgeAppIdentity(author, app1);
-        mds.createToken(author, app1).join();
-        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).creation())
-                .isNotEqualTo(oldToken.creation()));
-
-        // A regeneration authorized against the old token must not rotate the recreated one,
-        // even before the recreated token is deactivated.
-        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, oldToken).join())
-                .hasCauseInstanceOf(ChangeConflictException.class)
-                .hasStackTraceContaining("recreated concurrently");
-
-        // A regeneration with the matching token succeeds once it is deactivated.
-        mds.deactivateToken(author, app1).join();
-        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive())
-                .isFalse());
-        final Token newToken = (Token) mds.getAppIdentityRegistry().get(app1);
-        final Token returned = mds.regenerateTokenSecret(author, app1, newToken).join();
-        assertThat(returned.secret()).startsWith("appToken-");
-    }
-
-    @Test
-    void cannotRegenerateSecretConcurrently() {
-        final MetadataService mds = newMetadataService(manager);
-
-        mds.createToken(author, app1).join();
-        mds.deactivateToken(author, app1).join();
-        await().untilAsserted(() -> assertThat(mds.getAppIdentityRegistry().get(app1).isActive())
-                .isFalse());
-        final Token snapshot = (Token) mds.getAppIdentityRegistry().get(app1);
-
-        // Another regeneration is committed after the caller was authorized against the snapshot.
-        mds.regenerateTokenSecret(author, app1).join();
-
-        // The stale caller fails loudly instead of receiving a secret that will never work.
-        assertThatThrownBy(() -> mds.regenerateTokenSecret(author, app1, snapshot).join())
-                .hasCauseInstanceOf(ChangeConflictException.class)
-                .hasStackTraceContaining("regenerated concurrently");
-    }
-
-    @Test
     void cannotRegenerateSecretOfCertificate() {
         final MetadataService mds = newMetadataService(manager);
 

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -368,11 +368,18 @@ Anyone who is logged into the Central Dogma can create a new ``Application Token
 for everyone. So any owner of a project can add any token to their project. However only both the token
 creator and the system administrator are allowed to deactivate, remove and/or regenerate the token.
 
-If the secret of a token is leaked, the token creator or a system administrator can regenerate the secret
-with the ``Regenerate secret`` button of the web UI or ``POST /api/v1/appIdentities/{appId}/secret``.
-The old secret is revoked and a newly-generated secret is issued to the same application ID, so the roles
-and permissions granted to the token are preserved. Note that it may take a short time for the revocation
-to be propagated to the authorization cache of each server.
+If the secret of a token is leaked, the token creator or a system administrator can rotate the secret
+without losing the roles and permissions granted to the application ID:
+
+1. Deactivate the token. The leaked secret is revoked and stops authenticating. Note that it may take
+   a short time for the change to be propagated to the authorization cache of each server.
+2. Regenerate the secret with the ``Regenerate secret`` button of the web UI or
+   ``POST /api/v1/appIdentities/{appId}/secret``. A newly-generated secret is issued to the same
+   application ID, but it does not authenticate yet because the token is still deactivated. A token
+   must be deactivated before its secret is regenerated.
+3. Distribute the new secret to the clients of the token.
+4. Activate the token. The new secret starts authenticating once the activation is propagated to the
+   authorization cache of each server.
 
 There are two levels of a token, which are ``System Admin`` and ``User``. ``System Admin`` level token can be
 created by only the system administrators. A client who sends a request with the token is allowed to access

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -370,8 +370,9 @@ creator and the system administrator are allowed to deactivate, remove and/or re
 
 If the secret of a token is leaked, the token creator or a system administrator can regenerate the secret
 with the ``Regenerate secret`` button of the web UI or ``POST /api/v1/appIdentities/{appId}/secret``.
-The old secret is revoked immediately and a newly-generated secret is issued to the same application ID,
-so the roles and permissions granted to the token are preserved.
+The old secret is revoked and a newly-generated secret is issued to the same application ID, so the roles
+and permissions granted to the token are preserved. Note that it may take a short time for the revocation
+to be propagated to the authorization cache of each server.
 
 There are two levels of a token, which are ``System Admin`` and ``User``. ``System Admin`` level token can be
 created by only the system administrators. A client who sends a request with the token is allowed to access

--- a/site/src/sphinx/auth.rst
+++ b/site/src/sphinx/auth.rst
@@ -366,7 +366,12 @@ request comes from.
 
 Anyone who is logged into the Central Dogma can create a new ``Application Token``, and the token is shared
 for everyone. So any owner of a project can add any token to their project. However only both the token
-creator and the system administrator are allowed to deactivate and/or remove the token.
+creator and the system administrator are allowed to deactivate, remove and/or regenerate the token.
+
+If the secret of a token is leaked, the token creator or a system administrator can regenerate the secret
+with the ``Regenerate secret`` button of the web UI or ``POST /api/v1/appIdentities/{appId}/secret``.
+The old secret is revoked immediately and a newly-generated secret is issued to the same application ID,
+so the roles and permissions granted to the token are preserved.
 
 There are two levels of a token, which are ``System Admin`` and ``User``. ``System Admin`` level token can be
 created by only the system administrators. A client who sends a request with the token is allowed to access

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -367,7 +367,7 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['AppIdentity'],
     }),
-    regenerateAppIdentitySecret: builder.mutation({
+    regenerateAppIdentitySecret: builder.mutation<AppIdentityDto, { appId: string }>({
       query: ({ appId }) => ({
         url: `/api/v1/appIdentities/${appId}/secret`,
         method: 'POST',

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -367,6 +367,14 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['AppIdentity'],
     }),
+    regenerateAppIdentitySecret: builder.mutation({
+      query: ({ appId }) => ({
+        url: `/api/v1/appIdentities/${appId}/secret`,
+        method: 'POST',
+      }),
+      // Refetching remounts the table cell that shows the new secret in a modal, so the caller
+      // invalidates the 'AppIdentity' tag when the modal is closed instead.
+    }),
     getProjectMirrors: builder.query<MirrorDto[], string>({
       query: (projectName) => `/api/v1/projects/${projectName}/mirrors`,
       providesTags: ['Metadata'],
@@ -659,6 +667,7 @@ export const {
   useDeactivateAppIdentityMutation,
   useActivateAppIdentityMutation,
   useDeleteAppIdentityMutation,
+  useRegenerateAppIdentitySecretMutation,
   // File
   useGetFilesQuery,
   useGetFileContentQuery,

--- a/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
+++ b/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertIcon,
   Button,
   HStack,
   IconButton,
@@ -26,10 +28,12 @@ export const DisplaySecretModal = ({
   isOpen,
   onClose,
   response,
+  title = 'Application identity generated',
 }: {
   isOpen: boolean;
   onClose: () => void;
   response: AppIdentityDto;
+  title?: string;
 }) => {
   const dispatch = useAppDispatch();
   if (!response) return;
@@ -38,9 +42,15 @@ export const DisplaySecretModal = ({
     <Modal isOpen={isOpen} onClose={onClose} motionPreset="slideInBottom">
       <ModalOverlay />
       <ModalContent minWidth="max-content">
-        <ModalHeader>Application identity generated</ModalHeader>
+        <ModalHeader>{title}</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
+          {response.deactivation && (
+            <Alert status="warning" mb={4}>
+              <AlertIcon />
+              This app identity is inactive. The new secret will not work until the app identity is activated.
+            </Alert>
+          )}
           <TableContainer minWidth="max-content">
             <Table whiteSpace="normal">
               <Tbody>

--- a/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
+++ b/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
@@ -48,7 +48,8 @@ export const DisplaySecretModal = ({
           {response.deactivation && (
             <Alert status="warning" mb={4}>
               <AlertIcon />
-              This app identity is inactive. The new secret will not work until the app identity is activated.
+              This app identity is inactive. The new secret will not work until the app identity is activated,
+              so distribute it to the clients before activating.
             </Alert>
           )}
           <TableContainer minWidth="max-content">

--- a/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
+++ b/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
@@ -12,6 +12,7 @@ import {
   useDisclosure,
 } from '@chakra-ui/react';
 import { apiSlice, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
+import { AppIdentityDto } from 'dogma/features/app-identity/AppIdentity';
 import { DisplaySecretModal } from 'dogma/features/app-identity/DisplaySecretModal';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
@@ -28,7 +29,7 @@ export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; 
   } = useDisclosure();
   const dispatch = useAppDispatch();
   const [regenerateSecret, { isLoading, reset }] = useRegenerateAppIdentitySecretMutation();
-  const [appIdentityDetail, setAppIdentityDetail] = useState(null);
+  const [appIdentityDetail, setAppIdentityDetail] = useState<AppIdentityDto | null>(null);
   const mounted = useRef(true);
   const invalidationPending = useRef(false);
   useEffect(() => {

--- a/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
+++ b/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   HStack,
   Modal,
@@ -9,6 +10,7 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  Tooltip,
   useDisclosure,
 } from '@chakra-ui/react';
 import { apiSlice, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
@@ -20,7 +22,15 @@ import { useAppDispatch } from 'dogma/hooks';
 import { useEffect, useRef, useState } from 'react';
 import { MdRefresh } from 'react-icons/md';
 
-export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; hidden: boolean }) => {
+export const RegenerateAppIdentitySecret = ({
+  appId,
+  hidden,
+  disabled,
+}: {
+  appId: string;
+  hidden: boolean;
+  disabled?: boolean;
+}) => {
   const { isOpen, onToggle, onClose } = useDisclosure();
   const {
     isOpen: isSecretModalOpen,
@@ -76,16 +86,21 @@ export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; 
   };
   return (
     <>
-      <Button
-        size="sm"
-        colorScheme="orange"
-        hidden={hidden}
-        variant="ghost"
-        onClick={onToggle}
-        leftIcon={<MdRefresh />}
-      >
-        Regenerate secret
-      </Button>
+      <Tooltip label="Deactivate the token first to regenerate its secret." isDisabled={hidden || !disabled}>
+        {/* A disabled button does not emit hover events, so the tooltip wraps a Box instead. */}
+        <Box display="inline-block" hidden={hidden}>
+          <Button
+            size="sm"
+            colorScheme="orange"
+            isDisabled={disabled}
+            variant="ghost"
+            onClick={onToggle}
+            leftIcon={<MdRefresh />}
+          >
+            Regenerate secret
+          </Button>
+        </Box>
+      </Tooltip>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>
@@ -93,8 +108,8 @@ export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; 
           <ModalCloseButton />
           <ModalBody>
             <Text>
-              Regenerate the secret of application identity {`${appId}`}? The current secret is revoked
-              immediately and clients using it will no longer be able to authenticate.
+              Regenerate the secret of application identity {`${appId}`}? The app identity stays inactive and
+              the new secret will not work until the app identity is activated.
             </Text>
           </ModalBody>
           <ModalFooter>

--- a/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
+++ b/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
@@ -1,0 +1,124 @@
+import {
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { apiSlice, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
+import { DisplaySecretModal } from 'dogma/features/app-identity/DisplaySecretModal';
+import { newNotification } from 'dogma/features/notification/notificationSlice';
+import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
+import { useAppDispatch } from 'dogma/hooks';
+import { useEffect, useRef, useState } from 'react';
+import { MdRefresh } from 'react-icons/md';
+
+export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; hidden: boolean }) => {
+  const { isOpen, onToggle, onClose } = useDisclosure();
+  const {
+    isOpen: isSecretModalOpen,
+    onToggle: onSecretModalToggle,
+    onClose: onSecretModalClose,
+  } = useDisclosure();
+  const dispatch = useAppDispatch();
+  const [regenerateSecret, { isLoading, reset }] = useRegenerateAppIdentitySecretMutation();
+  const [appIdentityDetail, setAppIdentityDetail] = useState(null);
+  const mounted = useRef(true);
+  const invalidationPending = useRef(false);
+  useEffect(() => {
+    mounted.current = true;
+    // Refresh the list even if this component is unmounted before the secret modal is closed.
+    return () => {
+      mounted.current = false;
+      if (invalidationPending.current) {
+        invalidationPending.current = false;
+        dispatch(apiSlice.util.invalidateTags(['AppIdentity']));
+      }
+    };
+  }, [dispatch]);
+  const handleRegenerate = async () => {
+    try {
+      const response = await regenerateSecret({ appId }).unwrap();
+      if (!mounted.current) {
+        // Unmounted while the request was in flight; refresh the list right away.
+        dispatch(apiSlice.util.invalidateTags(['AppIdentity']));
+        return;
+      }
+      invalidationPending.current = true;
+      setAppIdentityDetail(response);
+      onClose();
+      onSecretModalToggle();
+    } catch (error) {
+      dispatch(
+        newNotification(
+          `Failed to regenerate the secret of ${appId}`,
+          ErrorMessageParser.parse(error),
+          'error',
+        ),
+      );
+    }
+  };
+  const handleSecretModalClose = () => {
+    onSecretModalClose();
+    setAppIdentityDetail(null);
+    reset();
+    // Refetch after the secret modal is closed; refetching earlier remounts this table cell
+    // and closes the modal before the user sees the new secret.
+    invalidationPending.current = false;
+    dispatch(apiSlice.util.invalidateTags(['AppIdentity']));
+  };
+  return (
+    <>
+      <Button
+        size="sm"
+        colorScheme="orange"
+        hidden={hidden}
+        variant="ghost"
+        onClick={onToggle}
+        leftIcon={<MdRefresh />}
+      >
+        Regenerate secret
+      </Button>
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>Are you sure?</ModalHeader>
+          <ModalCloseButton />
+          <ModalBody>
+            <Text>
+              Regenerate the secret of application identity {`${appId}`}? The current secret is revoked
+              immediately and clients using it will no longer be able to authenticate.
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <HStack spacing={3}>
+              <Button colorScheme="orange" variant="outline" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button
+                colorScheme="orange"
+                onClick={handleRegenerate}
+                isLoading={isLoading}
+                loadingText="Regenerating"
+              >
+                Regenerate
+              </Button>
+            </HStack>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <DisplaySecretModal
+        isOpen={isSecretModalOpen}
+        onClose={handleSecretModalClose}
+        response={appIdentityDetail}
+        title="Secret regenerated"
+      />
+    </>
+  );
+};

--- a/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
+++ b/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   HStack,
   Modal,
@@ -10,7 +9,6 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
-  Tooltip,
   useDisclosure,
 } from '@chakra-ui/react';
 import { apiSlice, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
@@ -22,15 +20,7 @@ import { useAppDispatch } from 'dogma/hooks';
 import { useEffect, useRef, useState } from 'react';
 import { MdRefresh } from 'react-icons/md';
 
-export const RegenerateAppIdentitySecret = ({
-  appId,
-  hidden,
-  disabled,
-}: {
-  appId: string;
-  hidden: boolean;
-  disabled?: boolean;
-}) => {
+export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; hidden: boolean }) => {
   const { isOpen, onToggle, onClose } = useDisclosure();
   const {
     isOpen: isSecretModalOpen,
@@ -86,21 +76,16 @@ export const RegenerateAppIdentitySecret = ({
   };
   return (
     <>
-      <Tooltip label="Deactivate the token first to regenerate its secret." isDisabled={hidden || !disabled}>
-        {/* A disabled button does not emit hover events, so the tooltip wraps a Box instead. */}
-        <Box display="inline-block" hidden={hidden}>
-          <Button
-            size="sm"
-            colorScheme="orange"
-            isDisabled={disabled}
-            variant="ghost"
-            onClick={onToggle}
-            leftIcon={<MdRefresh />}
-          >
-            Regenerate secret
-          </Button>
-        </Box>
-      </Tooltip>
+      <Button
+        size="sm"
+        colorScheme="orange"
+        hidden={hidden}
+        variant="ghost"
+        onClick={onToggle}
+        leftIcon={<MdRefresh />}
+      >
+        Regenerate secret
+      </Button>
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
         <ModalContent>

--- a/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
+++ b/webapp/src/dogma/features/app-identity/RegenerateAppIdentitySecret.tsx
@@ -20,7 +20,15 @@ import { useAppDispatch } from 'dogma/hooks';
 import { useEffect, useRef, useState } from 'react';
 import { MdRefresh } from 'react-icons/md';
 
-export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; hidden: boolean }) => {
+export const RegenerateAppIdentitySecret = ({
+  appId,
+  hidden,
+  onRegenerated,
+}: {
+  appId: string;
+  hidden: boolean;
+  onRegenerated?: () => void;
+}) => {
   const { isOpen, onToggle, onClose } = useDisclosure();
   const {
     isOpen: isSecretModalOpen,
@@ -69,6 +77,7 @@ export const RegenerateAppIdentitySecret = ({ appId, hidden }: { appId: string; 
     onSecretModalClose();
     setAppIdentityDetail(null);
     reset();
+    onRegenerated?.();
     // Refetch after the secret modal is closed; refetching earlier remounts this table cell
     // and closes the modal before the user sees the new secret.
     invalidationPending.current = false;

--- a/webapp/src/pages/app/settings/app-identities/index.tsx
+++ b/webapp/src/pages/app/settings/app-identities/index.tsx
@@ -12,6 +12,7 @@ import { useMemo } from 'react';
 import { DeactivateAppIdentity } from 'dogma/features/app-identity/DeactivateAppIdentity';
 import { ActivateAppIdentity } from 'dogma/features/app-identity/ActivateAppIdentity';
 import { DeleteAppIdentity } from 'dogma/features/app-identity/DeleteAppIdentity';
+import { RegenerateAppIdentitySecret } from 'dogma/features/app-identity/RegenerateAppIdentitySecret';
 import { Deferred } from 'dogma/common/components/Deferred';
 import SettingView from 'dogma/features/settings/SettingView';
 import { useAppSelector } from 'dogma/hooks';
@@ -78,6 +79,10 @@ const AppIdentityPage = () => {
           <Wrap>
             <ActivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
             <DeactivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() !== undefined} />
+            <RegenerateAppIdentitySecret
+              appId={info.row.original.appId}
+              hidden={!isToken(info.row.original) || info.row.original.deletion !== undefined}
+            />
             <DeleteAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
           </Wrap>
         ),

--- a/webapp/src/pages/app/settings/app-identities/index.tsx
+++ b/webapp/src/pages/app/settings/app-identities/index.tsx
@@ -82,6 +82,7 @@ const AppIdentityPage = () => {
             <RegenerateAppIdentitySecret
               appId={info.row.original.appId}
               hidden={!isToken(info.row.original) || info.row.original.deletion !== undefined}
+              disabled={info.getValue() === undefined}
             />
             <DeleteAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
           </Wrap>

--- a/webapp/src/pages/app/settings/app-identities/index.tsx
+++ b/webapp/src/pages/app/settings/app-identities/index.tsx
@@ -81,8 +81,11 @@ const AppIdentityPage = () => {
             <DeactivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() !== undefined} />
             <RegenerateAppIdentitySecret
               appId={info.row.original.appId}
-              hidden={!isToken(info.row.original) || info.row.original.deletion !== undefined}
-              disabled={info.getValue() === undefined}
+              hidden={
+                !isToken(info.row.original) ||
+                info.getValue() === undefined ||
+                info.row.original.deletion !== undefined
+              }
             />
             <DeleteAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
           </Wrap>

--- a/webapp/src/pages/app/settings/app-identities/index.tsx
+++ b/webapp/src/pages/app/settings/app-identities/index.tsx
@@ -8,7 +8,7 @@ import { UserRole } from 'dogma/common/components/UserRole';
 import { DataTableClientPagination } from 'dogma/common/components/table/DataTableClientPagination';
 import { useGetAppIdentitiesQuery } from 'dogma/features/api/apiSlice';
 import { AppIdentityDto, isToken, isCertificate } from 'dogma/features/app-identity/AppIdentity';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { DeactivateAppIdentity } from 'dogma/features/app-identity/DeactivateAppIdentity';
 import { ActivateAppIdentity } from 'dogma/features/app-identity/ActivateAppIdentity';
 import { DeleteAppIdentity } from 'dogma/features/app-identity/DeleteAppIdentity';
@@ -19,6 +19,14 @@ import { useAppSelector } from 'dogma/hooks';
 
 const AppIdentityPage = () => {
   const systemAdmin = useAppSelector((state) => state.auth.user?.systemAdmin ?? false);
+  // Tokens whose secret was regenerated during the current deactivation, keyed by
+  // `appId@deactivationTimestamp`. Hides the regenerate action until the token is
+  // deactivated again so that another regeneration does not revoke a secret being
+  // distributed to the clients.
+  const [regeneratedKeys, setRegeneratedKeys] = useState<Set<string>>(new Set());
+  const markRegenerated = useCallback((key: string) => {
+    setRegeneratedKeys((prev) => new Set(prev).add(key));
+  }, []);
   const columnHelper = createColumnHelper<AppIdentityDto>();
   const columns = useMemo(
     () => [
@@ -75,26 +83,31 @@ const AppIdentityPage = () => {
         header: 'Status',
       }),
       columnHelper.accessor((row: AppIdentityDto) => row.deactivation, {
-        cell: (info) => (
-          <Wrap>
-            <ActivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
-            <DeactivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() !== undefined} />
-            <RegenerateAppIdentitySecret
-              appId={info.row.original.appId}
-              hidden={
-                !isToken(info.row.original) ||
-                info.getValue() === undefined ||
-                info.row.original.deletion !== undefined
-              }
-            />
-            <DeleteAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
-          </Wrap>
-        ),
+        cell: (info) => {
+          const regeneratedKey = `${info.row.original.appId}@${info.getValue()?.timestamp}`;
+          return (
+            <Wrap>
+              <ActivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
+              <DeactivateAppIdentity appId={info.row.original.appId} hidden={info.getValue() !== undefined} />
+              <RegenerateAppIdentitySecret
+                appId={info.row.original.appId}
+                hidden={
+                  !isToken(info.row.original) ||
+                  info.getValue() === undefined ||
+                  info.row.original.deletion !== undefined ||
+                  regeneratedKeys.has(regeneratedKey)
+                }
+                onRegenerated={() => markRegenerated(regeneratedKey)}
+              />
+              <DeleteAppIdentity appId={info.row.original.appId} hidden={info.getValue() === undefined} />
+            </Wrap>
+          );
+        },
         header: 'Actions',
         enableSorting: false,
       }),
     ],
-    [columnHelper, systemAdmin],
+    [columnHelper, systemAdmin, regeneratedKeys, markRegenerated],
   );
   const { data, error, isLoading } = useGetAppIdentitiesQuery();
   return (

--- a/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
+++ b/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
@@ -1,0 +1,136 @@
+import '@testing-library/jest-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ReactElement } from 'react';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { RegenerateAppIdentitySecret } from 'dogma/features/app-identity/RegenerateAppIdentitySecret';
+import { apiSlice, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
+import { setupStore } from 'dogma/store';
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useRegenerateAppIdentitySecretMutation: jest.fn(),
+}));
+
+const regeneratedToken = {
+  appId: 'app-token-1',
+  type: 'TOKEN',
+  systemAdmin: false,
+  allowGuestAccess: false,
+  secret: 'appToken-regenerated-secret',
+  creation: { user: 'user@example.com', timestamp: '2024-01-01T00:00:00Z' },
+};
+
+// Renders with a store whose dispatched actions are recorded, so the tests can assert
+// when the AppIdentity cache invalidation is dispatched.
+function renderWithDispatchSpy(ui: ReactElement) {
+  const store = setupStore({});
+  const dispatched: unknown[] = [];
+  const originalDispatch = store.dispatch;
+  store.dispatch = ((action: never) => {
+    dispatched.push(action);
+    return originalDispatch(action);
+  }) as typeof store.dispatch;
+  const hasInvalidation = () => dispatched.some((action) => apiSlice.util.invalidateTags.match(action));
+  return { hasInvalidation, ...renderWithProviders(ui, { store }) };
+}
+
+describe('RegenerateAppIdentitySecret', () => {
+  let regenerateSecret: jest.Mock;
+  let reset: jest.Mock;
+
+  beforeEach(() => {
+    regenerateSecret = jest.fn();
+    reset = jest.fn();
+    (useRegenerateAppIdentitySecretMutation as jest.Mock).mockReturnValue([
+      regenerateSecret,
+      { isLoading: false, reset },
+    ]);
+  });
+
+  it('asks for confirmation before regenerating', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+
+    expect(screen.getByText(/The current secret is revoked immediately/)).toBeInTheDocument();
+    expect(regenerateSecret).not.toHaveBeenCalled();
+  });
+
+  it('regenerates the secret and shows it once confirmed', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    expect(regenerateSecret).toHaveBeenCalledWith({ appId: 'app-token-1' });
+    await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
+    expect(screen.getByText('appToken-regenerated-secret')).toBeInTheDocument();
+  });
+
+  it('warns that an inactive app identity needs activation', async () => {
+    regenerateSecret.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          ...regeneratedToken,
+          deactivation: { user: 'user@example.com', timestamp: '2024-01-02T00:00:00Z' },
+        }),
+    });
+    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
+    expect(screen.getByText(/This app identity is inactive/)).toBeInTheDocument();
+  });
+
+  it('refreshes the app identity list only after the secret modal is closed', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    const { hasInvalidation } = renderWithDispatchSpy(
+      <RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+    await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
+    // Refreshing while the modal is open would remount the table cell and close the modal.
+    expect(hasInvalidation()).toBe(false);
+
+    await userEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    await waitFor(() => expect(hasInvalidation()).toBe(true));
+    expect(reset).toHaveBeenCalled();
+  });
+
+  it('refreshes the app identity list when unmounted before the secret modal is closed', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    const { hasInvalidation, unmount } = renderWithDispatchSpy(
+      <RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+    await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
+    expect(hasInvalidation()).toBe(false);
+
+    unmount();
+
+    expect(hasInvalidation()).toBe(true);
+  });
+
+  it('does not show the secret modal when regeneration fails', async () => {
+    regenerateSecret.mockReturnValue({
+      unwrap: () => Promise.reject({ error: { status: 403, data: 'forbidden' } }),
+    });
+    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+
+    expect(regenerateSecret).toHaveBeenCalledWith({ appId: 'app-token-1' });
+    await waitFor(() => expect(screen.queryByText('Secret regenerated')).not.toBeInTheDocument());
+  });
+});

--- a/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
+++ b/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
@@ -12,6 +12,7 @@ jest.mock('dogma/features/api/apiSlice', () => ({
   useRegenerateAppIdentitySecretMutation: jest.fn(),
 }));
 
+// A regenerated token is always deactivated; the server rejects regenerating an active token.
 const regeneratedToken = {
   appId: 'app-token-1',
   type: 'TOKEN',
@@ -19,6 +20,7 @@ const regeneratedToken = {
   allowGuestAccess: false,
   secret: 'appToken-regenerated-secret',
   creation: { user: 'user@example.com', timestamp: '2024-01-01T00:00:00Z' },
+  deactivation: { user: 'user@example.com', timestamp: '2024-01-02T00:00:00Z' },
 };
 
 // Renders with a store whose dispatched actions are recorded, so the tests can assert
@@ -54,7 +56,9 @@ describe('RegenerateAppIdentitySecret', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
 
-    expect(screen.getByText(/The current secret is revoked immediately/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/the new secret will not work until the app identity is activated/),
+    ).toBeInTheDocument();
     expect(regenerateSecret).not.toHaveBeenCalled();
   });
 
@@ -71,13 +75,7 @@ describe('RegenerateAppIdentitySecret', () => {
   });
 
   it('warns that an inactive app identity needs activation', async () => {
-    regenerateSecret.mockReturnValue({
-      unwrap: () =>
-        Promise.resolve({
-          ...regeneratedToken,
-          deactivation: { user: 'user@example.com', timestamp: '2024-01-02T00:00:00Z' },
-        }),
-    });
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
     renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} />);
 
     await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
@@ -85,6 +83,18 @@ describe('RegenerateAppIdentitySecret', () => {
 
     await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
     expect(screen.getByText(/This app identity is inactive/)).toBeInTheDocument();
+  });
+
+  it('is disabled for an active token', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} disabled />);
+
+    const button = screen.getByRole('button', { name: /regenerate secret/i });
+    expect(button).toBeDisabled();
+
+    await userEvent.click(button);
+    expect(screen.queryByText(/stays inactive/)).not.toBeInTheDocument();
+    expect(regenerateSecret).not.toHaveBeenCalled();
   });
 
   it('refreshes the app identity list only after the secret modal is closed', async () => {

--- a/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
+++ b/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
@@ -85,6 +85,23 @@ describe('RegenerateAppIdentitySecret', () => {
     expect(screen.getByText(/This app identity is inactive/)).toBeInTheDocument();
   });
 
+  it('notifies the parent when the secret modal is closed after a regeneration', async () => {
+    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
+    const onRegenerated = jest.fn();
+    renderWithProviders(
+      <RegenerateAppIdentitySecret appId="app-token-1" hidden={false} onRegenerated={onRegenerated} />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Regenerate' }));
+    await waitFor(() => expect(screen.getByText('Secret regenerated')).toBeInTheDocument());
+    expect(onRegenerated).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: 'OK' }));
+
+    expect(onRegenerated).toHaveBeenCalledTimes(1);
+  });
+
   it('refreshes the app identity list only after the secret modal is closed', async () => {
     regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
     const { hasInvalidation } = renderWithDispatchSpy(

--- a/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
+++ b/webapp/tests/dogma/features/app-identity/RegenerateAppIdentitySecret.test.tsx
@@ -85,18 +85,6 @@ describe('RegenerateAppIdentitySecret', () => {
     expect(screen.getByText(/This app identity is inactive/)).toBeInTheDocument();
   });
 
-  it('is disabled for an active token', async () => {
-    regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
-    renderWithProviders(<RegenerateAppIdentitySecret appId="app-token-1" hidden={false} disabled />);
-
-    const button = screen.getByRole('button', { name: /regenerate secret/i });
-    expect(button).toBeDisabled();
-
-    await userEvent.click(button);
-    expect(screen.queryByText(/stays inactive/)).not.toBeInTheDocument();
-    expect(regenerateSecret).not.toHaveBeenCalled();
-  });
-
   it('refreshes the app identity list only after the secret modal is closed', async () => {
     regenerateSecret.mockReturnValue({ unwrap: () => Promise.resolve(regeneratedToken) });
     const { hasInvalidation } = renderWithDispatchSpy(

--- a/webapp/tests/pages/app/settings/app-identities/index.test.tsx
+++ b/webapp/tests/pages/app/settings/app-identities/index.test.tsx
@@ -90,10 +90,19 @@ describe('AppIdentityPage', () => {
     expect(getByText('app-admin-1')).toBeInTheDocument();
   });
 
-  it('offers the regenerate secret action only for live tokens', () => {
+  it('offers the regenerate secret action only for deactivated tokens', () => {
     (useGetAppIdentitiesQuery as jest.Mock).mockReturnValue({
       data: [
+        // An active token must be deactivated before its secret can be regenerated.
         mockIdentities[0],
+        {
+          appId: 'app-inactive-1',
+          type: 'TOKEN',
+          systemAdmin: false,
+          allowGuestAccess: false,
+          creation: { user: 'user@example.com', timestamp: '2024-01-02T00:00:00Z' },
+          deactivation: { user: 'user@example.com', timestamp: '2024-01-03T00:00:00Z' },
+        },
         {
           appId: 'app-cert-1',
           type: 'CERTIFICATE',
@@ -119,8 +128,12 @@ describe('AppIdentityPage', () => {
       preloadedState: { auth: baseAuthState },
     });
 
-    // Hidden buttons are excluded from the accessibility tree, so only the live token row's button
-    // is found; the certificate row and the token scheduled for deletion offer no regenerate action.
-    expect(getAllByRole('button', { name: /regenerate secret/i })).toHaveLength(1);
+    // Hidden buttons are excluded from the accessibility tree, so the buttons are found only for
+    // the token rows; certificates and tokens scheduled for deletion offer none. The active token
+    // row's button is disabled until the token is deactivated.
+    const buttons = getAllByRole('button', { name: /regenerate secret/i });
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toBeDisabled();
+    expect(buttons[1]).toBeEnabled();
   });
 });

--- a/webapp/tests/pages/app/settings/app-identities/index.test.tsx
+++ b/webapp/tests/pages/app/settings/app-identities/index.test.tsx
@@ -89,4 +89,38 @@ describe('AppIdentityPage', () => {
     expect(getByText('app-token-1')).toBeInTheDocument();
     expect(getByText('app-admin-1')).toBeInTheDocument();
   });
+
+  it('offers the regenerate secret action only for live tokens', () => {
+    (useGetAppIdentitiesQuery as jest.Mock).mockReturnValue({
+      data: [
+        mockIdentities[0],
+        {
+          appId: 'app-cert-1',
+          type: 'CERTIFICATE',
+          certificateId: 'cert/1',
+          systemAdmin: false,
+          allowGuestAccess: false,
+          creation: { user: 'user@example.com', timestamp: '2024-01-03T00:00:00Z' },
+        },
+        {
+          appId: 'app-deleted-1',
+          type: 'TOKEN',
+          systemAdmin: false,
+          allowGuestAccess: false,
+          creation: { user: 'user@example.com', timestamp: '2024-01-04T00:00:00Z' },
+          deactivation: { user: 'user@example.com', timestamp: '2024-01-05T00:00:00Z' },
+          deletion: { user: 'user@example.com', timestamp: '2024-01-05T00:00:00Z' },
+        },
+      ] as AppIdentityDto[],
+      error: undefined,
+      isLoading: false,
+    });
+    const { getAllByRole } = renderWithProviders(<AppIdentityPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    // Hidden buttons are excluded from the accessibility tree, so only the live token row's button
+    // is found; the certificate row and the token scheduled for deletion offer no regenerate action.
+    expect(getAllByRole('button', { name: /regenerate secret/i })).toHaveLength(1);
+  });
 });

--- a/webapp/tests/pages/app/settings/app-identities/index.test.tsx
+++ b/webapp/tests/pages/app/settings/app-identities/index.test.tsx
@@ -128,12 +128,8 @@ describe('AppIdentityPage', () => {
       preloadedState: { auth: baseAuthState },
     });
 
-    // Hidden buttons are excluded from the accessibility tree, so the buttons are found only for
-    // the token rows; certificates and tokens scheduled for deletion offer none. The active token
-    // row's button is disabled until the token is deactivated.
-    const buttons = getAllByRole('button', { name: /regenerate secret/i });
-    expect(buttons).toHaveLength(2);
-    expect(buttons[0]).toBeDisabled();
-    expect(buttons[1]).toBeEnabled();
+    // Hidden buttons are excluded from the accessibility tree, so only the deactivated token row's
+    // button is found; active tokens, certificates and tokens scheduled for deletion offer none.
+    expect(getAllByRole('button', { name: /regenerate secret/i })).toHaveLength(1);
   });
 });

--- a/webapp/tests/pages/app/settings/app-identities/index.test.tsx
+++ b/webapp/tests/pages/app/settings/app-identities/index.test.tsx
@@ -1,12 +1,15 @@
 import '@testing-library/jest-dom';
+import { waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from 'dogma/util/test-utils';
 import AppIdentityPage from 'pages/app/settings/app-identities';
 import { AppIdentityDto } from 'dogma/features/app-identity/AppIdentity';
-import { useGetAppIdentitiesQuery } from 'dogma/features/api/apiSlice';
+import { useGetAppIdentitiesQuery, useRegenerateAppIdentitySecretMutation } from 'dogma/features/api/apiSlice';
 
 jest.mock('dogma/features/api/apiSlice', () => ({
   ...jest.requireActual('dogma/features/api/apiSlice'),
   useGetAppIdentitiesQuery: jest.fn(),
+  useRegenerateAppIdentitySecretMutation: jest.fn(),
 }));
 
 jest.mock('next/router', () => ({
@@ -50,6 +53,10 @@ describe('AppIdentityPage', () => {
       error: undefined,
       isLoading: false,
     });
+    (useRegenerateAppIdentitySecretMutation as jest.Mock).mockReturnValue([
+      jest.fn(),
+      { isLoading: false, reset: jest.fn() },
+    ]);
   });
 
   it('hides the Level column for non-system-admin users', () => {
@@ -131,5 +138,38 @@ describe('AppIdentityPage', () => {
     // Hidden buttons are excluded from the accessibility tree, so only the deactivated token row's
     // button is found; active tokens, certificates and tokens scheduled for deletion offer none.
     expect(getAllByRole('button', { name: /regenerate secret/i })).toHaveLength(1);
+  });
+
+  it('hides the regenerate secret action once the secret is regenerated', async () => {
+    const inactiveToken: AppIdentityDto = {
+      appId: 'app-inactive-1',
+      type: 'TOKEN',
+      systemAdmin: false,
+      allowGuestAccess: false,
+      creation: { user: 'user@example.com', timestamp: '2024-01-01T00:00:00Z' },
+      deactivation: { user: 'user@example.com', timestamp: '2024-01-02T00:00:00Z' },
+    };
+    (useGetAppIdentitiesQuery as jest.Mock).mockReturnValue({
+      data: [inactiveToken],
+      error: undefined,
+      isLoading: false,
+    });
+    (useRegenerateAppIdentitySecretMutation as jest.Mock).mockReturnValue([
+      jest.fn().mockReturnValue({
+        unwrap: () => Promise.resolve({ ...inactiveToken, secret: 'appToken-regenerated-secret' }),
+      }),
+      { isLoading: false, reset: jest.fn() },
+    ]);
+    const { getByRole, getByText, queryByRole } = renderWithProviders(<AppIdentityPage />, {
+      preloadedState: { auth: baseAuthState },
+    });
+
+    await userEvent.click(getByRole('button', { name: /regenerate secret/i }));
+    await userEvent.click(getByRole('button', { name: 'Regenerate' }));
+    await waitFor(() => expect(getByText('Secret regenerated')).toBeInTheDocument());
+    await userEvent.click(getByRole('button', { name: 'OK' }));
+
+    // The action stays hidden until the token is deactivated again.
+    await waitFor(() => expect(queryByRole('button', { name: /regenerate secret/i })).not.toBeInTheDocument());
   });
 });


### PR DESCRIPTION
Motivation:

When the secret of an application token is leaked, the only remedy has been to
deactivate or delete the token and create a new one. This loses the roles and
permissions granted to the application ID and forces every project to register
the new token again. There should be a way to revoke the leaked secret and
issue a new one in place.

Modifications:

- Add `POST /api/v1/appIdentities/{appId}/secret` which issues a newly-generated
  secret to a deactivated token. Only the token creator or a system
  administrator is allowed to call it, the same as deletion.
- A token must be deactivated first and the new secret does not authenticate
  until the token is activated, so the rotation procedure is: deactivate,
  regenerate, distribute the new secret and activate.
- Fail with a conflict when the token was recreated or regenerated concurrently
  after the caller was authorized, so that nobody distributes a secret that
  will never work.
- Add a 'Regenerate secret' action with a confirmation dialog to the
  application identities settings page. The new secret is displayed once; the
  button is enabled only for deactivated tokens.
- Stop including the whole file content, which may contain secrets, in the
  exception message raised when a content transformer fails.

Result:

- Users can rotate a leaked token secret in place through the staged
  deactivate → regenerate → distribute → activate procedure; the application ID
  keeps its roles and permissions.
