### PR TITLE
Ensure a mirror can only use a credential of its own repository or project

### DIFF
--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -15,75 +15,92 @@
  */
 package com.linecorp.centraldogma.client.armeria;
 
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD2;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME2;
+import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.getAccessToken;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.UnknownHostException;
 import java.util.concurrent.CompletionException;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.client.WebClient;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
-import com.linecorp.centraldogma.common.InvalidPushException;
+import com.linecorp.centraldogma.common.PermissionException;
+import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.storage.project.Project;
+import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class ArmeriaCentralDogmaTest {
 
+    private static String regularUserAccessToken;
+
     @RegisterExtension
-    static CentralDogmaExtension dogma = new CentralDogmaExtension() {
+    static final CentralDogmaExtension dogma = new CentralDogmaExtension() {
+
         @Override
-        protected void scaffold(CentralDogma client) {
-            client.createProject("foo").join();
+        protected void configure(CentralDogmaBuilder builder) {
+            builder.authProviderFactory(new TestAuthProviderFactory());
+            builder.systemAdministrators(USERNAME);
+        }
+
+        @Override
+        protected String accessToken() {
+            return getAccessToken(WebClient.of("http://127.0.0.1:" + dogma.serverAddress().getPort()),
+                                  USERNAME, PASSWORD, true);
         }
     };
 
-    @Test
-    void pushFileToMetaRepositoryShouldFail() throws UnknownHostException {
-        final CentralDogma client = new ArmeriaCentralDogmaBuilder()
-                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
-                .build();
-
-        assertThatThrownBy(() -> client.forRepo("foo", Project.REPO_DOGMA)
-                                       .commit("summary", Change.ofJsonUpsert("/bar.json", "{ \"a\": \"b\" }"))
-                                       .push()
-                                       .join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(InvalidPushException.class);
+    @BeforeAll
+    static void setUp() {
+        regularUserAccessToken = getAccessToken(dogma.httpClient(), USERNAME2, PASSWORD2,
+                                                "regularUser", false);
     }
 
     @Test
-    void pushMirrorsJsonFileToMetaRepositoryShouldFail() throws UnknownHostException {
-        final CentralDogma client = new ArmeriaCentralDogmaBuilder()
-                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
-                .build();
-
-        // Mirror and credential files cannot be created or modified via the push API; they must be
-        // managed through the dedicated mirroring/credential REST API.
-        assertThatThrownBy(() -> client.forRepo("foo", Project.REPO_DOGMA)
-                                       .commit("summary",
-                                               Change.ofJsonUpsert("/repos/foo/mirrors/foo.json", "{}"))
-                                       .push()
-                                       .join())
-                .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(InvalidPushException.class);
+    void regularUserCannotPushFileToMetaRepository() throws UnknownHostException {
+        assertRegularUserCannotPushToMetaRepository(
+                Change.ofJsonUpsert("/bar.json", "{ \"a\": \"b\" }"));
     }
 
     @Test
-    void pushCredentialJsonFileToMetaRepositoryShouldFail() throws UnknownHostException {
-        final CentralDogma client = new ArmeriaCentralDogmaBuilder()
-                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
-                .build();
+    void regularUserCannotPushMirrorsJsonFileToMetaRepository() throws UnknownHostException {
+        assertRegularUserCannotPushToMetaRepository(
+                Change.ofJsonUpsert("/repos/foo/mirrors/foo.json", "{}"));
+    }
 
-        // Both project-level and repository-level credential files are rejected by the push API.
+    @Test
+    void regularUserCannotPushCredentialJsonFilesToMetaRepository() throws UnknownHostException {
+        assertRegularUserCannotPushToMetaRepository(
+                Change.ofJsonUpsert("/credentials/foo.json", "{}"),
+                Change.ofJsonUpsert("/repos/foo/credentials/bar.json", "{}"));
+    }
+
+    private static void assertRegularUserCannotPushToMetaRepository(Change<?>... changes)
+            throws UnknownHostException {
+        final CentralDogma client = newRegularUserClient();
+
+        // The dogma repository is system-admin-only, so a regular user is rejected before its
+        // changes are evaluated.
         assertThatThrownBy(() -> client.forRepo("foo", Project.REPO_DOGMA)
-                                       .commit("summary",
-                                               Change.ofJsonUpsert("/credentials/foo.json", "{}"),
-                                               Change.ofJsonUpsert("/repos/foo/credentials/bar.json", "{}"))
+                                       .commit("summary", changes)
                                        .push()
                                        .join())
                 .isInstanceOf(CompletionException.class)
-                .hasCauseInstanceOf(InvalidPushException.class);
+                .hasCauseInstanceOf(PermissionException.class);
+    }
+
+    private static CentralDogma newRegularUserClient() throws UnknownHostException {
+        return new ArmeriaCentralDogmaBuilder()
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
+                .accessToken(regularUserAccessToken)
+                .build();
     }
 }

--- a/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
+++ b/client/java-armeria/src/test/java/com/linecorp/centraldogma/client/armeria/ArmeriaCentralDogmaTest.java
@@ -15,7 +15,6 @@
  */
 package com.linecorp.centraldogma.client.armeria;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.UnknownHostException;
@@ -27,7 +26,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.InvalidPushException;
-import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
@@ -56,16 +54,36 @@ class ArmeriaCentralDogmaTest {
     }
 
     @Test
-    void pushMirrorsJsonFileToMetaRepository() throws UnknownHostException {
+    void pushMirrorsJsonFileToMetaRepositoryShouldFail() throws UnknownHostException {
         final CentralDogma client = new ArmeriaCentralDogmaBuilder()
                 .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
                 .build();
 
-        final PushResult result = client.forRepo("foo", Project.REPO_DOGMA)
-                                        .commit("summary",
-                                                Change.ofJsonUpsert("/repos/foo/mirrors/foo.json", "{}"))
-                                        .push()
-                                        .join();
-        assertThat(result.revision().major()).isPositive();
+        // Mirror and credential files cannot be created or modified via the push API; they must be
+        // managed through the dedicated mirroring/credential REST API.
+        assertThatThrownBy(() -> client.forRepo("foo", Project.REPO_DOGMA)
+                                       .commit("summary",
+                                               Change.ofJsonUpsert("/repos/foo/mirrors/foo.json", "{}"))
+                                       .push()
+                                       .join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(InvalidPushException.class);
+    }
+
+    @Test
+    void pushCredentialJsonFileToMetaRepositoryShouldFail() throws UnknownHostException {
+        final CentralDogma client = new ArmeriaCentralDogmaBuilder()
+                .host(dogma.serverAddress().getHostString(), dogma.serverAddress().getPort())
+                .build();
+
+        // Both project-level and repository-level credential files are rejected by the push API.
+        assertThatThrownBy(() -> client.forRepo("foo", Project.REPO_DOGMA)
+                                       .commit("summary",
+                                               Change.ofJsonUpsert("/credentials/foo.json", "{}"),
+                                               Change.ofJsonUpsert("/repos/foo/credentials/bar.json", "{}"))
+                                       .push()
+                                       .join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(InvalidPushException.class);
     }
 }

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/CentralDogmaMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/CentralDogmaMirrorTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.centraldogma.it.mirror.git;
 
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
 import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.PASSWORD;
 import static com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil.USERNAME;
@@ -25,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
@@ -35,19 +33,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import com.linecorp.armeria.client.BlockingWebClient;
 import com.linecorp.armeria.client.WebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
-import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.internal.credential.AccessTokenCredential;
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthMessageUtil;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
@@ -342,46 +345,35 @@ class CentralDogmaMirrorTest {
 
     private void pushMirrorSettings(String localPath, String remotePath,
                                     MirrorDirection direction, @Nullable String gitignore) {
-        final InetSocketAddress remoteAddr = remoteDogma.serverAddress();
-        final String remoteUri = "dogma://" + remoteAddr.getHostString() + ':' + remoteAddr.getPort() +
-                                 '/' + projName + '/' + REPO_FOO + ".dogma" + remotePath;
+        final BlockingWebClient client = localDogma.blockingHttpClient();
 
         final String credId = "access-token";
         final String credName = credentialName(projName, credId);
-        try {
-            localClient.forRepo(projName, Project.REPO_DOGMA)
-                       .commit("Add credential",
-                               Change.ofJsonUpsert(credentialFile(credName),
-                                                   "{ \"type\": \"ACCESS_TOKEN\"," +
-                                                   "  \"name\": \"" + credName + "\"," +
-                                                   "  \"accessToken\": \"" + remoteAccessToken + "\" }"))
-                       .push().join();
-        } catch (CompletionException e) {
-            if (!(e.getCause() instanceof RedundantChangeException)) {
-                throw e;
-            }
-        }
+        final CreateCredentialRequest credential =
+                new CreateCredentialRequest(credId, new AccessTokenCredential(credName, remoteAccessToken));
+        final ResponseEntity<PushResultDto> credentialResponse =
+                client.prepare()
+                      .post("/api/v1/projects/{proj}/credentials")
+                      .pathParam("proj", projName)
+                      .contentJson(credential)
+                      .asJson(PushResultDto.class)
+                      .execute();
+        assertThat(credentialResponse.status()).isEqualTo(HttpStatus.CREATED);
 
-        final StringBuilder config = new StringBuilder();
-        config.append('{')
-              .append("  \"id\": \"foo\",")
-              .append("  \"enabled\": true,")
-              .append("  \"direction\": \"").append(direction).append("\",")
-              .append("  \"localRepo\": \"").append(REPO_FOO).append("\",")
-              .append("  \"localPath\": \"").append(localPath).append("\",")
-              .append("  \"remoteUri\": \"").append(remoteUri).append("\",")
-              .append("  \"schedule\": \"0 0 0 1 1 ? 2099\",")
-              .append("  \"credentialName\": \"").append(credName).append('"');
-        if (gitignore != null) {
-            config.append(",  \"gitignore\": \"").append(gitignore.replace("\n", "\\n")).append('"');
-        }
-        config.append('}');
-
-        localClient.forRepo(projName, Project.REPO_DOGMA)
-                   .commit("Add mirror config",
-                           Change.ofJsonUpsert(
-                                   "/repos/" + REPO_FOO + "/mirrors/foo.json",
-                                   config.toString()))
-                   .push().join();
+        final InetSocketAddress remoteAddr = remoteDogma.serverAddress();
+        final String remoteUrl = remoteAddr.getHostString() + ':' + remoteAddr.getPort() +
+                                 '/' + projName + '/' + REPO_FOO + ".dogma";
+        final MirrorRequest mirror =
+                new MirrorRequest("foo", true, projName, "0 0 0 1 1 ? 2099", direction.name(), REPO_FOO,
+                                  localPath, "dogma", remoteUrl, remotePath, "", gitignore, credName, null);
+        final ResponseEntity<PushResultDto> response =
+                client.prepare()
+                      .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                      .pathParam("proj", projName)
+                      .pathParam("repo", REPO_FOO)
+                      .contentJson(mirror)
+                      .asJson(PushResultDto.class)
+                      .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
     }
 }

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ForceRefUpdateTest.java
@@ -16,7 +16,6 @@
 
 package com.linecorp.centraldogma.it.mirror.git;
 
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
 import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
 import static com.linecorp.centraldogma.internal.CredentialUtil.projectCredentialFile;
 import static com.linecorp.centraldogma.it.mirror.git.GitTestUtil.getFileContent;
@@ -47,15 +46,20 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.internal.credential.SshKeyCredential;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorState;
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.TestUtil;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
@@ -83,8 +87,6 @@ class ForceRefUpdateTest {
     private static MirroringService mirroringService;
     private String projName;
     private KeyPair keyPair;
-    private String privateKey;
-    private String publicKey;
 
     @BeforeAll
     static void init() {
@@ -99,18 +101,14 @@ class ForceRefUpdateTest {
 
         final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
         keyPair = kpg.generateKeyPair();
-        privateKey = Jackson.escapeText(KeyPairUtilsTest.toPemFormat(keyPair.getPrivate()));
-        publicKey = Jackson.escapeText(KeyPairUtilsTest.toPemFormat(keyPair.getPublic()));
     }
 
     @AfterEach
     void afterEach() {
-        dogma.client()
-             .forRepo(projName, Project.REPO_DOGMA)
-             .commit("cleanup",
-                     Change.ofRemoval(projectCredentialFile("ssh-key-id")),
-                     Change.ofRemoval("/repos/" + REPO_FOO + "/mirrors/foo.json"))
-             .push().join();
+        GitTestUtil.commitToMetaRepo(
+                dogma, projName, "cleanup",
+                Change.ofRemoval(projectCredentialFile("ssh-key-id")),
+                Change.ofRemoval("/repos/" + REPO_FOO + "/mirrors/foo.json"));
     }
 
     @Test
@@ -135,8 +133,9 @@ class ForceRefUpdateTest {
             sshd.start();
 
             final String gitUri = "git+ssh://127.0.0.1:" + sshd.getPort() + "/.git/";
+            // The credential must exist before creating a git+ssh mirror that references it.
+            pushCredentials();
             pushMirror(gitUri, MirrorDirection.LOCAL_TO_REMOTE);
-            pushCredentials(publicKey, privateKey);
 
             // 1. Perform the initial mirroring.
             mirroringService.mirror().join();
@@ -201,37 +200,42 @@ class ForceRefUpdateTest {
         }
     }
 
-    private void pushCredentials(String pubKey, String privKey) {
+    private void pushCredentials() {
         final String name = credentialName(projName, "ssh-key-id");
-        dogma.client().forRepo(projName, Project.REPO_DOGMA)
-             .commit("Add a mirror",
-                     Change.ofJsonUpsert(credentialFile(name),
-                                         '{' +
-                                         "  \"name\": \"" + name + "\"," +
-                                         "  \"type\": \"SSH_KEY\"," +
-                                         "  \"username\": \"" + "git" + "\"," +
-                                         "  \"publicKey\": \"" + pubKey + "\"," +
-                                         "  \"privateKey\": \"" + privKey + '"' +
-                                         '}')
-             ).push().join();
+        // Use the raw PEM text; the typed DTO is JSON-encoded by the client, which escapes it exactly once.
+        final CreateCredentialRequest credential = new CreateCredentialRequest(
+                "ssh-key-id",
+                new SshKeyCredential(name, "git",
+                                     KeyPairUtilsTest.toPemFormat(keyPair.getPublic()),
+                                     KeyPairUtilsTest.toPemFormat(keyPair.getPrivate()), null));
+        final ResponseEntity<PushResultDto> response =
+                dogma.blockingHttpClient().prepare()
+                     .post("/api/v1/projects/{proj}/credentials")
+                     .pathParam("proj", projName)
+                     .contentJson(credential)
+                     .asJson(PushResultDto.class)
+                     .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
     }
 
     private void pushMirror(String gitUri, MirrorDirection mirrorDirection) {
-        dogma.client().forRepo(projName, Project.REPO_DOGMA)
-             .commit("Add a mirror",
-                     Change.ofJsonUpsert("/repos/" + REPO_FOO + "/mirrors/foo.json",
-                                         '{' +
-                                         "  \"id\": \"foo\"," +
-                                         "  \"enabled\": true," +
-                                         "  \"type\": \"single\"," +
-                                         "  \"direction\": \"" + mirrorDirection.name() + "\"," +
-                                         "  \"localRepo\": \"" + REPO_FOO + "\"," +
-                                         "  \"localPath\": \"/\"," +
-                                         "  \"remoteUri\": \"" + gitUri + "\"," +
-                                         "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
-                                         "  \"credentialName\": \"" +
-                                         credentialName(projName, "ssh-key-id") + '"' +
-                                         '}'))
-             .push().join();
+        final String remoteScheme = "git+ssh";
+        String remoteUrl = gitUri.substring((remoteScheme + "://").length());
+        if (remoteUrl.endsWith("/")) {
+            remoteUrl = remoteUrl.substring(0, remoteUrl.length() - 1);
+        }
+        final MirrorRequest mirror =
+                new MirrorRequest("foo", true, projName, "0 0 0 1 1 ? 2099", mirrorDirection.name(), REPO_FOO,
+                                  "/", remoteScheme, remoteUrl, "/", "master", null,
+                                  credentialName(projName, "ssh-key-id"), null);
+        final ResponseEntity<PushResultDto> response =
+                dogma.blockingHttpClient().prepare()
+                     .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                     .pathParam("proj", projName)
+                     .pathParam("repo", REPO_FOO)
+                     .contentJson(mirror)
+                     .asJson(PushResultDto.class)
+                     .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
     }
 }

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorHttpsAuthTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorHttpsAuthTest.java
@@ -17,8 +17,8 @@
 package com.linecorp.centraldogma.it.mirror.git;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
 import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 
@@ -33,13 +33,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableSet;
 
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.credential.Credential;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class GitMirrorHttpsAuthTest {
@@ -99,27 +104,40 @@ class GitMirrorHttpsAuthTest {
     @ParameterizedTest(name = "{0}, {1}")
     @MethodSource("arguments")
     @DisabledIf("noCredentials")
-    void httpsAuth(String projName, String gitUri, JsonNode credential) {
+    void httpsAuth(String projName, String gitUri, JsonNode credential) throws Exception {
         client.createProject(projName).join();
         client.createRepository(projName, "main").join();
 
-        // Add /credentials/{id}.json and /mirrors/{id}.json
         final String credentialName = credential.get("name").asText();
-        client.forRepo(projName, Project.REPO_DOGMA)
-              .commit("Add a mirror",
-                      Change.ofJsonUpsert(credentialFile(credentialName), credential),
-                      Change.ofJsonUpsert("/repos/main/mirrors/main.json",
-                                          '{' +
-                                          "  \"id\": \"main\"," +
-                                          "  \"enabled\": true," +
-                                          "  \"type\": \"single\"," +
-                                          "  \"direction\": \"REMOTE_TO_LOCAL\"," +
-                                          "  \"localRepo\": \"main\"," +
-                                          "  \"localPath\": \"/\"," +
-                                          "  \"remoteUri\": \"" + gitUri + "\"," +
-                                          "  \"credentialName\": \"" + credentialName + '"' +
-                                          '}'))
-              .push().join();
+        final String credentialId = credentialName.substring(credentialName.lastIndexOf('/') + 1);
+        final BlockingWebClient webClient = dogma.blockingHttpClient();
+
+        final CreateCredentialRequest credentialRequest =
+                new CreateCredentialRequest(credentialId, Jackson.treeToValue(credential, Credential.class));
+        final ResponseEntity<PushResultDto> credentialResponse =
+                webClient.prepare()
+                         .post("/api/v1/projects/{proj}/credentials")
+                         .pathParam("proj", projName)
+                         .contentJson(credentialRequest)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(credentialResponse.status()).isEqualTo(HttpStatus.CREATED);
+
+        // git+https://github.com/line/centraldogma-authtest.git
+        final String remoteScheme = "git+https";
+        final String remoteUrl = gitUri.substring((remoteScheme + "://").length());
+        final MirrorRequest mirror =
+                new MirrorRequest("main", true, projName, "0 0 0 1 1 ? 2099", "REMOTE_TO_LOCAL", "main",
+                                  "/", remoteScheme, remoteUrl, "/", "main", null, credentialName, null);
+        final ResponseEntity<PushResultDto> mirrorResponse =
+                webClient.prepare()
+                         .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                         .pathParam("proj", projName)
+                         .pathParam("repo", "main")
+                         .contentJson(mirror)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(mirrorResponse.status()).isEqualTo(HttpStatus.CREATED);
 
         // Try to perform mirroring to see if authentication works as expected.
         mirroringService.mirror().join();

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
@@ -17,8 +17,6 @@
 package com.linecorp.centraldogma.it.mirror.git;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,7 +31,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.MergeCommand.FastForwardMode;
@@ -63,16 +60,19 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.hash.Hashing;
 
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
-import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
 import com.linecorp.centraldogma.server.internal.JGitUtil;
@@ -286,13 +286,29 @@ class GitMirrorIntegrationTest {
 
     @Test
     void remoteToLocal_gitignore() throws Exception {
-        pushMirrorSettings(null, "/first#master", "\"/exclude_if_root.txt\\nexclude_dir\"");
+        pushMirrorSettings(null, "/first#master", "/exclude_if_root.txt\nexclude_dir");
         checkGitignore("/first/#master");
     }
 
     @Test
     void remoteToLocal_gitignore_with_array() throws Exception {
-        pushMirrorSettings(null, "/first#master", "[\"/exclude_if_root.txt\", \"exclude_dir\"]");
+        // An array-form gitignore is only supported for backward compatibility and cannot be expressed via
+        // the mirroring REST API (MirrorRequest.gitignore is a string), so the config is committed directly
+        // to the meta repository.
+        GitTestUtil.commitToMetaRepo(
+                dogma, projName, "Add a mirror",
+                Change.ofJsonUpsert("/repos/" + REPO_FOO + "/mirrors/foo.json",
+                                    '{' +
+                                    "  \"id\": \"foo\"," +
+                                    "  \"enabled\": true," +
+                                    "  \"direction\": \"REMOTE_TO_LOCAL\"," +
+                                    "  \"localRepo\": \"" + REPO_FOO + "\"," +
+                                    "  \"localPath\": \"/\"," +
+                                    "  \"remoteUri\": \"" + gitUri + "/first#master\"," +
+                                    "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
+                                    "  \"credentialName\": \"\"," +
+                                    "  \"gitignore\": [\"/exclude_if_root.txt\", \"exclude_dir\"]" +
+                                    '}'));
         checkGitignore("/first/#master");
     }
 
@@ -535,10 +551,16 @@ class GitMirrorIntegrationTest {
 
     @CsvSource({ "meta", "dogma" })
     @ParameterizedTest
-    void cannotMirrorToInternalRepositories(String localRepo) {
-        assertThatThrownBy(() -> pushMirrorSettingsWithLocalRepo(localRepo, "/", "/", null))
-                .hasCauseInstanceOf(CentralDogmaException.class)
-                .hasMessageContaining("invalid localRepo: " + localRepo);
+    void cannotPushMirrorFileViaPushApi(String localRepo) {
+        // Mirror files cannot be created or modified via the push API; the dedicated mirroring REST API
+        // must be used instead.
+        assertThatThrownBy(() -> client.forRepo(projName, Project.REPO_DOGMA)
+                                       .commit("Add a mirror",
+                                               Change.ofJsonUpsert(
+                                                       "/repos/" + localRepo + "/mirrors/foo.json", "{}"))
+                                       .push().join())
+                .hasCauseInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
     }
 
     @Test
@@ -710,47 +732,37 @@ class GitMirrorIntegrationTest {
 
     private void pushMirrorSettings(String mirrorId, String localRepo, @Nullable String localPath,
                                     @Nullable String remotePath, @Nullable String gitignore) {
-        final String localPath0 = localPath == null ? "/" : localPath;
-        final String remoteUri = gitUri + firstNonNull(remotePath, "");
-        final String credentialName = credentialName(projName, "none");
-        try {
-            client.forRepo(projName, Project.REPO_DOGMA)
-                  .commit("Add /credentials/none",
-                          Change.ofJsonUpsert(credentialFile(credentialName),
-                                              "{ " +
-                                              "\"type\": \"NONE\", " +
-                                              "\"name\": \"" + credentialName + "\", " +
-                                              "\"enabled\": true " +
-                                              '}'))
-                  .push().join();
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof RedundantChangeException) {
-                // The same content can be pushed several times.
-            } else {
-                throw e;
-            }
-        }
-        client.forRepo(projName, Project.REPO_DOGMA)
-              .commit("Add /repos/" + localRepo + "/mirrors/" + mirrorId + ".json",
-                      Change.ofJsonUpsert("/repos/" + localRepo + "/mirrors/" + mirrorId + ".json",
-                                          '{' +
-                                          "  \"id\": \"" + mirrorId + "\"," +
-                                          "  \"enabled\": true," +
-                                          "  \"type\": \"single\"," +
-                                          "  \"direction\": \"REMOTE_TO_LOCAL\"," +
-                                          "  \"localRepo\": \"" + localRepo + "\"," +
-                                          "  \"localPath\": \"" + localPath0 + "\"," +
-                                          "  \"remoteUri\": \"" + remoteUri + "\"," +
-                                          "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
-                                          "  \"credentialName\": \"" + credentialName + "\"," +
-                                          "  \"gitignore\": " + firstNonNull(gitignore, "\"\"") +
-                                          '}'))
-              .push().join();
+        final ResponseEntity<PushResultDto> response =
+                dogma.blockingHttpClient().prepare()
+                     .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                     .pathParam("proj", projName)
+                     .pathParam("repo", localRepo)
+                     .contentJson(newMirrorRequest(mirrorId, localRepo, localPath, remotePath, gitignore))
+                     .asJson(PushResultDto.class)
+                     .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
     }
 
-    private void pushMirrorSettingsWithLocalRepo(String localRepo, @Nullable String localPath,
-                                                 @Nullable String remotePath, @Nullable String gitignore) {
-        pushMirrorSettings("foo", localRepo, localPath, remotePath, gitignore);
+    // git+file:///abs/path/.git -> (scheme: "git+file", url: "/abs/path/.git")
+    // The remote path may carry the branch as a URI fragment, e.g. "/first#master".
+    private MirrorRequest newMirrorRequest(String mirrorId, String localRepo, @Nullable String localPath,
+                                           @Nullable String remotePath, @Nullable String gitignore) {
+        final String remoteScheme = "git+file";
+        final String remoteUrl = gitUri.substring((remoteScheme + "://").length());
+        String remotePath0 = firstNonNull(remotePath, "/");
+        // The test git repositories use the 'master' branch by default.
+        String remoteBranch = "master";
+        final int fragmentIndex = remotePath0.indexOf('#');
+        if (fragmentIndex >= 0) {
+            remoteBranch = remotePath0.substring(fragmentIndex + 1);
+            remotePath0 = remotePath0.substring(0, fragmentIndex);
+        }
+        if (remotePath0.isEmpty()) {
+            remotePath0 = "/";
+        }
+        return new MirrorRequest(mirrorId, true, projName, "0 0 0 1 1 ? 2099", "REMOTE_TO_LOCAL",
+                                 localRepo, firstNonNull(localPath, "/"), remoteScheme, remoteUrl,
+                                 remotePath0, remoteBranch, gitignore, "", null);
     }
 
     private Entry<JsonNode> expectedMirrorState(Revision revision, String localPath, String remotePath)

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorIntegrationTest.java
@@ -66,9 +66,9 @@ import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Commit;
 import com.linecorp.centraldogma.common.Entry;
-import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
+import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
@@ -551,16 +551,13 @@ class GitMirrorIntegrationTest {
 
     @CsvSource({ "meta", "dogma" })
     @ParameterizedTest
-    void cannotPushMirrorFileViaPushApi(String localRepo) {
-        // Mirror files cannot be created or modified via the push API; the dedicated mirroring REST API
-        // must be used instead.
-        assertThatThrownBy(() -> client.forRepo(projName, Project.REPO_DOGMA)
-                                       .commit("Add a mirror",
-                                               Change.ofJsonUpsert(
-                                                       "/repos/" + localRepo + "/mirrors/foo.json", "{}"))
-                                       .push().join())
-                .hasCauseInstanceOf(InvalidPushException.class)
-                .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
+    void systemAdminCanPushMirrorFileViaPushApi(String localRepo) {
+        final PushResult result =
+                client.forRepo(projName, Project.REPO_DOGMA)
+                      .commit("Add a mirror",
+                              Change.ofJsonUpsert("/repos/" + localRepo + "/mirrors/foo.json", "{}"))
+                      .push().join();
+        assertThat(result.revision().major()).isPositive();
     }
 
     @Test

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorSshAuthTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitMirrorSshAuthTest.java
@@ -16,8 +16,8 @@
 
 package com.linecorp.centraldogma.it.mirror.git;
 
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
 import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -35,13 +35,18 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSet.Builder;
 import com.google.common.io.Resources;
 
+import com.linecorp.armeria.client.BlockingWebClient;
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
+import com.linecorp.centraldogma.server.credential.CreateCredentialRequest;
+import com.linecorp.centraldogma.server.credential.Credential;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
 
 class GitMirrorSshAuthTest {
@@ -79,27 +84,41 @@ class GitMirrorSshAuthTest {
     @ParameterizedTest(name = "{0}, {1}")
     @MethodSource("arguments")
     @DisabledIf("noSshKeys")
-    void sshAuth(String projName, String gitUri, JsonNode credential) {
+    void sshAuth(String projName, String gitUri, JsonNode credential) throws Exception {
         client.createProject(projName).join();
         client.createRepository(projName, "main").join();
 
-        // Add /credentials/{id}.json and /mirrors/{id}.json
         final String credentialName = credential.get("name").asText();
-        client.forRepo(projName, Project.REPO_DOGMA)
-              .commit("Add a mirror",
-                      Change.ofJsonUpsert(credentialFile(credentialName), credential),
-                      Change.ofJsonUpsert("/repos/main/mirrors/main.json",
-                                          '{' +
-                                          "  \"id\": \"main\"," +
-                                          "  \"enabled\": true," +
-                                          "  \"type\": \"single\"," +
-                                          "  \"direction\": \"REMOTE_TO_LOCAL\"," +
-                                          "  \"localRepo\": \"main\"," +
-                                          "  \"localPath\": \"/\"," +
-                                          "  \"remoteUri\": \"" + gitUri + "\"," +
-                                          "  \"credentialName\": \"" + credentialName + '"' +
-                                          '}'))
-              .push().join();
+        final String credentialId = credentialName.substring(credentialName.lastIndexOf('/') + 1);
+        final BlockingWebClient webClient = dogma.blockingHttpClient();
+
+        // Create the credential first; a git+ssh mirror requires an existing SSH_KEY credential.
+        final CreateCredentialRequest credentialRequest =
+                new CreateCredentialRequest(credentialId, Jackson.treeToValue(credential, Credential.class));
+        final ResponseEntity<PushResultDto> credentialResponse =
+                webClient.prepare()
+                         .post("/api/v1/projects/{proj}/credentials")
+                         .pathParam("proj", projName)
+                         .contentJson(credentialRequest)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(credentialResponse.status()).isEqualTo(HttpStatus.CREATED);
+
+        // git+ssh://github.com/line/centraldogma-authtest.git
+        final String remoteScheme = "git+ssh";
+        final String remoteUrl = gitUri.substring((remoteScheme + "://").length());
+        final MirrorRequest mirror =
+                new MirrorRequest("main", true, projName, "0 0 0 1 1 ? 2099", "REMOTE_TO_LOCAL", "main",
+                                  "/", remoteScheme, remoteUrl, "/", "main", null, credentialName, null);
+        final ResponseEntity<PushResultDto> mirrorResponse =
+                webClient.prepare()
+                         .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                         .pathParam("proj", projName)
+                         .pathParam("repo", "main")
+                         .contentJson(mirror)
+                         .asJson(PushResultDto.class)
+                         .execute();
+        assertThat(mirrorResponse.status()).isEqualTo(HttpStatus.CREATED);
 
         // Try to perform mirroring to see if authentication works as expected.
         mirroringService.mirror().join();

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitTestUtil.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitTestUtil.java
@@ -26,7 +26,25 @@ import org.eclipse.jgit.revwalk.RevWalk;
 import org.eclipse.jgit.treewalk.TreeWalk;
 import org.jspecify.annotations.Nullable;
 
+import com.linecorp.centraldogma.common.Author;
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.Revision;
+import com.linecorp.centraldogma.testing.junit.CentralDogmaExtension;
+
 public final class GitTestUtil {
+
+    /**
+     * Commits the given mirror or credential {@code changes} directly to the meta repository of
+     * {@code projectName}, bypassing the push API. Mirror and credential files can no longer be written
+     * through the push API (see {@code ContentServiceV1.checkMetaRepoPush}), so tests that need to inject
+     * such files (e.g. legacy or otherwise invalid configurations) commit them at the storage layer.
+     */
+    public static void commitToMetaRepo(CentralDogmaExtension dogma, String projectName,
+                                        String summary, Change<?>... changes) {
+        dogma.projectManager().get(projectName).metaRepo()
+             .commit(Revision.HEAD, System.currentTimeMillis(), Author.SYSTEM, summary, changes)
+             .join();
+    }
 
     public static byte @Nullable [] getFileContent(Git git, ObjectId commitId, String fileName)
             throws IOException {

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitTestUtil.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/GitTestUtil.java
@@ -35,9 +35,10 @@ public final class GitTestUtil {
 
     /**
      * Commits the given mirror or credential {@code changes} directly to the meta repository of
-     * {@code projectName}, bypassing the push API. Mirror and credential files can no longer be written
-     * through the push API (see {@code ContentServiceV1.checkMetaRepoPush}), so tests that need to inject
-     * such files (e.g. legacy or otherwise invalid configurations) commit them at the storage layer.
+     * {@code projectName}, bypassing the push API. Only a system administrator may write mirror and
+     * credential files through the push API (see {@code ContentServiceV1.checkMetaRepoPush}), so tests
+     * that need to inject such files (e.g. legacy or otherwise invalid configurations) commit them at the
+     * storage layer.
      */
     public static void commitToMetaRepo(CentralDogmaExtension dogma, String projectName,
                                         String summary, Change<?>... changes) {

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
@@ -17,8 +17,6 @@
 package com.linecorp.centraldogma.it.mirror.git;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialFile;
-import static com.linecorp.centraldogma.internal.CredentialUtil.credentialName;
 import static com.linecorp.centraldogma.it.mirror.git.GitMirrorIntegrationTest.addToGitIndex;
 import static net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,7 +30,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletionException;
 
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -53,15 +50,18 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import com.google.common.base.Strings;
 
+import com.linecorp.armeria.common.HttpStatus;
+import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.common.CentralDogmaException;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
+import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
-import com.linecorp.centraldogma.common.RedundantChangeException;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
+import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
+import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
 import com.linecorp.centraldogma.server.CentralDogmaBuilder;
 import com.linecorp.centraldogma.server.MirroringService;
 import com.linecorp.centraldogma.server.internal.mirror.MirrorState;
@@ -254,7 +254,7 @@ class LocalToRemoteGitMirrorTest {
             "/local/foo, /remote/bar"
     })
     void localToRemote_gitignore(String localPath, String remotePath) throws Exception {
-        pushMirrorSettings(localPath, remotePath, "\"/exclude_if_root.txt\\n**/exclude_dir\"");
+        pushMirrorSettings(localPath, remotePath, "/exclude_if_root.txt\n**/exclude_dir");
         checkGitignore(localPath, remotePath);
     }
 
@@ -266,7 +266,7 @@ class LocalToRemoteGitMirrorTest {
             "/local/foo, /remote/bar"
     })
     void localToRemote_gitignore_with_array(String localPath, String remotePath) throws Exception {
-        pushMirrorSettings(localPath, remotePath, "[\"/exclude_if_root.txt\", \"exclude_dir\"]");
+        pushMirrorSettingsWithArrayGitignore(localPath, remotePath);
         checkGitignore(localPath, remotePath);
     }
 
@@ -448,10 +448,16 @@ class LocalToRemoteGitMirrorTest {
 
     @CsvSource({ "meta", "dogma" })
     @ParameterizedTest
-    void cannotMirrorInternalRepositories(String localRepo) {
-        assertThatThrownBy(() -> pushMirrorSettings(localRepo, "/", "/", null, MirrorDirection.LOCAL_TO_REMOTE))
-                .hasCauseInstanceOf(CentralDogmaException.class)
-                .hasMessageContaining("invalid localRepo:");
+    void cannotPushMirrorFileViaPushApi(String localRepo) {
+        // Mirror files cannot be created or modified via the push API; the dedicated mirroring REST API
+        // must be used instead.
+        assertThatThrownBy(() -> client.forRepo(projName, Project.REPO_DOGMA)
+                                       .commit("Add a mirror",
+                                               Change.ofJsonUpsert(
+                                                       "/repos/" + localRepo + "/mirrors/foo.json", "{}"))
+                                       .push().join())
+                .hasCauseInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
     }
 
     private void pushMirrorSettings(@Nullable String localPath, @Nullable String remotePath,
@@ -473,42 +479,58 @@ class LocalToRemoteGitMirrorTest {
     private void pushMirrorSettings(String mirrorId, String localRepo, @Nullable String localPath,
                                     @Nullable String remotePath, @Nullable String gitignore,
                                     MirrorDirection direction) {
-        final String localPath0 = localPath == null ? "/" : localPath;
-        final String remoteUri = gitUri + firstNonNull(remotePath, "");
-        try {
-            final String credentialName = credentialName(projName, "none");
-            client.forRepo(projName, Project.REPO_DOGMA)
-                  .commit("Add /credentials/none",
-                          Change.ofJsonUpsert(credentialFile(credentialName),
-                                              "{ " +
-                                              "\"type\": \"NONE\"," +
-                                              "\"name\": \"" + credentialName + '"' +
-                                              '}'))
-                  .push().join();
-        } catch (CompletionException e) {
-            if (e.getCause() instanceof RedundantChangeException) {
-                // The same content can be pushed several times.
-            } else {
-                throw e;
-            }
+        final ResponseEntity<PushResultDto> response =
+                dogma.blockingHttpClient().prepare()
+                     .post("/api/v1/projects/{proj}/repos/{repo}/mirrors")
+                     .pathParam("proj", projName)
+                     .pathParam("repo", localRepo)
+                     .contentJson(newMirrorRequest(mirrorId, localRepo, localPath, remotePath,
+                                                   gitignore, direction))
+                     .asJson(PushResultDto.class)
+                     .execute();
+        assertThat(response.status()).isEqualTo(HttpStatus.CREATED);
+    }
+
+    // git+file:///abs/path/.git -> (scheme: "git+file", url: "/abs/path/.git")
+    private MirrorRequest newMirrorRequest(String mirrorId, String localRepo, @Nullable String localPath,
+                                           @Nullable String remotePath, @Nullable String gitignore,
+                                           MirrorDirection direction) {
+        final String remoteScheme = "git+file";
+        final String remoteUrl = gitUri.substring((remoteScheme + "://").length());
+        String remotePath0 = firstNonNull(remotePath, "/");
+        // The test git repositories use the 'master' branch by default.
+        String remoteBranch = "master";
+        final int fragmentIndex = remotePath0.indexOf('#');
+        if (fragmentIndex >= 0) {
+            remoteBranch = remotePath0.substring(fragmentIndex + 1);
+            remotePath0 = remotePath0.substring(0, fragmentIndex);
         }
-        client.forRepo(projName, Project.REPO_DOGMA)
-              .commit("Add /repos/" + localRepo + "/mirrors/" + mirrorId + ".json",
-                      Change.ofJsonUpsert("/repos/" + localRepo + "/mirrors/" + mirrorId + ".json",
-                                          '{' +
-                                          " \"id\": \"" + mirrorId + "\"," +
-                                          " \"enabled\": true," +
-                                          "  \"type\": \"single\"," +
-                                          "  \"direction\": \"" + direction + "\"," +
-                                          "  \"localRepo\": \"" + localRepo + "\"," +
-                                          "  \"localPath\": \"" + localPath0 + "\"," +
-                                          "  \"remoteUri\": \"" + remoteUri + "\"," +
-                                          "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
-                                          "  \"gitignore\": " + firstNonNull(gitignore, "\"\"") + ',' +
-                                          "  \"credentialName\": \"" +
-                                          credentialName(projName, "none") + '"' +
-                                          '}'))
-              .push().join();
+        if (remotePath0.isEmpty()) {
+            remotePath0 = "/";
+        }
+        return new MirrorRequest(mirrorId, true, projName, "0 0 0 1 1 ? 2099", direction.name(),
+                                 localRepo, firstNonNull(localPath, "/"), remoteScheme, remoteUrl,
+                                 remotePath0, remoteBranch, gitignore, "", null);
+    }
+
+    // Array-form gitignore is only supported for backward compatibility and cannot be expressed via the
+    // mirroring REST API (MirrorRequest.gitignore is a string), so the config is committed directly to the
+    // meta repository.
+    private void pushMirrorSettingsWithArrayGitignore(String localPath, String remotePath) {
+        GitTestUtil.commitToMetaRepo(
+                dogma, projName, "Add a mirror",
+                Change.ofJsonUpsert("/repos/" + REPO_FOO + "/mirrors/foo.json",
+                                    '{' +
+                                    " \"id\": \"foo\"," +
+                                    " \"enabled\": true," +
+                                    "  \"direction\": \"LOCAL_TO_REMOTE\"," +
+                                    "  \"localRepo\": \"" + REPO_FOO + "\"," +
+                                    "  \"localPath\": \"" + localPath + "\"," +
+                                    "  \"remoteUri\": \"" + gitUri + remotePath + "\"," +
+                                    "  \"schedule\": \"0 0 0 1 1 ? 2099\"," +
+                                    "  \"gitignore\": [\"/exclude_if_root.txt\", \"exclude_dir\"]," +
+                                    "  \"credentialName\": \"\"" +
+                                    '}'));
     }
 
     private Set<String> listFiles(ObjectId commitId) throws IOException {

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/LocalToRemoteGitMirrorTest.java
@@ -55,9 +55,9 @@ import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.centraldogma.client.CentralDogma;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.Entry;
-import com.linecorp.centraldogma.common.InvalidPushException;
 import com.linecorp.centraldogma.common.MirrorException;
 import com.linecorp.centraldogma.common.PathPattern;
+import com.linecorp.centraldogma.common.PushResult;
 import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
@@ -448,16 +448,13 @@ class LocalToRemoteGitMirrorTest {
 
     @CsvSource({ "meta", "dogma" })
     @ParameterizedTest
-    void cannotPushMirrorFileViaPushApi(String localRepo) {
-        // Mirror files cannot be created or modified via the push API; the dedicated mirroring REST API
-        // must be used instead.
-        assertThatThrownBy(() -> client.forRepo(projName, Project.REPO_DOGMA)
-                                       .commit("Add a mirror",
-                                               Change.ofJsonUpsert(
-                                                       "/repos/" + localRepo + "/mirrors/foo.json", "{}"))
-                                       .push().join())
-                .hasCauseInstanceOf(InvalidPushException.class)
-                .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
+    void systemAdminCanPushMirrorFileViaPushApi(String localRepo) {
+        final PushResult result =
+                client.forRepo(projName, Project.REPO_DOGMA)
+                      .commit("Add a mirror",
+                              Change.ofJsonUpsert("/repos/" + localRepo + "/mirrors/foo.json", "{}"))
+                      .push().join();
+        assertThat(result.revision().major()).isPositive();
     }
 
     private void pushMirrorSettings(@Nullable String localPath, @Nullable String remotePath,

--- a/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
+++ b/it/mirror/src/test/java/com/linecorp/centraldogma/it/mirror/git/ZoneAwareMirrorTest.java
@@ -51,10 +51,11 @@ import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.ResponseEntity;
 import com.linecorp.armeria.common.auth.AuthToken;
 import com.linecorp.centraldogma.client.CentralDogma;
-import com.linecorp.centraldogma.client.CentralDogmaRepository;
 import com.linecorp.centraldogma.client.armeria.ArmeriaCentralDogmaBuilder;
+import com.linecorp.centraldogma.common.Author;
 import com.linecorp.centraldogma.common.Change;
 import com.linecorp.centraldogma.common.MirrorException;
+import com.linecorp.centraldogma.common.Revision;
 import com.linecorp.centraldogma.internal.Jackson;
 import com.linecorp.centraldogma.internal.api.v1.MirrorRequest;
 import com.linecorp.centraldogma.internal.api.v1.PushResultDto;
@@ -65,7 +66,6 @@ import com.linecorp.centraldogma.server.internal.storage.repository.MirrorConfig
 import com.linecorp.centraldogma.server.mirror.MirrorDirection;
 import com.linecorp.centraldogma.server.mirror.MirrorResult;
 import com.linecorp.centraldogma.server.mirror.MirroringServicePluginConfig;
-import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaReplicationExtension;
 import com.linecorp.centraldogma.testing.internal.CentralDogmaRuleDelegate;
 import com.linecorp.centraldogma.testing.internal.auth.TestAuthProviderFactory;
@@ -180,8 +180,6 @@ class ZoneAwareMirrorTest {
 
     @Test
     void shouldWarnUnknownZoneForScheduledJob() throws Exception {
-        final CentralDogma client = cluster.servers().get(0).client();
-        final CentralDogmaRepository repo = client.forRepo(FOO_PROJ, Project.REPO_DOGMA);
         final String mirrorId = TEST_MIRROR_ID + "-unknown-zone";
         final String unknownZone = "unknown-zone";
 
@@ -218,8 +216,15 @@ class ZoneAwareMirrorTest {
         final Change<JsonNode> change = Change.ofJsonUpsert(
                 "/repos/bar-unknown-zone/mirrors/" + mirrorId + ".json",
                 Jackson.writeValueAsString(mirrorConfig));
-        repo.commit("Add a mirror having an invalid zone", change)
-            .push().join();
+        // The mirror pins an unknown zone, which the mirroring REST API would reject, so the config is
+        // committed directly to each replica's meta repository (bypassing the push API) to simulate a
+        // mirror whose zone became invalid after a zone-configuration change.
+        for (CentralDogmaRuleDelegate server : cluster.servers()) {
+            server.projectManager().get(FOO_PROJ).metaRepo()
+                  .commit(Revision.HEAD, System.currentTimeMillis(), Author.SYSTEM,
+                          "Add a mirror having an invalid zone", change)
+                  .join();
+        }
 
         await().untilAsserted(() -> {
             // Wait for 3 mirror tasks to be run to verify all jobs are executed in the same zone.

--- a/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
+++ b/server-mirror-git/src/test/java/com/linecorp/centraldogma/server/internal/mirror/DefaultMetaRepositoryWithMirrorTest.java
@@ -248,6 +248,95 @@ class DefaultMetaRepositoryWithMirrorTest {
     }
 
     @Test
+    void repoLevelCredentialForOwnRepo_isAccepted() {
+        // A mirror may reference a repository-level credential that belongs to its own repository.
+        final String aliceCredential = credentialName(project.name(), "foo", "alice");
+        final List<Change<?>> changes = ImmutableList.of(
+                Change.ofJsonUpsert(
+                        "/repos/foo/mirrors/foo.json",
+                        '{' +
+                        "  \"id\": \"foo\"," +
+                        "  \"enabled\": true," +
+                        "  \"schedule\": \"" + DEFAULT_SCHEDULE + "\"," +
+                        "  \"direction\": \"LOCAL_TO_REMOTE\"," +
+                        "  \"localRepo\": \"foo\"," +
+                        "  \"remoteUri\": \"git+ssh://foo.com/foo.git\"," +
+                        "  \"credentialName\": \"" + aliceCredential + '"' +
+                        '}'),
+                rawCredential(aliceCredential, "alice"));
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "", changes).join();
+        project.repos().create("foo", Author.SYSTEM);
+
+        final List<Mirror> mirrors = findMirrors();
+        assertThat(mirrors).hasSize(1);
+        assertThat(mirrors.get(0).credential()).isInstanceOf(SshKeyCredential.class);
+        assertThat(((SshKeyCredential) mirrors.get(0).credential()).username()).isEqualTo("alice");
+        // The single-mirror lookup should also succeed.
+        assertThatCode(() -> metaRepo.mirror("foo", "foo").join()).doesNotThrowAnyException();
+    }
+
+    @Test
+    void repoLevelCredentialForAnotherRepo_isRejected() {
+        // A repository-level credential that belongs to the 'bar' repository.
+        final String barCredential = credentialName(project.name(), "bar", "alice");
+        // A mirror in the 'foo' repository must not be able to use it, even when written directly via the
+        // low-level commit API which bypasses the MirrorRequest validation.
+        final List<Change<?>> changes = ImmutableList.of(
+                Change.ofJsonUpsert(
+                        "/repos/foo/mirrors/foo.json",
+                        '{' +
+                        "  \"id\": \"foo\"," +
+                        "  \"enabled\": true," +
+                        "  \"schedule\": \"" + DEFAULT_SCHEDULE + "\"," +
+                        "  \"direction\": \"LOCAL_TO_REMOTE\"," +
+                        "  \"localRepo\": \"foo\"," +
+                        "  \"remoteUri\": \"git+ssh://foo.com/foo.git\"," +
+                        "  \"credentialName\": \"" + barCredential + '"' +
+                        '}'),
+                rawCredential(barCredential, "alice"));
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "", changes).join();
+        project.repos().create("foo", Author.SYSTEM);
+        project.repos().create("bar", Author.SYSTEM);
+
+        // The bad mirror is skipped when loading all mirrors, ...
+        assertThat(metaRepo.mirrors().join()).isEmpty();
+        // ... and the single-mirror lookup surfaces the scope violation.
+        assertThatThrownBy(() -> metaRepo.mirror("foo", "foo").join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("repoName and credentialName do not match");
+    }
+
+    @Test
+    void projectLevelCredentialForAnotherProject_isRejected() {
+        // A project-level credential whose name points to a different project must be rejected.
+        // The credential file physically lives at '/credentials/alice.json' in this project's meta
+        // repository, but its embedded name claims to belong to 'other-project'.
+        final String otherProjectCredential = credentialName("other-project", "alice");
+        final List<Change<?>> changes = ImmutableList.of(
+                Change.ofJsonUpsert(
+                        "/repos/foo/mirrors/foo.json",
+                        '{' +
+                        "  \"id\": \"foo\"," +
+                        "  \"enabled\": true," +
+                        "  \"schedule\": \"" + DEFAULT_SCHEDULE + "\"," +
+                        "  \"direction\": \"LOCAL_TO_REMOTE\"," +
+                        "  \"localRepo\": \"foo\"," +
+                        "  \"remoteUri\": \"git+ssh://foo.com/foo.git\"," +
+                        "  \"credentialName\": \"" + otherProjectCredential + '"' +
+                        '}'),
+                rawCredential(otherProjectCredential, "alice"));
+        metaRepo.commit(Revision.HEAD, 0, Author.SYSTEM, "", changes).join();
+        project.repos().create("foo", Author.SYSTEM);
+
+        assertThat(metaRepo.mirrors().join()).isEmpty();
+        assertThatThrownBy(() -> metaRepo.mirror("foo", "foo").join())
+                .isInstanceOf(CompletionException.class)
+                .hasCauseInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("projectName and credentialName do not match");
+    }
+
+    @Test
     void xdsMirrorWithNonRootLocalPath_isRejected() {
         final MirrorRequest badMirror = new MirrorRequest(
                 "xds-mirror", true, INTERNAL_PROJECT_XDS, DEFAULT_SCHEDULE, "REMOTE_TO_LOCAL", "some-group",
@@ -298,6 +387,19 @@ class DefaultMetaRepositoryWithMirrorTest {
                         "  \"publicKey\": \"ssh-rsa BBBB\"," +
                         "  \"privateKey\": \"" + dummyKey + '"' +
                         '}'));
+    }
+
+    private static Change<?> rawCredential(String credentialName, String username) {
+        final String dummyKey = "-----BEGIN RSA PRIVATE KEY-----\\ntest\\n-----END RSA PRIVATE KEY-----";
+        return Change.ofJsonUpsert(
+                credentialFile(credentialName),
+                '{' +
+                "  \"name\": \"" + credentialName + "\"," +
+                "  \"type\": \"SSH_KEY\"," +
+                "  \"username\": \"" + username + "\"," +
+                "  \"publicKey\": \"ssh-rsa AAAA\"," +
+                "  \"privateKey\": \"" + dummyKey + '"' +
+                '}');
     }
 
     private static List<Credential> credentials(String projectName) {

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -76,6 +76,7 @@ import com.linecorp.centraldogma.internal.api.v1.RevertRequest;
 import com.linecorp.centraldogma.internal.api.v1.WatchResultDto;
 import com.linecorp.centraldogma.server.command.Command;
 import com.linecorp.centraldogma.server.command.CommandExecutor;
+import com.linecorp.centraldogma.server.internal.admin.auth.AuthUtil;
 import com.linecorp.centraldogma.server.internal.api.auth.RequiresRepositoryRole;
 import com.linecorp.centraldogma.server.internal.api.converter.ChangesRequestConverter;
 import com.linecorp.centraldogma.server.internal.api.converter.CommitMessageRequestConverter;
@@ -85,6 +86,7 @@ import com.linecorp.centraldogma.server.internal.api.converter.TemplateParamsCon
 import com.linecorp.centraldogma.server.internal.api.converter.WatchRequestConverter;
 import com.linecorp.centraldogma.server.internal.api.converter.WatchRequestConverter.WatchRequest;
 import com.linecorp.centraldogma.server.internal.api.variable.Templater;
+import com.linecorp.centraldogma.server.metadata.User;
 import com.linecorp.centraldogma.server.storage.project.Project;
 import com.linecorp.centraldogma.server.storage.project.ProjectManager;
 import com.linecorp.centraldogma.server.storage.repository.EntryTransformer;
@@ -207,10 +209,11 @@ public class ContentServiceV1 extends AbstractService {
     public CompletableFuture<PushResultDto> push(
             @Param @Default("-1") String revision,
             Repository repository,
-            Author author,
+            User user,
             CommitMessageDto commitMessage,
             @RequestConverter(ChangesRequestConverter.class) Iterable<Change<?>> changes) {
-        checkMetaRepoPush(repository.name(), changes);
+        final Author author = AuthUtil.getAuthor(user);
+        checkMetaRepoPush(user, repository.name(), changes);
         meterRegistry.counter("commits.push",
                               "project", repository.parent().name(),
                               "repository", repository.name())
@@ -578,21 +581,29 @@ public class ContentServiceV1 extends AbstractService {
         return repository.mergeFiles(rev, query).thenApply(DtoConverter::newMergedEntryDto);
     }
 
-    public static void checkMetaRepoPush(String repoName, Iterable<Change<?>> changes) {
+    public static void checkMetaRepoPush(@Nullable User user, String repoName, Iterable<Change<?>> changes) {
         if (Project.REPO_DOGMA.equals(repoName) || Project.REPO_META.equals(repoName)) {
+            final boolean isSystemAdmin = user != null && user.isSystemAdmin();
             for (Change<?> change : changes) {
                 final String path = change.path();
+                // Already checked in RequiresRepositoryRoleDecorator
                 if (METADATA_JSON.equals(path)) {
                     continue;
                 }
                 // Mirror and credential files must be managed via the dedicated mirroring and credential
                 // REST APIs, which validate the input (e.g. the credential scope). Writing them directly
-                // with the push API bypasses that validation, so it is not allowed.
+                // with the push API bypasses that validation, so it is allowed only for a system
+                // administrator, who is trusted to manage the internal repository directly.
                 if (isMirrorOrCredentialFile(path)) {
+                    if (isSystemAdmin) {
+                        continue;
+                    }
                     throw new InvalidPushException(
                             "Mirror and credential files cannot be modified via the push API. Use the " +
                             "mirroring or credential REST API instead. (path: " + path + ')');
                 }
+                // Any other file is reserved for internal usage and cannot be pushed via the API,
+                // even by a system administrator.
                 throw new InvalidPushException(
                         "The " + repoName + " repository is reserved for internal usage.");
             }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/api/ContentServiceV1.java
@@ -32,19 +32,15 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 import org.jspecify.annotations.Nullable;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Streams;
 
 import com.linecorp.armeria.common.HttpHeaderNames;
 import com.linecorp.armeria.common.HttpResponse;
@@ -109,8 +105,6 @@ public class ContentServiceV1 extends AbstractService {
 
     static final AttributeKey<Boolean> IS_WATCH_REQUEST =
             AttributeKey.valueOf(ContentServiceV1.class, "IS_WATCH_REQUEST");
-
-    private static final String MIRROR_LOCAL_REPO = "localRepo";
 
     private final WatchService watchService;
     private final MeterRegistry meterRegistry;
@@ -586,40 +580,21 @@ public class ContentServiceV1 extends AbstractService {
 
     public static void checkMetaRepoPush(String repoName, Iterable<Change<?>> changes) {
         if (Project.REPO_DOGMA.equals(repoName) || Project.REPO_META.equals(repoName)) {
-            final boolean hasChangesOtherThanMetaRepoFiles =
-                    Streams.stream(changes).anyMatch(change -> !(METADATA_JSON.equals(change.path()) ||
-                                                                 isMirrorOrCredentialFile(change.path())));
-            if (hasChangesOtherThanMetaRepoFiles) {
+            for (Change<?> change : changes) {
+                final String path = change.path();
+                if (METADATA_JSON.equals(path)) {
+                    continue;
+                }
+                // Mirror and credential files must be managed via the dedicated mirroring and credential
+                // REST APIs, which validate the input (e.g. the credential scope). Writing them directly
+                // with the push API bypasses that validation, so it is not allowed.
+                if (isMirrorOrCredentialFile(path)) {
+                    throw new InvalidPushException(
+                            "Mirror and credential files cannot be modified via the push API. Use the " +
+                            "mirroring or credential REST API instead. (path: " + path + ')');
+                }
                 throw new InvalidPushException(
                         "The " + repoName + " repository is reserved for internal usage.");
-            }
-
-            // TODO(ikhoon): Disallow creating a mirror with the commit API. Mirroring REST API should be used
-            //               to validate the input.
-            final Optional<String> notAllowedLocalRepo =
-                    Streams.stream(changes)
-                           .filter(change -> isMirrorOrCredentialFile(change.path()))
-                           .filter(change -> change.content() != null)
-                           .map(change -> {
-                               final Object content = change.content();
-                               if (content instanceof JsonNode) {
-                                   final JsonNode node = (JsonNode) content;
-                                   if (!node.isObject()) {
-                                       return null;
-                                   }
-                                   final JsonNode localRepoNode = node.get(MIRROR_LOCAL_REPO);
-                                   if (localRepoNode != null) {
-                                       final String localRepo = localRepoNode.textValue();
-                                       if (Project.isInternalRepo(localRepo)) {
-                                           return localRepo;
-                                       }
-                                   }
-                               }
-                               return null;
-                           }).filter(Objects::nonNull).findFirst();
-            if (notAllowedLocalRepo.isPresent()) {
-                throw new InvalidPushException("invalid " + MIRROR_LOCAL_REPO + ": " +
-                                               notAllowedLocalRepo.get());
             }
         }
     }

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConverter.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/storage/repository/MirrorConverter.java
@@ -16,6 +16,8 @@
  */
 package com.linecorp.centraldogma.server.internal.storage.repository;
 
+import static com.linecorp.centraldogma.internal.CredentialUtil.validateCredentialName;
+
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -60,6 +62,10 @@ public final class MirrorConverter {
 
     static Mirror convertToMirror(MirrorConfig mirrorConfig, Project parent, Credential credential,
                                   Map<String, List<String>> trustedHostKeys) {
+        // Defense-in-depth: ensure the mirror only references a credential that belongs to its own
+        // repository or its project.
+        validateCredentialName(parent.name(), mirrorConfig.localRepo(), mirrorConfig.credentialName());
+
         final MirrorContext mirrorContext = new MirrorContext(
                 mirrorConfig.id(), mirrorConfig.enabled(), mirrorConfig.cronSchedule(),
                 mirrorConfig.direction(),

--- a/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/internal/thrift/CentralDogmaServiceImpl.java
@@ -315,7 +315,7 @@ public class CentralDogmaServiceImpl implements CentralDogmaService.AsyncIface {
         final List<com.linecorp.centraldogma.common.Change<?>> convertedChanges =
                 convert(changes, Converter::convert);
         try {
-            checkMetaRepoPush(repositoryName, convertedChanges);
+            checkMetaRepoPush(null, repositoryName, convertedChanges);
         } catch (Exception e) {
             resultHandler.onError(e);
             return;

--- a/server/src/test/java/com/linecorp/centraldogma/server/internal/api/CheckMetaRepoPushTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/internal/api/CheckMetaRepoPushTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.centraldogma.server.internal.api;
+
+import static com.linecorp.centraldogma.server.internal.api.ContentServiceV1.checkMetaRepoPush;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.google.common.collect.ImmutableList;
+
+import com.linecorp.centraldogma.common.Change;
+import com.linecorp.centraldogma.common.InvalidPushException;
+import com.linecorp.centraldogma.server.metadata.User;
+import com.linecorp.centraldogma.server.storage.project.Project;
+
+/**
+ * Verifies the meta/dogma repository push restriction enforced by
+ * {@link ContentServiceV1#checkMetaRepoPush(User, String, Iterable)}.
+ *
+ * <p>The restriction is relaxed only for mirror and credential files pushed by a system
+ * administrator. A regular file remains reserved for internal usage and is rejected for
+ * everyone, including a system administrator.
+ */
+class CheckMetaRepoPushTest {
+
+    private static final String REGULAR_FILE = "/foo.json";
+    private static final String METADATA_FILE = "/metadata.json";
+    private static final String MIRROR_FILE = "/repos/foo/mirrors/bar.json";
+    private static final String REPO_CREDENTIAL_FILE = "/repos/foo/credentials/bar.json";
+    private static final String PROJECT_CREDENTIAL_FILE = "/credentials/bar.json";
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void systemAdminMayPushMirrorAndCredentialFiles(String repoName) {
+        assertThatCode(() -> checkMetaRepoPush(User.SYSTEM_ADMIN, repoName, changes(MIRROR_FILE)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> checkMetaRepoPush(User.SYSTEM_ADMIN, repoName, changes(REPO_CREDENTIAL_FILE)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> checkMetaRepoPush(User.SYSTEM_ADMIN, repoName, changes(PROJECT_CREDENTIAL_FILE)))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void systemAdminMayNotPushRegularFile(String repoName) {
+        // A regular file is reserved for internal usage even for a system administrator.
+        assertThatThrownBy(() -> checkMetaRepoPush(User.SYSTEM_ADMIN, repoName, changes(REGULAR_FILE)))
+                .isInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("reserved for internal usage");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void nonAdminMayNotPushMirrorOrCredentialFiles(String repoName) {
+        for (String path : ImmutableList.of(MIRROR_FILE, REPO_CREDENTIAL_FILE, PROJECT_CREDENTIAL_FILE)) {
+            assertThatThrownBy(() -> checkMetaRepoPush(User.DEFAULT, repoName, changes(path)))
+                    .isInstanceOf(InvalidPushException.class)
+                    .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void nonAdminMayNotPushRegularFile(String repoName) {
+        assertThatThrownBy(() -> checkMetaRepoPush(User.DEFAULT, repoName, changes(REGULAR_FILE)))
+                .isInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("reserved for internal usage");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void anyoneMayPushMetadataFile(String repoName) {
+        assertThatCode(() -> checkMetaRepoPush(User.SYSTEM_ADMIN, repoName, changes(METADATA_FILE)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> checkMetaRepoPush(User.DEFAULT, repoName, changes(METADATA_FILE)))
+                .doesNotThrowAnyException();
+        // The Thrift push path passes a null user.
+        assertThatCode(() -> checkMetaRepoPush(null, repoName, changes(METADATA_FILE)))
+                .doesNotThrowAnyException();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = { Project.REPO_DOGMA, Project.REPO_META })
+    void nullUserIsNotTreatedAsSystemAdmin(String repoName) {
+        // The Thrift push path passes a null user, which must not be granted the system-admin relaxation.
+        assertThatThrownBy(() -> checkMetaRepoPush(null, repoName, changes(MIRROR_FILE)))
+                .isInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("Mirror and credential files cannot be modified via the push API");
+        assertThatThrownBy(() -> checkMetaRepoPush(null, repoName, changes(REGULAR_FILE)))
+                .isInstanceOf(InvalidPushException.class)
+                .hasMessageContaining("reserved for internal usage");
+    }
+
+    @Test
+    void nonMetaRepositoryHasNoRestriction() {
+        // A regular repository accepts any file regardless of the user.
+        assertThatCode(() -> checkMetaRepoPush(User.DEFAULT, "myRepo", changes(REGULAR_FILE)))
+                .doesNotThrowAnyException();
+        assertThatCode(() -> checkMetaRepoPush(null, "myRepo", changes(MIRROR_FILE)))
+                .doesNotThrowAnyException();
+    }
+
+    private static Iterable<Change<?>> changes(String path) {
+        return ImmutableList.of(Change.ofJsonUpsert(path, "{}"));
+    }
+}


### PR DESCRIPTION
Motivation:

A mirror references a credential by name. The intended rule is that a mirror may only use a credential scoped to its own repository or to its project. However, this was only enforced when a mirror was created or updated through the dedicated mirroring REST API (in the MirrorRequest constructor). The resolution path performed no scope check, and the generic push API (HTTP content push and Thrift push) allowed mirror and credential files to be written directly to the meta repository, bypassing that validation entirely.

Modifications:

- MirrorConverter.convertToMirror: re-validate the credential scope against the mirror's project and localRepo when a mirror is built from stored config, so an out-of-scope credential is never used even if the config reached storage by some other path (defense-in-depth).
- ContentServiceV1.checkMetaRepoPush: reject any push to the dogma/meta repository that creates or modifies a mirror or credential file, directing callers to the dedicated mirroring/credential REST API. metadata.json remains allowed and other files remain rejected as before. Removed the now unreachable localRepo check and the imports/constant it required.

Result:

- A mirror can no longer use a credential that belongs to a different repository; it is limited to its own repository or its project.
- Mirror and credential files can only be managed through the mirroring and credential REST APIs.