### PR TITLE
Speed up the first file view by prefetching and compressing Monaco

### DIFF
--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -260,11 +260,10 @@ public class CentralDogma implements AutoCloseable {
 
     private static final int DEFAULT_MAX_FRAME_LENGTH = 1024 * 1024; // 1 MiB
 
-    // The largest pre-compressed web asset (e.g. the ~910 KiB Brotli-compressed Monaco TypeScript worker) is
-    // comfortably under 1 MiB, so we raise the FileService cache-entry limit above Armeria's 64 KiB default.
-    // Otherwise the heavy Monaco chunks and workers would exceed the default and be re-read from the classpath
-    // on every request instead of being served from the in-memory cache.
-    private static final int WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES = 1024 * 1024; // 1 MiB
+    // Keep enough room for its upstream growth while raising the FileService cache-entry limit above Armeria's
+    // 64 KiB default. Otherwise heavy Monaco chunks and workers would be re-read from the classpath on every
+    // request instead of being served from the in-memory cache.
+    static final int WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES = 2 * 1024 * 1024; // 2 MiB
 
     /**
      * Creates a new instance from the given configuration file.

--- a/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
+++ b/server/src/main/java/com/linecorp/centraldogma/server/CentralDogma.java
@@ -260,6 +260,12 @@ public class CentralDogma implements AutoCloseable {
 
     private static final int DEFAULT_MAX_FRAME_LENGTH = 1024 * 1024; // 1 MiB
 
+    // The largest pre-compressed web asset (e.g. the ~910 KiB Brotli-compressed Monaco TypeScript worker) is
+    // comfortably under 1 MiB, so we raise the FileService cache-entry limit above Armeria's 64 KiB default.
+    // Otherwise the heavy Monaco chunks and workers would exceed the default and be re-read from the classpath
+    // on every request instead of being served from the in-memory cache.
+    private static final int WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES = 1024 * 1024; // 1 MiB
+
     /**
      * Creates a new instance from the given configuration file.
      *
@@ -1116,6 +1122,7 @@ public class CentralDogma implements AutoCloseable {
                                 .cacheControl(ServerCacheControl.REVALIDATED)
                                 .autoDecompress(true)
                                 .serveCompressedFiles(true)
+                                .maxCacheEntrySizeBytes(WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES)
                                 .fallbackFileExtensions("html")
                                 .build());
         }

--- a/server/src/test/java/com/linecorp/centraldogma/server/WebappCacheEntrySizeTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/WebappCacheEntrySizeTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package com.linecorp.centraldogma.server;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+class WebappCacheEntrySizeTest {
+
+    private static final String WEBAPP_RESOURCE_ROOT = "com/linecorp/centraldogma/webapp";
+
+    @Test
+    void precompressedAssetsFitInTheFileServiceCache() throws Exception {
+        final URL resourceRoot =
+                WebappCacheEntrySizeTest.class.getClassLoader().getResource(WEBAPP_RESOURCE_ROOT);
+        assertThat(resourceRoot).as("webapp resource root").isNotNull();
+        assertThat(resourceRoot.getProtocol()).isEqualTo("file");
+
+        final Path root = Path.of(resourceRoot.toURI());
+        final List<String> oversizedAssets;
+        try (Stream<Path> paths = Files.walk(root)) {
+            oversizedAssets = paths.filter(Files::isRegularFile)
+                                   .filter(WebappCacheEntrySizeTest::isPrecompressedAsset)
+                                   .filter(path -> size(path) > CentralDogma.WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES)
+                                   .map(path -> root.relativize(path) + " (" + size(path) + " bytes)")
+                                   .collect(Collectors.toList());
+        }
+
+        assertThat(oversizedAssets)
+                .as("pre-compressed webapp assets must fit in the %,d-byte FileService cache entry",
+                    CentralDogma.WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES)
+                .isEmpty();
+    }
+
+    private static boolean isPrecompressedAsset(Path path) {
+        final String name = path.getFileName().toString();
+        return name.endsWith(".br") || name.endsWith(".gz");
+    }
+
+    private static long size(Path path) {
+        try {
+            return Files.size(path);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read webapp asset size: " + path, e);
+        }
+    }
+}

--- a/server/src/test/java/com/linecorp/centraldogma/server/WebappCacheEntrySizeTest.java
+++ b/server/src/test/java/com/linecorp/centraldogma/server/WebappCacheEntrySizeTest.java
@@ -19,10 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.JarURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -37,17 +39,9 @@ class WebappCacheEntrySizeTest {
         final URL resourceRoot =
                 WebappCacheEntrySizeTest.class.getClassLoader().getResource(WEBAPP_RESOURCE_ROOT);
         assertThat(resourceRoot).as("webapp resource root").isNotNull();
-        assertThat(resourceRoot.getProtocol()).isEqualTo("file");
 
-        final Path root = Path.of(resourceRoot.toURI());
-        final List<String> oversizedAssets;
-        try (Stream<Path> paths = Files.walk(root)) {
-            oversizedAssets = paths.filter(Files::isRegularFile)
-                                   .filter(WebappCacheEntrySizeTest::isPrecompressedAsset)
-                                   .filter(path -> size(path) > CentralDogma.WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES)
-                                   .map(path -> root.relativize(path) + " (" + size(path) + " bytes)")
-                                   .collect(Collectors.toList());
-        }
+        final List<String> oversizedAssets =
+                findOversizedAssets(resourceRoot, CentralDogma.WEBAPP_MAX_CACHE_ENTRY_SIZE_BYTES);
 
         assertThat(oversizedAssets)
                 .as("pre-compressed webapp assets must fit in the %,d-byte FileService cache entry",
@@ -55,9 +49,58 @@ class WebappCacheEntrySizeTest {
                 .isEmpty();
     }
 
+    private static List<String> findOversizedAssets(URL resourceRoot, long maxSizeBytes) throws Exception {
+        if ("file".equals(resourceRoot.getProtocol())) {
+            return findOversizedAssets(Path.of(resourceRoot.toURI()), maxSizeBytes);
+        }
+        if ("jar".equals(resourceRoot.getProtocol())) {
+            return findOversizedAssetsInJar(resourceRoot, maxSizeBytes);
+        }
+        throw new IllegalArgumentException("unsupported webapp resource protocol: " + resourceRoot);
+    }
+
+    private static List<String> findOversizedAssets(Path root, long maxSizeBytes) throws IOException {
+        try (Stream<Path> paths = Files.walk(root)) {
+            return paths.filter(Files::isRegularFile)
+                        .filter(WebappCacheEntrySizeTest::isPrecompressedAsset)
+                        .filter(path -> size(path) > maxSizeBytes)
+                        .map(path -> root.relativize(path) + " (" + size(path) + " bytes)")
+                        .collect(Collectors.toList());
+        }
+    }
+
+    private static List<String> findOversizedAssetsInJar(URL resourceRoot, long maxSizeBytes)
+            throws IOException {
+        final JarURLConnection connection = (JarURLConnection) resourceRoot.openConnection();
+        connection.setUseCaches(false);
+        final String root = connection.getEntryName();
+        if (root == null) {
+            throw new IllegalArgumentException("webapp resource root is missing from URL: " + resourceRoot);
+        }
+
+        try (JarFile jar = connection.getJarFile()) {
+            final String resourcePrefix = root + '/';
+            return jar.stream()
+                      .filter(entry -> !entry.isDirectory())
+                      .filter(entry -> entry.getName().startsWith(resourcePrefix))
+                      .filter(entry -> isPrecompressedAsset(entry.getName()))
+                      .filter(entry -> entry.getSize() > maxSizeBytes)
+                      .map(entry -> formatAssetSize(entry.getName().substring(resourcePrefix.length()),
+                                                     entry.getSize()))
+                      .collect(Collectors.toList());
+        }
+    }
+
     private static boolean isPrecompressedAsset(Path path) {
-        final String name = path.getFileName().toString();
+        return isPrecompressedAsset(path.getFileName().toString());
+    }
+
+    private static boolean isPrecompressedAsset(String name) {
         return name.endsWith(".br") || name.endsWith(".gz");
+    }
+
+    private static String formatAssetSize(String path, long size) {
+        return path + " (" + size + " bytes)";
     }
 
     private static long size(Path path) {

--- a/webapp/build.gradle
+++ b/webapp/build.gradle
@@ -46,6 +46,7 @@ tasks.register('buildWeb', NpmTask) {
     inputs.file('package.json')
     inputs.file('package-lock.json')
     inputs.file('next.config.js')
+    inputs.file('scripts/compress-static.mjs')
 
     outputs.dir('build/web')
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,7 +9,7 @@
     "develop": "NEXT_PUBLIC_HOST=\"http://127.0.0.1:36462\" NEXT_ENV=\"development\" next dev --hostname 127.0.0.1",
     "backend": "../gradlew runTestShiroServer -PnoWeb",
     "mock": "NEXT_ENV=\"development\" next dev",
-    "build": "next build",
+    "build": "next build && node scripts/compress-static.mjs",
     "start": "next start",
     "lint": "next lint",
     "lint:fix": "next lint --fix --ext .json,.js,.jsx,.ts,.tsx .",

--- a/webapp/scripts/compress-static.mjs
+++ b/webapp/scripts/compress-static.mjs
@@ -47,27 +47,26 @@ async function* walk(dir) {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   for (const entry of entries) {
     const fullPath = path.join(dir, entry.name);
-    let isDirectory = entry.isDirectory();
-    let isFile = entry.isFile();
-    // A symlink dirent reports neither isDirectory() nor isFile(); resolve it so linked asset dirs/files
-    // (possible in monorepo/CI layouts) are compressed instead of silently skipped.
-    if (entry.isSymbolicLink()) {
-      try {
-        const stats = await fs.stat(fullPath);
-        isDirectory = stats.isDirectory();
-        isFile = stats.isFile();
-      } catch {
-        // Dangling symlink: nothing to compress.
-        continue;
-      }
-    }
-    if (isDirectory) {
+    if (entry.isDirectory()) {
       if (SKIP_DIRECTORIES.has(entry.name)) {
         continue;
       }
       yield* walk(fullPath);
-    } else if (isFile) {
+    } else if (entry.isFile()) {
       yield fullPath;
+    } else if (entry.isSymbolicLink()) {
+      // Follow a symlink only when it resolves to a regular file, so linked assets (possible in monorepo/CI
+      // layouts) aren't silently skipped. Never recurse into a symlinked directory: a link pointing back to
+      // an ancestor forms a cycle that would re-traverse the tree until the filesystem's symlink limit is
+      // hit. Next.js export output doesn't nest linked directories, so skipping them is safe.
+      try {
+        const stats = await fs.stat(fullPath);
+        if (stats.isFile()) {
+          yield fullPath;
+        }
+      } catch {
+        // Dangling symlink: nothing to compress.
+      }
     }
   }
 }

--- a/webapp/scripts/compress-static.mjs
+++ b/webapp/scripts/compress-static.mjs
@@ -1,0 +1,153 @@
+/*
+ * Pre-compresses the static web build output into `.br` (Brotli) and `.gz` (gzip) siblings so the Central
+ * Dogma server can serve them directly via `FileService.serveCompressedFiles(true)` instead of shipping the
+ * multi-megabyte assets (e.g. the ~3.2MB Monaco chunk, the ~5.7MB TypeScript worker) uncompressed.
+ *
+ * Runs after `next build` against the final export output. The uncompressed originals are kept for clients
+ * that do not advertise `Accept-Encoding: br`/`gzip`; `FileService.autoDecompress(true)` covers the rest.
+ * Compression happens at build time, so we use the maximum Brotli quality regardless of CPU cost.
+ */
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import zlib from 'node:zlib';
+
+// Mirror next.config.js's `distDir` (`process.env.NEXT_DIST_DIR || 'build/web/'`). The trailing slash there
+// is irrelevant here because paths are always joined with `path.join`.
+const OUTPUT_DIR = process.env.NEXT_DIST_DIR || 'build/web';
+
+// Only text-based assets are worth compressing; binary media (png, ico, woff2, …) barely shrink.
+const COMPRESSIBLE_EXTENSIONS = new Set([
+  '.js',
+  '.mjs',
+  '.css',
+  '.html',
+  '.json',
+  '.svg',
+  '.txt',
+  '.map',
+  '.xml',
+  '.wasm',
+  '.webmanifest',
+]);
+
+// Next.js keeps its webpack build cache under `cache/`; it is never served, so skip it entirely.
+const SKIP_DIRECTORIES = new Set(['cache']);
+
+// Files below this size don't benefit once compression framing overhead is accounted for.
+const MIN_BYTES = 1024;
+
+// Async (libuv threadpool) variants so multiple files — and the gzip/brotli of a single file — can be
+// compressed concurrently instead of blocking the main thread one at a time.
+const gzipAsync = promisify(zlib.gzip);
+const brotliCompressAsync = promisify(zlib.brotliCompress);
+
+async function* walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    let isDirectory = entry.isDirectory();
+    let isFile = entry.isFile();
+    // A symlink dirent reports neither isDirectory() nor isFile(); resolve it so linked asset dirs/files
+    // (possible in monorepo/CI layouts) are compressed instead of silently skipped.
+    if (entry.isSymbolicLink()) {
+      try {
+        const stats = await fs.stat(fullPath);
+        isDirectory = stats.isDirectory();
+        isFile = stats.isFile();
+      } catch {
+        // Dangling symlink: nothing to compress.
+        continue;
+      }
+    }
+    if (isDirectory) {
+      if (SKIP_DIRECTORIES.has(entry.name)) {
+        continue;
+      }
+      yield* walk(fullPath);
+    } else if (isFile) {
+      yield fullPath;
+    }
+  }
+}
+
+// Compresses one file into `.gz`/`.br` siblings, returning its byte totals for reporting, or null when the
+// file is too small to be worth compressing. gzip and brotli run concurrently.
+async function compressFile(file) {
+  const original = await fs.readFile(file);
+  if (original.length < MIN_BYTES) {
+    return null;
+  }
+
+  const [gzip, brotli] = await Promise.all([
+    gzipAsync(original, { level: zlib.constants.Z_BEST_COMPRESSION }),
+    brotliCompressAsync(original, {
+      params: {
+        [zlib.constants.BROTLI_PARAM_QUALITY]: zlib.constants.BROTLI_MAX_QUALITY,
+        [zlib.constants.BROTLI_PARAM_SIZE_HINT]: original.length,
+      },
+    }),
+  ]);
+
+  // Only emit a variant that actually beats the original, so we never serve a larger "compressed" file.
+  const writes = [];
+  if (gzip.length < original.length) {
+    writes.push(fs.writeFile(`${file}.gz`, gzip));
+  }
+  if (brotli.length < original.length) {
+    writes.push(fs.writeFile(`${file}.br`, brotli));
+  }
+  await Promise.all(writes);
+
+  return {
+    originalLength: original.length,
+    // The size actually served to a brotli-capable client: the `.br` when it won, else the original.
+    compressedLength: Math.min(brotli.length, original.length),
+  };
+}
+
+async function main() {
+  const files = [];
+  for await (const file of walk(OUTPUT_DIR)) {
+    if (COMPRESSIBLE_EXTENSIONS.has(path.extname(file).toLowerCase())) {
+      files.push(file);
+    }
+  }
+
+  let fileCount = 0;
+  let originalTotal = 0;
+  let compressedTotal = 0;
+
+  // Compress files across a bounded worker pool so idle cores are used without spawning an unbounded number
+  // of concurrent compressions on large builds. JS is single-threaded, so grabbing `cursor` between awaits
+  // hands each worker a distinct file with no locking.
+  const concurrency = Math.max(1, os.cpus().length - 1);
+  let cursor = 0;
+  const worker = async () => {
+    while (cursor < files.length) {
+      const file = files[cursor];
+      cursor += 1;
+      const result = await compressFile(file);
+      if (result) {
+        fileCount += 1;
+        originalTotal += result.originalLength;
+        compressedTotal += result.compressedLength;
+      }
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(concurrency, files.length) }, worker));
+
+  const savedPct =
+    originalTotal === 0 ? '0.0' : ((1 - compressedTotal / originalTotal) * 100).toFixed(1);
+  const toMb = (bytes) => (bytes / 1e6).toFixed(2);
+  console.log(
+    `[compress-static] Precompressed ${fileCount} files in ${OUTPUT_DIR}: ` +
+      `${toMb(originalTotal)}MB -> ${toMb(compressedTotal)}MB brotli (${savedPct}% smaller).`,
+  );
+}
+
+main().catch((err) => {
+  console.error('[compress-static] Failed to precompress static assets:', err);
+  process.exitCode = 1;
+});

