### PR TITLE
Let plugins create encrypted repositories with custom project roles

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -540,7 +540,7 @@ public class CentralDogma implements AutoCloseable {
                 logger.info("Starting plugins on the leader replica ..");
                 pluginsForLeaderOnly
                         .start(cfg, pm, exec, meterRegistry, purgeWorker, projectInitializer,
-                               mirrorAccessController)
+                               mirrorAccessController, encryptionStorageManager)
                         .handle((unused, cause) -> {
                             if (cause == null) {
                                 logger.info("Started plugins on the leader replica.");
@@ -558,7 +558,7 @@ public class CentralDogma implements AutoCloseable {
                 final CompletableFuture<?> future =
                         pluginsForLeaderOnly
                                 .stop(cfg, pm, exec, meterRegistry, purgeWorker, projectInitializer,
-                                      mirrorAccessController)
+                                      mirrorAccessController, encryptionStorageManager)
                                 .handle((unused, cause) -> {
                                     if (cause == null) {
                                         logger.info("Stopped plugins on the leader replica.");
@@ -585,7 +585,7 @@ public class CentralDogma implements AutoCloseable {
                 logger.info("Starting plugins on the {} zone leader replica ..", zone);
                 pluginsForZoneLeaderOnly
                         .start(cfg, pm, exec, meterRegistry, purgeWorker, projectInitializer,
-                               mirrorAccessController)
+                               mirrorAccessController, encryptionStorageManager)
                         .handle((unused, cause) -> {
                             if (cause == null) {
                                 logger.info("Started plugins on the {} zone leader replica.", zone);
@@ -601,7 +601,7 @@ public class CentralDogma implements AutoCloseable {
                 final CompletableFuture<?> future =
                         pluginsForZoneLeaderOnly
                                 .stop(cfg, pm, exec, meterRegistry, purgeWorker,
-                                      projectInitializer, mirrorAccessController)
+                                      projectInitializer, mirrorAccessController, encryptionStorageManager)
                                 .handle((unused, cause) -> {
                                     if (cause == null) {
                                         logger.info("Stopped plugins on the {} zone leader replica.", zone);
@@ -850,7 +850,8 @@ public class CentralDogma implements AutoCloseable {
         if (pluginsForAllReplicas != null) {
             final PluginInitContext pluginInitContext =
                     new PluginInitContext(config(), pm, executor, meterRegistry, purgeWorker, sb,
-                                          authService, projectInitializer, mirrorAccessController);
+                                          authService, projectInitializer, mirrorAccessController,
+                                          encryptionStorageManager);
             pluginsForAllReplicas.plugins()
                                  .forEach(p -> {
                                      if (!(p instanceof AllReplicasPlugin)) {
@@ -1404,9 +1405,13 @@ public class CentralDogma implements AutoCloseable {
                             final ProjectManager pm = CentralDogma.this.pm;
                             final CommandExecutor executor = CentralDogma.this.executor;
                             final MeterRegistry meterRegistry = CentralDogma.this.meterRegistry;
-                            if (pm != null && executor != null && meterRegistry != null) {
+                            final EncryptionStorageManager encryptionStorageManager =
+                                    CentralDogma.this.encryptionStorageManager;
+                            if (pm != null && executor != null && meterRegistry != null &&
+                                encryptionStorageManager != null) {
                                 pluginsForAllReplicas.start(cfg, pm, executor, meterRegistry, purgeWorker,
-                                                            projectInitializer, mirrorAccessController).join();
+                                                            projectInitializer, mirrorAccessController,
+                                                            encryptionStorageManager).join();
                             }
                         }
                         serverHealth.setHealthy(true);
@@ -1424,9 +1429,13 @@ public class CentralDogma implements AutoCloseable {
                     final ProjectManager pm = CentralDogma.this.pm;
                     final CommandExecutor executor = CentralDogma.this.executor;
                     final MeterRegistry meterRegistry = CentralDogma.this.meterRegistry;
-                    if (pm != null && executor != null && meterRegistry != null) {
+                    final EncryptionStorageManager encryptionStorageManager =
+                            CentralDogma.this.encryptionStorageManager;
+                    if (pm != null && executor != null && meterRegistry != null &&
+                        encryptionStorageManager != null) {
                         pluginsForAllReplicas.stop(cfg, pm, executor, meterRegistry, purgeWorker,
-                                                   projectInitializer, mirrorAccessController).join();
+                                                   projectInitializer, mirrorAccessController,
+                                                   encryptionStorageManager).join();
                     }
                 }
                 CentralDogma.this.doStop();

--- a/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/PluginGroup.java
@@ -48,6 +48,7 @@ import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
 import com.linecorp.centraldogma.server.plugin.Plugin;
 import com.linecorp.centraldogma.server.plugin.PluginContext;
 import com.linecorp.centraldogma.server.plugin.PluginTarget;
+import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageManager;
 import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 
@@ -155,10 +156,11 @@ final class PluginGroup {
                                   CommandExecutor commandExecutor, MeterRegistry meterRegistry,
                                   ScheduledExecutorService purgeWorker,
                                   InternalProjectInitializer internalProjectInitializer,
-                                  MirrorAccessController mirrorAccessController) {
+                                  MirrorAccessController mirrorAccessController,
+                                  EncryptionStorageManager encryptionStorageManager) {
         final PluginContext context = new PluginContext(config, projectManager, commandExecutor, meterRegistry,
                                                         purgeWorker, internalProjectInitializer,
-                                                        mirrorAccessController);
+                                                        mirrorAccessController, encryptionStorageManager);
         return startStop.start(context, context, true);
     }
 
@@ -169,10 +171,12 @@ final class PluginGroup {
                                  CommandExecutor commandExecutor, MeterRegistry meterRegistry,
                                  ScheduledExecutorService purgeWorker,
                                  InternalProjectInitializer internalProjectInitializer,
-                                 MirrorAccessController mirrorAccessController) {
+                                 MirrorAccessController mirrorAccessController,
+                                 EncryptionStorageManager encryptionStorageManager) {
         return startStop.stop(
                 new PluginContext(config, projectManager, commandExecutor, meterRegistry, purgeWorker,
-                                  internalProjectInitializer, mirrorAccessController));
+                                  internalProjectInitializer, mirrorAccessController,
+                                  encryptionStorageManager));
     }
 
     private class PluginGroupStartStop extends StartStopSupport<PluginContext, PluginContext, Void, Void> {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceUtil.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceUtil.java
@@ -30,6 +30,7 @@ import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.metadata.ProjectRoles;
 import com.linecorp.centraldogma.server.metadata.RepositoryMetadata;
 import com.linecorp.centraldogma.server.metadata.Roles;
 import com.linecorp.centraldogma.server.metadata.UserAndTimestamp;
@@ -51,6 +52,15 @@ public final class RepositoryServiceUtil {
             CommandExecutor commandExecutor, MetadataService mds,
             Author author, String projectName, String repoName, boolean assignRoleToAuthor,
             boolean encrypt, @Nullable EncryptionStorageManager encryptionStorageManager) {
+        return createRepository(commandExecutor, mds, author, projectName, repoName, DEFAULT_PROJECT_ROLES,
+                                assignRoleToAuthor, encrypt, encryptionStorageManager);
+    }
+
+    public static CompletableFuture<Revision> createRepository(
+            CommandExecutor commandExecutor, MetadataService mds,
+            Author author, String projectName, String repoName, ProjectRoles projectRoles,
+            boolean assignRoleToAuthor, boolean encrypt,
+            @Nullable EncryptionStorageManager encryptionStorageManager) {
         final Map<String, RepositoryRole> users;
         final Map<String, RepositoryRole> appIds;
         if (!assignRoleToAuthor) {
@@ -66,7 +76,7 @@ public final class RepositoryServiceUtil {
             appIds = ImmutableMap.of();
         }
 
-        final Roles roles = new Roles(DEFAULT_PROJECT_ROLES, users, null, appIds);
+        final Roles roles = new Roles(projectRoles, users, null, appIds);
         final RepositoryMetadata repositoryMetadata =
                 RepositoryMetadata.of(repoName, roles, UserAndTimestamp.of(author));
 

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginContext.java
@@ -23,6 +23,7 @@ import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
+import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageManager;
 import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
@@ -41,6 +42,7 @@ public class PluginContext {
     private final ScheduledExecutorService purgeWorker;
     private final InternalProjectInitializer internalProjectInitializer;
     private final MirrorAccessController mirrorAccessController;
+    private final EncryptionStorageManager encryptionStorageManager;
 
     /**
      * Creates a new instance.
@@ -52,6 +54,7 @@ public class PluginContext {
      * @param purgeWorker the {@link ScheduledExecutorService} for the purging service
      * @param internalProjectInitializer the initializer for the internal projects
      * @param mirrorAccessController the controller which controls the access to the remote repos of mirrors
+     * @param encryptionStorageManager the manager for the storage of encrypted data at rest
      */
     public PluginContext(CentralDogmaConfig config,
                          ProjectManager projectManager,
@@ -59,7 +62,8 @@ public class PluginContext {
                          MeterRegistry meterRegistry,
                          ScheduledExecutorService purgeWorker,
                          InternalProjectInitializer internalProjectInitializer,
-                         MirrorAccessController mirrorAccessController) {
+                         MirrorAccessController mirrorAccessController,
+                         EncryptionStorageManager encryptionStorageManager) {
         this.config = requireNonNull(config, "config");
         this.projectManager = requireNonNull(projectManager, "projectManager");
         this.commandExecutor = requireNonNull(commandExecutor, "commandExecutor");
@@ -68,6 +72,8 @@ public class PluginContext {
         this.internalProjectInitializer = requireNonNull(internalProjectInitializer,
                                                          "internalProjectInitializer");
         this.mirrorAccessController = requireNonNull(mirrorAccessController, "mirrorAccessController");
+        this.encryptionStorageManager = requireNonNull(encryptionStorageManager,
+                                                       "encryptionStorageManager");
     }
 
     /**
@@ -117,5 +123,12 @@ public class PluginContext {
      */
     public MirrorAccessController mirrorAccessController() {
         return mirrorAccessController;
+    }
+
+    /**
+     * Returns the {@link EncryptionStorageManager}.
+     */
+    public EncryptionStorageManager encryptionStorageManager() {
+        return encryptionStorageManager;
     }
 }

--- a/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginInitContext.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/plugin/PluginInitContext.java
@@ -27,6 +27,7 @@ import com.linecorp.armeria.server.auth.AuthService;
 import com.linecorp.centraldogma.server.CentralDogmaConfig;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
 import com.linecorp.centraldogma.server.mirror.MirrorAccessController;
+import com.linecorp.centraldogma.server.storage.encryption.EncryptionStorageManager;
 import com.linecorp.centraldogma.server.storage.project.InternalProjectInitializer;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 
@@ -50,9 +51,10 @@ public final class PluginInitContext extends PluginContext {
                              ScheduledExecutorService purgeWorker, ServerBuilder serverBuilder,
                              Function<? super HttpService, AuthService> authService,
                              InternalProjectInitializer projectInitializer,
-                             MirrorAccessController mirrorAccessController) {
+                             MirrorAccessController mirrorAccessController,
+                             EncryptionStorageManager encryptionStorageManager) {
         super(config, projectManager, commandExecutor, meterRegistry, purgeWorker, projectInitializer,
-              mirrorAccessController);
+              mirrorAccessController, encryptionStorageManager);
         this.serverBuilder = requireNonNull(serverBuilder, "serverBuilder");
         this.authService = requireNonNull(authService, "authService");
     }

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceUtilTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/RepositoryServiceUtilTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.server.metadata.RepositoryMetadata.DEFAULT_PROJECT_ROLES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.RepositoryRole;
+import com.linecorp.centraldogma.internal.Util;
+import com.linecorp.centraldogma.server.command.Command;
+import com.linecorp.centraldogma.server.metadata.MetadataService;
+import com.linecorp.centraldogma.server.metadata.ProjectRoles;
+import com.linecorp.centraldogma.server.metadata.RepositoryMetadata;
+import com.linecorp.centraldogma.server.storage.encryption.NoopEncryptionStorageManager;
+import com.linecorp.centraldogma.testing.internal.ProjectManagerExtension;
+
+class RepositoryServiceUtilTest {
+
+    private static final String project = "foo";
+
+    private static final Author userAuthor = Author.ofEmail("user@localhost.localdomain");
+    private static final Author appAuthor =
+            new Author("app-1", "app-1" + Util.APP_IDENTITY_EMAIL_SUFFIX);
+
+    @RegisterExtension
+    final ProjectManagerExtension manager = new ProjectManagerExtension() {
+        @Override
+        protected void afterExecutorStarted() {
+            executor().execute(Command.createProject(userAuthor, project)).join();
+        }
+
+        @Override
+        protected boolean runForEachTest() {
+            return true;
+        }
+    };
+
+    private MetadataService newMetadataService() {
+        return new MetadataService(manager.projectManager(), manager.executor(),
+                                   manager.internalProjectInitializer());
+    }
+
+    @Test
+    void defaultOverloadUsesDefaultProjectRoles() {
+        final MetadataService mds = newMetadataService();
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo1",
+                                               false, null).join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo1").join();
+        assertThat(metadata.roles().projectRoles()).isEqualTo(DEFAULT_PROJECT_ROLES);
+        // WRITE for members, no role for guests.
+        assertThat(metadata.roles().projectRoles().member()).isEqualTo(RepositoryRole.WRITE);
+        assertThat(metadata.roles().projectRoles().guest()).isNull();
+    }
+
+    @Test
+    void customProjectRolesArePreserved() {
+        final MetadataService mds = newMetadataService();
+        final ProjectRoles projectRoles = ProjectRoles.of(RepositoryRole.READ, null);
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo2",
+                                               projectRoles, false, false, null).join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo2").join();
+        assertThat(metadata.roles().projectRoles()).isEqualTo(projectRoles);
+        assertThat(metadata.roles().projectRoles().member()).isEqualTo(RepositoryRole.READ);
+        assertThat(metadata.roles().projectRoles().guest()).isNull();
+    }
+
+    @Test
+    void customProjectRolesWithGuestRole() {
+        final MetadataService mds = newMetadataService();
+        final ProjectRoles projectRoles = ProjectRoles.of(RepositoryRole.WRITE, RepositoryRole.READ);
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo3",
+                                               projectRoles, false, false, null).join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo3").join();
+        assertThat(metadata.roles().projectRoles().member()).isEqualTo(RepositoryRole.WRITE);
+        assertThat(metadata.roles().projectRoles().guest()).isEqualTo(RepositoryRole.READ);
+    }
+
+    @Test
+    void notAssigningRoleToAuthorLeavesUserAndAppRolesEmpty() {
+        final MetadataService mds = newMetadataService();
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo4",
+                                               ProjectRoles.of(RepositoryRole.READ, null), false, false, null)
+                             .join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo4").join();
+        assertThat(metadata.roles().users()).isEmpty();
+        assertThat(metadata.roles().appIds()).isEmpty();
+    }
+
+    @Test
+    void assigningRoleToUserAuthorGrantsAdminToUser() {
+        final MetadataService mds = newMetadataService();
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo5",
+                                               ProjectRoles.of(RepositoryRole.READ, null), true, false, null)
+                             .join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo5").join();
+        assertThat(metadata.roles().users())
+                .isEqualTo(ImmutableMap.of(userAuthor.email(), RepositoryRole.ADMIN));
+        assertThat(metadata.roles().appIds()).isEmpty();
+    }
+
+    @Test
+    void assigningRoleToAppAuthorGrantsAdminToApp() {
+        final MetadataService mds = newMetadataService();
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, appAuthor, project, "repo6",
+                                               ProjectRoles.of(RepositoryRole.READ, null), true, false, null)
+                             .join();
+
+        final RepositoryMetadata metadata = mds.getRepo(project, "repo6").join();
+        assertThat(metadata.roles().appIds())
+                .isEqualTo(ImmutableMap.of(appAuthor.name(), RepositoryRole.ADMIN));
+        assertThat(metadata.roles().users()).isEmpty();
+    }
+
+    @Test
+    void createEncryptedFallsBackToNoopWhenDisabled() {
+        final MetadataService mds = newMetadataService();
+        RepositoryServiceUtil.createRepository(manager.executor(), mds, userAuthor, project, "repo7",
+                                               ProjectRoles.of(RepositoryRole.READ, null), false, false,
+                                               NoopEncryptionStorageManager.INSTANCE).join();
+        assertThat(manager.projectManager().get(project).repos().exists("repo7")).isTrue();
+    }
+}


### PR DESCRIPTION
Motivation:

Server-side plugins that create repositories call `Command.createRepository()` directly and register the repository metadata in a separate step. That bypasses what `RepositoryServiceUtil.createRepository()` already does for the REST API: generating a wrapped data encryption key so the repository is encrypted at rest, and adding the metadata as part of the same call.

Modifications:

- Expose the server's `EncryptionStorageManager` through `PluginContext` via a new `encryptionStorageManager()` accessor.

Result:

- A plugin can now create a repository through `RepositoryServiceUtil.createRepository()` that is encrypted when the server has encryption at rest enabled, and with the project roles it chooses.