### PR TITLE
Persist xDS list pagination in the URL so it survives navigation

### DIFF
--- a/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
+++ b/webapp/src/dogma/common/components/table/DataTableClientPagination.tsx
@@ -6,27 +6,15 @@ import {
   getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  PaginationState,
   SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { DataTable } from 'dogma/common/components/table/DataTable';
 import { Filter } from 'dogma/common/components/table/Filter';
 import { PAGE_SIZES, PaginationBar } from 'dogma/common/components/table/PaginationBar';
-import { useCallback, useEffect, useState } from 'react';
+import { useUrlPagination } from 'dogma/common/components/table/useUrlPagination';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
-
-const VALID_PAGE_SIZES: Set<number> = new Set(PAGE_SIZES);
-
-function parsePageIndex(value: string | string[] | undefined): number {
-  const n = Number(value);
-  return Number.isInteger(n) && n > 0 ? n - 1 : 0;
-}
-
-function parsePageSize(value: string | string[] | undefined): number {
-  const n = Number(value);
-  return VALID_PAGE_SIZES.has(n) ? n : 10;
-}
 
 export type DataTableClientPaginationProps<Data extends object> = {
   data: Data[];
@@ -41,40 +29,7 @@ export const DataTableClientPagination = <Data extends object>({
 
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize: 10,
-  });
-
-  const setPagination = useCallback(
-    (updater: PaginationState | ((old: PaginationState) => PaginationState)) => {
-      const newState = typeof updater === 'function' ? updater(pagination) : updater;
-      setPaginationState(newState);
-      const query = { ...router.query };
-      if (newState.pageIndex === 0) {
-        delete query.page;
-      } else {
-        query.page = String(newState.pageIndex + 1);
-      }
-      if (newState.pageSize === 10) {
-        delete query.pageSize;
-      } else {
-        query.pageSize = String(newState.pageSize);
-      }
-      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
-    },
-    [pagination, router],
-  );
-
-  useEffect(() => {
-    if (!router.isReady) {
-      return;
-    }
-    setPaginationState({
-      pageIndex: parsePageIndex(router.query?.page),
-      pageSize: parsePageSize(router.query?.pageSize),
-    });
-  }, [router.isReady, router.query?.page, router.query?.pageSize]);
+  const { pagination, onPaginationChange } = useUrlPagination({ pageSizes: PAGE_SIZES });
 
   const table = useReactTable({
     columns: columns || [],
@@ -85,7 +40,7 @@ export const DataTableClientPagination = <Data extends object>({
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    onPaginationChange: setPagination,
+    onPaginationChange,
     manualPagination: false,
     autoResetPageIndex: false,
     state: {

--- a/webapp/src/dogma/common/components/table/useUrlPagination.ts
+++ b/webapp/src/dogma/common/components/table/useUrlPagination.ts
@@ -1,0 +1,113 @@
+import { functionalUpdate, OnChangeFn, PaginationState, Table } from '@tanstack/react-table';
+import { useRouter } from 'next/router';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const DEFAULT_PAGE_SIZE = 10;
+
+// Parses the 1-indexed `page` query param into react-table's 0-indexed pageIndex, falling back to the first
+// page for a missing or malformed value. An out-of-range (too large) value is left as-is here and corrected by
+// useClampPageIndex once the row count is known.
+function parsePageIndex(value: string | string[] | undefined): number {
+  const n = Number(value);
+  return Number.isInteger(n) && n > 0 ? n - 1 : 0;
+}
+
+// Parses the `pageSize` query param, accepting it only when it is one of the offered sizes so a hand-edited URL
+// cannot force a size the selector could not otherwise display.
+function parsePageSize(
+  value: string | string[] | undefined,
+  pageSizes: readonly number[],
+  defaultPageSize: number,
+): number {
+  const n = Number(value);
+  return pageSizes.includes(n) ? n : defaultPageSize;
+}
+
+export interface UseUrlPaginationOptions {
+  // The page sizes offered by the size selector; a `pageSize` query param outside this set is ignored. May be
+  // an inline array — the hook does not depend on its identity.
+  pageSizes: readonly number[];
+  // The page size used when the URL carries no (valid) `pageSize`. Should be one of `pageSizes`.
+  defaultPageSize?: number;
+}
+
+export interface UrlPagination {
+  pagination: PaginationState;
+  onPaginationChange: OnChangeFn<PaginationState>;
+}
+
+/**
+ * Mirrors a TanStack Table's pagination into the URL query (`page`, `pageSize`) so it survives navigation:
+ * opening a row's detail page and pressing the browser Back button restores the same page and page size
+ * instead of resetting to the first page. `page` is 1-indexed in the URL, and both params are omitted while at
+ * their defaults to keep URLs clean. Routing is shallow, so persisting the state never refetches data.
+ *
+ * Consumers must wire the returned `pagination`/`onPaginationChange` into `useReactTable` as controlled state
+ * and set `autoResetPageIndex: false`; otherwise an asynchronous data load would reset the restored page back
+ * to the first one, reintroducing the very bug this hook fixes. Because auto-reset is off, also call
+ * {@link useClampPageIndex} so a stale page cannot outlive a shrinking data set.
+ */
+export function useUrlPagination({
+  pageSizes,
+  defaultPageSize = DEFAULT_PAGE_SIZE,
+}: UseUrlPaginationOptions): UrlPagination {
+  const router = useRouter();
+  const [pagination, setPagination] = useState<PaginationState>({ pageIndex: 0, pageSize: defaultPageSize });
+
+  // Hold the latest valid sizes in a ref so the URL-sync effect does not take `pageSizes` as a dependency.
+  // A caller passing an inline array (a new reference every render) would otherwise re-run the effect on every
+  // render — and since the effect calls setPagination with a fresh object, that would be an infinite loop.
+  const pageSizesRef = useRef(pageSizes);
+  pageSizesRef.current = pageSizes;
+
+  const onPaginationChange = useCallback<OnChangeFn<PaginationState>>(
+    (updater) => {
+      const next = functionalUpdate(updater, pagination);
+      setPagination(next);
+      const query = { ...router.query };
+      if (next.pageIndex === 0) {
+        delete query.page;
+      } else {
+        query.page = String(next.pageIndex + 1);
+      }
+      if (next.pageSize === defaultPageSize) {
+        delete query.pageSize;
+      } else {
+        query.pageSize = String(next.pageSize);
+      }
+      router.push({ pathname: router.pathname, query }, undefined, { shallow: true });
+    },
+    [pagination, router, defaultPageSize],
+  );
+
+  // Sync from the URL once the router is ready and whenever the params change (including the browser Back
+  // button), which is what restores the page after returning from a detail page.
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    setPagination({
+      pageIndex: parsePageIndex(router.query?.page),
+      pageSize: parsePageSize(router.query?.pageSize, pageSizesRef.current, defaultPageSize),
+    });
+  }, [router.isReady, router.query?.page, router.query?.pageSize, defaultPageSize]);
+
+  return { pagination, onPaginationChange };
+}
+
+/**
+ * Corrects the table's page index when it falls outside the available pages — e.g. a hand-edited or stale
+ * `?page=` URL, or a data set that shrank (a resource was deleted, or a filter narrowed the results) while a
+ * later page was selected. Without this, a controlled table with `autoResetPageIndex: false` keeps the stale
+ * index and renders an empty body under a nonsensical "Page 5 of 3". Clamps to the last available page and
+ * routes the change through the table so it is mirrored back into the URL by {@link useUrlPagination}.
+ */
+export function useClampPageIndex<Data>(table: Table<Data>): void {
+  const { pageIndex } = table.getState().pagination;
+  const pageCount = table.getPageCount();
+  useEffect(() => {
+    if (pageCount > 0 && pageIndex > pageCount - 1) {
+      table.setPageIndex(pageCount - 1);
+    }
+  }, [table, pageIndex, pageCount]);
+}

--- a/webapp/src/dogma/features/xds/GroupList.tsx
+++ b/webapp/src/dogma/features/xds/GroupList.tsx
@@ -37,14 +37,14 @@ import {
 } from '@tanstack/react-table';
 import { useMemo, useState } from 'react';
 import { DataTable } from 'dogma/features/xds/DataTable';
-import { GroupDto } from 'dogma/features/xds/XdsTypes';
+import { GroupDto, XDS_PAGE_SIZES } from 'dogma/features/xds/XdsTypes';
+import { useClampPageIndex, useUrlPagination } from 'dogma/common/components/table/useUrlPagination';
 
 const columnHelper = createColumnHelper<GroupDto>();
 
-const PAGE_SIZES = [10, 20, 50, 100];
-
 export const GroupList = ({ groups }: { groups: GroupDto[] }) => {
   const [globalFilter, setGlobalFilter] = useState('');
+  const { pagination, onPaginationChange } = useUrlPagination({ pageSizes: XDS_PAGE_SIZES });
 
   // The group can be deleted from within the group (group detail page), not from this list, so that deletion
   // requires opening the group first.
@@ -69,14 +69,28 @@ export const GroupList = ({ groups }: { groups: GroupDto[] }) => {
   const table = useReactTable({
     data: groups,
     columns,
-    state: { globalFilter },
+    state: { globalFilter, pagination },
     onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize: 10 } },
+    // Pagination is controlled via the URL (useUrlPagination); auto-reset would discard the page restored
+    // from the URL as soon as the groups finish loading.
+    autoResetPageIndex: false,
   });
+  // Auto-reset is off, so keep the page index within bounds when a filter narrows the list to fewer pages.
+  useClampPageIndex(table);
+
+  // With auto-reset disabled, filtering no longer moves back to the first page on its own, so a narrowing
+  // filter could otherwise strand the user on a now-empty later page. Reset explicitly instead.
+  const handleFilterChange = (value: string) => {
+    setGlobalFilter(value);
+    if (pagination.pageIndex !== 0) {
+      table.setPageIndex(0);
+    }
+  };
 
   if (groups.length === 0) {
     return <Text color="gray.500">No groups yet. Create one to get started.</Text>;
@@ -96,7 +110,7 @@ export const GroupList = ({ groups }: { groups: GroupDto[] }) => {
           <Input
             placeholder="Search groups"
             value={globalFilter}
-            onChange={(e) => setGlobalFilter(e.target.value)}
+            onChange={(e) => handleFilterChange(e.target.value)}
           />
         </InputGroup>
       </HStack>
@@ -124,7 +138,7 @@ export const GroupList = ({ groups }: { groups: GroupDto[] }) => {
           Next
         </Button>
         <Select size="sm" w="auto" value={pageSize} onChange={(e) => table.setPageSize(Number(e.target.value))}>
-          {PAGE_SIZES.map((size) => (
+          {XDS_PAGE_SIZES.map((size) => (
             <option key={size} value={size}>
               {size} / page
             </option>

--- a/webapp/src/dogma/features/xds/ResourceHistory.tsx
+++ b/webapp/src/dogma/features/xds/ResourceHistory.tsx
@@ -48,6 +48,7 @@ import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo, useState } from 'react';
 import { VscGitCommit } from 'react-icons/vsc';
 import { DataTable } from 'dogma/features/xds/DataTable';
+import { useClampPageIndex, useUrlPagination } from 'dogma/common/components/table/useUrlPagination';
 import { Deferred } from 'dogma/common/components/Deferred';
 import { Loading } from 'dogma/common/components/Loading';
 import { Author } from 'dogma/common/components/Author';
@@ -57,7 +58,7 @@ import { HistoryDto } from 'dogma/features/history/HistoryDto';
 import { FileDto } from 'dogma/features/file/FileDto';
 import { useGetGroupHistoryQuery } from 'dogma/features/xds/xdsApiSlice';
 import { useGetFileContentQuery, useGetFilesQuery } from 'dogma/features/api/apiSlice';
-import { XDS_PROJECT } from 'dogma/features/xds/XdsTypes';
+import { XDS_PAGE_SIZES, XDS_PROJECT } from 'dogma/features/xds/XdsTypes';
 
 const columnHelper = createColumnHelper<HistoryDto>();
 
@@ -321,15 +322,22 @@ export const ResourceHistory = ({ group, filePath }: { group: string; filePath?:
 
   // Memoized so the table receives a stable data reference across re-renders (react-table requires this).
   const rows = useMemo(() => data || [], [data]);
+  const { pagination, onPaginationChange } = useUrlPagination({ pageSizes: XDS_PAGE_SIZES });
   const table = useReactTable({
     data: rows,
     columns,
+    state: { pagination },
+    onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize: 10 } },
+    // Pagination is controlled via the URL (useUrlPagination); auto-reset would discard the page restored
+    // from the URL as soon as the history finishes loading.
+    autoResetPageIndex: false,
   });
+  // Auto-reset is off, so keep the page index within bounds if the history is truncated to fewer pages.
+  useClampPageIndex(table);
 
   return (
     <Deferred isLoading={isLoading} error={error}>
@@ -369,7 +377,7 @@ export const ResourceHistory = ({ group, filePath }: { group: string; filePath?:
                     value={pageSize}
                     onChange={(e) => table.setPageSize(Number(e.target.value))}
                   >
-                    {[10, 20, 50, 100].map((size) => (
+                    {XDS_PAGE_SIZES.map((size) => (
                       <option key={size} value={size}>
                         {size} / page
                       </option>

--- a/webapp/src/dogma/features/xds/ResourceList.tsx
+++ b/webapp/src/dogma/features/xds/ResourceList.tsx
@@ -30,8 +30,15 @@ import { useMemo, useState } from 'react';
 import { DataTable } from 'dogma/features/xds/DataTable';
 import { DeleteConfirmationModal } from 'dogma/common/components/DeleteConfirmationModal';
 import { Deferred } from 'dogma/common/components/Deferred';
+import { useClampPageIndex, useUrlPagination } from 'dogma/common/components/table/useUrlPagination';
 import { useDeleteResourceMutation, useListResourcesQuery } from 'dogma/features/xds/xdsApiSlice';
-import { resourceName, XdsResourceDto, XdsResourceType, XDS_RESOURCE_META } from 'dogma/features/xds/XdsTypes';
+import {
+  resourceName,
+  XdsResourceDto,
+  XdsResourceType,
+  XDS_PAGE_SIZES,
+  XDS_RESOURCE_META,
+} from 'dogma/features/xds/XdsTypes';
 import { useGroupWriteAccess } from 'dogma/features/xds/useGroupWriteAccess';
 import { useAppDispatch } from 'dogma/hooks';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
@@ -124,15 +131,22 @@ export const ResourceList = ({ group, type }: { group: string; type: XdsResource
 
   // Memoized so the table receives a stable data reference across re-renders (react-table requires this).
   const resources = useMemo(() => data || [], [data]);
+  const { pagination, onPaginationChange } = useUrlPagination({ pageSizes: XDS_PAGE_SIZES });
   const table = useReactTable({
     data: resources,
     columns,
+    state: { pagination },
+    onPaginationChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    initialState: { pagination: { pageSize: 10 } },
+    // Pagination is controlled via the URL (useUrlPagination); auto-reset would discard the page restored
+    // from the URL as soon as the resources finish loading.
+    autoResetPageIndex: false,
   });
+  // Auto-reset is off, so keep the page index within bounds when a deletion shrinks the list to fewer pages.
+  useClampPageIndex(table);
 
   return (
     <Deferred isLoading={isLoading} error={error}>
@@ -188,7 +202,7 @@ export const ResourceList = ({ group, type }: { group: string; type: XdsResource
                     value={pageSize}
                     onChange={(e) => table.setPageSize(Number(e.target.value))}
                   >
-                    {[10, 20, 50, 100].map((size) => (
+                    {XDS_PAGE_SIZES.map((size) => (
                       <option key={size} value={size}>
                         {size} / page
                       </option>

--- a/webapp/src/dogma/features/xds/XdsTypes.ts
+++ b/webapp/src/dogma/features/xds/XdsTypes.ts
@@ -23,6 +23,10 @@ export type XdsResourceType = 'listeners' | 'routes' | 'clusters' | 'endpoints';
 
 export const XDS_RESOURCE_TYPES: XdsResourceType[] = ['listeners', 'routes', 'clusters', 'endpoints'];
 
+// The page sizes offered by the paginated xDS lists (groups, resources, history). Also the set of valid
+// `pageSize` URL query values; anything else falls back to the first (default) size.
+export const XDS_PAGE_SIZES = [10, 20, 50, 100] as const;
+
 export interface XdsResourceTypeMeta {
   type: XdsResourceType;
   // Human readable, singular label.

--- a/webapp/tests/dogma/common/components/table/useUrlPagination.test.tsx
+++ b/webapp/tests/dogma/common/components/table/useUrlPagination.test.tsx
@@ -1,0 +1,143 @@
+import { act, renderHook } from '@testing-library/react';
+import { useUrlPagination } from 'dogma/common/components/table/useUrlPagination';
+import { XDS_PAGE_SIZES } from 'dogma/features/xds/XdsTypes';
+
+const mockPush = jest.fn();
+let mockQuery: Record<string, string | string[]> = {};
+let mockIsReady = true;
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: mockIsReady,
+    query: mockQuery,
+    pathname: '/app/xds',
+    push: mockPush,
+  }),
+}));
+
+function render() {
+  return renderHook(() => useUrlPagination({ pageSizes: XDS_PAGE_SIZES }));
+}
+
+describe('useUrlPagination', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockQuery = {};
+    mockIsReady = true;
+  });
+
+  describe('reading state from the URL', () => {
+    it('defaults to the first page and the default size when no params are present', () => {
+      const { result } = render();
+      expect(result.current.pagination).toEqual({ pageIndex: 0, pageSize: 10 });
+    });
+
+    it('reads the 1-indexed page param as a 0-indexed pageIndex', () => {
+      mockQuery = { page: '3' };
+      const { result } = render();
+      expect(result.current.pagination.pageIndex).toBe(2);
+    });
+
+    it.each(['0', '-1', '1.5', 'abc', ''])('falls back to the first page for a malformed page=%s', (page) => {
+      mockQuery = { page };
+      const { result } = render();
+      expect(result.current.pagination.pageIndex).toBe(0);
+    });
+
+    it('reads a page size that the selector offers', () => {
+      mockQuery = { pageSize: '20' };
+      const { result } = render();
+      expect(result.current.pagination.pageSize).toBe(20);
+    });
+
+    it.each(['15', '999', 'abc', ''])('ignores an unsupported pageSize=%s', (pageSize) => {
+      mockQuery = { pageSize };
+      const { result } = render();
+      expect(result.current.pagination.pageSize).toBe(10);
+    });
+
+    it('does not read the URL until the router is ready', () => {
+      mockIsReady = false;
+      mockQuery = { page: '3', pageSize: '20' };
+      const { result } = render();
+      expect(result.current.pagination).toEqual({ pageIndex: 0, pageSize: 10 });
+    });
+  });
+
+  describe('writing state to the URL', () => {
+    it('writes the 1-indexed page with shallow routing', () => {
+      const { result } = render();
+      act(() => result.current.onPaginationChange({ pageIndex: 1, pageSize: 10 }));
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { page: '2' } }, undefined, {
+        shallow: true,
+      });
+    });
+
+    it('omits the page param on the first page and the pageSize param at the default size', () => {
+      mockQuery = { page: '4', pageSize: '20' };
+      const { result } = render();
+      act(() => result.current.onPaginationChange({ pageIndex: 0, pageSize: 10 }));
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: {} }, undefined, { shallow: true });
+    });
+
+    it('writes a non-default page size', () => {
+      const { result } = render();
+      act(() => result.current.onPaginationChange({ pageIndex: 0, pageSize: 20 }));
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { pageSize: '20' } }, undefined, {
+        shallow: true,
+      });
+    });
+
+    it('supports a functional updater based on the current state', () => {
+      mockQuery = { page: '2' };
+      const { result } = render();
+      act(() => result.current.onPaginationChange((old) => ({ ...old, pageIndex: old.pageIndex + 1 })));
+      expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { page: '3' } }, undefined, {
+        shallow: true,
+      });
+    });
+
+    it('preserves unrelated query params (e.g. the xDS group and section)', () => {
+      mockQuery = { name: 'my-group', type: 'clusters' };
+      const { result } = render();
+      act(() => result.current.onPaginationChange({ pageIndex: 1, pageSize: 20 }));
+      expect(mockPush).toHaveBeenCalledWith(
+        { pathname: '/app/xds', query: { name: 'my-group', type: 'clusters', page: '2', pageSize: '20' } },
+        undefined,
+        { shallow: true },
+      );
+    });
+  });
+
+  describe('reacting to router changes after mount', () => {
+    // This is the exact path the back-navigation fix hinges on: on a fresh remount the router starts
+    // not-ready with an empty query, then hydrates with the restored params. The effect must defer the read
+    // until then and fire on the transition — this test would fail if router.isReady were dropped from the
+    // effect dependencies.
+    it('performs the deferred read once the router becomes ready', () => {
+      mockIsReady = false;
+      mockQuery = {};
+      const { result, rerender } = render();
+      expect(result.current.pagination).toEqual({ pageIndex: 0, pageSize: 10 });
+
+      mockIsReady = true;
+      mockQuery = { page: '3', pageSize: '20' };
+      rerender();
+
+      expect(result.current.pagination).toEqual({ pageIndex: 2, pageSize: 20 });
+    });
+
+    // Guards against the effect being narrowed to only [router.isReady]: it must also re-run when the query
+    // params themselves change on an already-mounted instance (browser forward/back within the same page).
+    it('re-syncs when the query params change on an already-mounted instance', () => {
+      mockQuery = { page: '2' };
+      const { result, rerender } = render();
+      expect(result.current.pagination.pageIndex).toBe(1);
+
+      mockQuery = {};
+      rerender();
+
+      expect(result.current.pagination.pageIndex).toBe(0);
+    });
+  });
+});

--- a/webapp/tests/dogma/features/xds/GroupList.test.tsx
+++ b/webapp/tests/dogma/features/xds/GroupList.test.tsx
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { GroupList } from 'dogma/features/xds/GroupList';
+import { GroupDto } from 'dogma/features/xds/XdsTypes';
+
+const mockPush = jest.fn();
+let mockQuery: Record<string, string | string[]> = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: mockQuery,
+    pathname: '/app/xds',
+    push: mockPush,
+  }),
+}));
+
+// Ids are zero-padded so text assertions ('group-01' vs 'group-11') are unambiguous.
+function makeGroups(n: number): GroupDto[] {
+  return Array.from({ length: n }, (_, i) => ({ id: `group-${String(i + 1).padStart(2, '0')}` }));
+}
+
+describe('GroupList – URL-persisted pagination', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockQuery = {};
+  });
+
+  it('renders the first page by default', () => {
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(10);
+    expect(screen.getByText('group-01')).toBeInTheDocument();
+    expect(screen.queryByText('group-11')).not.toBeInTheDocument();
+  });
+
+  it('restores the page from the ?page query param (back-navigation fix)', () => {
+    mockQuery = { page: '2' };
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+    // Page 2 shows groups 11–20, not 1–10.
+    expect(screen.getAllByTestId('table-row')).toHaveLength(10);
+    expect(screen.getByText('group-11')).toBeInTheDocument();
+    expect(screen.queryByText('group-01')).not.toBeInTheDocument();
+  });
+
+  it('restores the page size from the ?pageSize query param', () => {
+    mockQuery = { pageSize: '20' };
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(20);
+    expect(screen.getByText('group-20')).toBeInTheDocument();
+    expect(screen.queryByText('group-21')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toHaveValue('20');
+  });
+
+  it('writes the next page to the URL with shallow routing', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { page: '2' } }, undefined, {
+      shallow: true,
+    });
+  });
+
+  it('writes the selected page size to the URL', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+
+    await user.selectOptions(screen.getByRole('combobox'), '20');
+
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { pageSize: '20' } }, undefined, {
+      shallow: true,
+    });
+  });
+
+  it('drops the page param when returning to the first page', async () => {
+    const user = userEvent.setup();
+    mockQuery = { page: '2' };
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+
+    await user.click(screen.getByRole('button', { name: /previous/i }));
+
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: {} }, undefined, { shallow: true });
+  });
+
+  it('resets to the first page when the filter changes so it cannot strand the user on an empty page', async () => {
+    const user = userEvent.setup();
+    mockQuery = { page: '2' };
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+
+    // Filtering from page 2 to a single-page result set must move back to page 1 and render its rows, not
+    // leave the user stranded on a now-nonexistent page 2. 'group-0' matches only group-01..group-09.
+    await user.type(screen.getByPlaceholderText(/search groups/i), 'group-0');
+
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: {} }, undefined, { shallow: true });
+    expect(screen.getByText('group-01')).toBeInTheDocument();
+    expect(screen.queryByText('group-11')).not.toBeInTheDocument();
+  });
+
+  it('clamps an out-of-range ?page to the last page and corrects the URL', () => {
+    mockQuery = { page: '9' };
+    renderWithProviders(<GroupList groups={makeGroups(25)} />);
+
+    // 25 groups / 10 per page = 3 pages; page 9 is out of range, so it is clamped to the last page (3).
+    expect(mockPush).toHaveBeenCalledWith({ pathname: '/app/xds', query: { page: '3' } }, undefined, {
+      shallow: true,
+    });
+    expect(screen.getAllByTestId('table-row')).toHaveLength(5);
+    expect(screen.getByText('group-21')).toBeInTheDocument();
+  });
+});

--- a/webapp/tests/dogma/features/xds/ResourceHistory.test.tsx
+++ b/webapp/tests/dogma/features/xds/ResourceHistory.test.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { ResourceHistory } from 'dogma/features/xds/ResourceHistory';
+import { HistoryDto } from 'dogma/features/history/HistoryDto';
+import * as xdsApiSlice from 'dogma/features/xds/xdsApiSlice';
+
+const mockPush = jest.fn();
+let mockQuery: Record<string, string | string[]> = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: mockQuery,
+    pathname: '/app/xds/group',
+    push: mockPush,
+  }),
+}));
+
+// Monaco cannot mount in JSDOM; the diff editor is only reached via the (unopened) modal, so stub it out.
+jest.mock('dogma/common/components/JsonDiffEditor', () => ({
+  JsonDiffEditor: () => null,
+}));
+
+jest.mock('dogma/features/xds/xdsApiSlice', () => ({
+  // Preserve reducerPath/reducer so the Redux store initialises correctly.
+  ...jest.requireActual('dogma/features/xds/xdsApiSlice'),
+  useGetGroupHistoryQuery: jest.fn(),
+}));
+
+function makeCommits(n: number): HistoryDto[] {
+  return Array.from({ length: n }, (_, i) => {
+    const label = `commit-${String(i + 1).padStart(2, '0')}`;
+    return {
+      revision: n - i,
+      author: { name: 'System', email: 'system@localhost' },
+      commitMessage: { summary: label, detail: '', markup: 'PLAINTEXT' },
+      pushedAt: '2026-01-01T00:00:00Z',
+    };
+  });
+}
+
+describe('ResourceHistory – URL-persisted pagination', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockQuery = {};
+    jest.mocked(xdsApiSlice.useGetGroupHistoryQuery).mockReturnValue({
+      data: makeCommits(25),
+      isLoading: false,
+      error: undefined,
+    } as any);
+  });
+
+  it('restores the page from the ?page query param (back-navigation fix)', () => {
+    mockQuery = { name: 'g', type: 'history', page: '2' };
+    renderWithProviders(<ResourceHistory group="g" />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(10);
+    expect(screen.getByText('commit-11')).toBeInTheDocument();
+    expect(screen.queryByText('commit-01')).not.toBeInTheDocument();
+  });
+
+  it('writes the next page to the URL while preserving the group and section params', async () => {
+    const user = userEvent.setup();
+    mockQuery = { name: 'g', type: 'history' };
+    renderWithProviders(<ResourceHistory group="g" />);
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      { pathname: '/app/xds/group', query: { name: 'g', type: 'history', page: '2' } },
+      undefined,
+      { shallow: true },
+    );
+  });
+
+  it('restores the page size from the ?pageSize query param', () => {
+    mockQuery = { name: 'g', type: 'history', pageSize: '20' };
+    renderWithProviders(<ResourceHistory group="g" />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(20);
+  });
+
+  it('writes the selected page size to the URL', async () => {
+    const user = userEvent.setup();
+    mockQuery = { name: 'g', type: 'history' };
+    renderWithProviders(<ResourceHistory group="g" />);
+
+    await user.selectOptions(screen.getByRole('combobox'), '20');
+
+    expect(mockPush).toHaveBeenCalledWith(
+      { pathname: '/app/xds/group', query: { name: 'g', type: 'history', pageSize: '20' } },
+      undefined,
+      { shallow: true },
+    );
+  });
+});