--- a/webapp/src/dogma/common/components/JsonDiffEditor.tsx
+++ b/webapp/src/dogma/common/components/JsonDiffEditor.tsx
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import { DiffEditor, loader } from '@monaco-editor/react';
+import { DiffEditor } from '@monaco-editor/react';
 import { useColorMode } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Loading } from 'dogma/common/components/Loading';
+import { loadMonaco } from 'dogma/features/file/MonacoLoader';
 
 interface JsonDiffEditorProps {
   // The left-hand (baseline) document, e.g. the content before a change.
@@ -34,14 +35,15 @@ export const JsonDiffEditor = ({ original, modified, height = '60vh' }: JsonDiff
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      const monaco = await import('monaco-editor');
-      loader.config({ monaco });
-      await loader.init();
-      if (active) {
-        setReady(true);
-      }
-    })();
+    loadMonaco()
+      .then(() => {
+        if (active) {
+          setReady(true);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load local monaco-editor:', err);
+      });
     return () => {
       active = false;
     };

--- a/webapp/src/dogma/common/components/JsonEditor.tsx
+++ b/webapp/src/dogma/common/components/JsonEditor.tsx
@@ -13,10 +13,11 @@
  * License for the specific language governing permissions and limitations
  * under the License.
  */
-import Editor, { loader } from '@monaco-editor/react';
+import Editor from '@monaco-editor/react';
 import { useColorMode } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 import { Loading } from 'dogma/common/components/Loading';
+import { loadMonaco } from 'dogma/features/file/MonacoLoader';
 
 interface JsonEditorProps {
   value: string;
@@ -40,14 +41,15 @@ export const JsonEditor = ({
 
   useEffect(() => {
     let active = true;
-    (async () => {
-      const monaco = await import('monaco-editor');
-      loader.config({ monaco });
-      await loader.init();
-      if (active) {
-        setReady(true);
-      }
-    })();
+    loadMonaco()
+      .then(() => {
+        if (active) {
+          setReady(true);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load local monaco-editor:', err);
+      });
     return () => {
       active = false;
     };

--- a/webapp/src/dogma/features/file/MonacoLoader.ts
+++ b/webapp/src/dogma/features/file/MonacoLoader.ts
@@ -1,5 +1,13 @@
 import { useEffect, useState } from 'react';
-import { loader } from '@monaco-editor/react';
+import { loader, Monaco } from '@monaco-editor/react';
+
+// Worker bundle URLs emitted by MonacoWebpackPlugin (see next.config.js). The filenames are stable
+// (no content hash), so both the Monaco worker resolver and the prefetch logic reference them directly.
+const WORKER_URLS = {
+  editor: '/_next/static/editor.worker.js',
+  json: '/_next/static/json.worker.js',
+  ts: '/_next/static/ts.worker.js',
+};
 
 // Helper to define the worker paths (matches next.config.js)
 const setupMonacoEnv = () => {
@@ -9,38 +17,124 @@ const setupMonacoEnv = () => {
       getWorkerUrl: function (_moduleId: any, label: string) {
         switch (label) {
           case 'json':
-            return '/_next/static/json.worker.js';
+            return WORKER_URLS.json;
           case 'javascript':
           case 'typescript':
-            return '/_next/static/ts.worker.js';
+            return WORKER_URLS.ts;
           default:
-            return '/_next/static/editor.worker.js';
+            return WORKER_URLS.editor;
         }
       },
     };
   }
 };
 
-export const useLocalMonaco = () => {
-  //eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [monaco, setMonaco] = useState<any>(null);
+// A single shared promise so the monaco-editor chunk is fetched and the loader configured exactly once,
+// whether triggered by prefetch or by an editor component mounting.
+let monacoPromise: Promise<Monaco> | null = null;
+
+export const loadMonaco = (): Promise<Monaco> => {
+  if (typeof window === 'undefined') {
+    return Promise.reject(new Error('Monaco can only be loaded in the browser'));
+  }
+  if (!monacoPromise) {
+    setupMonacoEnv();
+    monacoPromise = import('monaco-editor')
+      .then((monaco) => {
+        // Tell the wrapper to use our locally bundled instance instead of the CDN, then fully initialize it.
+        loader.config({ monaco });
+        return loader.init();
+      })
+      .catch((err) => {
+        // Don't cache a failed load. A transient error (e.g. a chunk-download failure during the idle
+        // prefetch) must not poison the singleton, or every later caller would get the same rejection and the
+        // editor could never recover. Clear it so the next call retries, then re-throw for the current caller.
+        monacoPromise = null;
+        throw err;
+      });
+  }
+  return monacoPromise;
+};
+
+export const useLocalMonaco = (): Monaco | null => {
+  const [monaco, setMonaco] = useState<Monaco | null>(null);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setupMonacoEnv();
-
-      import('monaco-editor')
-        .then((monacoInstance) => {
-          // Tell the wrapper to use our local instance instead of CDN
-          loader.config({ monaco: monacoInstance });
-
-          setMonaco(monacoInstance);
-        })
-        .catch((err) => {
-          console.error('Failed to load local monaco-editor:', err);
-        });
-    }
+    let active = true;
+    loadMonaco()
+      .then((instance) => {
+        if (active) {
+          setMonaco(instance);
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load local monaco-editor:', err);
+      });
+    return () => {
+      active = false;
+    };
   }, []);
 
   return monaco;
+};
+
+// Warm the browser cache for the language worker bundles. `rel="prefetch"` is a low-priority hint, so it
+// never competes with resources the current page actually needs. Idempotent: skips URLs already linked.
+const prefetchWorkers = () => {
+  for (const href of Object.values(WORKER_URLS)) {
+    if (document.head.querySelector(`link[rel="prefetch"][href="${href}"]`)) {
+      continue;
+    }
+    const link = document.createElement('link');
+    link.rel = 'prefetch';
+    // Deliberately omit `as="worker"`: a plain prefetch lands the response in the HTTP cache and is reused
+    // by the later `new Worker(url)` fetch. Setting `as="worker"` is inconsistently honored across browsers
+    // and can make the prefetched entry ineligible for reuse, causing the worker to be downloaded twice.
+    link.href = href;
+    document.head.appendChild(link);
+  }
+};
+
+// Kick off Monaco loading ahead of the first file view so the editor opens instantly. Safe to call
+// repeatedly: loadMonaco() is a singleton and prefetchWorkers() is idempotent.
+export const prefetchMonaco = () => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  prefetchWorkers();
+  loadMonaco().catch((err) => {
+    console.error('Failed to prefetch monaco-editor:', err);
+  });
+};
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+// Prefetch Monaco during browser idle time once `enabled` is true. The download runs asynchronously and at
+// low priority, so it never blocks the current page — Monaco is simply ready by the time a file is opened.
+export const useMonacoPrefetch = (enabled: boolean) => {
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') {
+      return;
+    }
+    const idleWindow = window as IdleWindow;
+    let idleHandle = 0;
+    let timeoutHandle = 0;
+    if (idleWindow.requestIdleCallback) {
+      idleHandle = idleWindow.requestIdleCallback(() => prefetchMonaco(), { timeout: 3000 });
+    } else {
+      // Browsers without requestIdleCallback (e.g. Safari) fall back to a short deferral.
+      timeoutHandle = window.setTimeout(() => prefetchMonaco(), 1500);
+    }
+    return () => {
+      if (idleHandle && idleWindow.cancelIdleCallback) {
+        idleWindow.cancelIdleCallback(idleHandle);
+      }
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+    };
+  }, [enabled]);
 };

--- a/webapp/src/pages/_app.tsx
+++ b/webapp/src/pages/_app.tsx
@@ -13,6 +13,7 @@ import { Loading } from 'dogma/common/components/Loading';
 import Head from 'next/head';
 import { useAppSelector } from 'dogma/hooks';
 import { ServerConfigLoader } from 'dogma/features/server-config/ServerConfigLoader';
+import { useMonacoPrefetch } from 'dogma/features/file/MonacoLoader';
 
 const WEB_AUTH_LOGIN = '/web/auth/login';
 
@@ -33,6 +34,11 @@ function GlobalCsrfMetaTag() {
 let urlRewrite = false;
 const DogmaApp = ({ Component, pageProps }: AppPropsWithLayout) => {
   const router = useRouter();
+  // Prefetch the Monaco editor bundle during idle time (skipped on the login page) so the first file
+  // view opens instantly instead of blocking on a multi-megabyte download. Gated on `router.isReady` so
+  // the decision uses the resolved pathname and never schedules a prefetch on the login page during the
+  // pre-hydration window when `router.pathname` may not yet be settled.
+  useMonacoPrefetch(router.isReady && router.pathname !== WEB_AUTH_LOGIN);
   if (!router.isReady) {
     return <Loading />;
   }

--- a/webapp/tests/dogma/feature/file/MonacoLoader.test.ts
+++ b/webapp/tests/dogma/feature/file/MonacoLoader.test.ts
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+import { prefetchMonaco, useMonacoPrefetch } from 'dogma/features/file/MonacoLoader';
+
+// The real monaco-editor package is a multi-megabyte browser bundle; mock it so the loader logic can be
+// tested in jsdom without loading it.
+jest.mock('monaco-editor', () => ({ __esModule: true, editor: {}, languages: {} }), { virtual: true });
+
+jest.mock('@monaco-editor/react', () => ({
+  loader: {
+    config: jest.fn(),
+    init: jest.fn().mockResolvedValue({ editor: {} }),
+  },
+}));
+
+describe('MonacoLoader', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  describe('loadMonaco', () => {
+    it('imports monaco and configures the loader exactly once across calls', async () => {
+      // Isolate the module so its `monacoPromise` singleton (and the mock call counts) start fresh, without
+      // resetting the shared React instance the hook tests rely on.
+      await jest.isolateModulesAsync(async () => {
+        const { loadMonaco } = require('dogma/features/file/MonacoLoader');
+        const { loader } = require('@monaco-editor/react');
+
+        const first = loadMonaco();
+        const second = loadMonaco();
+
+        // Same shared promise — not a new import/config per call.
+        expect(first).toBe(second);
+
+        await first;
+
+        expect(loader.config).toHaveBeenCalledTimes(1);
+        expect(loader.init).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    it('retries after a failed load instead of caching the rejection', async () => {
+      await jest.isolateModulesAsync(async () => {
+        const { loadMonaco } = require('dogma/features/file/MonacoLoader');
+        const { loader } = require('@monaco-editor/react');
+
+        // The `@monaco-editor/react` mock is shared across `isolateModulesAsync` blocks, so clear its call
+        // count here to keep the assertions below independent of other tests' invocations.
+        loader.init.mockClear();
+        // Simulate a transient load failure (e.g. a chunk-download error) on the first attempt, then success.
+        loader.init.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue({ editor: {} });
+
+        // The first attempt rejects...
+        await expect(loadMonaco()).rejects.toThrow('network blip');
+
+        // ...and the failure must not be cached: the next call retries and succeeds rather than returning the
+        // same rejected promise, so the editor can recover once the network does.
+        await expect(loadMonaco()).resolves.toEqual({ editor: {} });
+        expect(loader.init).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('prefetchMonaco', () => {
+    const expectedHrefs = [
+      '/_next/static/editor.worker.js',
+      '/_next/static/json.worker.js',
+      '/_next/static/ts.worker.js',
+    ];
+
+    it('injects a prefetch link for every worker bundle', () => {
+      prefetchMonaco();
+
+      const links = Array.from(document.head.querySelectorAll('link[rel="prefetch"]')) as HTMLLinkElement[];
+      const hrefs = links.map((link) => link.getAttribute('href'));
+
+      expect(hrefs).toEqual(expect.arrayContaining(expectedHrefs));
+      expect(links).toHaveLength(expectedHrefs.length);
+      // A plain prefetch (no `as`) is used so the response is reused by the later worker fetch; see
+      // prefetchWorkers().
+      expect(links.every((link) => link.getAttribute('as') === null)).toBe(true);
+    });
+
+    it('does not duplicate prefetch links when called repeatedly', () => {
+      prefetchMonaco();
+      prefetchMonaco();
+
+      expect(document.head.querySelectorAll('link[rel="prefetch"]')).toHaveLength(expectedHrefs.length);
+    });
+  });
+
+  describe('useMonacoPrefetch', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('schedules a prefetch during idle time when enabled', () => {
+      renderHook(() => useMonacoPrefetch(true));
+
+      // Nothing prefetched synchronously — it is deferred until the browser is idle.
+      expect(document.head.querySelectorAll('link[rel="prefetch"]')).toHaveLength(0);
+
+      // jsdom has no requestIdleCallback, so the setTimeout fallback fires the prefetch.
+      jest.runOnlyPendingTimers();
+
+      expect(document.head.querySelectorAll('link[rel="prefetch"]').length).toBeGreaterThan(0);
+    });
+
+    it('does nothing when disabled', () => {
+      renderHook(() => useMonacoPrefetch(false));
+      jest.runOnlyPendingTimers();
+
+      expect(document.head.querySelectorAll('link[rel="prefetch"]')).toHaveLength(0);
+    });
+
+    it('cancels the pending prefetch on unmount', () => {
+      const { unmount } = renderHook(() => useMonacoPrefetch(true));
+      unmount();
+      jest.runOnlyPendingTimers();
+
+      expect(document.head.querySelectorAll('link[rel="prefetch"]')).toHaveLength(0);
+    });
+  });
+});

--- a/webapp/tests/scripts/compress-static.test.ts
+++ b/webapp/tests/scripts/compress-static.test.ts
@@ -92,4 +92,18 @@ describe('compress-static', () => {
     expect(await exists(`${target}.br`)).toBe(true);
     expect(await exists(`${link}.br`)).toBe(true);
   });
+
+  it('does not recurse into a symlinked directory cycle', async () => {
+    const file = path.join(dir, 'app.js');
+    await fs.writeFile(file, COMPRESSIBLE);
+    // A directory symlink pointing back to an ancestor forms a cycle. Recursing into it re-traverses the tree
+    // over and over (until the filesystem hits its symlink limit), re-compressing every file many times.
+    await fs.symlink(dir, path.join(dir, 'self'));
+
+    const { stdout } = await run(dir);
+
+    // The real file is compressed exactly once and the symlinked directory is never descended into.
+    expect(await exists(`${file}.br`)).toBe(true);
+    expect(stdout).toContain('Precompressed 1 files');
+  });
 });

--- a/webapp/tests/scripts/compress-static.test.ts
+++ b/webapp/tests/scripts/compress-static.test.ts
@@ -1,0 +1,95 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+
+// The build script is an ESM `.mjs` that runs on import; jest transforms modules to CJS (breaking
+// `import.meta`), so exercise it as a real subprocess against a temporary output directory instead.
+const execFileAsync = promisify(execFile);
+const SCRIPT = path.resolve(__dirname, '../../scripts/compress-static.mjs');
+
+// Repetitive JS text that is comfortably above MIN_BYTES (1024) and compresses to a fraction of its size.
+const COMPRESSIBLE = 'console.log("compress me");\n'.repeat(200);
+
+const run = (distDir: string) =>
+  execFileAsync('node', [SCRIPT], { env: { ...process.env, NEXT_DIST_DIR: distDir } });
+
+const exists = async (p: string): Promise<boolean> => {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+describe('compress-static', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'compress-static-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('writes .br and .gz siblings for compressible files above the size threshold', async () => {
+    const file = path.join(dir, 'app.js');
+    await fs.writeFile(file, COMPRESSIBLE);
+
+    await run(dir);
+
+    expect(await exists(`${file}.br`)).toBe(true);
+    expect(await exists(`${file}.gz`)).toBe(true);
+    // The emitted brotli variant must actually be smaller than the original.
+    const [original, brotli] = await Promise.all([fs.stat(file), fs.stat(`${file}.br`)]);
+    expect(brotli.size).toBeLessThan(original.size);
+  });
+
+  it('skips files below the minimum size', async () => {
+    const file = path.join(dir, 'tiny.js');
+    await fs.writeFile(file, 'x'.repeat(100));
+
+    await run(dir);
+
+    expect(await exists(`${file}.br`)).toBe(false);
+    expect(await exists(`${file}.gz`)).toBe(false);
+  });
+
+  it('skips non-compressible extensions', async () => {
+    const file = path.join(dir, 'image.png');
+    await fs.writeFile(file, COMPRESSIBLE); // large enough, but not a text asset
+
+    await run(dir);
+
+    expect(await exists(`${file}.br`)).toBe(false);
+    expect(await exists(`${file}.gz`)).toBe(false);
+  });
+
+  it('skips the webpack cache directory', async () => {
+    const cacheDir = path.join(dir, 'cache');
+    await fs.mkdir(cacheDir);
+    const file = path.join(cacheDir, 'chunk.js');
+    await fs.writeFile(file, COMPRESSIBLE);
+
+    await run(dir);
+
+    expect(await exists(`${file}.br`)).toBe(false);
+    expect(await exists(`${file}.gz`)).toBe(false);
+  });
+
+  it('follows symlinked files instead of skipping them', async () => {
+    const target = path.join(dir, 'real.js');
+    await fs.writeFile(target, COMPRESSIBLE);
+    const link = path.join(dir, 'linked.js');
+    await fs.symlink(target, link);
+
+    await run(dir);
+
+    // Both the real file and the symlink are compressed into their own siblings.
+    expect(await exists(`${target}.br`)).toBe(true);
+    expect(await exists(`${link}.br`)).toBe(true);
+  });
+});


### PR DESCRIPTION
Motivation:

Opening a file for the first time was slow because the multi-megabyte Monaco editor bundle was downloaded only when the editor first mounted, and the static assets were served uncompressed.

Modifications:

- Add a shared `loadMonaco()` singleton and prefetch Monaco (core chunk + language workers) during browser idle time via `useMonacoPrefetch`, wired into `_app.tsx` (skipped on the login page).

Result:

- The first file view opens without waiting on the Monaco download.