### PR TITLE
Render metadata property forms in the web UI

### DIFF
--- a/site/src/sphinx/setup-configuration.rst
+++ b/site/src/sphinx/setup-configuration.rst
@@ -298,7 +298,8 @@ Core properties
             }
 
       - the declared schemas are exposed via ``GET /api/v1/metadataProperties`` so that clients such as
-        the web UI can render input forms for the declared properties.
+        the web UI can render input forms for the declared properties. The web UI uses the standard
+        ``title`` and ``description`` keywords of each property as the form label and its help text.
 
 .. _replication:
 

--- a/webapp/src/dogma/features/api/apiSlice.ts
+++ b/webapp/src/dogma/features/api/apiSlice.ts
@@ -24,6 +24,7 @@ import { ProjectMetadataDto } from 'dogma/features/project/ProjectMetadataDto';
 import { FileContentDto } from 'dogma/features/file/FileContentDto';
 import { RevisionDto } from 'dogma/features/history/RevisionDto';
 import { AppIdentityDto } from 'dogma/features/app-identity/AppIdentity';
+import { MetadataProperties } from 'dogma/features/metadata-properties/MetadataProperties';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { DeleteUserOrAppIdentityRepositoryRoleDto } from 'dogma/features/repo/settings/DeleteUserOrAppIdentityRepositoryRoleDto';
 import { AddUserOrAppIdentityRepositoryRoleDto } from 'dogma/features/repo/settings/AddUserOrAppIdentityRepositoryRoleDto';
@@ -592,6 +593,12 @@ export const apiSlice = createApi({
         method: 'GET',
       }),
     }),
