### PR TITLE
Make xDS resource versions deterministic across replicas

### DIFF
--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResources.java
@@ -18,13 +18,16 @@ package com.linecorp.centraldogma.xds.internal;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.Message;
 
@@ -90,22 +93,23 @@ final class CentralDogmaSnapshotResources<T extends Message> extends SnapshotRes
                 return versionedResource.version();
             }
 
-            final List<VersionedResource<T>> collected = resourceNames.stream().sorted().distinct()
-                                                                      .map(versionedResources::get)
-                                                                      .filter(Objects::nonNull)
-                                                                      .collect(toImmutableList());
+            final List<String> collected = resourceNames.stream().sorted().distinct()
+                                                        .map(versionedResources::get)
+                                                        .filter(Objects::nonNull)
+                                                        .map(VersionedResource::version)
+                                                        .collect(toImmutableList());
             if (collected.isEmpty()) {
                 // There is no resource with the given names.
                 return "";
             }
             if (collected.size() == 1) {
-                return collected.get(0).version();
+                return collected.get(0);
             }
             if (collected.size() == versionedResources.size()) {
                 return allResourceVersion();
             }
 
-            return Hashing.sha256().hashInt(collected.hashCode()).toString();
+            return hashVersions(collected.stream());
         };
     }
 
@@ -120,15 +124,21 @@ final class CentralDogmaSnapshotResources<T extends Message> extends SnapshotRes
         if (allResourceVersion != null) {
             return allResourceVersion;
         }
-        // Hash the resources in a canonical order. `versionedResources` is built from
-        // HashMap iteration, whose order is not guaranteed to be stable across snapshot
-        // rebuilds even when the resource set is unchanged.
-        final List<VersionedResource<T>> sorted =
+        return allResourceVersion = hashVersions(
                 versionedResources.entrySet().stream()
                                   .sorted(Map.Entry.comparingByKey())
-                                  .map(Map.Entry::getValue)
-                                  .collect(toImmutableList());
-        return allResourceVersion = Hashing.sha256().hashInt(sorted.hashCode()).toString();
+                                  .map(entry -> entry.getValue().version()));
+    }
+
+    /**
+     * Hashes the given per-resource versions into a single version. The caller is responsible for supplying the
+     * versions in a canonical (resource-name-sorted) order so the result is deterministic.
+     */
+    private static String hashVersions(Stream<String> versions) {
+        final Hasher hasher = Hashing.sha256().newHasher();
+        // The NUL separator keeps the concatenation unambiguous regardless of the individual version lengths.
+        versions.forEach(version -> hasher.putString(version, StandardCharsets.UTF_8).putByte((byte) 0));
+        return hasher.hash().toString();
     }
 
     @Override

--- a/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaXdsResources.java
+++ b/xds/src/main/java/com/linecorp/centraldogma/xds/internal/CentralDogmaXdsResources.java
@@ -15,6 +15,7 @@
  */
 package com.linecorp.centraldogma.xds.internal;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -22,6 +23,8 @@ import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.Hashing;
+import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.Message;
 
 import io.envoyproxy.controlplane.cache.Resources.ResourceType;
