### PR TITLE
Add endsWith/startsWith/under factory methods to PathPattern

### DIFF
--- a/common/src/main/java/com/linecorp/centraldogma/common/DefaultPathPattern.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/DefaultPathPattern.java
@@ -31,6 +31,11 @@ final class DefaultPathPattern implements PathPattern {
 
     private static final Pattern PATH_PATTERN_PATTERN = Pattern.compile("^[- /*_.0-9a-zA-Z]+$");
 
+    /**
+     * The pattern that a file extension must match; only alphanumeric characters are allowed.
+     */
+    private static final Pattern EXTENSION_PATTERN = Pattern.compile("^[a-zA-Z0-9]+$");
+
     static final String ALL = "/**";
 
     static final DefaultPathPattern allPattern = new DefaultPathPattern(ALL, ALL);
@@ -98,6 +103,19 @@ final class DefaultPathPattern implements PathPattern {
         checkArgument(PATH_PATTERN_PATTERN.matcher(pattern).matches(),
                       "pattern: %s (expected: %s)", pattern, PATH_PATTERN_PATTERN);
         return pattern;
+    }
+
+    /**
+     * Strips an optional leading dot from {@code extension} and validates that the rest consists of
+     * alphanumeric characters only.
+     */
+    static String normalizeExtension(String extension) {
+        final String normalized = extension.startsWith(".") ? extension.substring(1) : extension;
+        checkArgument(!normalized.isEmpty(), "extension is empty.");
+        checkArgument(EXTENSION_PATTERN.matcher(normalized).matches(),
+                      "extension: %s (expected: an alphanumeric extension such as \"json\" or \".json\")",
+                      extension);
+        return normalized;
     }
 
     @Override

--- a/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
@@ -15,9 +15,12 @@
  */
 package com.linecorp.centraldogma.common;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.common.DefaultPathPattern.ALL;
 import static com.linecorp.centraldogma.common.DefaultPathPattern.allPattern;
 import static java.util.Objects.requireNonNull;
+
+import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
@@ -35,6 +38,11 @@ import com.google.common.collect.Streams;
  * </ul>
  */
 public interface PathPattern {
+
+    /**
+     * The pattern that a file extension must match; only alphanumeric characters are allowed.
+     */
+    Pattern EXTENSION_PATTERN = Pattern.compile("^[a-zA-Z0-9]+$");
 
     /**
      * Returns the path pattern that represents all files.
@@ -65,15 +73,17 @@ public interface PathPattern {
     /**
      * Creates a path pattern that matches the files whose extension is the specified {@code extension}.
      * A leading dot in {@code extension} is optional and is added automatically if missing.
+     * The {@code extension} must consist of alphanumeric characters only.
      * For example, {@code PathPattern.ofExtension("json")} matches all JSON files at any depth,
      * which is equivalent to <code>PathPattern.of("/&#42;&#42;/*.json")</code>.
      */
     static PathPattern ofExtension(String extension) {
         requireNonNull(extension, "extension");
-        if (extension.startsWith(".")) {
-            return of("/**/*" + extension);
-        }
-        return of("/**/*." + extension);
+        final String normalized = extension.startsWith(".") ? extension.substring(1) : extension;
+        checkArgument(EXTENSION_PATTERN.matcher(normalized).matches(),
+                      "extension: %s (expected: an alphanumeric extension such as \"json\" or \".json\")",
+                      extension);
+        return of("/**/*." + normalized);
     }
 
     /**
@@ -82,14 +92,14 @@ public interface PathPattern {
      * The match is not restricted to complete path segments; for example,
      * {@code PathPattern.startsWith("/foo/ba")} matches both {@code /foo/bar/a.txt} and {@code /foo/baz.txt},
      * which is equivalent to <code>PathPattern.of("/foo/ba&#42;&#42;")</code>.
+     * The {@code prefix} must not contain a wildcard character ({@code '*'}).
      * Use {@link #under(String)} to match only the files under a directory.
      */
     static PathPattern startsWith(String prefix) {
         requireNonNull(prefix, "prefix");
-        if (prefix.startsWith("/")) {
-            return of(prefix + "**");
-        }
-        return of('/' + prefix + "**");
+        checkArgument(prefix.indexOf('*') < 0, "prefix: %s (must not contain '*')", prefix);
+        final String normalized = prefix.startsWith("/") ? prefix : '/' + prefix;
+        return of(normalized + "**");
     }
 
     /**
@@ -99,9 +109,11 @@ public interface PathPattern {
      * complete path segments; for example, {@code PathPattern.under("/foo/bar")} matches {@code /foo/bar/a.txt}
      * but not {@code /foo/bar-baz.txt}, which is equivalent to
      * <code>PathPattern.of("/foo/bar/&#42;&#42;")</code>.
+     * The {@code directory} must not contain a wildcard character ({@code '*'}).
      */
     static PathPattern under(String directory) {
         requireNonNull(directory, "directory");
+        checkArgument(directory.indexOf('*') < 0, "directory: %s (must not contain '*')", directory);
         String dir = directory;
         if (!dir.startsWith("/")) {
             dir = '/' + dir;

--- a/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
@@ -63,39 +63,53 @@ public interface PathPattern {
     }
 
     /**
-     * Creates a path pattern that matches the files whose extension is the specified {@code suffix}.
-     * A leading dot in {@code suffix} is optional and is added automatically if missing.
-     * For example, {@code PathPattern.endsWith("json")} matches all JSON files at any depth,
+     * Creates a path pattern that matches the files whose extension is the specified {@code extension}.
+     * A leading dot in {@code extension} is optional and is added automatically if missing.
+     * For example, {@code PathPattern.ofExtension("json")} matches all JSON files at any depth,
      * which is equivalent to <code>PathPattern.of("/&#42;&#42;/*.json")</code>.
      */
-    static PathPattern endsWith(String suffix) {
-        requireNonNull(suffix, "suffix");
-        if (suffix.startsWith(".")) {
-            return of("/**/*" + suffix);
+    static PathPattern ofExtension(String extension) {
+        requireNonNull(extension, "extension");
+        if (extension.startsWith(".")) {
+            return of("/**/*" + extension);
         }
-        return of("/**/*." + suffix);
+        return of("/**/*." + extension);
     }
 
     /**
-     * Creates a path pattern that matches the files under the specified {@code prefix} directory.
-     * For example, {@code PathPattern.startsWith("/foo/bar")} matches all files under
-     * the directory {@code /foo/bar}, which is equivalent to
-     * <code>PathPattern.of("/foo/bar/&#42;&#42;")</code>.
+     * Creates a path pattern that matches the files whose path starts with the specified {@code prefix}.
+     * The {@code prefix} is anchored at the root, so a leading slash is added automatically if missing.
+     * The match is not restricted to complete path segments; for example,
+     * {@code PathPattern.startsWith("/foo/ba")} matches both {@code /foo/bar/a.txt} and {@code /foo/baz.txt},
+     * which is equivalent to <code>PathPattern.of("/foo/ba&#42;&#42;")</code>.
+     * Use {@link #under(String)} to match only the files under a directory.
      */
     static PathPattern startsWith(String prefix) {
         requireNonNull(prefix, "prefix");
-        if (prefix.endsWith("/")) {
+        if (prefix.startsWith("/")) {
             return of(prefix + "**");
         }
-        return of(prefix + "/**");
+        return of('/' + prefix + "**");
     }
 
     /**
      * Creates a path pattern that matches the files under the specified {@code directory}.
-     * This is an alias of {@link #startsWith(String)}.
+     * The {@code directory} is anchored at the root, so a leading slash is added automatically if missing,
+     * and a trailing slash is optional. Unlike {@link #startsWith(String)}, the match is restricted to
+     * complete path segments; for example, {@code PathPattern.under("/foo/bar")} matches {@code /foo/bar/a.txt}
+     * but not {@code /foo/bar-baz.txt}, which is equivalent to
+     * <code>PathPattern.of("/foo/bar/&#42;&#42;")</code>.
      */
     static PathPattern under(String directory) {
-        return startsWith(directory);
+        requireNonNull(directory, "directory");
+        String dir = directory;
+        if (!dir.startsWith("/")) {
+            dir = '/' + dir;
+        }
+        if (dir.endsWith("/")) {
+            return of(dir + "**");
+        }
+        return of(dir + "/**");
     }
 
     /**

--- a/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
@@ -63,6 +63,42 @@ public interface PathPattern {
     }
 
     /**
+     * Creates a path pattern that matches the files whose extension is the specified {@code suffix}.
+     * A leading dot in {@code suffix} is optional and is added automatically if missing.
+     * For example, {@code PathPattern.endsWith("json")} matches all JSON files at any depth,
+     * which is equivalent to <code>PathPattern.of("/&#42;&#42;/*.json")</code>.
+     */
+    static PathPattern endsWith(String suffix) {
+        requireNonNull(suffix, "suffix");
+        if (suffix.startsWith(".")) {
+            return of("/**/*" + suffix);
+        }
+        return of("/**/*." + suffix);
+    }
+
+    /**
+     * Creates a path pattern that matches the files under the specified {@code prefix} directory.
+     * For example, {@code PathPattern.startsWith("/foo/bar")} matches all files under
+     * the directory {@code /foo/bar}, which is equivalent to
+     * <code>PathPattern.of("/foo/bar/&#42;&#42;")</code>.
+     */
+    static PathPattern startsWith(String prefix) {
+        requireNonNull(prefix, "prefix");
+        if (prefix.endsWith("/")) {
+            return of(prefix + "**");
+        }
+        return of(prefix + "/**");
+    }
+
+    /**
+     * Creates a path pattern that matches the files under the specified {@code directory}.
+     * This is an alias of {@link #startsWith(String)}.
+     */
+    static PathPattern under(String directory) {
+        return startsWith(directory);
+    }
+
+    /**
      * Returns the path pattern that concatenates the {@code patterns} using ','.
      */
     String patternString();

--- a/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
+++ b/common/src/main/java/com/linecorp/centraldogma/common/PathPattern.java
@@ -18,9 +18,8 @@ package com.linecorp.centraldogma.common;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.linecorp.centraldogma.common.DefaultPathPattern.ALL;
 import static com.linecorp.centraldogma.common.DefaultPathPattern.allPattern;
+import static com.linecorp.centraldogma.common.DefaultPathPattern.normalizeExtension;
 import static java.util.Objects.requireNonNull;
-
-import java.util.regex.Pattern;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
@@ -38,11 +37,6 @@ import com.google.common.collect.Streams;
  * </ul>
  */
 public interface PathPattern {
-
-    /**
-     * The pattern that a file extension must match; only alphanumeric characters are allowed.
-     */
-    Pattern EXTENSION_PATTERN = Pattern.compile("^[a-zA-Z0-9]+$");
 
     /**
      * Returns the path pattern that represents all files.
@@ -79,11 +73,7 @@ public interface PathPattern {
      */
     static PathPattern ofExtension(String extension) {
         requireNonNull(extension, "extension");
-        final String normalized = extension.startsWith(".") ? extension.substring(1) : extension;
-        checkArgument(EXTENSION_PATTERN.matcher(normalized).matches(),
-                      "extension: %s (expected: an alphanumeric extension such as \"json\" or \".json\")",
-                      extension);
-        return of("/**/*." + normalized);
+        return of("/**/*." + normalizeExtension(extension));
     }
 
     /**
@@ -97,6 +87,7 @@ public interface PathPattern {
      */
     static PathPattern startsWith(String prefix) {
         requireNonNull(prefix, "prefix");
+        checkArgument(!prefix.isEmpty(), "prefix is empty.");
         checkArgument(prefix.indexOf('*') < 0, "prefix: %s (must not contain '*')", prefix);
         final String normalized = prefix.startsWith("/") ? prefix : '/' + prefix;
         return of(normalized + "**");
@@ -113,6 +104,7 @@ public interface PathPattern {
      */
     static PathPattern under(String directory) {
         requireNonNull(directory, "directory");
+        checkArgument(!directory.isEmpty(), "directory is empty.");
         checkArgument(directory.indexOf('*') < 0, "directory: %s (must not contain '*')", directory);
         String dir = directory;
         if (!dir.startsWith("/")) {

--- a/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
@@ -47,21 +47,26 @@ class DefaultPathPatternTest {
     }
 
     @Test
-    void endsWith() {
-        assertThat(PathPattern.endsWith("json").patternString()).isEqualTo("/**/*.json");
-        assertThat(PathPattern.endsWith(".json").patternString()).isEqualTo("/**/*.json");
+    void ofExtension() {
+        assertThat(PathPattern.ofExtension("json").patternString()).isEqualTo("/**/*.json");
+        assertThat(PathPattern.ofExtension(".json").patternString()).isEqualTo("/**/*.json");
     }
 
     @Test
     void startsWith() {
-        assertThat(PathPattern.startsWith("/foo/bar").patternString()).isEqualTo("/foo/bar/**");
-        assertThat(PathPattern.startsWith("/foo/bar/").patternString()).isEqualTo("/foo/bar/**");
+        assertThat(PathPattern.startsWith("/foo/bar").patternString()).isEqualTo("/foo/bar**");
+        // A leading slash is added automatically so the prefix is anchored at the root.
+        assertThat(PathPattern.startsWith("foo/bar").patternString()).isEqualTo("/foo/bar**");
+        // The match is not restricted to complete path segments.
+        assertThat(PathPattern.startsWith("/foo/ba").patternString()).isEqualTo("/foo/ba**");
     }
 
     @Test
     void under() {
-        assertThat(PathPattern.under("/foo/bar").patternString())
-                .isEqualTo(PathPattern.startsWith("/foo/bar").patternString());
+        assertThat(PathPattern.under("/foo/bar").patternString()).isEqualTo("/foo/bar/**");
+        assertThat(PathPattern.under("/foo/bar/").patternString()).isEqualTo("/foo/bar/**");
+        // A leading slash is added automatically so the directory is anchored at the root.
+        assertThat(PathPattern.under("foo/bar").patternString()).isEqualTo("/foo/bar/**");
     }
 
     @Test

--- a/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
@@ -80,6 +80,12 @@ class DefaultPathPatternTest {
     }
 
     @Test
+    void startsWithRejectsEmpty() {
+        assertThatThrownBy(() -> PathPattern.startsWith(""))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void under() {
         assertThat(PathPattern.under("/foo/bar").patternString()).isEqualTo("/foo/bar/**");
         assertThat(PathPattern.under("/foo/bar/").patternString()).isEqualTo("/foo/bar/**");
@@ -90,6 +96,12 @@ class DefaultPathPatternTest {
     @Test
     void underRejectsWildcard() {
         assertThatThrownBy(() -> PathPattern.under("/a/**"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void underRejectsEmpty() {
+        assertThatThrownBy(() -> PathPattern.under(""))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
@@ -53,6 +53,18 @@ class DefaultPathPatternTest {
     }
 
     @Test
+    void ofExtensionRejectsNonAlphanumeric() {
+        assertThatThrownBy(() -> PathPattern.ofExtension("/foo/bar"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PathPattern.ofExtension("json.gz"))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PathPattern.ofExtension(""))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> PathPattern.ofExtension("."))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void startsWith() {
         assertThat(PathPattern.startsWith("/foo/bar").patternString()).isEqualTo("/foo/bar**");
         // A leading slash is added automatically so the prefix is anchored at the root.
@@ -62,11 +74,23 @@ class DefaultPathPatternTest {
     }
 
     @Test
+    void startsWithRejectsWildcard() {
+        assertThatThrownBy(() -> PathPattern.startsWith("/foo/*"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void under() {
         assertThat(PathPattern.under("/foo/bar").patternString()).isEqualTo("/foo/bar/**");
         assertThat(PathPattern.under("/foo/bar/").patternString()).isEqualTo("/foo/bar/**");
         // A leading slash is added automatically so the directory is anchored at the root.
         assertThat(PathPattern.under("foo/bar").patternString()).isEqualTo("/foo/bar/**");
+    }
+
+    @Test
+    void underRejectsWildcard() {
+        assertThatThrownBy(() -> PathPattern.under("/a/**"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
+++ b/common/src/test/java/com/linecorp/centraldogma/common/DefaultPathPatternTest.java
@@ -47,6 +47,24 @@ class DefaultPathPatternTest {
     }
 
     @Test
+    void endsWith() {
+        assertThat(PathPattern.endsWith("json").patternString()).isEqualTo("/**/*.json");
+        assertThat(PathPattern.endsWith(".json").patternString()).isEqualTo("/**/*.json");
+    }
+
+    @Test
+    void startsWith() {
+        assertThat(PathPattern.startsWith("/foo/bar").patternString()).isEqualTo("/foo/bar/**");
+        assertThat(PathPattern.startsWith("/foo/bar/").patternString()).isEqualTo("/foo/bar/**");
+    }
+
+    @Test
+    void under() {
+        assertThat(PathPattern.under("/foo/bar").patternString())
+                .isEqualTo(PathPattern.startsWith("/foo/bar").patternString());
+    }
+
+    @Test
     void testEncodePathPattern() {
         assertThat(encodePathPattern("/")).isEqualTo("/");
         assertThat(encodePathPattern(" ")).isEqualTo("%20");


### PR DESCRIPTION
Motivation:

As pointed out in #659, creating a `PathPattern` that matches all files with a given extension or all files under a given directory currently requires the caller to hand-write a glob string (e.g. `PathPattern.of("/**/*.json")` or `PathPattern.of("/foo/bar/**")`). Common factory methods for these two everyday cases would make the API easier to discover and use correctly.

Modifications:

- Add `PathPattern.endsWith(String suffix)`, which builds a pattern matching files by extension at any depth (e.g. `PathPattern.endsWith("json")` and `PathPattern.endsWith(".json")` both produce `/**/*.json`).
- Add `PathPattern.startsWith(String prefix)`, which builds a pattern matching all files under the given directory (e.g. `PathPattern.startsWith("/foo/bar")` produces `/foo/bar/**`; a trailing slash on `prefix` is handled).
- Add `PathPattern.under(String directory)` as a more readable alias for `startsWith(String)`.
- Add unit tests for all three new methods in `DefaultPathPatternTest`.

This PR intentionally covers only the `endsWith`/`startsWith`/`under` factory methods requested in #659. The issue's last example (composing multiple patterns so that a file must match *all* of them, e.g. `/foo/bar/**/*.json`) would require the matching engine to support AND-composition in addition to the current OR-only semantics (see `PathPattern`'s class Javadoc and `PathPatternFilter`), which is a larger design change. I'd suggest tracking that separately if there's still interest — happy to help with it as a follow-up once the direction is confirmed.

Result:

- Closes part of #659 (the `endsWith`/`startsWith`/`under` factory methods; AND-composition and `builder()` are left for a follow-up discussion).
- `PathPattern` now provides convenient factory methods for the two most common patterns, without changing any existing behavior.

Test plan:

```
$ ./gradlew :common:test --tests "com.linecorp.centraldogma.common.DefaultPathPatternTest"
BUILD SUCCESSFUL
6 tests completed, 0 failed (3 new: endsWith(), startsWith(), under())

$ ./gradlew :common:checkstyleMain :common:checkstyleTest
BUILD SUCCESSFUL

$ ./gradlew :common:javadoc
BUILD SUCCESSFUL
```