+    getMetadataProperties: builder.query<MetadataProperties, void>({
+      query: () => ({
+        url: `/api/v1/metadataProperties`,
+        method: 'GET',
+      }),
+    }),
     isXdsWebEnabled: builder.query<boolean, void>({
       query: () => ({
         url: `/api/v1/xds/web`,
@@ -632,6 +639,8 @@ export const {
   useGetXdsClientsQuery,
   useGetXdsAppsQuery,
   useGetXdsSnapshotQuery,
+  // Metadata properties
+  useGetMetadataPropertiesQuery,
   // Project
   useGetProjectsQuery,
   useRestoreProjectMutation,

--- a/webapp/src/dogma/features/app-identity/AppIdentity.ts
+++ b/webapp/src/dogma/features/app-identity/AppIdentity.ts
@@ -10,6 +10,7 @@ export interface AppIdentity {
   creation: UserAndTimestamp;
   deactivation?: UserAndTimestamp;
   deletion?: UserAndTimestamp;
+  properties?: Record<string, unknown>;
 }
 
 export interface Token extends AppIdentity {

--- a/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
+++ b/webapp/src/dogma/features/app-identity/DisplaySecretModal.tsx
@@ -19,6 +19,7 @@ import {
 import { DateWithTooltip } from 'dogma/common/components/DateWithTooltip';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
 import { AppIdentityDto, isToken, isCertificate } from 'dogma/features/app-identity/AppIdentity';
+import { MetadataPropertiesSchema } from 'dogma/features/metadata-properties/MetadataProperties';
 import { useAppDispatch } from 'dogma/hooks';
 import { MdContentCopy } from 'react-icons/md';
 
@@ -26,10 +27,12 @@ export const DisplaySecretModal = ({
   isOpen,
   onClose,
   response,
+  schema,
 }: {
   isOpen: boolean;
   onClose: () => void;
   response: AppIdentityDto;
+  schema?: MetadataPropertiesSchema;
 }) => {
   const dispatch = useAppDispatch();
   if (!response) return;
@@ -73,6 +76,13 @@ export const DisplaySecretModal = ({
                     <Td>{response.certificateId}</Td>
                   </Tr>
                 )}
+                {response.properties &&
+                  Object.entries(response.properties).map(([key, value]) => (
+                    <Tr key={key}>
+                      <Td>{schema?.properties?.[key]?.title || key}</Td>
+                      <Td>{String(value)}</Td>
+                    </Tr>
+                  ))}
                 <Tr>
                   <Td>Level</Td>
                   <Td>{systemAdmin ? 'System Admin' : 'User'}</Td>

--- a/webapp/src/dogma/features/app-identity/NewAppIdentity.tsx
+++ b/webapp/src/dogma/features/app-identity/NewAppIdentity.tsx
@@ -28,9 +28,15 @@ import { useAddNewAppIdentityMutation } from 'dogma/features/api/apiSlice';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import { useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { Controller, FormProvider, useForm } from 'react-hook-form';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import { useAppDispatch, useAppSelector } from 'dogma/hooks';
+import { useGetMetadataPropertiesQuery } from 'dogma/features/api/apiSlice';
+import {
+  MetadataPropertiesFormData,
+  toMetadataProperties,
+} from 'dogma/features/metadata-properties/MetadataProperties';
+import { MetadataPropertiesFields } from 'dogma/features/metadata-properties/MetadataPropertiesFields';
 
 const APP_ID_PATTERN = /^[0-9A-Za-z](?:[-+_0-9A-Za-z\.]*[0-9A-Za-z])?$/;
 
@@ -39,7 +45,7 @@ type FormData = {
   type: 'TOKEN' | 'CERTIFICATE';
   certificateId?: string;
   isSystemAdmin: boolean;
-};
+} & MetadataPropertiesFormData;
 
 export const NewAppIdentity = () => {
   const mtlsEnabled = useAppSelector((state) => state.serverConfig.mtlsEnabled);
@@ -60,6 +66,11 @@ export const NewAppIdentity = () => {
     onToggle: onSecretModalToggle,
     onClose: onSecretModalClose,
   } = useDisclosure();
+  const methods = useForm<FormData>({
+    defaultValues: {
+      type: 'TOKEN',
+    },
+  });
   const {
     register,
     handleSubmit,
@@ -67,12 +78,9 @@ export const NewAppIdentity = () => {
     watch,
     control,
     formState: { errors },
-  } = useForm<FormData>({
-    defaultValues: {
-      type: 'TOKEN',
-    },
-  });
+  } = methods;
   const [addNewAppIdentity, { isLoading }] = useAddNewAppIdentityMutation();
+  const { data: metadataProperties } = useGetMetadataPropertiesQuery();
   const [appIdentityDetail, setAppIdentityDetail] = useState(null);
   const dispatch = useAppDispatch();
   const { user } = useAppSelector((state) => state.auth);
@@ -91,6 +99,10 @@ export const NewAppIdentity = () => {
     params.set('isSystemAdmin', String(formData.isSystemAdmin || false));
     if (formData.type === 'CERTIFICATE' && formData.certificateId) {
       params.set('certificateId', formData.certificateId);
+    }
+    const properties = toMetadataProperties(metadataProperties?.appIdentity, formData);
+    if (properties) {
+      params.set('properties', JSON.stringify(properties));
     }
     const data = params.toString();
     try {
@@ -128,82 +140,105 @@ export const NewAppIdentity = () => {
           </PopoverHeader>
           <PopoverArrow />
           <PopoverCloseButton />
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <PopoverBody minWidth="md">
-              <FormControl mb={4}>
-                <FormLabel>Type</FormLabel>
-                <Controller
-                  name="type"
-                  control={control}
-                  render={({ field: { onChange, value } }) => (
-                    <RadioGroup value={value} onChange={onChange}>
-                      <Stack direction="row" spacing={4}>
-                        <Radio value="TOKEN">Token</Radio>
-                        {mtlsEnabled && <Radio value="CERTIFICATE">Certificate</Radio>}
-                      </Stack>
-                    </RadioGroup>
-                  )}
-                />
-              </FormControl>
+          <FormProvider {...methods}>
+            <form onSubmit={handleSubmit(onSubmit)} noValidate>
+              <PopoverBody minWidth="md">
+                <FormControl mb={4}>
+                  <FormLabel>Type</FormLabel>
+                  <Controller
+                    name="type"
+                    control={control}
+                    render={({ field: { onChange, value } }) => (
+                      <RadioGroup value={value} onChange={onChange}>
+                        <Stack direction="row" spacing={4}>
+                          <Radio value="TOKEN">Token</Radio>
+                          {mtlsEnabled && <Radio value="CERTIFICATE">Certificate</Radio>}
+                        </Stack>
+                      </RadioGroup>
+                    )}
+                  />
+                </FormControl>
 
-              <FormControl isInvalid={errors.appId ? true : false} isRequired>
-                <FormLabel>Application ID</FormLabel>
-                <Input
-                  type="text"
-                  placeholder="my-app-id"
-                  {...register('appId', { pattern: APP_ID_PATTERN })}
-                />
-                <FormHelperText pl={1}>App ID used to access project repositories.</FormHelperText>
-                {errors.appId && (
-                  <FormErrorMessage>The first/last character must be alphanumeric</FormErrorMessage>
-                )}
-              </FormControl>
-
-              {selectedType === 'CERTIFICATE' && (
-                <FormControl mt={4} isInvalid={errors.certificateId ? true : false} isRequired>
-                  <FormLabel>Certificate ID</FormLabel>
+                <FormControl isInvalid={errors.appId ? true : false} isRequired>
+                  <FormLabel>Application ID</FormLabel>
                   <Input
                     type="text"
-                    placeholder="certificate-id"
-                    {...register('certificateId', {
-                      required: selectedType === 'CERTIFICATE',
+                    placeholder="my-app-id"
+                    {...register('appId', {
+                      required: 'Application ID is required',
+                      pattern: {
+                        value: APP_ID_PATTERN,
+                        message: 'The first/last character must be alphanumeric',
+                      },
                     })}
                   />
-                  <FormHelperText pl={1}>
-                    Certificate identifier for mTLS authentication (e.g., CN or SPIFFE ID).
-                  </FormHelperText>
-                  {errors.certificateId && <FormErrorMessage>Certificate ID is required</FormErrorMessage>}
+                  {errors.appId ? (
+                    <FormErrorMessage>{errors.appId.message}</FormErrorMessage>
+                  ) : (
+                    <FormHelperText pl={1}>App ID used to access project repositories.</FormHelperText>
+                  )}
                 </FormControl>
-              )}
 
-              {user.roles.includes('LEVEL_SYSTEM_ADMIN') && (
-                <Flex mt={4}>
-                  <Spacer />
-                  <Checkbox colorScheme="teal" {...register('isSystemAdmin')}>
-                    System Administrator-Level App Identity
-                  </Checkbox>
-                </Flex>
-              )}
-            </PopoverBody>
-            <PopoverFooter border="0" display="flex" alignItems="center" justifyContent="space-between" pb={4}>
-              <Spacer />
-              <Button
-                type="submit"
-                colorScheme="teal"
-                variant="ghost"
-                isLoading={isLoading}
-                loadingText="Creating"
+                {selectedType === 'CERTIFICATE' && (
+                  <FormControl mt={4} isInvalid={errors.certificateId ? true : false} isRequired>
+                    <FormLabel>Certificate ID</FormLabel>
+                    <Input
+                      type="text"
+                      placeholder="certificate-id"
+                      {...register('certificateId', {
+                        required: selectedType === 'CERTIFICATE',
+                      })}
+                    />
+                    {errors.certificateId ? (
+                      <FormErrorMessage>Certificate ID is required</FormErrorMessage>
+                    ) : (
+                      <FormHelperText pl={1}>
+                        Certificate identifier for mTLS authentication (e.g., CN or SPIFFE ID).
+                      </FormHelperText>
+                    )}
+                  </FormControl>
+                )}
+
+                {metadataProperties?.appIdentity && (
+                  <MetadataPropertiesFields schema={metadataProperties.appIdentity} />
+                )}
+
+                {user.roles.includes('LEVEL_SYSTEM_ADMIN') && (
+                  <Flex mt={4}>
+                    <Spacer />
+                    <Checkbox colorScheme="teal" {...register('isSystemAdmin')}>
+                      System Administrator-Level App Identity
+                    </Checkbox>
+                  </Flex>
+                )}
+              </PopoverBody>
+              <PopoverFooter
+                border="0"
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                pb={4}
               >
-                Create
-              </Button>
-            </PopoverFooter>
-          </form>
+                <Spacer />
+                <Button
+                  type="submit"
+                  colorScheme="teal"
+                  variant="ghost"
+                  isLoading={isLoading}
+                  loadingText="Creating"
+                >
+                  Create
+                </Button>
+              </PopoverFooter>
+            </form>
+          </FormProvider>
         </PopoverContent>
       </Popover>
       <DisplaySecretModal
         isOpen={isSecretModalOpen}
         onClose={onSecretModalClose}
         response={appIdentityDetail}
+        schema={metadataProperties?.appIdentity}
       />
     </>
   );

--- a/webapp/src/dogma/features/metadata-properties/MetadataProperties.ts
+++ b/webapp/src/dogma/features/metadata-properties/MetadataProperties.ts
@@ -1,0 +1,80 @@
+export interface MetadataPropertySchema {
+  type?: string;
+  pattern?: string;
+  enum?: (string | number)[];
+  title?: string;
+  description?: string;
+  examples?: unknown[];
+}
+
+export interface MetadataPropertiesSchema {
+  properties?: Record<string, MetadataPropertySchema>;
+  required?: string[];
+}
+
+// The response of `GET /api/v1/metadataProperties`. Each field is the JSON Schema that the
+// `properties` of the corresponding resource must conform to at creation time.
+export interface MetadataProperties {
+  project?: MetadataPropertiesSchema;
+  repo?: MetadataPropertiesSchema;
+  appIdentity?: MetadataPropertiesSchema;
+}
+
+// The form fields managed by `MetadataPropertiesFields`.
+export type MetadataPropertiesFormData = {
+  properties?: Record<string, string | boolean>;
+  propertiesJson?: string;
+};
+
+export function hasDeclaredProperties(schema: MetadataPropertiesSchema | undefined): boolean {
+  return !!schema && !!schema.properties && Object.keys(schema.properties).length > 0;
+}
+
+export function validateJsonObject(value?: string): string | true {
+  if (!value || value.trim() === '') {
+    return true;
+  }
+  try {
+    const parsed = JSON.parse(value);
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return 'Must be a JSON object';
+    }
+    return true;
+  } catch {
+    return 'Invalid JSON';
+  }
+}
+
+// Builds the `properties` object of a creation request from the form values, converting each value
+// to the type declared in the schema. Returns undefined if there is nothing to send.
+export function toMetadataProperties(
+  schema: MetadataPropertiesSchema | undefined,
+  formData: MetadataPropertiesFormData,
+): Record<string, unknown> | undefined {
+  if (!schema) {
+    return undefined;
+  }
+  if (!hasDeclaredProperties(schema)) {
+    const json = formData.propertiesJson?.trim();
+    return json ? JSON.parse(json) : undefined;
+  }
+  const result: Record<string, unknown> = {};
+  for (const [name, property] of Object.entries(schema.properties)) {
+    const value = formData.properties?.[name];
+    if (value === undefined || value === '') {
+      continue;
+    }
+    switch (property.type) {
+      case 'boolean':
+        result[name] = value === true || value === 'true';
+        break;
+      case 'integer':
+      case 'number':
+        result[name] = Number(value);
+        break;
+      default:
+        result[name] = value;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/webapp/src/dogma/features/metadata-properties/MetadataPropertiesFields.tsx
+++ b/webapp/src/dogma/features/metadata-properties/MetadataPropertiesFields.tsx
@@ -1,0 +1,141 @@
+import {
+  Checkbox,
+  Code,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Select,
+  Textarea,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import { FieldError, useFormContext } from 'react-hook-form';
+import {
+  hasDeclaredProperties,
+  MetadataPropertiesFormData,
+  MetadataPropertiesSchema,
+  MetadataPropertySchema,
+  validateJsonObject,
+} from 'dogma/features/metadata-properties/MetadataProperties';
+
+const PATTERN_MISMATCH = 'PATTERN_MISMATCH';
+
+// Renders input fields for the metadata properties declared in the JSON Schema of a resource type.
+// Must be rendered inside a react-hook-form `FormProvider`.
+export const MetadataPropertiesFields = ({ schema }: { schema: MetadataPropertiesSchema }) => {
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext<MetadataPropertiesFormData>();
+
+  if (!hasDeclaredProperties(schema)) {
+    // The schema declares its shape without a top-level `properties` keyword; fall back to raw JSON.
+    const error = errors.propertiesJson;
+    return (
+      <FormControl mt={4} isInvalid={!!error}>
+        <FormLabel>Properties (JSON)</FormLabel>
+        <Textarea
+          placeholder='{ "key": "value" }'
+          {...register('propertiesJson', { validate: validateJsonObject })}
+        />
+        {!error && <FormHelperText pl={1}>Additional properties required by this server.</FormHelperText>}
+        {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
+      </FormControl>
+    );
+  }
+
+  const required = schema.required || [];
+  return (
+    <>
+      {Object.entries(schema.properties).map(([name, property]) => (
+        <PropertyField key={name} name={name} property={property} isRequired={required.includes(name)} />
+      ))}
+    </>
+  );
+};
+
+const PropertyField = ({
+  name,
+  property,
+  isRequired,
+}: {
+  name: string;
+  property: MetadataPropertySchema;
+  isRequired: boolean;
+}) => {
+  const {
+    register,
+    watch,
+    formState: { errors },
+  } = useFormContext<MetadataPropertiesFormData>();
+  const emptySelectColor = useColorModeValue('gray.500', 'whiteAlpha.500');
+  const error = errors.properties?.[name] as FieldError | undefined;
+  const fieldName = `properties.${name}` as const;
+  const label = property.title || name;
+  const selectedValue = watch(fieldName);
+
+  if (property.type === 'boolean') {
+    return (
+      <FormControl mt={4}>
+        <Checkbox colorScheme="teal" {...register(fieldName)}>
+          {label}
+        </Checkbox>
+        {property.description && <FormHelperText pl={1}>{property.description}</FormHelperText>}
+      </FormControl>
+    );
+  }
+
+  const validate = (value: unknown): string | true => {
+    if (value === undefined || value === '') {
+      return isRequired ? `${label} is required` : true;
+    }
+    if (property.pattern && !new RegExp(property.pattern).test(String(value))) {
+      return PATTERN_MISMATCH;
+    }
+    return true;
+  };
+
+  let input;
+  if (property.enum) {
+    input = (
+      <Select
+        placeholder={`Select ${label}`}
+        color={selectedValue ? 'inherit' : emptySelectColor}
+        {...register(fieldName, { validate })}
+      >
+        {property.enum.map((value) => (
+          <option key={String(value)} value={String(value)}>
+            {String(value)}
+          </option>
+        ))}
+      </Select>
+    );
+  } else {
+    input = (
+      <Input
+        type={property.type === 'integer' || property.type === 'number' ? 'number' : 'text'}
+        placeholder={property.examples?.length ? String(property.examples[0]) : label}
+        {...register(fieldName, { validate })}
+      />
+    );
+  }
+  return (
+    <FormControl mt={4} isInvalid={!!error} isRequired={isRequired}>
+      <FormLabel>{label}</FormLabel>
+      {input}
+      {property.description && !error && <FormHelperText pl={1}>{property.description}</FormHelperText>}
+      {error && (
+        <FormErrorMessage>
+          {error.message === PATTERN_MISMATCH ? (
+            <>
+              Must match the pattern: <Code ml={1}>{property.pattern}</Code>
+            </>
+          ) : (
+            error.message
+          )}
+        </FormErrorMessage>
+      )}
+    </FormControl>
+  );
+};

--- a/webapp/src/dogma/features/project/NewProject.tsx
+++ b/webapp/src/dogma/features/project/NewProject.tsx
@@ -15,34 +15,42 @@ import {
   Spacer,
   useDisclosure,
 } from '@chakra-ui/react';
-import { useAddNewProjectMutation } from 'dogma/features/api/apiSlice';
+import { useAddNewProjectMutation, useGetMetadataPropertiesQuery } from 'dogma/features/api/apiSlice';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
 import { useAppDispatch } from 'dogma/hooks';
 import Router from 'next/router';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { SerializedError } from '@reduxjs/toolkit';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import { IoMdArrowDropdown } from 'react-icons/io';
+import {
+  MetadataPropertiesFormData,
+  toMetadataProperties,
+} from 'dogma/features/metadata-properties/MetadataProperties';
+import { MetadataPropertiesFields } from 'dogma/features/metadata-properties/MetadataPropertiesFields';
 
 const ENTITY_NAME_PATTERN = /^[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$/;
 
 type FormData = {
   name: string;
-};
+} & MetadataPropertiesFormData;
 
 export const NewProject = () => {
   const [addNewProject, { isLoading }] = useAddNewProjectMutation();
+  const { data: metadataProperties } = useGetMetadataPropertiesQuery();
+  const methods = useForm<FormData>();
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<FormData>();
+  } = methods;
   const { isOpen, onToggle, onClose } = useDisclosure();
   const dispatch = useAppDispatch();
   const onSubmit = async (data: FormData) => {
-    const response = await addNewProject(data);
+    const properties = toMetadataProperties(metadataProperties?.project, data);
+    const response = await addNewProject({ name: data.name, properties });
     if ((response as { error: FetchBaseQueryError | SerializedError }).error) {
       dispatch(
         newNotification(
@@ -71,33 +79,40 @@ export const NewProject = () => {
         </PopoverHeader>
         <PopoverArrow />
         <PopoverCloseButton />
-        <form onSubmit={handleSubmit(onSubmit)}>
-          <PopoverBody minWidth="max-content">
-            <FormControl isInvalid={errors.name ? true : false} isRequired>
-              <FormLabel>Project name</FormLabel>
-              <Input
-                type="text"
-                placeholder="my-project-name"
-                {...register('name', { pattern: ENTITY_NAME_PATTERN })}
-              />
-              {errors.name && (
-                <FormErrorMessage>The first/last character must be alphanumeric</FormErrorMessage>
-              )}
-            </FormControl>
-          </PopoverBody>
-          <PopoverFooter border="0" display="flex" alignItems="center" justifyContent="space-between" pb={4}>
-            <Spacer />
-            <Button
-              type="submit"
-              colorScheme="teal"
-              variant="ghost"
-              isLoading={isLoading}
-              loadingText="Creating"
-            >
-              Create
-            </Button>
-          </PopoverFooter>
-        </form>
+        <FormProvider {...methods}>
+          <form onSubmit={handleSubmit(onSubmit)} noValidate>
+            <PopoverBody minWidth="max-content">
+              <FormControl isInvalid={errors.name ? true : false} isRequired>
+                <FormLabel>Project name</FormLabel>
+                <Input
+                  type="text"
+                  placeholder="my-project-name"
+                  {...register('name', {
+                    required: 'Project name is required',
+                    pattern: {
+                      value: ENTITY_NAME_PATTERN,
+                      message: 'The first/last character must be alphanumeric',
+                    },
+                  })}
+                />
+                {errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
+              </FormControl>
+              {metadataProperties?.project && <MetadataPropertiesFields schema={metadataProperties.project} />}
+            </PopoverBody>
+            <PopoverFooter border="0" display="flex" alignItems="center" justifyContent="space-between" pb={4}>
+              <Spacer />
+              <Button
+                type="submit"
+                colorScheme="teal"
+                variant="ghost"
+                isLoading={isLoading}
+                loadingText="Creating"
+              >
+                Create
+              </Button>
+            </PopoverFooter>
+          </form>
+        </FormProvider>
       </PopoverContent>
     </Popover>
   );

--- a/webapp/src/dogma/features/repo/NewRepo.tsx
+++ b/webapp/src/dogma/features/repo/NewRepo.tsx
@@ -15,31 +15,38 @@ import {
   Spacer,
   useDisclosure,
 } from '@chakra-ui/react';
-import { useAddNewRepoMutation } from 'dogma/features/api/apiSlice';
+import { useAddNewRepoMutation, useGetMetadataPropertiesQuery } from 'dogma/features/api/apiSlice';
 import { newNotification } from 'dogma/features/notification/notificationSlice';
 import { useAppDispatch } from 'dogma/hooks';
 import Router from 'next/router';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { SerializedError } from '@reduxjs/toolkit';
 import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import ErrorMessageParser from 'dogma/features/services/ErrorMessageParser';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import { WithProjectRole } from 'dogma/features/auth/ProjectRole';
+import {
+  MetadataPropertiesFormData,
+  toMetadataProperties,
+} from 'dogma/features/metadata-properties/MetadataProperties';
+import { MetadataPropertiesFields } from 'dogma/features/metadata-properties/MetadataPropertiesFields';
 
 const ENTITY_NAME_PATTERN = /^[0-9A-Za-z](?:[-+_0-9A-Za-z.]*[0-9A-Za-z])?$/;
 
 type FormData = {
   name: string;
-};
+} & MetadataPropertiesFormData;
 
 export const NewRepo = ({ projectName }: { projectName: string }) => {
   const [addNewRepo, { isLoading }] = useAddNewRepoMutation();
+  const { data: metadataProperties } = useGetMetadataPropertiesQuery();
+  const methods = useForm<FormData>();
   const {
     register,
     handleSubmit,
     reset,
     formState: { errors },
-  } = useForm<FormData>();
+  } = methods;
   const { isOpen, onToggle, onClose } = useDisclosure();
   const dispatch = useAppDispatch();
 
@@ -49,7 +56,8 @@ export const NewRepo = ({ projectName }: { projectName: string }) => {
 
   const onSubmit = async (data: FormData) => {
     try {
-      const response = await addNewRepo({ projectName, data }).unwrap();
+      const properties = toMetadataProperties(metadataProperties?.repo, data);
+      const response = await addNewRepo({ projectName, data: { name: data.name, properties } }).unwrap();
       if ((response as { error: FetchBaseQueryError | SerializedError }).error) {
         throw (response as { error: FetchBaseQueryError | SerializedError }).error;
       }
@@ -77,39 +85,46 @@ export const NewRepo = ({ projectName }: { projectName: string }) => {
             </PopoverHeader>
             <PopoverArrow />
             <PopoverCloseButton />
-            <form onSubmit={handleSubmit(onSubmit)}>
-              <PopoverBody minWidth="max-content">
-                <FormControl isInvalid={errors.name ? true : false} isRequired>
-                  <FormLabel>Repository name</FormLabel>
-                  <Input
-                    type="text"
-                    placeholder="my-repo-name"
-                    {...register('name', { pattern: ENTITY_NAME_PATTERN })}
-                  />
-                  {errors.name && (
-                    <FormErrorMessage>The first/last character must be alphanumeric</FormErrorMessage>
-                  )}
-                </FormControl>
-              </PopoverBody>
-              <PopoverFooter
-                border="0"
-                display="flex"
-                alignItems="center"
-                justifyContent="space-between"
-                pb={4}
-              >
-                <Spacer />
-                <Button
-                  type="submit"
-                  colorScheme="teal"
-                  variant="ghost"
-                  isLoading={isLoading}
-                  loadingText="Creating"
+            <FormProvider {...methods}>
+              <form onSubmit={handleSubmit(onSubmit)} noValidate>
+                <PopoverBody minWidth="max-content">
+                  <FormControl isInvalid={errors.name ? true : false} isRequired>
+                    <FormLabel>Repository name</FormLabel>
+                    <Input
+                      type="text"
+                      placeholder="my-repo-name"
+                      {...register('name', {
+                        required: 'Repository name is required',
+                        pattern: {
+                          value: ENTITY_NAME_PATTERN,
+                          message: 'The first/last character must be alphanumeric',
+                        },
+                      })}
+                    />
+                    {errors.name && <FormErrorMessage>{errors.name.message}</FormErrorMessage>}
+                  </FormControl>
+                  {metadataProperties?.repo && <MetadataPropertiesFields schema={metadataProperties.repo} />}
+                </PopoverBody>
+                <PopoverFooter
+                  border="0"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="space-between"
+                  pb={4}
                 >
-                  Create
-                </Button>
-              </PopoverFooter>
-            </form>
+                  <Spacer />
+                  <Button
+                    type="submit"
+                    colorScheme="teal"
+                    variant="ghost"
+                    isLoading={isLoading}
+                    loadingText="Creating"
+                  >
+                    Create
+                  </Button>
+                </PopoverFooter>
+              </form>
+            </FormProvider>
           </PopoverContent>
         </Popover>
       )}

--- a/webapp/tests/dogma/features/metadata-properties/MetadataProperties.test.ts
+++ b/webapp/tests/dogma/features/metadata-properties/MetadataProperties.test.ts
@@ -1,0 +1,72 @@
+import {
+  hasDeclaredProperties,
+  toMetadataProperties,
+  validateJsonObject,
+} from 'dogma/features/metadata-properties/MetadataProperties';
+
+describe('hasDeclaredProperties', () => {
+  it('returns true only when the schema declares top-level properties', () => {
+    expect(hasDeclaredProperties(undefined)).toBe(false);
+    expect(hasDeclaredProperties({})).toBe(false);
+    expect(hasDeclaredProperties({ properties: {} })).toBe(false);
+    expect(hasDeclaredProperties({ properties: { serviceId: { type: 'string' } } })).toBe(true);
+  });
+});
+
+describe('validateJsonObject', () => {
+  it('accepts an empty value and a JSON object', () => {
+    expect(validateJsonObject(undefined)).toBe(true);
+    expect(validateJsonObject('')).toBe(true);
+    expect(validateJsonObject('{ "a": 1 }')).toBe(true);
+  });
+
+  it('rejects invalid JSON and non-object values', () => {
+    expect(validateJsonObject('not-json')).toBe('Invalid JSON');
+    expect(validateJsonObject('[1]')).toBe('Must be a JSON object');
+    expect(validateJsonObject('null')).toBe('Must be a JSON object');
+    expect(validateJsonObject('42')).toBe('Must be a JSON object');
+  });
+});
+
+describe('toMetadataProperties', () => {
+  const schema = {
+    properties: {
+      serviceId: { type: 'string' },
+      replicas: { type: 'integer' },
+      canary: { type: 'boolean' },
+    },
+    required: ['serviceId'],
+  };
+
+  it('returns undefined without a schema or without values', () => {
+    expect(toMetadataProperties(undefined, { properties: { serviceId: 'foo' } })).toBeUndefined();
+    expect(toMetadataProperties(schema, {})).toBeUndefined();
+    expect(toMetadataProperties(schema, { properties: { serviceId: '' } })).toBeUndefined();
+  });
+
+  it('converts values to the declared types', () => {
+    expect(
+      toMetadataProperties(schema, {
+        properties: { serviceId: 'foo', replicas: '3', canary: true },
+      }),
+    ).toEqual({ serviceId: 'foo', replicas: 3, canary: true });
+  });
+
+  it('ignores values that are not declared in the schema', () => {
+    expect(
+      toMetadataProperties(schema, {
+        properties: { serviceId: 'foo', undeclared: 'x' },
+      }),
+    ).toEqual({ serviceId: 'foo' });
+  });
+
+  it('parses the raw JSON field when the schema has no top-level properties', () => {
+    const refSchema = { required: ['serviceId'] };
+    expect(toMetadataProperties(refSchema, { propertiesJson: '{ "serviceId": "foo", "extra": 1 }' })).toEqual({
+      serviceId: 'foo',
+      extra: 1,
+    });
+    expect(toMetadataProperties(refSchema, { propertiesJson: '' })).toBeUndefined();
+    expect(toMetadataProperties(refSchema, {})).toBeUndefined();
+  });
+});

--- a/webapp/tests/dogma/features/metadata-properties/MetadataPropertiesFields.test.tsx
+++ b/webapp/tests/dogma/features/metadata-properties/MetadataPropertiesFields.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { MetadataPropertiesFields } from 'dogma/features/metadata-properties/MetadataPropertiesFields';
+import { MetadataPropertiesSchema } from 'dogma/features/metadata-properties/MetadataProperties';
+
+const Harness = ({ schema }: { schema: MetadataPropertiesSchema }) => {
+  const methods = useForm();
+  return (
+    <FormProvider {...methods}>
+      <MetadataPropertiesFields schema={schema} />
+    </FormProvider>
+  );
+};
+
+describe('MetadataPropertiesFields', () => {
+  it('renders an input per declared property', () => {
+    render(
+      <Harness
+        schema={{
+          properties: {
+            serviceId: { type: 'string', description: 'The ID of the owning service.' },
+            replicas: { type: 'integer' },
+          },
+          required: ['serviceId'],
+        }}
+      />,
+    );
+    expect(screen.getByLabelText(/serviceId/)).toBeInTheDocument();
+    expect(screen.getByText('The ID of the owning service.')).toBeInTheDocument();
+    expect(screen.getByLabelText(/replicas/)).toHaveAttribute('type', 'number');
+  });
+
+  it('renders a select for an enum property', () => {
+    render(
+      <Harness
+        schema={{
+          properties: { env: { type: 'string', enum: ['dev', 'prod'] } },
+        }}
+      />,
+    );
+    const select = screen.getByLabelText(/env/);
+    expect(select.tagName).toBe('SELECT');
+    expect(screen.getByRole('option', { name: 'dev' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'prod' })).toBeInTheDocument();
+  });
+
+  it('renders a checkbox for a boolean property', () => {
+    render(<Harness schema={{ properties: { canary: { type: 'boolean' } } }} />);
+    expect(screen.getByRole('checkbox', { name: 'canary' })).toBeInTheDocument();
+  });
+
+  it('falls back to a raw JSON field when the schema has no top-level properties', () => {
+    render(<Harness schema={{ required: ['serviceId'] }} />);
+    expect(screen.getByLabelText(/Properties \(JSON\)/)).toBeInTheDocument();
+  });
+});

--- a/webapp/tests/dogma/features/project/NewProject.test.tsx
+++ b/webapp/tests/dogma/features/project/NewProject.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { NewProject } from 'dogma/features/project/NewProject';
+import { renderWithProviders } from 'dogma/util/test-utils';
+import { useAddNewProjectMutation, useGetMetadataPropertiesQuery } from 'dogma/features/api/apiSlice';
+
+jest.mock('next/router', () => ({
+  ...jest.requireActual('next/router'),
+  push: jest.fn(),
+}));
+
+jest.mock('dogma/features/api/apiSlice', () => ({
+  ...jest.requireActual('dogma/features/api/apiSlice'),
+  useAddNewProjectMutation: jest.fn(),
+  useGetMetadataPropertiesQuery: jest.fn(),
+}));
+
+describe('NewProject', () => {
+  let mockAddNewProject: jest.Mock;
+
+  beforeEach(() => {
+    mockAddNewProject = jest.fn().mockResolvedValue({ data: {} });
+    (useAddNewProjectMutation as jest.Mock).mockReturnValue([mockAddNewProject, { isLoading: false }]);
+    (useGetMetadataPropertiesQuery as jest.Mock).mockReturnValue({ data: {} });
+  });
+
+  it('creates a project without properties when nothing is declared', async () => {
+    renderWithProviders(<NewProject />);
+    fireEvent.change(screen.getByPlaceholderText('my-project-name'), { target: { value: 'foo' } });
+    fireEvent.click(screen.getByText('Create'));
+    await waitFor(() => expect(mockAddNewProject).toHaveBeenCalledWith({ name: 'foo', properties: undefined }));
+  });
+
+  it('renders the declared properties and sends them on submit', async () => {
+    (useGetMetadataPropertiesQuery as jest.Mock).mockReturnValue({
+      data: {
+        project: {
+          properties: { serviceId: { type: 'string' } },
+          required: ['serviceId'],
+        },
+      },
+    });
+    renderWithProviders(<NewProject />);
+
+    fireEvent.change(screen.getByPlaceholderText('my-project-name'), { target: { value: 'foo' } });
+    fireEvent.change(screen.getByPlaceholderText('serviceId'), { target: { value: 'payment-service' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    await waitFor(() =>
+      expect(mockAddNewProject).toHaveBeenCalledWith({
+        name: 'foo',
+        properties: { serviceId: 'payment-service' },
+      }),
+    );
+  });
+
+  it('does not submit when a required property is missing', async () => {
+    (useGetMetadataPropertiesQuery as jest.Mock).mockReturnValue({
+      data: {
+        project: {
+          properties: { serviceId: { type: 'string' } },
+          required: ['serviceId'],
+        },
+      },
+    });
+    renderWithProviders(<NewProject />);
+
+    fireEvent.change(screen.getByPlaceholderText('my-project-name'), { target: { value: 'foo' } });
+    fireEvent.click(screen.getByText('Create'));
+
+    // The empty required property blocks the native form validation.
+    await waitFor(() => expect(screen.getByLabelText(/serviceId/)).toBeInvalid());
+    expect(mockAddNewProject).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Motivation:

#1350 added declarable metadata property schemas to the server,
but the web UI could not render input forms for them.

Modifications:

- Fetch the declared schemas via `GET /api/v1/metadataProperties` and render
  input fields for them in the project, repository and app identity creation
  popovers — text inputs with pattern validation, enum selects and checkboxes,
  using the schema `title`, `description` and `examples` as the label, help
  text and placeholder.
- Fall back to a raw JSON textarea when a schema declares no top-level
  `properties` keyword.
- Send the entered values as the `properties` of the creation requests, and
  show the stored values in the app identity secret modal.
- Use a single inline validation path (`noValidate` + react-hook-form) in the
  creation forms so required and pattern errors render consistently.

Result:

- Together with #1350, closes #1346.
- The creation dialogs prompt for the properties declared in
  `metadataProperties` and reject invalid values before submission. Nothing
  changes when the server declares nothing.