@@ -69,29 +72,53 @@ final class CentralDogmaXdsResources {
     void setCluster(String groupName, Cluster cluster) {
         final Map<String, VersionedResource<Cluster>> groupClusters =
                 clusterResources.computeIfAbsent(groupName, k -> new HashMap<>());
-        groupClusters.put(cluster.getName(), VersionedResource.create(cluster));
+        groupClusters.put(cluster.getName(), versionedResource(cluster));
         clusterUpdated = true;
     }
 
     void setEndpoint(String groupName, ClusterLoadAssignment endpoint) {
         final Map<String, VersionedResource<ClusterLoadAssignment>> groupEndpoints =
                 endpointResources.computeIfAbsent(groupName, k -> new HashMap<>());
-        groupEndpoints.put(endpoint.getClusterName(), VersionedResource.create(endpoint));
+        groupEndpoints.put(endpoint.getClusterName(), versionedResource(endpoint));
         endpointUpdated = true;
     }
 
     void setListener(String groupName, Listener listener) {
         final Map<String, VersionedResource<Listener>> groupListeners =
                 listenerResources.computeIfAbsent(groupName, k -> new HashMap<>());
-        groupListeners.put(listener.getName(), VersionedResource.create(listener));
+        groupListeners.put(listener.getName(), versionedResource(listener));
         listenerUpdated = true;
     }
 
     void setRoute(String groupName, RouteConfiguration route) {
         final Map<String, VersionedResource<RouteConfiguration>> groupRoutes =
                 routeResources.computeIfAbsent(groupName, k -> new HashMap<>());
-        groupRoutes.put(route.getName(), VersionedResource.create(route));
+        groupRoutes.put(route.getName(), versionedResource(route));
         routeUpdated = true;
+    }
+
+    private static <T extends Message> VersionedResource<T> versionedResource(T resource) {
+        return VersionedResource.create(resource, stableVersion(resource));
+    }
+
+    /**
+     * Computes a version that is deterministic across replicas for the given resource.
+     *
+     * <p>{@link VersionedResource#create(Message)} derives the version from {@link Message#hashCode()}, which
+     * folds in the identity hash of the message descriptor (a per-JVM singleton).
+     */
+    static String stableVersion(Message resource) {
+        final byte[] serialized = new byte[resource.getSerializedSize()];
+        final CodedOutputStream out = CodedOutputStream.newInstance(serialized);
+        out.useDeterministicSerialization();
+        try {
+            resource.writeTo(out);
+            out.checkNoSpaceLeft();
+        } catch (IOException e) {
+            // Should never reach here
+            throw new Error();
+        }
+        return Hashing.sha256().hashBytes(serialized).toString();
     }
 
     void removeCluster(String groupName, String path) {

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResourcesTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaSnapshotResourcesTest.java
@@ -96,6 +96,47 @@ class CentralDogmaSnapshotResourcesTest {
                 .isNotEqualTo(ascending.version(ImmutableList.of()));
     }
 
+    @Test
+    void wildcardVersionDependsOnResourceVersionsNotProtobufHashCode() {
+        // Same resource names and same per-resource versions, but different underlying protobuf content (hence
+        // different Message.hashCode()). The wildcard version must be a function of the per-resource versions
+        // only, so these two must be equal. This guards against regressing to hashing
+        // VersionedResource.hashCode(), which folds in Message.hashCode() (the descriptor identity hash is not
+        // stable across replicas).
+        final SnapshotResources<Cluster> a = clusterSnapshot(
+                versioned("foo/cluster", "v-foo", "content-a"),
+                versioned("bar/cluster", "v-bar", "content-a"));
+        final SnapshotResources<Cluster> b = clusterSnapshot(
+                versioned("foo/cluster", "v-foo", "content-b"),
+                versioned("bar/cluster", "v-bar", "content-b"));
+        assertThat(a.version(ImmutableList.of())).isEqualTo(b.version(ImmutableList.of()));
+
+        // A genuine per-resource version change must still change the wildcard version.
+        final SnapshotResources<Cluster> c = clusterSnapshot(
+                versioned("foo/cluster", "v-foo", "content-a"),
+                versioned("bar/cluster", "v-bar-CHANGED", "content-a"));
+        assertThat(c.version(ImmutableList.of())).isNotEqualTo(a.version(ImmutableList.of()));
+    }
+
+    @Test
+    void namedSubsetVersionDependsOnResourceVersionsNotProtobufHashCode() {
+        // Same as above, but for an explicit subset of resource names (the multi-resource branch).
+        final SnapshotResources<Cluster> a = clusterSnapshot(
+                versioned("foo/cluster", "v-foo", "content-a"),
+                versioned("bar/cluster", "v-bar", "content-a"),
+                versioned("baz/cluster", "v-baz", "content-a"));
+        final SnapshotResources<Cluster> b = clusterSnapshot(
+                versioned("foo/cluster", "v-foo", "content-b"),
+                versioned("bar/cluster", "v-bar", "content-b"),
+                versioned("baz/cluster", "v-baz", "content-b"));
+        final ImmutableList<String> subset = ImmutableList.of("foo/cluster", "bar/cluster");
+        assertThat(a.version(subset)).isEqualTo(b.version(subset));
+        // The subset version differs from the full (wildcard) version.
+        assertThat(a.version(subset)).isNotEqualTo(a.version(ImmutableList.of()));
+        // Order of the requested names does not matter.
+        assertThat(a.version(subset)).isEqualTo(a.version(ImmutableList.of("bar/cluster", "foo/cluster")));
+    }
+
     private static SnapshotResources<Cluster> clusterSnapshot(String... groups) {
         final ImmutableMap.Builder<String, Map<String, VersionedResource<Cluster>>> builder =
                 ImmutableMap.builder();
@@ -105,5 +146,25 @@ class CentralDogmaSnapshotResourcesTest {
                     clusterName, VersionedResource.create(Cluster.newBuilder().setName(clusterName).build())));
         }
         return CentralDogmaSnapshotResources.create(builder.build(), ResourceType.CLUSTER);
+    }
+
+    @SafeVarargs
+    private static SnapshotResources<Cluster> clusterSnapshot(VersionedResource<Cluster>... resources) {
+        final ImmutableMap.Builder<String, Map<String, VersionedResource<Cluster>>> builder =
+                ImmutableMap.builder();
+        for (VersionedResource<Cluster> resource : resources) {
+            final String name = resource.resource().getName();
+            builder.put(name, ImmutableMap.of(name, resource));
+        }
+        return CentralDogmaSnapshotResources.create(builder.build(), ResourceType.CLUSTER);
+    }
+
+    // Builds a Cluster with the given name and an arbitrary content knob (altStatName), paired with an explicit
+    // version. The explicit version lets a test hold the version fixed while varying the content, so it can
+    // assert the aggregate version ignores the protobuf content (and its unstable hashCode) and depends only on
+    // the per-resource versions.
+    private static VersionedResource<Cluster> versioned(String name, String version, String content) {
+        return VersionedResource.create(
+                Cluster.newBuilder().setName(name).setAltStatName(content).build(), version);
     }
 }

