### PR TITLE
Make the xDS all-resource version deterministic across replicas

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
@@ -120,9 +120,15 @@ final class CentralDogmaSnapshotResources<T extends Message> extends SnapshotRes
         if (allResourceVersion != null) {
             return allResourceVersion;
         }
-        return allResourceVersion = Hashing.sha256()
-                                           .hashInt(versionedResources.values().hashCode())
-                                           .toString();
+        // Hash the resources in a canonical order. `versionedResources` is built from
+        // HashMap iteration, whose order is not guaranteed to be stable across snapshot
+        // rebuilds even when the resource set is unchanged.
+        final List<VersionedResource<T>> sorted =
+                versionedResources.entrySet().stream()
+                                  .sorted(Map.Entry.comparingByKey())
+                                  .map(Map.Entry::getValue)
+                                  .collect(toImmutableList());
+        return allResourceVersion = Hashing.sha256().hashInt(sorted.hashCode()).toString();
     }
 
     @Override

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResourcesTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResourcesTest.java
@@ -74,4 +74,36 @@ class CentralDogmaSnapshotResourcesTest {
         assertThat(snapshotResources.version(ImmutableList.of("foo/cluster", "bar/cluster", "qux/cluster")))
                 .isEqualTo(fooBarVersion);
     }
+
+    @Test
+    void wildcardVersionIsStableRegardlessOfInsertionOrder() {
+        // The same three clusters.
+        final SnapshotResources<Cluster> ascending = clusterSnapshot("foo", "bar", "baz");
+        final SnapshotResources<Cluster> descending = clusterSnapshot("baz", "bar", "foo");
+
+        // The wildcard version (empty resource names) must be identical for identical content.
+        assertThat(ascending.version(ImmutableList.of()))
+                .isEqualTo(descending.version(ImmutableList.of()));
+        // "*" and the explicit full set resolve to the same wildcard version too.
+        assertThat(ascending.version(ImmutableList.of("*")))
+                .isEqualTo(descending.version(ImmutableList.of()));
+        assertThat(ascending.version(ImmutableList.of("foo/cluster", "bar/cluster", "baz/cluster")))
+                .isEqualTo(descending.version(ImmutableList.of()));
+
+        // A genuine content change must still change the wildcard version.
+        final SnapshotResources<Cluster> changed = clusterSnapshot("foo", "bar", "qux");
+        assertThat(changed.version(ImmutableList.of()))
+                .isNotEqualTo(ascending.version(ImmutableList.of()));
+    }
+
+    private static SnapshotResources<Cluster> clusterSnapshot(String... groups) {
+        final ImmutableMap.Builder<String, Map<String, VersionedResource<Cluster>>> builder =
+                ImmutableMap.builder();
+        for (String group : groups) {
+            final String clusterName = group + "/cluster";
+            builder.put(group, ImmutableMap.of(
+                    clusterName, VersionedResource.create(Cluster.newBuilder().setName(clusterName).build())));
+        }
+        return CentralDogmaSnapshotResources.create(builder.build(), ResourceType.CLUSTER);
+    }
 }


### PR DESCRIPTION
Motivation:

A wildcard (empty resource_names) LDS/CDS request from an app-scoped client resolves its version_info through
CentralDogmaSnapshotResources.allResourceVersion(), which hashed versionedResources.values() in map-iteration order. That order is derived from HashMap iteration, so it is not stable: it differs between two maps that hold identical content but were built in a different order.

Because the xDS control plane runs on every replica (ALL_REPLICAS), each replica builds its snapshot from its own HashMaps and therefore hashes the same resources in a different order, producing a different version_info for byte-identical content.

Modifications:

- CentralDogmaSnapshotResources.allResourceVersion(): hash the resources in a canonical, resource-name-sorted order instead of in versionedResources.values() iteration order. This mirrors the name-sorted hashing already used for an explicit set of resource names in resourceVersionResolver.

Result:

- All replicas compute the same version_info for identical resource content, so wildcard (LDS/CDS) clients no longer see version_info flap when their stream moves between replicas.