--- a/webapp/tests/dogma/features/xds/ResourceList.test.tsx
+++ b/webapp/tests/dogma/features/xds/ResourceList.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { ResourceList } from 'dogma/features/xds/ResourceList';
+import { XdsResourceDto } from 'dogma/features/xds/XdsTypes';
+import * as xdsApiSlice from 'dogma/features/xds/xdsApiSlice';
+
+const mockPush = jest.fn();
+let mockQuery: Record<string, string | string[]> = {};
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: true,
+    query: mockQuery,
+    pathname: '/app/xds/group',
+    push: mockPush,
+  }),
+}));
+
+// Read-only view so the list has no action column or modal, keeping the pagination behaviour isolated.
+jest.mock('dogma/features/xds/useGroupWriteAccess', () => ({
+  useGroupWriteAccess: () => ({ hasWrite: false, isLoading: false }),
+}));
+
+jest.mock('dogma/features/xds/xdsApiSlice', () => ({
+  // Preserve reducerPath/reducer so the Redux store initialises correctly.
+  ...jest.requireActual('dogma/features/xds/xdsApiSlice'),
+  useListResourcesQuery: jest.fn(),
+  useDeleteResourceMutation: jest.fn(),
+}));
+
+function makeResources(n: number): XdsResourceDto[] {
+  return Array.from({ length: n }, (_, i) => {
+    const id = `c${String(i + 1).padStart(2, '0')}`;
+    return { id, path: `/clusters/${id}.yaml`, revision: 1 };
+  });
+}
+
+describe('ResourceList – URL-persisted pagination', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+    mockQuery = {};
+    jest.mocked(xdsApiSlice.useListResourcesQuery).mockReturnValue({
+      data: makeResources(25),
+      isLoading: false,
+      error: undefined,
+    } as any);
+    jest
+      .mocked(xdsApiSlice.useDeleteResourceMutation)
+      .mockReturnValue([jest.fn(), { isLoading: false }] as any);
+  });
+
+  it('restores the page from the ?page query param (back-navigation fix)', () => {
+    mockQuery = { name: 'g', type: 'clusters', page: '2' };
+    renderWithProviders(<ResourceList group="g" type="clusters" />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(10);
+    expect(screen.getByText('groups/g/clusters/c11')).toBeInTheDocument();
+    expect(screen.queryByText('groups/g/clusters/c01')).not.toBeInTheDocument();
+  });
+
+  it('writes the next page to the URL while preserving the group and section params', async () => {
+    const user = userEvent.setup();
+    mockQuery = { name: 'g', type: 'clusters' };
+    renderWithProviders(<ResourceList group="g" type="clusters" />);
+
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      { pathname: '/app/xds/group', query: { name: 'g', type: 'clusters', page: '2' } },
+      undefined,
+      { shallow: true },
+    );
+  });
+
+  it('restores the page size from the ?pageSize query param', () => {
+    mockQuery = { name: 'g', type: 'clusters', pageSize: '20' };
+    renderWithProviders(<ResourceList group="g" type="clusters" />);
+    expect(screen.getAllByTestId('table-row')).toHaveLength(20);
+  });
+
+  it('writes the selected page size to the URL', async () => {
+    const user = userEvent.setup();
+    mockQuery = { name: 'g', type: 'clusters' };
+    renderWithProviders(<ResourceList group="g" type="clusters" />);
+
+    await user.selectOptions(screen.getByRole('combobox'), '20');
+
+    expect(mockPush).toHaveBeenCalledWith(
+      { pathname: '/app/xds/group', query: { name: 'g', type: 'clusters', pageSize: '20' } },
+      undefined,
+      { shallow: true },
+    );
+  });
+
+  // Regression: with autoResetPageIndex disabled, a deletion that shrinks the list below the current page
+  // must not strand the user on a blank page — useClampPageIndex clamps back to the last valid page.
+  it('clamps to the last page when a deletion shrinks the list below the current page', () => {
+    mockQuery = { name: 'g', type: 'clusters', page: '3' };
+    const { rerender } = renderWithProviders(<ResourceList group="g" type="clusters" />);
+    // Page 3 of 3 is valid for 25 resources.
+    expect(screen.getByText('groups/g/clusters/c21')).toBeInTheDocument();
+
+    // A deletion refetches the same mounted list with far fewer rows (now a single page).
+    jest.mocked(xdsApiSlice.useListResourcesQuery).mockReturnValue({
+      data: makeResources(5),
+      isLoading: false,
+      error: undefined,
+    } as any);
+    rerender(<ResourceList group="g" type="clusters" />);
+
+    expect(mockPush).toHaveBeenCalledWith(
+      { pathname: '/app/xds/group', query: { name: 'g', type: 'clusters' } },
+      undefined,
+      { shallow: true },
+    );
+    expect(screen.getAllByTestId('table-row')).toHaveLength(5);
+    expect(screen.getByText('groups/g/clusters/c01')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Motivation:

The xDS group list (and the per-group resource and history lists) kept their pagination only in TanStack Table's in-memory state.

Modifications:

- Add a reusable useUrlPagination hook (webapp/src/dogma/common/components/table/useUrlPagination.ts) that mirrors pageIndex/pageSize into the URL query (`page`, 1-indexed, and `pageSize`) with shallow routing, omits both params while at their defaults, and reads them back through a router.isReady-gated effect so the state is restored on mount and on Back/Forward. The valid page sizes are held in a ref so an inline `pageSizes` array cannot turn the sync effect into a render loop.

Result:

- xDS list pagination now survives navigation.