--- a/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaXdsResourcesTest.java
+++ b/xds/src/test/java/com/linecorp/centraldogma/xds/internal/CentralDogmaXdsResourcesTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 LY Corporation
+ *
+ * LY Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.xds.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.hash.Hashing;
+import com.google.protobuf.CodedOutputStream;
+
+import io.envoyproxy.envoy.config.cluster.v3.Cluster;
+
+class CentralDogmaXdsResourcesTest {
+
+    @Test
+    void stableVersionIsHashOfDeterministicSerialization() throws Exception {
+        final Cluster cluster = Cluster.newBuilder().setName("foo").setAltStatName("bar").build();
+
+        // The version must be the SHA-256 of the deterministically serialized bytes, not something derived from
+        // Cluster.hashCode() (which folds in the descriptor identity hash and is not stable across replicas).
+        final byte[] serialized = new byte[cluster.getSerializedSize()];
+        final CodedOutputStream out = CodedOutputStream.newInstance(serialized);
+        out.useDeterministicSerialization();
+        cluster.writeTo(out);
+        out.checkNoSpaceLeft();
+        final String expected = Hashing.sha256().hashBytes(serialized).toString();
+
+        assertThat(CentralDogmaXdsResources.stableVersion(cluster)).isEqualTo(expected);
+        assertThat(CentralDogmaXdsResources.stableVersion(cluster)).hasSize(64); // SHA-256 hex length.
+    }
+
+    @Test
+    void stableVersionIsContentBasedAndStable() {
+        final Cluster a1 = Cluster.newBuilder().setName("foo").setAltStatName("x").build();
+        final Cluster a2 = Cluster.newBuilder().setName("foo").setAltStatName("x").build();
+        // Identical content -> identical version, regardless of the message instance.
+        assertThat(CentralDogmaXdsResources.stableVersion(a1))
+                .isEqualTo(CentralDogmaXdsResources.stableVersion(a2));
+
+        // Different content -> different version.
+        final Cluster b = Cluster.newBuilder().setName("foo").setAltStatName("y").build();
+        assertThat(CentralDogmaXdsResources.stableVersion(a1))
+                .isNotEqualTo(CentralDogmaXdsResources.stableVersion(b));
+    }
+}


### PR DESCRIPTION
Motivation:

A wildcard (empty resource_names) LDS/CDS request whose stream is load-balanced across replicas received a different version_info on essentially every request even when no resource had changed, forcing a needless re-push.

The version ultimately derives from protobuf Message.hashCode(): VersionedResource.create(resource) hashes resource.hashCode() into the per-resource version(), and CentralDogmaSnapshotResources hashed List<VersionedResource>.hashCode() (via AutoValue's resource().hashCode()) for the all-resource and multi-resource versions. But the generated Message.hashCode() folds in getDescriptor().hashCode(), and Descriptors.Descriptor does not override hashCode(), so it resolves to the identity hash of the descriptor singleton. That identity hash is constant within a JVM but differs across JVMs, so byte-identical content produces a different version on every replica.

Modifications:

- CentralDogmaXdsResources: compute each resource's version from the SHA-256 of its deterministically serialized bytes (CodedOutputStream.useDeterministicSerialization()) and pass it to VersionedResource.create(resource, version), instead of relying on the hashCode-based single-argument create(). Deterministic serialization is identical across JVMs and also normalizes protobuf map field ordering (e.g. metadata). Applied to clusters, endpoints, listeners and routes.

Result:

- All replicas compute the same version_info for identical resource content, so wildcard (and named) LDS/CDS clients no longer see version_info flap when their stream moves between replicas.